### PR TITLE
Clean up warnings in compiler module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -845,7 +845,7 @@ lazy val compiler = configureAsSubproject(project)
       ).get
     },
     Compile / scalacOptions ++= Seq(
-      "-Xlint:-inaccessible,-nonlocal-return,-valpattern,-doc-detached,_",
+      "-Xlint:-inaccessible,-nonlocal-return,-valpattern,_",
       "-Wconf:cat=deprecation&msg=early initializers:s", // compiler heavily relies upon early initializers
     ),
     Compile / doc / scalacOptions ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -844,7 +844,10 @@ lazy val compiler = configureAsSubproject(project)
         --- (base ** "Scaladoc*ModelTest.scala") // exclude test classes that depend on partest
       ).get
     },
-    Compile / scalacOptions += "-Xlint:-deprecation,-inaccessible,-nonlocal-return,-valpattern,-doc-detached,_",
+    Compile / scalacOptions ++= Seq(
+      "-Xlint:-inaccessible,-nonlocal-return,-valpattern,-doc-detached,_",
+      "-Wconf:cat=deprecation&msg=early initializers:s", // compiler heavily relies upon early initializers
+    ),
     Compile / doc / scalacOptions ++= Seq(
       "-doc-root-content", (Compile / sourceDirectory).value + "/rootdoc.txt"
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -845,7 +845,8 @@ lazy val compiler = configureAsSubproject(project)
       ).get
     },
     Compile / scalacOptions ++= Seq(
-      "-Xlint:-inaccessible,-nonlocal-return,-valpattern,_",
+      "-Xlint:-valpattern,_",
+      "-feature",
       "-Wconf:cat=deprecation&msg=early initializers:s", // compiler heavily relies upon early initializers
     ),
     Compile / doc / scalacOptions ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -845,7 +845,7 @@ lazy val compiler = configureAsSubproject(project)
       ).get
     },
     Compile / scalacOptions ++= Seq(
-      "-Xlint:-valpattern,_",
+      "-Xlint",
       "-feature",
       "-Wconf:cat=deprecation&msg=early initializers:s", // compiler heavily relies upon early initializers
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -802,6 +802,7 @@ lazy val compiler = configureAsSubproject(project)
   .settings(generateBuildCharacterFileSettings)
   .settings(Osgi.settings)
   .settings(AutomaticModuleName.settings("scala.tools.nsc"))
+  .settings(fatalWarningsSettings)
   .settings(
     name := "scala-compiler",
     description := "Scala Compiler",
@@ -848,6 +849,8 @@ lazy val compiler = configureAsSubproject(project)
       "-Xlint",
       "-feature",
       "-Wconf:cat=deprecation&msg=early initializers:s", // compiler heavily relies upon early initializers
+      "-Wconf:msg=match may not be exhaustive:i",
+      "-Ypatmat-exhaust-depth", "80",
     ),
     Compile / doc / scalacOptions ++= Seq(
       "-doc-root-content", (Compile / sourceDirectory).value + "/rootdoc.txt"

--- a/src/compiler/scala/reflect/macros/contexts/Enclosures.scala
+++ b/src/compiler/scala/reflect/macros/contexts/Enclosures.scala
@@ -23,6 +23,7 @@ trait Enclosures {
   private lazy val site       = callsiteTyper.context
 
   private def lenientEnclosure[T <: Tree : ClassTag]: Tree = site.nextEnclosing(c => classTag[T].runtimeClass.isInstance(c.tree)).tree
+  @deprecated("c.enclosingTree-style APIs are now deprecated; consult the scaladoc for more information", "2.13.4")
   private def strictEnclosure[T <: Tree : ClassTag]: T = site.nextEnclosing(c => classTag[T].runtimeClass.isInstance(c.tree)) match {
     case analyzer.NoContext => throw EnclosureException(classTag[T].runtimeClass, site.enclosingContextChain map (_.tree))
     case cx => cx.tree.asInstanceOf[T]
@@ -31,18 +32,23 @@ trait Enclosures {
   val macroApplication: Tree                      = expandee
   def enclosingPackage: PackageDef                = site.nextEnclosing(_.tree.isInstanceOf[PackageDef]).tree.asInstanceOf[PackageDef]
   lazy val enclosingClass: Tree                   = lenientEnclosure[ImplDef]
+  @deprecated("c.enclosingTree-style APIs are now deprecated; consult the scaladoc for more information", "2.13.4")
   def enclosingImpl: ImplDef                      = strictEnclosure[ImplDef]
+  @deprecated("c.enclosingTree-style APIs are now deprecated; consult the scaladoc for more information", "2.13.4")
   def enclosingTemplate: Template                 = strictEnclosure[Template]
   lazy val enclosingImplicits: List[ImplicitCandidate] = site.openImplicits.map(_.toImplicitCandidate)
   private val analyzerOpenMacros                  = universe.analyzer.openMacros
   val enclosingMacros: List[Context]              = this :: analyzerOpenMacros // include self
   lazy val enclosingMethod: Tree                       = lenientEnclosure[DefDef]
+  @deprecated("c.enclosingTree-style APIs are now deprecated; consult the scaladoc for more information", "2.13.4")
   def enclosingDef: DefDef                        = strictEnclosure[DefDef]
   lazy val enclosingPosition: Position            = if (this.macroApplication.pos ne NoPosition) this.macroApplication.pos else {
     analyzerOpenMacros.collectFirst {
       case x if x.macroApplication.pos ne NoPosition => x.macroApplication.pos
     }.getOrElse(NoPosition)
   }
+  @deprecated("c.enclosingTree-style APIs are now deprecated; consult the scaladoc for more information", "2.13.4")
   val enclosingUnit: CompilationUnit              = universe.currentRun.currentUnit
+  @deprecated("c.enclosingTree-style APIs are now deprecated; consult the scaladoc for more information", "2.13.4")
   val enclosingRun: Run                           = universe.currentRun
 }

--- a/src/compiler/scala/reflect/macros/contexts/Internals.scala
+++ b/src/compiler/scala/reflect/macros/contexts/Internals.scala
@@ -21,7 +21,7 @@ trait Internals extends scala.tools.nsc.transform.TypingTransformers {
   lazy val internal: ContextInternalApi = new global.SymbolTableInternal with ContextInternalApi {
     val enclosingOwner = callsiteTyper.context.owner
 
-    class HofTransformer(hof: (Tree, TransformApi) => Tree) extends Transformer {
+    class HofTransformer(hof: (Tree, TransformApi) => Tree) extends AstTransformer {
       val api = new TransformApi {
         def recur(tree: Tree): Tree = hof(tree, this)
         def default(tree: Tree): Tree = superTransform(tree)

--- a/src/compiler/scala/reflect/macros/contexts/Parsers.scala
+++ b/src/compiler/scala/reflect/macros/contexts/Parsers.scala
@@ -27,7 +27,7 @@ trait Parsers {
     val oldReporter = global.reporter
     try {
       global.reporter = sreporter
-      val parser = newUnitParser(new CompilationUnit(newSourceFile(code, "<macro>")) {
+      val parser = newUnitParser(new global.CompilationUnit(newSourceFile(code, "<macro>")) {
         override implicit val fresh: FreshNameCreator = currentFreshNameCreator
       })
       val tree = gen.mkTreeOrBlock(parser.parseStatsOrPackages())

--- a/src/compiler/scala/reflect/macros/runtime/MacroRuntimes.scala
+++ b/src/compiler/scala/reflect/macros/runtime/MacroRuntimes.scala
@@ -36,7 +36,7 @@ trait MacroRuntimes extends JavaReflectionRuntimes {
   /** Default implementation of `macroRuntime`.
    *  Can be overridden by analyzer plugins (see AnalyzerPlugins.pluginsMacroRuntime for more details)
    */
-  private val macroRuntimesCache = perRunCaches.newWeakMap[Symbol, MacroRuntime]
+  private val macroRuntimesCache = perRunCaches.newWeakMap[Symbol, MacroRuntime]()
   def standardMacroRuntime(expandee: Tree): MacroRuntime = {
     val macroDef = expandee.symbol
     macroLogVerbose(s"looking for macro implementation: $macroDef")

--- a/src/compiler/scala/reflect/quasiquotes/Reifiers.scala
+++ b/src/compiler/scala/reflect/quasiquotes/Reifiers.scala
@@ -13,7 +13,7 @@
 package scala.reflect
 package quasiquotes
 
-import java.lang.UnsupportedOperationException
+import scala.annotation.nowarn
 import scala.reflect.reify.{Reifier => ReflectReifier}
 import scala.reflect.internal.Flags._
 
@@ -86,7 +86,7 @@ trait Reifiers { self: Quasiquotes =>
         val isVarPattern = tree match { case Bind(name, Ident(nme.WILDCARD)) => true case _ => false }
         val cases =
           if(isVarPattern) {
-            val Ident(name) :: Nil = freevars
+            val Ident(name) :: Nil = freevars: @nowarn("msg=match may not be exhaustive")
             // cq"$name: $treeType => $SomeModule($name)" :: Nil
             CaseDef(Bind(name, Typed(Ident(nme.WILDCARD), TypeTree(treeType))),
               EmptyTree, Apply(Ident(SomeModule), List(Ident(name)))) :: Nil
@@ -422,7 +422,7 @@ trait Reifiers { self: Quasiquotes =>
           case List(elem) if fill.isDefinedAt(elem) => fill(elem)
           case elems => mkList(elems.map(fallback))
         }
-        val head :: tail = group(xs) { (a, b) => !fill.isDefinedAt(a) && !fill.isDefinedAt(b) }
+        val head :: tail = group(xs) { (a, b) => !fill.isDefinedAt(a) && !fill.isDefinedAt(b) }: @nowarn("msg=match may not be exhaustive")
         tail.foldLeft[Tree](reifyGroup(head)) { (tree, lst) => Apply(Select(tree, nme.PLUSPLUS), List(reifyGroup(lst))) }
       }
 

--- a/src/compiler/scala/reflect/reify/codegen/GenSymbols.scala
+++ b/src/compiler/scala/reflect/reify/codegen/GenSymbols.scala
@@ -184,7 +184,7 @@ trait GenSymbols {
       val reification = reificode(sym)
       import reification.{name, binding}
       val tree = reification.tree updateAttachment ReifyBindingAttachment(binding)
-      state.symtab += (sym, name.toTermName, tree)
+      state.symtab = state.symtab.add(sym, name.toTermName, tree)
     }
     fromSymtab
   }

--- a/src/compiler/scala/reflect/reify/phases/Metalevels.scala
+++ b/src/compiler/scala/reflect/reify/phases/Metalevels.scala
@@ -113,7 +113,7 @@ trait Metalevels {
    *  The reasoning from Example 2 still holds here - we do need to inline the freevar that refers to x.
    *  However, we must not touch anything inside the splice'd block, because it's not getting reified.
    */
-  val metalevels = new Transformer {
+  val metalevels = new AstTransformer {
     var insideSplice = false
     val inlineableBindings = mutable.Map[TermName, Tree]()
 

--- a/src/compiler/scala/reflect/reify/phases/Reshape.scala
+++ b/src/compiler/scala/reflect/reify/phases/Reshape.scala
@@ -37,7 +37,7 @@ trait Reshape {
    *    * Transforming Annotated(annot, expr) into Typed(expr, TypeTree(Annotated(annot, _))
    *    * Non-idempotencies of the typechecker: https://github.com/scala/bug/issues/5464
    */
-  val reshape = new Transformer {
+  val reshape = new AstTransformer {
     var currentSymbol: Symbol = NoSymbol
 
     override def transform(tree0: Tree) = {

--- a/src/compiler/scala/reflect/reify/utils/SymbolTables.scala
+++ b/src/compiler/scala/reflect/reify/utils/SymbolTables.scala
@@ -85,7 +85,7 @@ trait SymbolTables {
       new SymbolTable(newSymtab, newAliases)
     }
 
-    private def add(sym: Symbol, name0: TermName, reification: Tree): SymbolTable = {
+    def add(sym: Symbol, name0: TermName, reification: Tree): SymbolTable = {
       def freshName(name0: TermName): TermName = {
         var name = name0.toString
         name = name.replace(".type", "$type")

--- a/src/compiler/scala/tools/nsc/CompilationUnits.scala
+++ b/src/compiler/scala/tools/nsc/CompilationUnits.scala
@@ -12,9 +12,10 @@
 
 package scala.tools.nsc
 
-import scala.reflect.internal.util.{ SourceFile, NoSourceFile, FreshNameCreator }
+import scala.annotation.nowarn
+import scala.reflect.internal.util.{FreshNameCreator, NoSourceFile, SourceFile}
 import scala.collection.mutable
-import scala.collection.mutable.{ LinkedHashSet, ListBuffer }
+import scala.collection.mutable.{LinkedHashSet, ListBuffer}
 
 trait CompilationUnits { global: Global =>
 
@@ -39,6 +40,7 @@ trait CompilationUnits { global: Global =>
   /** One unit of compilation that has been submitted to the compiler.
     * It typically corresponds to a single file of source code.  It includes
     * error-reporting hooks.  */
+  @nowarn("""cat=deprecation&origin=scala\.reflect\.macros\.Universe\.CompilationUnitContextApi""")
   class CompilationUnit(val source: SourceFile, freshNameCreator: FreshNameCreator) extends CompilationUnitContextApi { self =>
     def this(source: SourceFile) = this(source, new FreshNameCreator)
     /** the fresh name creator */

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -711,7 +711,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
 
   // sequences the phase assembly
   protected def computePhaseDescriptors: List[SubComponent] = {
-    /** Allow phases to opt out of the phase assembly. */
+    /* Allow phases to opt out of the phase assembly. */
     def cullPhases(phases: List[SubComponent]) = {
       val enabled = if (settings.debug && settings.isInfo) phases else phases filter (_.enabled)
       def isEnabled(q: String) = enabled exists (_.phaseName == q)

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -18,7 +18,7 @@ import java.io.{Closeable, FileNotFoundException, IOException}
 import java.net.URL
 import java.nio.charset._
 
-import scala.annotation.tailrec
+import scala.annotation.{nowarn, tailrec}
 import scala.collection.{immutable, mutable}
 import scala.reflect.ClassTag
 import scala.reflect.internal.pickling.PickleBuffer
@@ -1130,8 +1130,8 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
   override protected[scala] def currentRunProfilerAfterCompletion(root: Symbol, associatedFile: AbstractFile): Unit =
     curRun.profiler.afterCompletion(root, associatedFile)
 
-  /** A Run is a single execution of the compiler on a set of units.
-   */
+  /** A Run is a single execution of the compiler on a set of units. */
+  @nowarn("""cat=deprecation&origin=scala\.reflect\.macros\.Universe\.RunContextApi""")
   class Run extends RunContextApi with RunReporting with RunParsing {
     /** Have been running into too many init order issues with Run
      *  during erroneous conditions.  Moved all these vals up to the

--- a/src/compiler/scala/tools/nsc/PipelineMain.scala
+++ b/src/compiler/scala/tools/nsc/PipelineMain.scala
@@ -21,6 +21,7 @@ import java.util.{Collections, Locale}
 import javax.tools.Diagnostic.Kind
 import javax.tools.{Diagnostic, DiagnosticListener, JavaFileObject, ToolProvider}
 
+import scala.annotation.nowarn
 import scala.collection.{immutable, mutable}
 import scala.collection.immutable.ArraySeq.unsafeWrapArray
 import scala.concurrent._
@@ -76,6 +77,7 @@ class PipelineMainClass(argFiles: Seq[Path], pipelineSettings: PipelineMain.Pipe
     p.getParent.resolve(changedFileName)
   }
 
+  @nowarn("cat=lint-inaccessible")
   def writeDotFile(logDir: Path, dependsOn: mutable.LinkedHashMap[Task, List[Dependency]]): Unit = {
     val builder = new java.lang.StringBuilder()
     builder.append("digraph projects {\n")

--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -30,7 +30,7 @@ import scala.util.matching.Regex
 trait Reporting extends internal.Reporting { self: ast.Positions with CompilationUnits with internal.Symbols =>
   def settings: Settings
 
-  @deprecated("use `globalError` instead")
+  @deprecated("use `globalError` instead", since = "2.13.4")
   def error(msg: String): Unit = globalError(msg)
 
   // a new instance of this class is created for every Run (access the current instance via `runReporting`)

--- a/src/compiler/scala/tools/nsc/ScriptRunner.scala
+++ b/src/compiler/scala/tools/nsc/ScriptRunner.scala
@@ -139,7 +139,7 @@ abstract class AbstractScriptRunner(settings: GenericRunnerSettings) extends Scr
         }
       }
 
-      val err = if (!jarOK) recompile else None
+      val err = if (!jarOK) recompile() else None
       err orElse handler(jarFile.toAbsolute.path) filterNot { case NoScriptError => true case _ => false }
     }
 

--- a/src/compiler/scala/tools/nsc/ast/Trees.scala
+++ b/src/compiler/scala/tools/nsc/ast/Trees.scala
@@ -173,8 +173,9 @@ trait Trees extends scala.reflect.internal.Trees { self: Global =>
   @nowarn("""cat=deprecation&origin=scala\.tools\.nsc\.ast\.Trees\.Transformer""")
   final type AstTransformer = Transformer
 
+  // TODO: deprecate when we can cleanly cross-compile without warnings
+  // @deprecated("use AstTransformer instead", since = "2.13.4")
   @nowarn("msg=shadowing a nested class of a parent is deprecated")
-  @deprecated("use AstTransformer instead", since = "2.13.4")
   class Transformer extends InternalTransformer {
     def transformUnit(unit: CompilationUnit): Unit = {
       try unit.body = transform(unit.body)

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -432,9 +432,9 @@ trait Scanners extends ScannersCommon {
         token = nl
       }
 
-      /** A leading symbolic or backquoted identifier is treated as an infix operator
-       *  if it is followed by at least one ' ' and a token on the same line
-       *  that can start an expression.
+      /* A leading symbolic or backquoted identifier is treated as an infix operator
+       * if it is followed by at least one ' ' and a token on the same line
+       * that can start an expression.
        */
       def isLeadingInfixOperator =
         allowLeadingInfixOperators &&

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -13,7 +13,7 @@
 package scala.tools.nsc
 package backend.jvm
 
-import scala.annotation.{switch, tailrec}
+import scala.annotation.{nowarn, switch, tailrec}
 import scala.collection.mutable.ListBuffer
 import scala.reflect.internal.Flags
 import scala.tools.asm
@@ -215,7 +215,7 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
 
     def genPrimitiveOp(tree: Apply, expectedType: BType): BType = {
       val sym = tree.symbol
-      val Apply(fun @ Select(receiver, _), _) = tree
+      val Apply(fun @ Select(receiver, _), _) = tree: @nowarn("msg=match may not be exhaustive")
       val code = scalaPrimitives.getPrimitive(sym, receiver.tpe)
 
       import scalaPrimitives.{isArithmeticOp, isArrayOp, isComparisonOp, isLogicalOp}
@@ -715,7 +715,7 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
     } // end of genApply()
 
     private def genArrayValue(av: ArrayValue): BType = {
-      val ArrayValue(tpt @ TypeTree(), elems) = av
+      val ArrayValue(tpt @ TypeTree(), elems) = av: @nowarn("msg=match may not be exhaustive")
 
       val elmKind       = tpeTK(tpt)
       val generatedType = ArrayBType(elmKind)

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -19,6 +19,7 @@ import scala.tools.nsc.symtab._
 import scala.tools.asm
 import GenBCode._
 import BackendReporting._
+import scala.annotation.nowarn
 
 /*
  *  @author  Miguel Garcia, http://lampwww.epfl.ch/~magarcia/ScalaCompilerCornerReloaded/
@@ -533,7 +534,7 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
               val forwarderDefDef = {
                 val dd1 = global.gen.mkStatic(deriveDefDef(dd)(_ => EmptyTree), newTermName(traitSuperAccessorName(sym)), _.cloneSymbol.withoutAnnotations)
                 dd1.symbol.setFlag(Flags.ARTIFACT).resetFlag(Flags.OVERRIDE)
-                val selfParam :: realParams = dd1.vparamss.head.map(_.symbol)
+                val selfParam :: realParams = dd1.vparamss.head.map(_.symbol): @nowarn("msg=match may not be exhaustive")
                 deriveDefDef(dd1)(_ =>
                   atPos(dd1.pos)(
                     Apply(Select(global.gen.mkAttributedIdent(selfParam).setType(sym.owner.typeConstructor), dd.symbol),

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSyncAndTry.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSyncAndTry.scala
@@ -243,7 +243,7 @@ abstract class BCodeSyncAndTry extends BCodeBodyBuilder {
       val endTryBody = currProgramPoint()
       bc goTo postHandlers
 
-      /**
+      /*
        * A return within a `try` or `catch` block where a `finally` is present ("early return")
        * emits a store of the result to a local, jump to a "cleanup" version of the `finally` block,
        * and sets `shouldEmitCleanup = true` (see [[PlainBodyBuilder.genReturn]]).

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromClassfile.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromClassfile.scala
@@ -93,7 +93,7 @@ abstract class BTypesFromClassfile {
 
     val flags = classNode.access
 
-    /**
+    /*
      * Find all nested classes of classNode. The innerClasses attribute contains all nested classes
      * that are declared inside classNode or used in the bytecode of classNode. So some of them are
      * nested in some other class than classNode, and we need to filter them.

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -163,7 +163,7 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
   final def typeToBType(t: Type): BType = {
     import definitions.ArrayClass
 
-    /**
+    /*
      * Primitive types are represented as TypeRefs to the class symbol of, for example, scala.Int.
      * The `primitiveTypeMap` maps those class symbols to the corresponding PrimitiveBType.
      */
@@ -175,7 +175,7 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
       }
     }
 
-    /**
+    /*
      * When compiling Array.scala, the type parameter T is not erased and shows up in method
      * signatures, e.g. `def apply(i: Int): T`. A TypeRef for T is replaced by ObjectRef.
      */
@@ -266,7 +266,7 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
   }))
 
   private def computeClassInfo(classSym: Symbol, classBType: ClassBType): Right[Nothing, ClassInfo] = {
-    /**
+    /*
      * Reconstruct the classfile flags from a Java defined class symbol.
      *
      * The implementation of this method is slightly different from `javaFlags` in BTypesFromSymbols.
@@ -406,7 +406,7 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
       nestedClasses ++ companionModuleMembers
     }
 
-    /**
+    /*
      * For nested java classes, the scala compiler creates both a class and a module (and therefore
      * a module class) symbol. For example, in `class A { class B {} }`, the nestedClassSymbols
      * for A contain both the class B and the module class B.

--- a/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
@@ -14,6 +14,7 @@ package scala.tools.nsc
 package backend
 package jvm
 
+import scala.annotation.nowarn
 import scala.tools.asm.Opcodes
 
 /**
@@ -60,6 +61,7 @@ abstract class GenBCode extends SubComponent {
 
   val postProcessor: PostProcessor { val bTypes: self.bTypes.type } = new { val bTypes: self.bTypes.type = self.bTypes } with PostProcessor
 
+  @nowarn("cat=lint-inaccessible")
   var generatedClassHandler: GeneratedClassHandler = _
 
   val phaseName = "jvm"

--- a/src/compiler/scala/tools/nsc/backend/jvm/GeneratedClassHandler.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GeneratedClassHandler.scala
@@ -146,7 +146,7 @@ private[jvm] object GeneratedClassHandler {
           }
       }
 
-      /**
+      /*
        * Go through each task in submission order, wait for it to finish and report its messages.
        * When finding task that has not completed, steal work from the executor's queue and run
        * it on the main thread (which we are on here), until the task is done.

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
@@ -16,7 +16,7 @@ package analysis
 
 import java.util.concurrent.ConcurrentHashMap
 
-import scala.annotation.{switch, tailrec}
+import scala.annotation.{nowarn, switch, tailrec}
 import scala.collection.immutable.BitSet
 import scala.collection.immutable.ArraySeq.unsafeWrapArray
 import scala.collection.mutable
@@ -441,7 +441,7 @@ abstract class BackendUtils extends PerRunInit {
 
     for (nestedClass <- allNestedClasses) {
       // Extract the innerClassEntry - we know it exists, enclosingNestedClassesChain only returns nested classes.
-      val Some(e) = nestedClass.innerClassAttributeEntry.get
+      val Some(e) = nestedClass.innerClassAttributeEntry.get: @nowarn("msg=match may not be exhaustive")
       jclass.visitInnerClass(e.name, e.outerName, e.innerName, e.flags)
     }
   }

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/BoxUnbox.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/BoxUnbox.scala
@@ -198,9 +198,9 @@ abstract class BoxUnbox {
 
       var maxStackGrowth = 0
 
-      /** Method M1 for eliminating box-unbox pairs (see doc comment in the beginning of this file) */
+      /* Method M1 for eliminating box-unbox pairs (see doc comment in the beginning of this file) */
       def replaceBoxOperationsSingleCreation(creation: BoxCreation, finalCons: Set[BoxConsumer], boxKind: BoxKind, keepBox: Boolean): Unit = {
-        /**
+        /*
          * If the box is eliminated, all copy operations (loads, stores, others) of the box need to
          * be removed. This method returns all copy operations that should be removed.
          *
@@ -275,9 +275,9 @@ abstract class BoxUnbox {
         }
       }
 
-      /** Method M2 for eliminating box-unbox pairs (see doc comment in the beginning of this file) */
+      /* Method M2 for eliminating box-unbox pairs (see doc comment in the beginning of this file) */
       def replaceBoxOperationsMultipleCreations(allCreations: Set[BoxCreation], allConsumers: Set[BoxConsumer], boxKind: BoxKind): Unit = {
-        /**
+        /*
          * If a single-value size-1 box is eliminated, local variables slots holding the box are
          * reused to hold the unboxed value. In case there's an entry for that local variable in the
          * method's local variables table (debug info), adapt the type.
@@ -305,7 +305,7 @@ abstract class BoxUnbox {
           }
         }
 
-        /** Remove box creations - leave the boxed value(s) on the stack instead. */
+        /* Remove box creations - leave the boxed value(s) on the stack instead. */
         def replaceCreationOps(): Unit = {
           for (creation <- allCreations) creation.loadInitialValues match {
             case None =>
@@ -317,7 +317,7 @@ abstract class BoxUnbox {
           }
         }
 
-        /**
+        /*
          * Replace a value extraction operation. For a single-value box, the extraction operation can
          * just be removed. An extraction from a multi-value box is replaced by POP operations for the
          * non-used values, and an xSTORE / xLOAD for the extracted value. Example: tuple3._2 becomes

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/ByteCodeRepository.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/ByteCodeRepository.scala
@@ -14,6 +14,7 @@ package scala.tools.nsc
 package backend.jvm
 package opt
 
+import scala.annotation.nowarn
 import scala.collection.{concurrent, mutable}
 import scala.jdk.CollectionConverters._
 import scala.tools.asm
@@ -181,6 +182,7 @@ abstract class ByteCodeRepository extends PerRunInit {
       val visited = mutable.Set.empty[InternalName]
       val found = mutable.ListBuffer.empty[(MethodNode, ClassNode)]
 
+      @nowarn("cat=lint-nonlocal-return")
       def findIn(owner: ClassNode): Option[ClassNotFound] = {
         for (i <- owner.interfaces.asScala if !visited(i)) classNode(i) match {
           case Left(e) => return Some(e)

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/CopyProp.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/CopyProp.scala
@@ -292,7 +292,7 @@ abstract class CopyProp {
 
       lazy val prodCons = new ProdConsAnalyzer(method, owner)
 
-      /**
+      /*
        * Returns the producers for the stack value `inputSlot` consumed by `cons`, if the consumer
        * instruction is the only consumer for all of these producers.
        *
@@ -300,7 +300,7 @@ abstract class CopyProp {
        * block, this method returns Set.empty.
        */
       def producersIfSingleConsumer(cons: AbstractInsnNode, inputSlot: Int): Set[AbstractInsnNode] = {
-        /**
+        /*
          * True if the values produced by `prod` are all the same. Most instructions produce a single
          * value. DUP and DUP2 (with a size-2 input) produce two equivalent values. However, there
          * are some exotic instructions that produce multiple non-equal values (DUP_X1, SWAP, ...).
@@ -338,7 +338,7 @@ abstract class CopyProp {
         if (singleConsumer) prods else Set.empty
       }
 
-      /**
+      /*
        * For a POP instruction that is the single consumer of its producers, remove the POP and
        * enqueue the producers.
        */
@@ -351,7 +351,7 @@ abstract class CopyProp {
         }
       }
 
-      /**
+      /*
        * Traverse the method in its initial state and collect all POP instructions and side-effect
        * free constructor invocations that can be eliminated.
        */
@@ -372,7 +372,7 @@ abstract class CopyProp {
         }
       }
 
-      /**
+      /*
        * Eliminate the `numArgs` inputs of the instruction `prod` (which was eliminated). For
        * each input value
        *   - if the `prod` instruction is the single consumer, enqueue the producers of the input
@@ -394,9 +394,7 @@ abstract class CopyProp {
         if (pops.nonEmpty) toInsertBefore(prod) = pops.toList
       }
 
-      /**
-       * Eliminate LMF `indy` and its inputs.
-       */
+      /* Eliminate LMF `indy` and its inputs. */
       def handleClosureInst(indy: InvokeDynamicInsnNode): Unit = {
         toRemove += indy
         callGraph.removeClosureInstantiation(indy, method)
@@ -647,7 +645,7 @@ abstract class CopyProp {
       }
     }
 
-    /**
+    /*
      * Try to pair `insn` with its correspondent on the stack
      *   - if the stack top is a store and `insn` is a corresponding load, create a pair
      *   - otherwise, check the two top stack values for `null; store`. if it matches, create

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/CopyProp.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/CopyProp.scala
@@ -14,7 +14,7 @@ package scala.tools.nsc
 package backend.jvm
 package opt
 
-import scala.annotation.{switch, tailrec}
+import scala.annotation.{nowarn, switch, tailrec}
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import scala.tools.asm.Opcodes._
@@ -660,7 +660,7 @@ abstract class CopyProp {
 
       @tailrec def tryPairing(): Unit = {
         if (completesStackTop(insn)) {
-          val (store: VarInsnNode, depends) = pairStartStack.pop()
+          val (store: VarInsnNode, depends) = pairStartStack.pop(): @nowarn("msg=match may not be exhaustive")
           addDepends(mkRemovePair(store, insn, depends.toList))
         } else if (pairStartStack.nonEmpty) {
           val (top, topDepends) = pairStartStack.pop()

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
@@ -528,7 +528,7 @@ abstract class Inliner {
     val elided = mutable.Set.empty[InlineRequest]
     def nonElidedRequests(methodNode: MethodNode): Set[InlineRequest] = requestsByMethod(methodNode) diff elided
 
-    /**
+    /*
      * Break cycles in the inline request graph by removing callsites.
      *
      * The list `requests` is traversed left-to-right, removing those callsites that are part of a
@@ -1173,7 +1173,7 @@ abstract class Inliner {
    *     error occurred
    */
   def findIllegalAccess(instructions: InsnList, calleeDeclarationClass: ClassBType, destinationClass: ClassBType): Either[(AbstractInsnNode, OptimizerWarning), List[AbstractInsnNode]] = {
-    /**
+    /*
      * Check if `instruction` can be transplanted to `destinationClass`.
      *
      * If the instruction references a class, method or field that cannot be found in the

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
@@ -14,7 +14,7 @@ package scala.tools.nsc
 package backend.jvm
 package opt
 
-import scala.annotation.tailrec
+import scala.annotation.{nowarn, tailrec}
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import scala.tools.asm
@@ -685,7 +685,7 @@ abstract class Inliner {
    */
   def inlineCallsite(callsite: Callsite, aliasFrame: Option[AliasingFrame[Value]] = None, updateCallGraph: Boolean = true): Map[AbstractInsnNode, AbstractInsnNode] = {
     import callsite._
-    val Right(callsiteCallee) = callsite.callee
+    val Right(callsiteCallee) = callsite.callee: @nowarn("msg=match may not be exhaustive")
     import callsiteCallee.{callee, calleeDeclarationClass, sourceFilePath}
 
     val isStatic = isStaticMethod(callee)
@@ -989,7 +989,7 @@ abstract class Inliner {
    */
   def earlyCanInlineCheck(callsite: Callsite): Option[CannotInlineWarning] = {
     import callsite.{callsiteClass, callsiteMethod}
-    val Right(callsiteCallee) = callsite.callee
+    val Right(callsiteCallee) = callsite.callee: @nowarn("msg=match may not be exhaustive")
     import callsiteCallee.{callee, calleeDeclarationClass}
 
     if (isSynchronizedMethod(callee)) {
@@ -1023,7 +1023,7 @@ abstract class Inliner {
    */
   def canInlineCallsite(callsite: Callsite): Option[CannotInlineWarning] = {
     import callsite.{callsiteClass, callsiteInstruction, callsiteMethod, callsiteStackHeight}
-    val Right(callsiteCallee) = callsite.callee
+    val Right(callsiteCallee) = callsite.callee: @nowarn("msg=match may not be exhaustive")
     import callsiteCallee.{callee, calleeDeclarationClass}
 
     def calleeDesc = s"${callee.name} of type ${callee.desc} in ${calleeDeclarationClass.internalName}"

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/LocalOpt.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/LocalOpt.scala
@@ -267,7 +267,7 @@ abstract class LocalOpt {
       currentTrace = after
     }
 
-    /**
+    /*
      * Runs the optimizations that depend on each other in a loop until reaching a fixpoint. See
      * comment in class [[LocalOpt]].
      *
@@ -806,7 +806,7 @@ object LocalOptImpls {
    * before, so that `BackendUtils.isLabelReachable` gives a correct answer.
    */
   def removeEmptyExceptionHandlers(method: MethodNode): RemoveHandlersResult = {
-    /** True if there exists code between start and end. */
+    /* True if there exists code between start and end. */
     @tailrec
     def containsExecutableCode(start: AbstractInsnNode, end: LabelNode): Boolean = {
       start != end && ((start.getOpcode: @switch) match {
@@ -1027,7 +1027,7 @@ object LocalOptImpls {
       removeJumpFromMap(jump)
     }
 
-    /**
+    /*
      * Removes a conditional jump if it is followed by a GOTO to the same destination.
      *
      *      CondJump l;  [nops];  GOTO l;  [...]
@@ -1048,7 +1048,7 @@ object LocalOptImpls {
       case _ => false
     }
 
-    /**
+    /*
      * Replace jumps to a sequence of GOTO instructions by a jump to the final destination.
      *
      * {{{
@@ -1070,7 +1070,7 @@ object LocalOptImpls {
       case _ => false
     }
 
-    /**
+    /*
      * Eliminates unnecessary jump instructions
      *
      * {{{
@@ -1088,7 +1088,7 @@ object LocalOptImpls {
       case _ => false
     }
 
-    /**
+    /*
      * If the "else" part of a conditional branch is a simple GOTO, negates the conditional branch
      * and eliminates the GOTO.
      *
@@ -1119,7 +1119,7 @@ object LocalOptImpls {
       case _ => false
     }
 
-    /**
+    /*
      * Inlines xRETURN and ATHROW
      *
      * {{{
@@ -1147,20 +1147,20 @@ object LocalOptImpls {
       case _ => false
     })
 
-    /**
-      * Replace conditional jump instructions with GOTO or NOP if statically known to be true or false.
-      *
-      * {{{
-      *      ICONST_0; IFEQ l;
-      *   => ICONST_0; POP; GOTO l;
-      *
-      *      ICONST_1; IFEQ l;
-      *   => ICONST_1; POP;
-      * }}}
-      *
-      * Note that the LOAD/POP pairs will be removed later by `eliminatePushPop`, and the code between
-      * the GOTO and `l` will be removed by DCE (if it's not jumped into from somewhere else).
-      */
+    /*
+     * Replace conditional jump instructions with GOTO or NOP if statically known to be true or false.
+     *
+     * {{{
+     *      ICONST_0; IFEQ l;
+     *   => ICONST_0; POP; GOTO l;
+     *
+     *      ICONST_1; IFEQ l;
+     *   => ICONST_1; POP;
+     * }}}
+     *
+     * Note that the LOAD/POP pairs will be removed later by `eliminatePushPop`, and the code between
+     * the GOTO and `l` will be removed by DCE (if it's not jumped into from somewhere else).
+     */
     def simplifyConstantConditions(instruction: AbstractInsnNode): Boolean = {
       def replace(jump: JumpInsnNode, success: Boolean): Boolean = {
         if (success) method.instructions.insert(jump, new JumpInsnNode(GOTO, jump.label))

--- a/src/compiler/scala/tools/nsc/fsc/CompileServer.scala
+++ b/src/compiler/scala/tools/nsc/fsc/CompileServer.scala
@@ -133,7 +133,7 @@ class StandardCompileServer(fixPort: Int = 0) extends SocketServer(fixPort) {
       }
       unequal.isEmpty
     }
-    /** Create a new compiler instance */
+    /* Create a new compiler instance */
     def newGlobal(settings: Settings, reporter: Reporter) = Global(settings, reporter)
 
     if (command.shouldStopWithInfo)

--- a/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
@@ -676,7 +676,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
     def varDecl(pos: Position, mods: Modifiers, tpt: Tree, name: TermName): ValDef = {
       val tpt1 = optArrayBrackets(tpt)
 
-      /** Tries to detect final static literals syntactically and returns a constant type replacement */
+      /* Tries to detect final static literals syntactically and returns a constant type replacement */
       def optConstantTpe(): Tree = {
         def constantTpe(const: Constant): Tree = TypeTree(ConstantType(const))
 

--- a/src/compiler/scala/tools/nsc/plugins/Plugins.scala
+++ b/src/compiler/scala/tools/nsc/plugins/Plugins.scala
@@ -16,6 +16,7 @@ package plugins
 import java.net.URL
 import java.util
 
+import scala.annotation.nowarn
 import scala.reflect.internal.util.ScalaClassLoader
 import scala.reflect.io.Path
 import scala.tools.nsc.Reporting.WarningCategory
@@ -121,7 +122,7 @@ trait Plugins { global: Global =>
     {
       if (plugins.isEmpty) return Nil // early return
 
-      val plug :: tail      = plugins
+      val plug :: tail      = plugins: @nowarn("msg=match may not be exhaustive") // just checked if it's empty
       val plugPhaseNames    = Set(plug.components map (_.phaseName): _*)
       def withoutPlug       = pick(tail, plugNames, plugPhaseNames)
       def withPlug          = plug :: pick(tail, plugNames + plug.name, phaseNames ++ plugPhaseNames)

--- a/src/compiler/scala/tools/nsc/profile/Profiler.scala
+++ b/src/compiler/scala/tools/nsc/profile/Profiler.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import javax.management.openmbean.CompositeData
 import javax.management.{Notification, NotificationEmitter, NotificationListener}
 
+import scala.annotation.nowarn
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.internal.util.ChromeTrace
 import scala.reflect.io.AbstractFile
@@ -352,12 +353,16 @@ object EventType extends Enumeration {
 }
 
 sealed trait ProfileReporter {
+  @nowarn("cat=lint-inaccessible")
   def reportBackground(profiler: RealProfiler, threadRange: ProfileRange): Unit
+  @nowarn("cat=lint-inaccessible")
   def reportForeground(profiler: RealProfiler, threadRange: ProfileRange): Unit
 
   def reportGc(data: GcEventData): Unit
 
+  @nowarn("cat=lint-inaccessible")
   def header(profiler: RealProfiler) :Unit
+  @nowarn("cat=lint-inaccessible")
   def close(profiler: RealProfiler) :Unit
 }
 
@@ -382,15 +387,18 @@ object NoOpProfileReporter extends ProfileReporter {
 }
 
 class StreamProfileReporter(out:PrintWriter) extends ProfileReporter {
+  @nowarn("cat=lint-inaccessible")
   override def header(profiler: RealProfiler): Unit = {
     out.println(s"info, ${profiler.id}, version, 2, output, ${profiler.outDir}")
     out.println(s"header(main/background),startNs,endNs,runId,phaseId,phaseName,purpose,task-count,threadId,threadName,runNs,idleNs,cpuTimeNs,userTimeNs,allocatedByte,heapSize")
     out.println(s"header(GC),startNs,endNs,startMs,endMs,name,action,cause,threads")
   }
 
+  @nowarn("cat=lint-inaccessible")
   override def reportBackground(profiler: RealProfiler, threadRange: ProfileRange): Unit = {
     reportCommon(EventType.BACKGROUND, profiler, threadRange)
   }
+  @nowarn("cat=lint-inaccessible")
   override def reportForeground(profiler: RealProfiler, threadRange: ProfileRange): Unit = {
     reportCommon(EventType.MAIN, profiler, threadRange)
   }
@@ -404,6 +412,7 @@ class StreamProfileReporter(out:PrintWriter) extends ProfileReporter {
     out.println(s"${EventType.GC},$start,${data.reportTimeNs},${data.gcStartMillis}, ${data.gcEndMillis},${data.name},${data.action},${data.cause},${data.threads}")
   }
 
+  @nowarn("cat=lint-inaccessible")
   override def close(profiler: RealProfiler): Unit = {
     out.flush()
     out.close()

--- a/src/compiler/scala/tools/nsc/profile/ProfilerPlugin.scala
+++ b/src/compiler/scala/tools/nsc/profile/ProfilerPlugin.scala
@@ -12,6 +12,7 @@
 
 package scala.tools.nsc.profile
 
+import scala.annotation.nowarn
 import scala.tools.nsc.{Phase, Settings}
 
 /**
@@ -28,6 +29,7 @@ trait ProfilerPlugin {
     * @param settings the setting for the current compile
     * @return the run specific profiler, that will receive updates as the compile progresses
     */
+  @nowarn("cat=lint-inaccessible")
   def generate(profiler: RealProfiler, settings: Settings): ProfilerPluginRun
 }
 

--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -636,7 +636,7 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
         case _ => true
       }
 
-      /**
+      /*
        * Expand an expanding option, if necessary recursively. Expanding options are not included in
        * the result (consistent with "_", which is not in `value` either).
        *

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -14,6 +14,7 @@ package scala.tools
 package nsc
 package settings
 
+import scala.annotation.nowarn
 import scala.tools.nsc.Reporting.WarningCategory
 
 /** Settings influencing the printing of warnings.
@@ -221,7 +222,7 @@ trait Warnings {
   def warnRecurseWithDefault     = lint contains RecurseWithDefault
   def unitSpecialization         = lint contains UnitSpecialization
   def multiargInfix              = lint contains MultiargInfix
-  def lintImplicitRecursion      = lint.contains(ImplicitRecursion) || warnSelfImplicit
+  def lintImplicitRecursion      = lint.contains(ImplicitRecursion) || (warnSelfImplicit: @nowarn("cat=deprecation"))
 
   // The Xlint warning group.
   val lint = MultiChoiceSetting(

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -1046,10 +1046,10 @@ abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
         cls.associatedFile = file
         mod.moduleClass.associatedFile = file
 
-        /**
-          * need to set privateWithin here because the classfile of a nested protected class is public in bytecode,
-          * so propagatePackageBoundary will not set it when the symbols are completed
-          */
+        /*
+         * need to set privateWithin here because the classfile of a nested protected class is public in bytecode,
+         * so propagatePackageBoundary will not set it when the symbols are completed
+         */
         if (jflags.isProtected) {
           cls.privateWithin = cls.enclosingPackage
           mod.privateWithin = cls.enclosingPackage

--- a/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
@@ -24,7 +24,7 @@ import scala.reflect.internal.util.shortClassOfInstance
 import scala.collection.mutable
 import PickleFormat._
 import Flags._
-import scala.annotation.tailrec
+import scala.annotation.{nowarn, tailrec}
 
 /**
  * Serialize a top-level module and/or class.
@@ -68,6 +68,7 @@ abstract class Pickler extends SubComponent {
       else
         None
 
+    @nowarn("cat=lint-nonlocal-return")
     def apply(unit: CompilationUnit): Unit = {
       def pickle(tree: Tree): Unit = {
         tree match {

--- a/src/compiler/scala/tools/nsc/tasty/TastyUnpickler.scala
+++ b/src/compiler/scala/tools/nsc/tasty/TastyUnpickler.scala
@@ -13,9 +13,11 @@
 package scala.tools.nsc.tasty
 
 import scala.collection.mutable
-
-import scala.tools.tasty.{TastyFormat, TastyRefs, TastyReader, TastyName, ErasedTypeRef, Signature, TastyHeaderUnpickler}
-import TastyFormat.NameTags._, TastyRefs.NameRef, TastyName._
+import scala.tools.tasty.{ErasedTypeRef, Signature, TastyFormat, TastyHeaderUnpickler, TastyName, TastyReader, TastyRefs}
+import TastyFormat.NameTags._
+import TastyRefs.NameRef
+import TastyName._
+import scala.annotation.nowarn
 import scala.reflect.io.AbstractFile
 
 /**The entry point to TASTy unpickling for nsc, initialises a [[TastyUniverse#Context]] with the root symbols of a
@@ -40,7 +42,7 @@ object TastyUnpickler {
     val unpickler = new TastyUnpickler[tasty.type](new TastyReader(bytes))(tasty)
     unpickler.readHeader()
     unpickler.readNames()
-    val Some(astReader) = unpickler.readSection("ASTs")
+    val Some(astReader) = unpickler.readSection("ASTs"): @nowarn("msg=match may not be exhaustive")
     val treeUnpickler = new TreeUnpickler[tasty.type](astReader, unpickler.nameAtRef)(tasty)
     treeUnpickler.enterTopLevel(classRoot, objectRoot)
   }

--- a/src/compiler/scala/tools/nsc/transform/AccessorSynthesis.scala
+++ b/src/compiler/scala/tools/nsc/transform/AccessorSynthesis.scala
@@ -118,7 +118,7 @@ trait AccessorSynthesis extends Transform with ast.TreeDSL {
 
 
   // TODO: better way to communicate from info transform to tree transform?
-  private[this] val _bitmapInfo  = perRunCaches.newMap[Symbol, BitmapInfo]
+  private[this] val _bitmapInfo  = perRunCaches.newMap[Symbol, BitmapInfo]()
   private[this] val _slowPathFor = perRunCaches.newMap[Symbol, Symbol]()
 
   def checkedAccessorSymbolSynth(clz: Symbol): CheckedAccessorSymbolSynth =
@@ -315,7 +315,7 @@ trait AccessorSynthesis extends Transform with ast.TreeDSL {
     class SynthInitCheckedAccessorsIn(clazz: Symbol) extends SynthCheckedAccessorsTreesInClass(clazz) {
 
       // Add statements to the body of a constructor to set the 'init' bit for each field initialized in the constructor
-      private object addInitBitsTransformer extends Transformer {
+      private object addInitBitsTransformer extends AstTransformer {
         override def transformStats(stats: List[Tree], exprOwner: Symbol) = {
           val checkedStats = stats flatMap {
             // Mark field as initialized after an assignment

--- a/src/compiler/scala/tools/nsc/transform/CleanUp.scala
+++ b/src/compiler/scala/tools/nsc/transform/CleanUp.scala
@@ -15,6 +15,7 @@ package transform
 
 import symtab._
 import Flags._
+import scala.annotation.nowarn
 import scala.collection._
 import scala.tools.nsc.Reporting.WarningCategory
 
@@ -402,7 +403,7 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
         case IntTpe => sw // can switch directly on ints
         case StringTpe =>
           // these assumptions about the shape of the tree are justified by the codegen in MatchOptimization
-          val Match(Typed(selTree, _), cases) = sw
+          val Match(Typed(selTree, _), cases) = sw: @nowarn("msg=match may not be exhaustive")
           def selArg = selTree match {
             case x: Ident   => REF(x.symbol)
             case x: Literal => x

--- a/src/compiler/scala/tools/nsc/transform/CleanUp.scala
+++ b/src/compiler/scala/tools/nsc/transform/CleanUp.scala
@@ -31,7 +31,7 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
   private val entryPoints = perRunCaches.newSet[Symbol]() // : List[Symbol] = Nil
   def getEntryPoints: List[String] = entryPoints.toList.map(_.fullName('.')).sorted
 
-  protected def newTransformer(unit: CompilationUnit): Transformer =
+  protected def newTransformer(unit: CompilationUnit): AstTransformer =
     new CleanUpTransformer(unit)
 
   class CleanUpTransformer(unit: CompilationUnit) extends StaticsTransformer {
@@ -490,7 +490,7 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
 
           stats prepend Match(newSel, newCases :+ CaseDef(Ident(nme.WILDCARD), EmptyTree, fail()))
 
-          val res = Block(stats.result : _*)
+          val res = Block(stats.result() : _*)
           localTyper.typedPos(sw.pos)(res)
         case _ => globalError(s"unhandled switch scrutinee type ${sw.selector.tpe}: $sw"); sw
       }

--- a/src/compiler/scala/tools/nsc/transform/Constructors.scala
+++ b/src/compiler/scala/tools/nsc/transform/Constructors.scala
@@ -28,7 +28,7 @@ abstract class Constructors extends Statics with Transform with TypingTransforme
   /** the following two members override abstract members in Transform */
   val phaseName: String = "constructors"
 
-  protected def newTransformer(unit: CompilationUnit): Transformer =
+  protected def newTransformer(unit: CompilationUnit): AstTransformer =
     new ConstructorTransformer(unit)
 
   private val guardedCtorStats: mutable.Map[Symbol, List[Tree]] = perRunCaches.newMap[Symbol, List[Tree]]()
@@ -353,7 +353,7 @@ abstract class Constructors extends Statics with Transform with TypingTransforme
        */
       def rewriteArrayUpdate(tree: Tree): Tree = {
         val arrayUpdateMethod = currentRun.runDefinitions.arrayUpdateMethod
-        val adapter = new Transformer {
+        val adapter = new AstTransformer {
           override def transform(t: Tree): Tree = t match {
             case Apply(fun @ Select(receiver, method), List(xs, idx, v)) if fun.symbol == arrayUpdateMethod =>
               localTyper.typed(Apply(gen.mkAttributedSelect(xs, arrayUpdateMethod), List(idx, v)))
@@ -487,7 +487,7 @@ abstract class Constructors extends Statics with Transform with TypingTransforme
     }
 
     // A transformer for expressions that go into the constructor
-    object intoConstructor extends Transformer {
+    object intoConstructor extends AstTransformer {
       /*
       * `usesSpecializedField` makes a difference in deciding whether constructor-statements
       * should be guarded in a `guardSpecializedFieldInit` class, ie in a class that's the generic super-class of

--- a/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
+++ b/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
@@ -62,7 +62,7 @@ abstract class Delambdafy extends Transform with TypingTransformers with ast.Tre
     def apply(unit: global.CompilationUnit): Unit = ()
   }
 
-  protected def newTransformer(unit: CompilationUnit): Transformer =
+  protected def newTransformer(unit: CompilationUnit): AstTransformer =
     new DelambdafyTransformer(unit)
 
   class DelambdafyTransformer(unit: CompilationUnit) extends TypingTransformer(unit) {

--- a/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
+++ b/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
@@ -159,20 +159,20 @@ abstract class Delambdafy extends Transform with TypingTransformers with ast.Tre
       val samParamTypes = exitingErasure(sam.info.paramTypes)
       val samResultType = exitingErasure(sam.info.resultType)
 
-      /** How to satisfy the linking invariants of https://docs.oracle.com/javase/8/docs/api/java/lang/invoke/LambdaMetafactory.html
-        *
-        * Given samMethodType: (U1..Un)Ru and function type T1,..., Tn => Rt (the target method created by uncurry)
-        *
-        * Do we need a bridge, or can we use the original lambda target for implMethod: (<captured args> A1..An)Ra
-        * (We can ignore capture here.)
-        *
-        * If, for i=1..N:
-        *  Ai =:= Ui || (Ai <:< Ui <:< AnyRef)
-        *  Ru =:= void || (Ra =:= Ru || (Ra <:< AnyRef, Ru <:< AnyRef))
-        *
-        * We can use the target method as-is -- if not, we create a bridging one that uses the types closest
-        * to the target method that still meet the above requirements.
-        */
+      /* How to satisfy the linking invariants of https://docs.oracle.com/javase/8/docs/api/java/lang/invoke/LambdaMetafactory.html
+       *
+       * Given samMethodType: (U1..Un)Ru and function type T1,..., Tn => Rt (the target method created by uncurry)
+       *
+       * Do we need a bridge, or can we use the original lambda target for implMethod: (<captured args> A1..An)Ra
+       * (We can ignore capture here.)
+       *
+       * If, for i=1..N:
+       *  Ai =:= Ui || (Ai <:< Ui <:< AnyRef)
+       *  Ru =:= void || (Ra =:= Ru || (Ra <:< AnyRef, Ru <:< AnyRef))
+       *
+       * We can use the target method as-is -- if not, we create a bridging one that uses the types closest
+       * to the target method that still meet the above requirements.
+       */
       val resTpOk = (
            samResultType =:= UnitTpe
         || functionResultType =:= samResultType

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -13,9 +13,9 @@
 package scala.tools.nsc
 package transform
 
-import scala.annotation.tailrec
+import scala.annotation.{nowarn, tailrec}
 import scala.reflect.internal.ClassfileConstants._
-import scala.collection.{ mutable, immutable }
+import scala.collection.{immutable, mutable}
 import symtab._
 import Flags._
 import scala.reflect.internal.Mode._
@@ -446,7 +446,7 @@ abstract class Erasure extends InfoTransform
 
       case Block(stats, expr) =>
         // needs `hasSymbolField` check because `supercall` could be a block (named / default args)
-        val (presuper, supercall :: rest) = stats span (t => t.hasSymbolWhich(_ hasFlag PRESUPER))
+        val (presuper, supercall :: rest) = stats span (t => t.hasSymbolWhich(_ hasFlag PRESUPER)): @nowarn("msg=match may not be exhaustive")
         treeCopy.Block(tree, presuper ::: (supercall :: mixinConstructorCalls ::: rest), expr)
     }
   }

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -35,7 +35,7 @@ abstract class Erasure extends InfoTransform
 
   val requiredDirectInterfaces = perRunCaches.newAnyRefMap[Symbol, mutable.Set[Symbol]]()
 
-  def newTransformer(unit: CompilationUnit): Transformer =
+  def newTransformer(unit: CompilationUnit): AstTransformer =
     new ErasureTransformer(unit)
 
   override def keepsTypeParams = false
@@ -359,10 +359,10 @@ abstract class Erasure extends InfoTransform
             if (unboxedVCs) {
               val unboxedSeen = (tp memberType sym.derivedValueClassUnbox).finalResultType
               jsig(unboxedSeen, existentiallyBound, toplevel, unboxedVCs = true)
-            } else classSig
+            } else classSig()
           }
           else if (sym.isClass)
-            classSig
+            classSig()
           else
             jsig(erasure(sym0)(tp), existentiallyBound, toplevel, unboxedVCs)
         case PolyType(tparams, restpe) =>
@@ -855,8 +855,8 @@ abstract class Erasure extends InfoTransform
   }
 
   /** The erasure transformer */
-  class ErasureTransformer(unit: CompilationUnit) extends Transformer {
-    import overridingPairs.Cursor
+  class ErasureTransformer(unit: CompilationUnit) extends AstTransformer {
+    import overridingPairs.PairsCursor
 
     private def doubleDefError(pair: SymbolPair): Unit = {
       import pair._
@@ -913,7 +913,7 @@ abstract class Erasure extends InfoTransform
       }
     }
 
-    private class DoubleDefsCursor(root: Symbol) extends Cursor(root) {
+    private class DoubleDefsCursor(root: Symbol) extends PairsCursor(root) {
       // specialized members have no type history before 'specialize', causing double def errors for curried defs
       override def exclude(sym: Symbol): Boolean = (
            sym.isType

--- a/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExtensionMethods.scala
@@ -30,7 +30,7 @@ abstract class ExtensionMethods extends Transform with TypingTransformers {
   /** the following two members override abstract members in Transform */
   val phaseName: String = "extmethods"
 
-  def newTransformer(unit: CompilationUnit): Transformer =
+  def newTransformer(unit: CompilationUnit): AstTransformer =
     new Extender(unit)
 
   private def companionModuleForce(sym: Symbol) = {

--- a/src/compiler/scala/tools/nsc/transform/Fields.scala
+++ b/src/compiler/scala/tools/nsc/transform/Fields.scala
@@ -86,7 +86,7 @@ abstract class Fields extends InfoTransform with ast.TreeDSL with TypingTransfor
   /** the following two members override abstract members in Transform */
   val phaseName: String = "fields"
 
-  protected def newTransformer(unit: CompilationUnit): Transformer = new FieldsTransformer(unit)
+  protected def newTransformer(unit: CompilationUnit): AstTransformer = new FieldsTransformer(unit)
   override def transformInfo(sym: Symbol, tp: Type): Type =
     if (sym.isJavaDefined || sym.isPackageClass || !sym.isClass) tp
     else synthFieldsAndAccessors(tp)
@@ -205,7 +205,7 @@ abstract class Fields extends InfoTransform with ast.TreeDSL with TypingTransfor
 
 
   // can't use the referenced field since it already tracks the module's moduleClass
-  private[this] val moduleOrLazyVarOf = perRunCaches.newMap[Symbol, Symbol]
+  private[this] val moduleOrLazyVarOf = perRunCaches.newMap[Symbol, Symbol]()
 
   // TODO: can we drop FINAL? In any case, since these variables are MUTABLE, they cannot and will
   // not be emitted as ACC_FINAL. They are FINAL in the Scala sense, though: cannot be overridden.

--- a/src/compiler/scala/tools/nsc/transform/Fields.scala
+++ b/src/compiler/scala/tools/nsc/transform/Fields.scala
@@ -220,25 +220,25 @@ abstract class Fields extends InfoTransform with ast.TreeDSL with TypingTransfor
     def needsInit = Apply(Select(moduleVarRef, Object_eq), List(CODE.NULL))
     val init = Assign(moduleVarRef, gen.newModule(module, moduleVar.info))
 
-    /** double-checked locking following https://shipilev.net/blog/2014/safe-public-construction/#_safe_publication
-      *
-      * public class SafeDCLFactory {
-      *   private volatile Singleton instance;
-      *
-      *   public Singleton get() {
-      *     if (instance == null) {  // check 1
-      *       synchronized(this) {
-      *         if (instance == null) { // check 2
-      *           instance = new Singleton();
-      *         }
-      *       }
-      *     }
-      *     return instance;
-      *   }
-      * }
-      *
-      * TODO: optimize using local variable?
-      */
+    /* double-checked locking following https://shipilev.net/blog/2014/safe-public-construction/#_safe_publication
+     *
+     * public class SafeDCLFactory {
+     *   private volatile Singleton instance;
+     *
+     *   public Singleton get() {
+     *     if (instance == null) {  // check 1
+     *       synchronized(this) {
+     *         if (instance == null) { // check 2
+     *           instance = new Singleton();
+     *         }
+     *       }
+     *     }
+     *     return instance;
+     *   }
+     * }
+     *
+     * TODO: optimize using local variable?
+     */
     val computeName = nme.newLazyValSlowComputeName(module.name)
     val computeMethod = DefDef(NoMods, computeName, Nil, ListOfNil, TypeTree(UnitTpe), gen.mkSynchronized(monitorHolder)(If(needsInit, init, EmptyTree)))
     Block(computeMethod :: If(needsInit, Apply(Ident(computeName), Nil), EmptyTree) :: Nil,

--- a/src/compiler/scala/tools/nsc/transform/Flatten.scala
+++ b/src/compiler/scala/tools/nsc/transform/Flatten.scala
@@ -116,9 +116,9 @@ abstract class Flatten extends InfoTransform {
 
   def transformInfo(sym: Symbol, tp: Type): Type = flattened(tp)
 
-  protected def newTransformer(unit: CompilationUnit): Transformer = new Flattener
+  protected def newTransformer(unit: CompilationUnit): AstTransformer = new Flattener
 
-  class Flattener extends Transformer {
+  class Flattener extends AstTransformer {
     /** Buffers for lifted out classes */
     private val liftedDefs = perRunCaches.newMap[Symbol, ListBuffer[Tree]]()
 

--- a/src/compiler/scala/tools/nsc/transform/InfoTransform.scala
+++ b/src/compiler/scala/tools/nsc/transform/InfoTransform.scala
@@ -13,6 +13,8 @@
 package scala.tools.nsc
 package transform
 
+import scala.annotation.nowarn
+
 /**
  * An InfoTransform contains a compiler phase that transforms trees and symbol infos -- making sure they stay consistent.
  * The symbol info is transformed assuming it is consistent right before this phase.
@@ -29,11 +31,16 @@ trait InfoTransform extends Transform {
   def transformInfo(sym: Symbol, tpe: Type): Type
 
   override def newPhase(prev: scala.tools.nsc.Phase): StdPhase =
-    new Phase(prev)
+    new InfoPhase(prev)
 
   protected def changesBaseClasses = true
   protected def keepsTypeParams = true
 
+  @nowarn("""cat=deprecation&origin=scala\.tools\.nsc\.transform\.InfoTransform\.Phase""")
+  final type InfoPhase = Phase
+
+  @nowarn("msg=shadowing a nested class of a parent is deprecated")
+  @deprecated("use InfoPhase instead", since = "2.13.4")
   class Phase(prev: scala.tools.nsc.Phase) extends super.Phase(prev) {
     override val keepsTypeParams = InfoTransform.this.keepsTypeParams
 

--- a/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
+++ b/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
@@ -53,7 +53,7 @@ abstract class LambdaLift extends InfoTransform {
     if (sym.isCapturedVariable) capturedVariableType(sym, tpe = lifted(tp), erasedTypes = true)
     else lifted(tp)
 
-  protected def newTransformer(unit: CompilationUnit): Transformer =
+  protected def newTransformer(unit: CompilationUnit): AstTransformer =
     new LambdaLifter(unit)
 
   class LambdaLifter(unit: CompilationUnit) extends explicitOuter.OuterPathTransformer(unit) {

--- a/src/compiler/scala/tools/nsc/transform/Mixin.scala
+++ b/src/compiler/scala/tools/nsc/transform/Mixin.scala
@@ -410,10 +410,10 @@ abstract class Mixin extends Transform with ast.TreeDSL with AccessorSynthesis {
 
 // --------- term transformation -----------------------------------------------
 
-  protected def newTransformer(unit: CompilationUnit): Transformer =
+  protected def newTransformer(unit: CompilationUnit): AstTransformer =
     new MixinTransformer(unit)
 
-  class MixinTransformer(unit : CompilationUnit) extends Transformer with AccessorTreeSynthesis {
+  class MixinTransformer(unit : CompilationUnit) extends AstTransformer with AccessorTreeSynthesis {
     /** The typer */
     private var localTyper: erasure.Typer = _
     protected def typedPos(pos: Position)(tree: Tree): Tree = localTyper.typedPos(pos)(tree)

--- a/src/compiler/scala/tools/nsc/transform/OverridingPairs.scala
+++ b/src/compiler/scala/tools/nsc/transform/OverridingPairs.scala
@@ -28,8 +28,9 @@ abstract class OverridingPairs extends SymbolPairs {
   @nowarn("""cat=deprecation&origin=scala\.tools\.nsc\.transform\.OverridingPairs\.Cursor""")
   final type PairsCursor = Cursor
 
+  // TODO: deprecate when we can cleanly cross-compile without warnings
+  // @deprecated("use PairsCursor instead", since = "2.13.4")
   @nowarn("msg=shadowing a nested class of a parent is deprecated")
-  @deprecated("use PairsCursor instead", since = "2.13.4")
   class Cursor(base: Symbol) extends super.Cursor(base) {
     /** Symbols to exclude: Here these are constructors and private/artifact symbols,
      *  including bridges. But it may be refined in subclasses.

--- a/src/compiler/scala/tools/nsc/transform/OverridingPairs.scala
+++ b/src/compiler/scala/tools/nsc/transform/OverridingPairs.scala
@@ -13,6 +13,7 @@
 package scala.tools.nsc
 package transform
 
+import scala.annotation.nowarn
 import scala.reflect.internal.SymbolPairs
 
 /** A class that yields a kind of iterator (`Cursor`),
@@ -24,6 +25,11 @@ import scala.reflect.internal.SymbolPairs
 abstract class OverridingPairs extends SymbolPairs {
   import global._
 
+  @nowarn("""cat=deprecation&origin=scala\.tools\.nsc\.transform\.OverridingPairs\.Cursor""")
+  final type PairsCursor = Cursor
+
+  @nowarn("msg=shadowing a nested class of a parent is deprecated")
+  @deprecated("use PairsCursor instead", since = "2.13.4")
   class Cursor(base: Symbol) extends super.Cursor(base) {
     /** Symbols to exclude: Here these are constructors and private/artifact symbols,
      *  including bridges. But it may be refined in subclasses.
@@ -55,7 +61,7 @@ abstract class OverridingPairs extends SymbolPairs {
       (low.isField || high.isField)
   }
 
-  final class BridgesCursor(base: Symbol) extends Cursor(base) {
+  final class BridgesCursor(base: Symbol) extends PairsCursor(base) {
     // Varargs bridges may need generic bridges due to the non-repeated part of the signature of the involved methods.
     // The vararg bridge is generated during refchecks (probably to simplify override checking),
     // but then the resulting varargs "bridge" method may itself need an actual erasure bridge.

--- a/src/compiler/scala/tools/nsc/transform/PostErasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/PostErasure.scala
@@ -24,7 +24,7 @@ trait PostErasure extends InfoTransform with TypingTransformers with scala.refle
 
   val phaseName: String = "posterasure"
 
-  def newTransformer(unit: CompilationUnit): Transformer = new PostErasureTransformer(unit)
+  def newTransformer(unit: CompilationUnit): AstTransformer = new PostErasureTransformer(unit)
   override def changesBaseClasses = false
 
   class PostErasureTransformer(unit: CompilationUnit) extends TypingTransformer(unit) {

--- a/src/compiler/scala/tools/nsc/transform/SampleTransform.scala
+++ b/src/compiler/scala/tools/nsc/transform/SampleTransform.scala
@@ -24,10 +24,10 @@ abstract class SampleTransform extends Transform {
   /** the following two members override abstract members in Transform */
   val phaseName: String = "sample-phase"
 
-  protected def newTransformer(unit: CompilationUnit): Transformer =
+  protected def newTransformer(unit: CompilationUnit): AstTransformer =
     new SampleTransformer(unit)
 
-  class SampleTransformer(unit: CompilationUnit) extends Transformer {
+  class SampleTransformer(unit: CompilationUnit) extends AstTransformer {
 
     override def transform(tree: Tree): Tree = {
       val tree1 = super.transform(tree);      // transformers always maintain `currentOwner`.

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -14,6 +14,7 @@ package scala
 package tools.nsc
 package transform
 
+import scala.annotation.nowarn
 import scala.collection.mutable
 import scala.tools.nsc.symtab.Flags
 import scala.tools.nsc.Reporting.WarningCategory
@@ -83,7 +84,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
    */
 
   /** For a given class and concrete type arguments, give its specialized class */
-  val specializedClass = perRunCaches.newAnyRefMap[Symbol, mutable.AnyRefMap[TypeEnv, Symbol]]
+  val specializedClass = perRunCaches.newAnyRefMap[Symbol, mutable.AnyRefMap[TypeEnv, Symbol]]()
 
   /** Map a method symbol to a list of its specialized overloads in the same class. */
   private val overloads = perRunCaches.newMap[Symbol, List[Overload]]() withDefaultValue Nil
@@ -200,7 +201,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
 
   /** Just to mark uncheckable */
   override def newPhase(prev: scala.tools.nsc.Phase): StdPhase = new SpecializationPhase(prev)
-  class SpecializationPhase(prev: scala.tools.nsc.Phase) extends super.Phase(prev) {
+  class SpecializationPhase(prev: scala.tools.nsc.Phase) extends InfoPhase(prev) {
     override def checkable = false
     override def run(): Unit = {
       super.run()
@@ -227,7 +228,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
     }
   }
 
-  protected def newTransformer(unit: CompilationUnit): Transformer =
+  protected def newTransformer(unit: CompilationUnit): AstTransformer =
     new SpecializationTransformer(unit)
 
   abstract class SpecializedInfo {
@@ -1371,6 +1372,11 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
     private val (castfrom, castto) = casts.unzip
     private object CastMap extends SubstTypeMap(castfrom.toList, castto.toList)
 
+    @nowarn("""cat=deprecation&origin=scala\.tools\.nsc\.transform\.SpecializeTypes\.Duplicator\.BodyDuplicator""")
+    final type SpecializeBodyDuplicator = BodyDuplicator
+
+    @nowarn("msg=shadowing a nested class of a parent is deprecated")
+    @deprecated("use SpecializeBodyDuplicator instead", since = "2.13.4")
     class BodyDuplicator(_context: Context) extends super.BodyDuplicator(_context) {
       override def castType(tree: Tree, pt: Type): Tree = {
         tree modifyType fixType
@@ -1386,7 +1392,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
       }
     }
 
-    protected override def newBodyDuplicator(context: Context) = new BodyDuplicator(context)
+    protected override def newBodyDuplicator(context: Context): SpecializeBodyDuplicator = new SpecializeBodyDuplicator(context)
   }
 
   /** Introduced to fix scala/bug#7343: Phase ordering problem between Duplicators and Specialization.

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -1899,7 +1899,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
     private def addBody(tree: DefDef, source: Symbol): DefDef = {
       val symbol = tree.symbol
       debuglog("specializing body of" + symbol.defString)
-      val DefDef(_, _, tparams, vparams :: Nil, tpt, _) = tree
+      val DefDef(_, _, tparams, vparams :: Nil, tpt, _) = tree: @nowarn("msg=match may not be exhaustive")
       val env = typeEnv(symbol)
       val origtparams = source.typeParams.filter(tparam => !env.contains(tparam) || !isPrimitiveValueType(env(tparam)))
       if (origtparams.nonEmpty || symbol.typeParams.nonEmpty)

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -1044,6 +1044,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
      *   * m overrides a method whose type contains specialized type variables
      *   * there is a valid specialization environment that maps the overridden method type to m's type.
      */
+    @nowarn("cat=lint-nonlocal-return")
     def needsSpecialOverride(overriding: Symbol): (Symbol, TypeEnv) = {
       def checkOverriddenTParams(overridden: Symbol): Unit = {
         foreach2(overridden.info.typeParams, overriding.info.typeParams) { (baseTvar, derivedTvar) =>

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -1608,11 +1608,11 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
         }
       }
 
-      /** Computes residual type parameters after rewiring, like "String" in the following example:
-       *  {{{
-       *    def specMe[@specialized T, U](t: T, u: U) = ???
-       *    specMe[Int, String](1, "2") => specMe\$mIc\$sp[String](1, "2")
-       *  }}}
+      /* Computes residual type parameters after rewiring, like "String" in the following example:
+       * {{{
+       *   def specMe[@specialized T, U](t: T, u: U) = ???
+       *   specMe[Int, String](1, "2") => specMe\$mIc\$sp[String](1, "2")
+       * }}}
        */
       def computeResidualTypeVars(baseTree: Tree, specMember: Symbol, specTree: Tree, baseTargs: List[Tree], env: TypeEnv): Tree = {
         val residualTargs = symbol.info.typeParams zip baseTargs collect {

--- a/src/compiler/scala/tools/nsc/transform/Statics.scala
+++ b/src/compiler/scala/tools/nsc/transform/Statics.scala
@@ -16,7 +16,7 @@ package transform
 abstract class Statics extends Transform with ast.TreeDSL {
   import global._
 
-  trait StaticsTransformer extends Transformer {
+  trait StaticsTransformer extends AstTransformer {
     /** generate a static constructor with symbol fields inits, or an augmented existing static ctor
       */
     def staticConstructor(body: List[Tree], localTyper: analyzer.Typer, pos: Position)(newStaticInits: List[Tree]): Tree =

--- a/src/compiler/scala/tools/nsc/transform/Transform.scala
+++ b/src/compiler/scala/tools/nsc/transform/Transform.scala
@@ -21,7 +21,7 @@ package transform
 trait Transform extends SubComponent {
 
   /** The transformer factory */
-  protected def newTransformer(unit: global.CompilationUnit): global.Transformer
+  protected def newTransformer(unit: global.CompilationUnit): global.AstTransformer
 
   /** Create a new phase which applies transformer */
   def newPhase(prev: scala.tools.nsc.Phase): StdPhase = new Phase(prev)

--- a/src/compiler/scala/tools/nsc/transform/TypingTransformers.scala
+++ b/src/compiler/scala/tools/nsc/transform/TypingTransformers.scala
@@ -29,7 +29,7 @@ trait TypingTransformers {
   else // TODO: AM: should some phases use a regular rootContext instead of a post-typer one??
     analyzer.newTyper(analyzer.rootContextPostTyper(unit, EmptyTree))
 
-  abstract class TypingTransformer(initLocalTyper: global.analyzer.Typer) extends Transformer {
+  abstract class TypingTransformer(initLocalTyper: global.analyzer.Typer) extends AstTransformer {
     def this(unit: CompilationUnit) = this(newRootLocalTyper(unit))
     var localTyper: analyzer.Typer = initLocalTyper
     currentOwner = localTyper.context.owner

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -68,7 +68,7 @@ abstract class UnCurry extends InfoTransform
 
   val phaseName: String = "uncurry"
 
-  def newTransformer(unit: CompilationUnit): Transformer = new UnCurryTransformer(unit)
+  def newTransformer(unit: CompilationUnit): AstTransformer = new UnCurryTransformer(unit)
   override def changesBaseClasses = false
 
 // ------ Type transformation --------------------------------------------------------
@@ -287,15 +287,15 @@ abstract class UnCurry extends InfoTransform
             else if (tp.upperBound ne tp) getClassTag(tp.upperBound)
             else localTyper.TyperErrorGen.MissingClassTagError(tree, tp)
           }
-          def traversableClassTag(tpe: Type): Tree = {
-            (tpe baseType TraversableClass).typeArgs match {
+          def iterableClassTag(tpe: Type): Tree = {
+            (tpe baseType IterableClass).typeArgs match {
               case targ :: _  => getClassTag(targ)
               case _          => EmptyTree
             }
           }
           exitingUncurry {
             localTyper.typedPos(pos) {
-              gen.mkMethodCall(tree, toArraySym, Nil, List(traversableClassTag(tree.tpe)))
+              gen.mkMethodCall(tree, toArraySym, Nil, List(iterableClassTag(tree.tpe)))
             }
           }
         }
@@ -783,7 +783,7 @@ abstract class UnCurry extends InfoTransform
           val viter = vparamss.iterator.flatten
           val piter = dd.symbol.info.paramss.iterator.flatten
           while (viter.hasNext && piter.hasNext)
-            addParamTransform(viter.next, piter.next)
+            addParamTransform(viter.next(), piter.next())
 
           (allParamsBuf.toList, packedParamsSymsBuf.toList, tempValsBuf.toList)
         }

--- a/src/compiler/scala/tools/nsc/transform/async/AsyncPhase.scala
+++ b/src/compiler/scala/tools/nsc/transform/async/AsyncPhase.scala
@@ -52,7 +52,7 @@ abstract class AsyncPhase extends Transform with TypingTransformers with AnfTran
     }.updateAttachment(ChangeOwnerAttachment(owner))
   }
 
-  def newTransformer(unit: CompilationUnit): Transformer = new AsyncTransformer(unit)
+  def newTransformer(unit: CompilationUnit): AstTransformer = new AsyncTransformer(unit)
 
   private def compileTimeOnlyPrefix: String = "[async] "
 
@@ -110,7 +110,8 @@ abstract class AsyncPhase extends Transform with TypingTransformers with AnfTran
               deriveTemplate(impl)(liftedTrees ::: _)
             })
           }
-          assert(localTyper.context.owner == cd.symbol.owner)
+          assert(localTyper.context.owner == cd.symbol.owner,
+            "local typer context's owner must be ClassDef symbol's owner")
           val withFields = new UseFields(localTyper, cd.symbol, applySym, liftedSyms).transform(cd1)
           withFields
 
@@ -192,7 +193,7 @@ abstract class AsyncPhase extends Transform with TypingTransformers with AnfTran
     private class UseFields(initLocalTyper: analyzer.Typer, stateMachineClass: Symbol,
                             applySym: Symbol, liftedSyms: Set[Symbol]) extends explicitOuter.OuterPathTransformer(initLocalTyper) {
       private def fieldSel(tree: Tree) = {
-        assert(currentOwner != NoSymbol)
+        assert(currentOwner != NoSymbol, "currentOwner cannot be NoSymbol")
         val outerOrThis = if (stateMachineClass == currentClass) gen.mkAttributedThis(stateMachineClass) else {
           // These references need to be selected from an outer reference, because explicitouter
           // has already run we must perform this transform explicitly here.

--- a/src/compiler/scala/tools/nsc/transform/async/ExprBuilder.scala
+++ b/src/compiler/scala/tools/nsc/transform/async/ExprBuilder.scala
@@ -12,6 +12,7 @@
 
 package scala.tools.nsc.transform.async
 
+import scala.annotation.nowarn
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 
@@ -328,7 +329,7 @@ trait ExprBuilder extends TransformUtils with AsyncAnalysis {
     private def buildNestedStatesFirstForInlining(nestedTree: Tree, endState: Int): (AsyncState, List[AsyncState]) = {
       val (nestedStats, nestedExpr) = statsAndExpr(nestedTree)
       val nestedBuilder = new AsyncBlockBuilder(nestedStats, nestedExpr, currState, endState, StateTransitionStyle.None, Some(this))
-      val ((inlinedState :: Nil), nestedStates) = nestedBuilder.build.partition(_.state == currState)
+      val (inlinedState :: Nil, nestedStates) = nestedBuilder.build.partition(_.state == currState): @nowarn("msg=match may not be exhaustive")
       inlinedState.nextStates.foreach(stateBuilder.nextStates += _)
       (inlinedState, nestedStates)
     }
@@ -475,7 +476,7 @@ trait ExprBuilder extends TransformUtils with AsyncAnalysis {
 
       // Filter out dead or trivial states.
       private def filterStates(all: List[AsyncState]): List[AsyncState] = if (compactStates) {
-        val ((initial :: Nil), rest) = all.partition(_.state == blockBuilder.startState)
+        val (initial :: Nil, rest) = all.partition(_.state == blockBuilder.startState): @nowarn("msg=match may not be exhaustive")
         val map = all.iterator.map(x => (x.state, x)).toMap
         val seen = mutable.HashSet[Int]()
         seen.add(all.last.state)

--- a/src/compiler/scala/tools/nsc/transform/async/Lifter.scala
+++ b/src/compiler/scala/tools/nsc/transform/async/Lifter.scala
@@ -69,7 +69,7 @@ trait Lifter extends ExprBuilder {
               }
             }
             companionship.record(classesBuffer, moduleClassesBuffer)
-            assert(!expr.isInstanceOf[ClassDef])
+            assert(!expr.isInstanceOf[ClassDef], "expression cannot be a class def")
             super.traverse(tree)
           case _ =>
             super.traverse(tree)

--- a/src/compiler/scala/tools/nsc/transform/async/LiveVariables.scala
+++ b/src/compiler/scala/tools/nsc/transform/async/LiveVariables.scala
@@ -12,6 +12,7 @@
 
 package scala.tools.nsc.transform.async
 
+import scala.collection.immutable.ArraySeq
 import scala.collection.mutable
 import scala.reflect.internal.Flags._
 
@@ -110,7 +111,7 @@ trait LiveVariables extends ExprBuilder {
       g.finish()
     }
 
-    graph.lastReferences[Int](liftedSyms.toArray[Symbol])(_.t.state)
+    graph.lastReferences[Int](ArraySeq.unsafeWrapArray(liftedSyms.toArray[Symbol]))(_.t.state)
   }
 
   private final class Graph[T] {
@@ -177,7 +178,7 @@ trait LiveVariables extends ExprBuilder {
     }
     private var finished = false
     def finish(): this.type = {
-      assert(!finished)
+      assert(!finished, "cannot finish when already finished")
       for (node <- nodes.valuesIterator) {
         foreachWithIndex(node.succTs) {(succT, i) =>
           val succ = nodes(succT)
@@ -189,7 +190,7 @@ trait LiveVariables extends ExprBuilder {
       this
     }
     def lastReferences[K](syms: IndexedSeq[Symbol])(keyMapping: Node => K): mutable.LinkedHashMap[K, (mutable.LinkedHashSet[Symbol], mutable.LinkedHashSet[Symbol])] = {
-      assert(finished)
+      assert(finished, "lastReferences before finished")
       val symIndices: Map[Symbol, Int] = syms.zipWithIndex.toMap
       val nodeValues = nodes.values.toArray
       nodeValues.foreach { node =>
@@ -225,11 +226,11 @@ trait LiveVariables extends ExprBuilder {
           result
         }
       }
-      mutable.LinkedHashMap(nodeValues.map { x =>
+      mutable.LinkedHashMap(ArraySeq.unsafeWrapArray(nodeValues.map { x =>
         val pre = toSymSet(x.deadOnEntryLiveOnPredecessorExit)
         val post = toSymSet(x.deadOnExitLiveOnEntry)
         (keyMapping(x), (pre, post))
-      }: _*)
+      }): _*)
     }
   }
 }

--- a/src/compiler/scala/tools/nsc/transform/async/LiveVariables.scala
+++ b/src/compiler/scala/tools/nsc/transform/async/LiveVariables.scala
@@ -47,7 +47,7 @@ trait LiveVariables extends ExprBuilder {
         liftedSyms -= sym
     }
 
-    /**
+    /*
      *  Traverse statements of an `AsyncState`, collect `Ident`-s referring to lifted fields.
      *
      *  @param  as  a state of an `async` expression

--- a/src/compiler/scala/tools/nsc/transform/async/StateSet.scala
+++ b/src/compiler/scala/tools/nsc/transform/async/StateSet.scala
@@ -15,7 +15,7 @@ package scala.tools.nsc.transform.async
 import java.util
 import java.util.function.{Consumer, IntConsumer}
 
-import scala.collection.JavaConverters.{asScalaIteratorConverter, iterableAsScalaIterableConverter}
+import scala.jdk.CollectionConverters._
 
 // Set for StateIds, which are either small positive integers or -symbolID.
 final class StateSet {

--- a/src/compiler/scala/tools/nsc/transform/async/TransformUtils.scala
+++ b/src/compiler/scala/tools/nsc/transform/async/TransformUtils.scala
@@ -198,7 +198,7 @@ private[async] trait TransformUtils extends AsyncTransformStates {
       t.setAttachments(t.attachments.addElement(NoAwait))
     }
 
-    val stack = mutable.ArrayStack[Tree]()
+    val stack = mutable.Stack[Tree]()
 
     override def traverse(tree: Tree): Unit = {
       stack.push(tree)

--- a/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
@@ -13,6 +13,7 @@
 package scala
 package tools.nsc.transform.patmat
 
+import scala.annotation.nowarn
 import scala.collection.mutable
 import scala.collection.immutable.ArraySeq
 import scala.reflect.internal.util.Collections._
@@ -483,7 +484,7 @@ trait Logic extends Debugging  {
     type Solvable
 
     def propToSolvable(p: Prop): Solvable = {
-      val (eqAxiom, pure :: Nil) = removeVarEq(List(p), modelNull = false)
+      val (eqAxiom, pure :: Nil) = removeVarEq(List(p), modelNull = false): @nowarn("msg=match may not be exhaustive")
       eqFreePropToSolvable(And(eqAxiom, pure))
     }
 

--- a/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
@@ -204,14 +204,14 @@ trait Logic extends Debugging  {
         else if (size == 2) { // Specialized versions for size 2+3
           val it = ops0.iterator
           val result = checkPair(it.next(), it.next())
-          assert(!it.hasNext)
+          assert(!it.hasNext, "iterator must be empty")
           result
         } else if (size == 3) {
           val it = ops0.iterator
           val a = it.next()
           val b = it.next()
           val c = it.next()
-          assert(!it.hasNext)
+          assert(!it.hasNext, "iterator must be empty")
           checkPair(a, b) || checkPair(a, c) || checkPair(b, c)
         } else {
           val ops = new Array[Prop](size)

--- a/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
@@ -609,7 +609,7 @@ trait ScalaLogic extends Interface with Logic with TreeAndTypeAnalysis {
           // else  debug.patmat("NOT implies: "+(lower, upper))
 
 
-        /** Does V=A preclude V=B?
+        /* Does V=A preclude V=B?
          *
          * (0) A or B must be in the domain to draw any conclusions.
          *

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
@@ -593,7 +593,7 @@ trait MatchTranslation {
 
       protected def spliceApply(pos: Position, binder: Symbol): (Tree, Boolean) = {
         var needsSubst = false
-        object splice extends Transformer {
+        object splice extends AstTransformer {
           def binderRef(pos: Position): Tree =
             REF(binder) setPos pos
           override def transform(t: Tree) = t match {

--- a/src/compiler/scala/tools/nsc/transform/patmat/PatternExpansion.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/PatternExpansion.scala
@@ -163,7 +163,7 @@ trait PatternExpansion {
       val res = resultOfGetInMonad()
       // Can't only check for _1 thanks to pos/t796.
       if (res.hasNonPrivateMember(nme._1) && res.hasNonPrivateMember(nme._2))
-        Some(Stream.from(1).map(n => res.nonPrivateMember(newTermName("_" + n))).
+        Some(LazyList.from(1).map(n => res.nonPrivateMember(newTermName("_" + n))).
              takeWhile(m => m.isMethod && m.paramLists.isEmpty).toList.map(m => res.memberType(m).resultType))
       else None
     }

--- a/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
@@ -58,7 +58,7 @@ trait PatternMatching extends Transform
 
   val phaseName: String = "patmat"
 
-  def newTransformer(unit: CompilationUnit): Transformer = new MatchTransformer(unit)
+  def newTransformer(unit: CompilationUnit): AstTransformer = new MatchTransformer(unit)
 
   class MatchTransformer(unit: CompilationUnit) extends TypingTransformer(unit) {
     override def transform(tree: Tree): Tree = tree match {
@@ -215,7 +215,7 @@ trait Interface extends ast.TreeDSL {
     }
 
     class Substitution(val from: List[Symbol], val to: List[Tree]) {
-      import global.{Transformer, Ident, NoType, TypeTree, SingleType}
+      import global.{AstTransformer, Ident, NoType, TypeTree, SingleType}
 
       private def typedStable(t: Tree) = typer.typed(t.shallowDuplicate, Mode.MonoQualifierModes | Mode.TYPEPATmode)
       lazy val toTypes: List[Type] = to map (tree => typedStable(tree).tpe)
@@ -248,7 +248,7 @@ trait Interface extends ast.TreeDSL {
           case _          => false
         }
 
-        object substIdentsForTrees extends Transformer {
+        object substIdentsForTrees extends AstTransformer {
           private def typedIfOrigTyped(to: Tree, origTp: Type): Tree =
             if (origTp == null || origTp == NoType) to
             // important: only type when actually substituting and when original tree was typed

--- a/src/compiler/scala/tools/nsc/transform/patmat/Solving.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Solving.scala
@@ -240,7 +240,7 @@ trait Solving extends Logic {
         // no need for auxiliary variable
         def not(a: Lit): Lit = -a
 
-        /**
+        /*
          * This encoding adds 3n-4 variables auxiliary variables
          * to encode that at most 1 symbol can be set.
          * See also "Towards an Optimal CNF Encoding of Boolean Cardinality Constraints"

--- a/src/compiler/scala/tools/nsc/transform/patmat/Solving.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Solving.scala
@@ -95,7 +95,8 @@ trait Solving extends Logic {
 
     final case class Solvable(cnf: Cnf, symbolMapping: SymbolMapping) {
       def ++(other: Solvable) = {
-        require(this.symbolMapping eq other.symbolMapping)
+        require(this.symbolMapping eq other.symbolMapping,
+          "this and other must have the same symbol mapping (same reference)")
         Solvable(cnf ++ other.cnf, symbolMapping)
       }
 

--- a/src/compiler/scala/tools/nsc/transform/patmat/Solving.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Solving.scala
@@ -14,7 +14,7 @@ package scala.tools.nsc.transform.patmat
 
 import java.util
 
-import scala.annotation.tailrec
+import scala.annotation.{nowarn, tailrec}
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.{immutable, mutable}
 import scala.reflect.internal.util.StatisticsStatics
@@ -258,7 +258,7 @@ trait Solving extends Logic {
                 @inline
                 def /\(a: Lit, b: Lit) = addClauseProcessed(clause(a, b))
 
-                val (mid, xn :: Nil) = tail.splitAt(tail.size - 1)
+                val (mid, xn :: Nil) = tail.splitAt(tail.size - 1): @nowarn("msg=match may not be exhaustive")
 
                 // 1 <= x1,...,xn <==>
                 //

--- a/src/compiler/scala/tools/nsc/typechecker/ConstantFolder.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ConstantFolder.scala
@@ -145,13 +145,13 @@ abstract class ConstantFolder {
     case nme.XOR => Constant(x.longValue ^ y.longValue)
     case nme.AND => Constant(x.longValue & y.longValue)
     case nme.LSL if x.tag <= IntTag
-                 => Constant(x.intValue << y.longValue)
+                 => Constant(x.intValue << y.longValue.toInt)
     case nme.LSL => Constant(x.longValue <<  y.longValue)
     case nme.LSR if x.tag <= IntTag
-                 => Constant(x.intValue >>> y.longValue)
+                 => Constant(x.intValue >>> y.longValue.toInt)
     case nme.LSR => Constant(x.longValue >>> y.longValue)
     case nme.ASR if x.tag <= IntTag
-                 => Constant(x.intValue >> y.longValue)
+                 => Constant(x.intValue >> y.longValue.toInt)
     case nme.ASR => Constant(x.longValue >> y.longValue)
     case nme.EQ  => Constant(x.longValue == y.longValue)
     case nme.NE  => Constant(x.longValue != y.longValue)

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -412,7 +412,7 @@ trait ContextErrors {
             }
             val semicolon = orEmpty(linePrecedes(qual, sel))(s"possible cause: maybe a semicolon is missing before `$nameString`?")
             val notAnyRef = orEmpty(ObjectClass.info.member(name).exists)(notAnyRefMessage(target))
-            val javaRules = orEmpty(owner.isJavaDefined && owner.isClass && !owner.isPackage) {
+            val javaRules = orEmpty(owner.isJavaDefined && owner.isClass && !owner.hasPackageFlag) {
               val (jtype, jmember) = cx.javaFindMember(target, name, _.isStaticMember)
               orEmpty(jmember != NoSymbol) {
                 val more = sm"""Static Java members belong to companion objects in Scala;

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -13,9 +13,10 @@
 package scala.tools.nsc
 package typechecker
 
-import scala.reflect.internal.util.StringOps.{ countElementsAsString, countAsString }
+import scala.reflect.internal.util.StringOps.{countAsString, countElementsAsString}
 import java.lang.System.{lineSeparator => EOL}
-import scala.annotation.tailrec
+
+import scala.annotation.{nowarn, tailrec}
 import scala.reflect.runtime.ReflectionUtils
 import scala.reflect.macros.runtime.AbortMacroException
 import scala.util.control.{ControlThrowable, NonFatal}
@@ -1406,7 +1407,7 @@ trait ContextErrors {
                 | $pre2 ${info2.sym.fullLocationString} of type ${info2.tpe}
                 | $trailer"""
         def viewMsg = {
-          val found :: req :: _ = pt.typeArgs
+          val found :: req :: _ = pt.typeArgs: @nowarn("msg=match may not be exhaustive")
           def explanation = {
             val sym = found.typeSymbol
             // Explain some common situations a bit more clearly. Some other

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -108,14 +108,14 @@ trait Contexts { self: Analyzer =>
 
   var lastAccessCheckDetails: String = ""
 
-  val rootImportsCached = perRunCaches.newMap[CompilationUnit, List[Symbol]]
+  val rootImportsCached = perRunCaches.newMap[CompilationUnit, List[Symbol]]()
 
-  val excludedRootImportsCached = perRunCaches.newMap[CompilationUnit, List[Symbol]]
+  val excludedRootImportsCached = perRunCaches.newMap[CompilationUnit, List[Symbol]]()
 
   // register an import for the narrow purpose of excluding root imports of predef modules
   def registerImport(ctx: Context, imp: Import): Unit = {
     val sym = imp.expr.symbol
-    if (sym != null && !sym.isPackage && ctx.enclosingNonImportContext.owner.isPackage && rootImports(ctx.unit).contains(sym)) {
+    if (sym != null && !sym.hasPackageFlag && ctx.enclosingNonImportContext.owner.hasPackageFlag && rootImports(ctx.unit).contains(sym)) {
       var current = excludedRootImportsCached.get(ctx.unit).getOrElse(Nil)
       current = sym :: current
       excludedRootImportsCached += ctx.unit -> current
@@ -853,7 +853,7 @@ trait Contexts { self: Analyzer =>
       case x: Import => "" + x
       case Template(parents, `noSelfType`, body) =>
         val pstr = if ((parents eq null) || parents.isEmpty) "Nil" else parents mkString " "
-        val bstr = if (body eq null) "" else body.length + " stats"
+        val bstr = if (body eq null) "" else "" + body.length + " stats"
         s"""Template($pstr, _, $bstr)"""
       case x => s"${tree.shortClass}${treeIdString}:${treeTruncated}"
     }
@@ -1547,7 +1547,7 @@ trait Contexts { self: Analyzer =>
       })
 
       // If the defSym is at 4, and there is a def at 1 in scope due to packaging, then the reference is ambiguous.
-      if (foreignDefined && !defSym.isPackage && !thisContext.unit.isJava) {
+      if (foreignDefined && !defSym.hasPackageFlag && !thisContext.unit.isJava) {
         val defSym0 = defSym
         val pre0    = pre
         val cx0     = cx

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -19,7 +19,7 @@ package scala
 package tools.nsc
 package typechecker
 
-import scala.annotation.tailrec
+import scala.annotation.{nowarn, tailrec}
 import scala.collection.mutable
 import mutable.{LinkedHashMap, ListBuffer}
 import scala.util.matching.Regex
@@ -1030,6 +1030,7 @@ trait Implicits {
 
       /** True if a given ImplicitInfo (already known isValid) is eligible.
        */
+      @nowarn("cat=lint-inaccessible")
       def survives(info: ImplicitInfo, shadower: Shadower) = (
            !isIneligible(info)                      // cyclic, erroneous, shadowed, or specially excluded
         && isPlausiblyCompatible(info.tpe, wildPt)  // optimization to avoid matchesPt

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -483,7 +483,7 @@ trait Implicits {
     private def dominates(dtor: Type, dted: Type): Boolean = {
       @annotation.tailrec def sumComplexity(acc: Int, xs: List[Type]): Int = xs match {
         case h :: t => sumComplexity(acc + complexity(h), t)
-        case _: Nil.type => acc
+        case _      => acc
       }
 
       def complexity(tp: Type): Int = tp.dealias match {

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -696,7 +696,7 @@ trait Implicits {
               } else {
                 // we can't usefully prune views any further because we would need to type an application
                 // of the view to the term as is done in the computation of itree2 in typedImplicit1.
-                tvars.foreach(_.constr.stopWideningIfPrecluded)
+                tvars.foreach(_.constr.stopWideningIfPrecluded())
                 val targs = solvedTypes(tvars, allUndetparams, varianceInType(wildPt), upper = false, lubDepth(tpInstantiated :: wildPt :: Nil))
                 val adjusted = adjustTypeArgs(allUndetparams, tvars, targs)
                 val tpSubst = deriveTypeWithWildcards(adjusted.undetParams)(tp.instantiateTypeParams(adjusted.okParams, adjusted.okArgs))
@@ -1183,7 +1183,7 @@ trait Implicits {
       }
 
       if (eligible.nonEmpty)
-        printTyping(tree, eligible.size + s" eligible for pt=$pt at ${fullSiteString(context)}")
+        printTyping(tree, "" + eligible.size + s" eligible for pt=$pt at ${fullSiteString(context)}")
 
       /** Faster implicit search.  Overall idea:
        *   - prune aggressively
@@ -1425,7 +1425,7 @@ trait Implicits {
       }
       emptyInfos.foreach(infoMap.remove)
       if (infoMap.nonEmpty)
-        printTyping(tree, infoMap.size + " implicits in companion scope")
+        printTyping(tree, "" + infoMap.size + " implicits in companion scope")
 
       infoMap
     }
@@ -1453,7 +1453,7 @@ trait Implicits {
           if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopTimer(subtypeETNanos, start)
           implicitsCache(pt) = implicitInfoss1
           if (implicitsCache.size >= sizeLimit)
-            implicitsCache -= implicitsCache.keysIterator.next
+            implicitsCache -= implicitsCache.keysIterator.next()
           implicitInfoss1
       }
     }

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -414,7 +414,7 @@ trait Infer extends Checkable {
       if (if (useWeaklyCompatible) isWeaklyCompatible(resTpVars, pt) else isCompatible(resTpVars, pt)) {
         // If conforms has just solved a tvar as a singleton type against pt, then we need to
         // prevent it from being widened later by adjustTypeArgs
-        tvars.foreach(_.constr.stopWideningIfPrecluded)
+        tvars.foreach(_.constr.stopWideningIfPrecluded())
 
         // If the restpe is an implicit method, and the expected type is fully defined
         // optimize type variables wrt to the implicit formals only; ignore the result type.

--- a/src/compiler/scala/tools/nsc/typechecker/MacroAnnotationNamers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MacroAnnotationNamers.scala
@@ -394,7 +394,7 @@ trait MacroAnnotationNamers { self: Analyzer =>
               } else None
             } else None
 
-          annZippers.iterator.flatMap(annz => maybeExpand(annz.annotation, annz.annottee, annz.owner)).nextOption match {
+          annZippers.iterator.flatMap(annz => maybeExpand(annz.annotation, annz.annottee, annz.owner)).nextOption() match {
             case Some(expanded) =>
               // TODO: The workaround employed in https://github.com/scalamacros/paradise/issues/19
               // no longer works because of the REPL refactoring in 2.13.0-M2.

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -220,7 +220,7 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
       // there's another gotcha
       // if you don't assign a ConstantType to a constant
       // then pickling will crash
-      new Transformer {
+      new AstTransformer {
         override def transform(tree: Tree) = {
           tree match {
             case Literal(const @ Constant(x)) if tree.tpe == null => tree setType ConstantType(const)
@@ -855,7 +855,7 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
    */
   var hasPendingMacroExpansions = false // JZ this is never reset to false. What is its purpose? Should it not be stored in Context?
   def typerShouldExpandDeferredMacros: Boolean = hasPendingMacroExpansions && !delayed.isEmpty
-  private val forced = perRunCaches.newWeakSet[Tree]
+  private val forced = perRunCaches.newWeakSet[Tree]()
   private val delayed = perRunCaches.newWeakMap[Tree, scala.collection.mutable.Set[Symbol]]()
   private def isDelayed(expandee: Tree) = !delayed.isEmpty && (delayed contains expandee)
   def clearDelayed(): Unit = delayed.clear()
@@ -897,7 +897,7 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
    *  See the documentation for `macroExpand` for more information.
    */
   def macroExpandAll(typer: Typer, expandee: Tree): Tree =
-    new Transformer {
+    new AstTransformer {
       override def transform(tree: Tree) = super.transform(tree match {
         // todo. expansion should work from the inside out
         case tree if (delayed contains tree) && calculateUndetparams(tree).isEmpty && !tree.isErroneous =>

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -13,7 +13,7 @@
 package scala.tools.nsc
 package typechecker
 
-import scala.annotation.tailrec
+import scala.annotation.{nowarn, tailrec}
 import scala.collection.mutable
 import symtab.Flags._
 import scala.reflect.internal.util.ListOfNil
@@ -425,6 +425,7 @@ trait Namers extends MethodSynthesis {
     /** Given a ClassDef or ModuleDef, verifies there isn't a companion which
      *  has been defined in a separate file.
      */
+    @nowarn("cat=lint-nonlocal-return")
     def validateCompanionDefs(tree: ImplDef): Unit = {
       val sym    = tree.symbol orElse { return }
       val ctx    = if (context.owner.isPackageObjectClass) context.outer else context
@@ -847,6 +848,7 @@ trait Namers extends MethodSynthesis {
 
 // --- Lazy Type Assignment --------------------------------------------------
 
+    @nowarn("cat=lint-nonlocal-return")
     def findCyclicalLowerBound(tp: Type): Symbol = {
       tp match {
         case TypeBounds(lo, _) =>

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -32,7 +32,7 @@ trait Namers extends MethodSynthesis {
   /** Replaces any Idents for which cond is true with fresh TypeTrees().
    *  Does the same for any trees containing EmptyTrees.
    */
-  private class TypeTreeSubstituter(cond: Name => Boolean) extends Transformer {
+  private class TypeTreeSubstituter(cond: Name => Boolean) extends AstTransformer {
     override def transform(tree: Tree): Tree = tree match {
       case Ident(name) if cond(name) => TypeTree()
       case _                         => super.transform(tree)
@@ -686,7 +686,7 @@ trait Namers extends MethodSynthesis {
             val userDefined = ownerInfo.memberBasedOnName(sym.name, BridgeFlags | SYNTHETIC)
 
             (userDefined != NoSymbol) && {
-              assert(userDefined != sym)
+              assert(userDefined != sym, "userDefined symbol cannot be the same as symbol of which it is a member")
               val alts = userDefined.alternatives // could be just the one, if this member isn't overloaded
               // don't compute any further `memberInfo`s if there's an error somewhere
               alts.exists(_.isErroneous) || {

--- a/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
@@ -16,7 +16,8 @@ package typechecker
 import symtab.Flags._
 import scala.collection.mutable
 import scala.reflect.ClassTag
-import PartialFunction.{ cond => when }
+import PartialFunction.{cond => when}
+import scala.annotation.nowarn
 
 /**
  *  @author Lukas Rytz
@@ -526,7 +527,7 @@ trait NamesDefaults { self: Analyzer =>
     val namelessArgs = {
       var positionalAllowed = true
       def stripNamedArg(arg: NamedArg, argIndex: Int): Tree = {
-        val NamedArg(Ident(name), rhs) = arg
+        val NamedArg(Ident(name), rhs) = arg: @nowarn("msg=match may not be exhaustive")
         params indexWhere (p => matchesName(p, name, argIndex)) match {
           case -1 =>
             val warnVariableInScope = !currentRun.isScala3 && context0.lookupSymbol(name, _.isVariable).isSuccess

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -78,7 +78,7 @@ abstract class RefChecks extends Transform {
     false
   }
 
-  class RefCheckTransformer(unit: CompilationUnit) extends Transformer {
+  class RefCheckTransformer(unit: CompilationUnit) extends AstTransformer {
 
     var localTyper: analyzer.Typer = typer
     var currentApplication: Tree = EmptyTree
@@ -523,7 +523,7 @@ abstract class RefChecks extends Transform {
         }
       }
 
-      val opc = new overridingPairs.Cursor(clazz)
+      val opc = new overridingPairs.PairsCursor(clazz)
       while (opc.hasNext) {
         if (!opc.high.isClass)
           checkOverride(opc.currentPair)
@@ -1146,7 +1146,7 @@ abstract class RefChecks extends Transform {
       }
       val receiver = underlyingClass(qual.tpe)
       val actual   = underlyingClass(other.tpe)
-      def typesString = normalizeAll(qual.tpe.widen)+" and "+normalizeAll(other.tpe.widen)
+      def typesString = "" + normalizeAll(qual.tpe.widen) + " and " + normalizeAll(other.tpe.widen)
       def nonSensiblyEquals() = {
         refchecksWarning(pos, s"comparing values of types $typesString using `${name.decode}` is unsafe due to cooperative equality; use `==` instead", WarningCategory.OtherNonCooperativeEquals)
       }

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -284,10 +284,10 @@ abstract class RefChecks extends Transform {
         macroStr + member.defStringSeenAs(self.memberInfo(member)) + location
       }
 
-      /** Check that all conditions for overriding `other` by `member` of class `clazz` are met.
-        *
-        * TODO: error messages could really be improved, including how they are composed
-        */
+      /* Check that all conditions for overriding `other` by `member` of class `clazz` are met.
+       *
+       * TODO: error messages could really be improved, including how they are composed
+       */
       def checkOverride(pair: SymbolPair): Unit = {
         import pair.{highType, lowType, highInfo, rootType}
 

--- a/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
@@ -77,7 +77,7 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
   /** The following flags may be set by this phase: */
   override def phaseNewFlags: Long = notPRIVATE
 
-  protected def newTransformer(unit: CompilationUnit): Transformer =
+  protected def newTransformer(unit: CompilationUnit): AstTransformer =
     new SuperAccTransformer(unit)
 
   class SuperAccTransformer(unit: CompilationUnit) extends TypingTransformer(unit) {

--- a/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
@@ -21,6 +21,7 @@ package typechecker
 
 import scala.collection.{immutable, mutable}
 import mutable.ListBuffer
+import scala.annotation.nowarn
 import scala.tools.nsc.Reporting.WarningCategory
 import symtab.Flags._
 
@@ -143,7 +144,7 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
       }
 
     private def transformSuperSelect(sel: Select): Tree = {
-      val Select(sup @ Super(_, mix), name) = sel
+      val Select(sup @ Super(_, mix), name) = sel: @nowarn("msg=match may not be exhaustive")
       val sym   = sel.symbol
       val clazz = sup.symbol
 
@@ -483,7 +484,7 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
         newAcc setInfoAndEnter accType(newAcc)
 
         val code = DefDef(newAcc, {
-          val (receiver :: _) :: tail = newAcc.paramss
+          val (receiver :: _) :: tail = newAcc.paramss: @nowarn("msg=match may not be exhaustive")
           val base: Tree              = Select(Ident(receiver), sym)
           foldLeft2(tail, sym.info.paramss)(base){ (acc, params, pps) =>
             val y = map2(params, pps)( (param, pp) =>  makeArg(param, receiver, pp.tpe))
@@ -548,7 +549,7 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
         val accessorType = MethodType(params, UnitTpe)
 
         protAcc setInfoAndEnter accessorType
-        val obj :: value :: Nil = params
+        val obj :: value :: Nil = params: @nowarn("msg=match may not be exhaustive")
         storeAccessorDefinition(clazz, DefDef(protAcc, Assign(Select(Ident(obj), field.name), Ident(value))))
 
         protAcc

--- a/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
@@ -252,7 +252,7 @@ trait SyntheticMethods extends ast.TreeDSL {
     /* The _1, _2, etc. methods to implement ProductN, disabled
      * until we figure out how to introduce ProductN without cycles.
      */
-    /****
+    /*
     def productNMethods = {
       val accs = accessors.toIndexedSeq
       1 to arity map (num => productProj(arity, num) -> (() => projectionMethod(accs(num - 1), num)))
@@ -260,7 +260,7 @@ trait SyntheticMethods extends ast.TreeDSL {
     def projectionMethod(accessor: Symbol, num: Int) = {
       createMethod(nme.productAccessorName(num), accessor.tpe.resultType)(_ => REF(accessor))
     }
-    ****/
+    */
 
     // methods for both classes and objects
     def productMethods: List[(Symbol, () => Tree)] = {

--- a/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
@@ -129,7 +129,7 @@ abstract class TreeCheckers extends Analyzer {
     def reportChanges(): Unit = {
       // new symbols
       if (newSyms.nonEmpty) {
-        informFn(newSyms.size + " new symbols.")
+        informFn("" + newSyms.size + " new symbols.")
         val toPrint = if (settings.debug) sortedNewSyms mkString " " else ""
 
         newSyms.clear()

--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -19,7 +19,7 @@ import scala.util.chaining._
 import scala.util.control.Exception.ultimately
 import symtab.Flags._
 import PartialFunction.{cond, condOpt}
-import scala.annotation.tailrec
+import scala.annotation.{nowarn, tailrec}
 import scala.tools.nsc.Reporting.WarningCategory
 
 /** An interface to enable higher configurability of diagnostic messages
@@ -219,6 +219,7 @@ trait TypeDiagnostics {
    *
    *  TODO: handle type aliases better.
    */
+  @nowarn("cat=lint-nonlocal-return")
   def explainVariance(found: Type, req: Type): String = {
     found.baseTypeSeq.toList foreach { tp =>
       if (tp.typeSymbol isSubClass req.typeSymbol) {

--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -652,12 +652,12 @@ trait TypeDiagnostics {
     }
     object skipMacroExpansion extends UnusedPrivates {
       override def traverse(t: Tree): Unit =
-        if (!hasMacroExpansionAttachment(t) && !(t.hasSymbol && isExpanded(t.symbol)))
+        if (!hasMacroExpansionAttachment(t) && !(t.hasSymbolField && isExpanded(t.symbol)))
           super.traverse(t)
     }
     object checkMacroExpandee extends UnusedPrivates {
       override def traverse(t: Tree): Unit =
-        if (!(t.hasSymbol && isExpanded(t.symbol)))
+        if (!(t.hasSymbolField && isExpanded(t.symbol)))
           super.traverse(if (hasMacroExpansionAttachment(t)) macroExpandee(t) else t)
     }
 
@@ -730,7 +730,7 @@ trait TypeDiagnostics {
       if (settings.warnUnusedParams) {
         def isImplementation(m: Symbol): Boolean = {
           def classOf(s: Symbol): Symbol = if (s.isClass || s == NoSymbol) s else classOf(s.owner)
-          val opc = new overridingPairs.Cursor(classOf(m))
+          val opc = new overridingPairs.PairsCursor(classOf(m))
           opc.iterator.exists(pair => pair.low == m)
         }
         import PartialFunction._

--- a/src/compiler/scala/tools/nsc/typechecker/TypeStrings.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeStrings.scala
@@ -13,10 +13,12 @@
 package scala.tools.nsc
 package typechecker
 
-import java.lang.{ reflect => r }
+import java.lang.{reflect => r}
 import r.TypeVariable
+
 import scala.reflect.NameTransformer
 import NameTransformer._
+import scala.collection.immutable.ArraySeq
 import scala.reflect.runtime.{universe => ru}
 import scala.reflect.{ClassTag, classTag}
 
@@ -205,7 +207,7 @@ trait TypeStrings {
     else scalaName(xs.head)
   }
   private def tparamString(clazz: JClass): String = {
-    brackets(clazz.getTypeParameters map tvarString: _*)
+    brackets(ArraySeq.unsafeWrapArray(clazz.getTypeParameters map tvarString): _*)
   }
 
   private def tparamString[T: ru.TypeTag] : String = {

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -836,7 +836,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                 // scala/bug#10066 Need to patch the enclosing tree in the context to make translation of Dynamic
                 // work during fallback typechecking below.
                 val resetContext: Context = {
-                  object substResetForOriginal extends Transformer {
+                  object substResetForOriginal extends AstTransformer {
                     override def transform(tree: Tree): Tree = {
                       if (tree eq original) resetTree
                       else super.transform(tree)

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3279,22 +3279,22 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             val sym = e.sym
             val sym1 = e1.sym
 
-            /** From the spec (refchecks checks other conditions regarding erasing to the same type and default arguments):
-              *
-              * A block expression [... its] statement sequence may not contain two definitions or
-              * declarations that bind the same name --> `inBlock`
-              *
-              * It is an error if a template directly defines two matching members.
-              *
-              * A member definition $M$ _matches_ a member definition $M'$, if $M$ and $M'$ bind the same name,
-              * and one of following holds:
-              *   1. Neither $M$ nor $M'$ is a method definition.
-              *   2. $M$ and $M'$ define both monomorphic methods with equivalent argument types.
-              *   3. $M$ defines a parameterless method and $M'$ defines a method with an empty parameter list `()` or _vice versa_.
-              *   4. $M$ and $M'$ define both polymorphic methods with equal number of argument types $\overline T$, $\overline T'$
-              *      and equal numbers of type parameters $\overline t$, $\overline t'$, say,
-              *      and  $\overline T' = [\overline t'/\overline t]\overline T$.
-              */
+            /* From the spec (refchecks checks other conditions regarding erasing to the same type and default arguments):
+             *
+             * A block expression [... its] statement sequence may not contain two definitions or
+             * declarations that bind the same name --> `inBlock`
+             *
+             * It is an error if a template directly defines two matching members.
+             *
+             * A member definition $M$ _matches_ a member definition $M'$, if $M$ and $M'$ bind the same name,
+             * and one of following holds:
+             *   1. Neither $M$ nor $M'$ is a method definition.
+             *   2. $M$ and $M'$ define both monomorphic methods with equivalent argument types.
+             *   3. $M$ defines a parameterless method and $M'$ defines a method with an empty parameter list `()` or _vice versa_.
+             *   4. $M$ and $M'$ define both polymorphic methods with equal number of argument types $\overline T$, $\overline T'$
+             *      and equal numbers of type parameters $\overline t$, $\overline t'$, say,
+             *      and  $\overline T' = [\overline t'/\overline t]\overline T$.
+             */
             if (!(accesses(sym, sym1) || accesses(sym1, sym))  // TODO: does this purely defer errors until later?
                 && (inBlock || !(sym.isMethod || sym1.isMethod) || (sym.tpe matches sym1.tpe))
                 // default getters are defined twice when multiple overloads have defaults.
@@ -4814,15 +4814,15 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       }
 
 
-      /** Eta expand an expression like `m _`, where `m` denotes a method or a by-name argument
-        *
-        * The spec says:
-        * The expression `$e$ _` is well-formed if $e$ is of method type or if $e$ is a call-by-name parameter.
-        *   (1) If $e$ is a method with parameters, `$e$ _` represents $e$ converted to a function type
-        *       by [eta expansion](#eta-expansion).
-        *   (2) If $e$ is a parameterless method or call-by-name parameter of type `=> $T$`, `$e$ _` represents
-        *       the function of type `() => $T$`, which evaluates $e$ when it is applied to the empty parameter list `()`.
-        */
+      /* Eta expand an expression like `m _`, where `m` denotes a method or a by-name argument
+       *
+       * The spec says:
+       * The expression `$e$ _` is well-formed if $e$ is of method type or if $e$ is a call-by-name parameter.
+       *   (1) If $e$ is a method with parameters, `$e$ _` represents $e$ converted to a function type
+       *       by [eta expansion](#eta-expansion).
+       *   (2) If $e$ is a parameterless method or call-by-name parameter of type `=> $T$`, `$e$ _` represents
+       *       the function of type `() => $T$`, which evaluates $e$ when it is applied to the empty parameter list `()`.
+       */
       def typedEta(methodValue: Tree): Tree = methodValue.tpe match {
         case tp@(MethodType(_, _) | PolyType(_, MethodType(_, _))) => // (1)
           if (tp.params.lengthCompare(definitions.MaxFunctionArity) > 0) MaxFunctionArityError(methodValue, s"; method ${methodValue.symbol.name} cannot be eta-expanded because it takes ${tp.params.length} arguments")

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -14,7 +14,7 @@ package scala
 package tools.nsc
 package typechecker
 
-import scala.annotation.tailrec
+import scala.annotation.{nowarn, tailrec}
 import scala.collection.mutable
 import scala.reflect.internal.{Chars, TypesStats}
 import scala.reflect.internal.util.{FreshNameCreator, ListOfNil, Statistics, StatisticsStatics}
@@ -3843,6 +3843,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     /**
      * Convert an annotation constructor call into an AnnotationInfo.
      */
+    @nowarn("cat=lint-nonlocal-return")
     def typedAnnotation(ann: Tree, annotee: Option[Tree], mode: Mode = EXPRmode): AnnotationInfo = context.withinAnnotation {
       var hasError: Boolean = false
       var unmappable: Boolean = false

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1691,7 +1691,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     private def normalizeFirstParent(parents: List[Tree]): List[Tree] = {
       @annotation.tailrec
       def explode0(parents: List[Tree]): List[Tree] = {
-        val supertpt :: rest = parents // parents is always non-empty here - it only grows
+        val supertpt :: rest = parents: @nowarn("msg=match may not be exhaustive") // parents is always non-empty here - it only grows
         if (supertpt.tpe.typeSymbol == AnyClass) {
           supertpt setType AnyRefTpe
           parents

--- a/src/compiler/scala/tools/nsc/util/ShowPickled.scala
+++ b/src/compiler/scala/tools/nsc/util/ShowPickled.scala
@@ -158,7 +158,7 @@ object ShowPickled extends Names {
         val accessBoundary = (
           for (idx <- privateWithin) yield {
             val s = entryList nameAt idx
-            idx + "(" + s + ")"
+            "" + idx + "(" + s + ")"
           }
         )
         val flagString = {
@@ -190,7 +190,7 @@ object ShowPickled extends Names {
      */
     def printEntry(i: Int): Unit = {
       buf.readIndex = index(i)
-      p(i + "," + buf.readIndex + ": ")
+      p("" + i + "," + buf.readIndex + ": ")
       val tag = buf.readByte()
       out.print(tag2string(tag))
       val len = buf.readNat()

--- a/src/compiler/scala/tools/nsc/util/StackTracing.scala
+++ b/src/compiler/scala/tools/nsc/util/StackTracing.scala
@@ -55,7 +55,7 @@ private[util] trait StackTracing extends Any {
       val trace  = e.getStackTrace
       val frames = if (share.isEmpty) trace else {
         val spare   = share.reverseIterator
-        val trimmed = trace.reverse dropWhile (spare.hasNext && spare.next == _)
+        val trimmed = trace.reverse dropWhile (spare.hasNext && spare.next() == _)
         trimmed.reverse
       }
       val prefix = frames.takeWhile(p)

--- a/src/compiler/scala/tools/reflect/FormatInterpolator.scala
+++ b/src/compiler/scala/tools/reflect/FormatInterpolator.scala
@@ -156,7 +156,7 @@ abstract class FormatInterpolator {
           }
         }
         if (ms.hasNext) {
-          Conversion(ms.next, part.pos, args.size) match {
+          Conversion(ms.next(), part.pos, args.size) match {
             case Some(op) if op.isLiteral => s_%()
             case Some(op) if op.indexed =>
               if (op.index map (_ == n) getOrElse true) accept(op)
@@ -172,7 +172,7 @@ abstract class FormatInterpolator {
       }
       // any remaining conversions must be either literals or indexed
       while (ms.hasNext) {
-        Conversion(ms.next, part.pos, args.size) match {
+        Conversion(ms.next(), part.pos, args.size) match {
           case Some(op) if first && op.hasFlag('<')   => op.badFlag('<', "No last arg")
           case Some(op) if op.isLiteral || op.indexed => // OK
           case Some(op) => errorLeading(op)

--- a/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
+++ b/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
@@ -110,7 +110,7 @@ abstract class ToolBoxFactory[U <: JavaUniverse](val u: U) { factorySelf =>
           if (namesakes.length > 0) name += ("$" + (namesakes.length + 1))
           freeTermNames += (ft -> newTermName(name + nme.REIFY_FREE_VALUE_SUFFIX))
         })
-        val expr = new Transformer {
+        val expr = new AstTransformer {
           override def transform(tree: Tree): Tree =
             if (tree.hasSymbolField && tree.symbol.isFreeTerm) {
               tree match {
@@ -167,7 +167,7 @@ abstract class ToolBoxFactory[U <: JavaUniverse](val u: U) { factorySelf =>
             }
 
           val invertedIndex = freeTerms map (_.swap)
-          val indexed = new Transformer {
+          val indexed = new AstTransformer {
             override def transform(tree: Tree): Tree =
               tree match {
                 case Ident(name: TermName) if invertedIndex contains name =>

--- a/src/compiler/scala/tools/tasty/TastyFlags.scala
+++ b/src/compiler/scala/tools/tasty/TastyFlags.scala
@@ -155,7 +155,7 @@ object TastyFlags {
           buf += f(flag)
         }
       }
-      buf.result
+      buf.result()
     }
   }
 

--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -834,7 +834,7 @@ class IMain(val settings: Settings, parentClassLoaderOverride: Option[ClassLoade
 
 
     private val USER_CODE_PLACEHOLDER = newTermName("$user_code_placeholder$")
-    private object spliceUserCode extends Transformer {
+    private object spliceUserCode extends AstTransformer {
       var parents: List[Tree] = Nil
       override def transform(tree: Tree): Tree = {
         parents ::= tree

--- a/src/repl/scala/tools/nsc/interpreter/ReplGlobal.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplGlobal.scala
@@ -59,8 +59,8 @@ trait ReplGlobal extends Global {
     override val runsBefore: List[String] = List("uncurry")
     /** Name of the phase that this phase must follow immediately. */
     override val runsRightAfter: Option[String] = None
-    override protected def newTransformer(unit: CompilationUnit): Transformer = new WrapperCleanupTransformer
-    class WrapperCleanupTransformer extends Transformer {
+    override protected def newTransformer(unit: CompilationUnit): AstTransformer = new WrapperCleanupTransformer
+    class WrapperCleanupTransformer extends AstTransformer {
       override def transformUnit(unit: CompilationUnit): Unit = {
         if (settings.Yreplclassbased.value) super.transformUnit(unit)
       }

--- a/test/files/neg/macro-incompatible-macro-engine-a/Plugin_1.scala
+++ b/test/files/neg/macro-incompatible-macro-engine-a/Plugin_1.scala
@@ -13,7 +13,7 @@ class Plugin(val global: Global) extends NscPlugin {
   addMacroPlugin(MacroPlugin)
 
   object MacroPlugin extends MacroPlugin {
-    def fixupBinding(tree: Tree) = new Transformer {
+    def fixupBinding(tree: Tree) = new AstTransformer {
       override def transform(tree: Tree) = {
         tree match {
           case Literal(const @ Constant(x)) if tree.tpe == null => tree setType ConstantType(const)

--- a/test/files/neg/macro-incompatible-macro-engine-b/Plugin_1.scala
+++ b/test/files/neg/macro-incompatible-macro-engine-b/Plugin_1.scala
@@ -13,7 +13,7 @@ class Plugin(val global: Global) extends NscPlugin {
   addMacroPlugin(MacroPlugin)
 
   object MacroPlugin extends MacroPlugin {
-    def fixupBinding(tree: Tree) = new Transformer {
+    def fixupBinding(tree: Tree) = new AstTransformer {
       override def transform(tree: Tree) = {
         tree match {
           case Literal(const @ Constant(x)) if tree.tpe == null => tree setType ConstantType(const)


### PR DESCRIPTION
Follow-up to #9237

Not labeled `internal` because there are some user-facing(?) deprecations.