### PR TITLE
remove null to ExecutionContext.global

### DIFF
--- a/src/library/scala/concurrent/ExecutionContext.scala
+++ b/src/library/scala/concurrent/ExecutionContext.scala
@@ -139,7 +139,7 @@ object ExecutionContext {
    *
    * @return the global `ExecutionContext`
    */
-  final lazy val global: ExecutionContextExecutor = impl.ExecutionContextImpl.createDefaultExecutorService()
+  final lazy val global: ExecutionContextExecutor = impl.ExecutionContextImpl.createDefaultExecutorService(defaultReporter)
 
   /**
    * WARNING: Only ever execute logic which will quickly return control to the caller.

--- a/src/library/scala/concurrent/ExecutionContext.scala
+++ b/src/library/scala/concurrent/ExecutionContext.scala
@@ -139,7 +139,7 @@ object ExecutionContext {
    *
    * @return the global `ExecutionContext`
    */
-  final lazy val global: ExecutionContextExecutor = impl.ExecutionContextImpl.fromExecutor(null: Executor)
+  final lazy val global: ExecutionContextExecutor = impl.ExecutionContextImpl.createDefaultExecutorService()
 
   /**
    * WARNING: Only ever execute logic which will quickly return control to the caller.

--- a/src/library/scala/concurrent/impl/ExecutionContextImpl.scala
+++ b/src/library/scala/concurrent/impl/ExecutionContextImpl.scala
@@ -77,7 +77,7 @@ private[concurrent] object ExecutionContextImpl {
       })
   }
 
-  def createDefaultExecutorService(reporter: Throwable => Unit): ExecutionContextExecutorService = {
+  def createDefaultExecutorService(reporter: Throwable => Unit = ExecutionContext.defaultReporter): ExecutionContextExecutorService = {
     def getInt(name: String, default: String) = (try System.getProperty(name, default) catch {
       case e: SecurityException => default
     }) match {
@@ -116,29 +116,24 @@ private[concurrent] object ExecutionContextImpl {
   }
 
   def fromExecutor(e: Executor, reporter: Throwable => Unit = ExecutionContext.defaultReporter): ExecutionContextExecutor =
-    e match {
-      case null => createDefaultExecutorService(reporter)
-      case some => new ExecutionContextImpl(some, reporter)
-    }
+    new ExecutionContextImpl(e, reporter)
+
 
   def fromExecutorService(es: ExecutorService, reporter: Throwable => Unit = ExecutionContext.defaultReporter):
-    ExecutionContextExecutorService = es match {
-      case null => createDefaultExecutorService(reporter)
-      case some =>
-        new ExecutionContextImpl(some, reporter) with ExecutionContextExecutorService {
-            private[this] final def asExecutorService: ExecutorService = executor.asInstanceOf[ExecutorService]
-            final override def shutdown() = asExecutorService.shutdown()
-            final override def shutdownNow() = asExecutorService.shutdownNow()
-            final override def isShutdown = asExecutorService.isShutdown
-            final override def isTerminated = asExecutorService.isTerminated
-            final override def awaitTermination(l: Long, timeUnit: TimeUnit) = asExecutorService.awaitTermination(l, timeUnit)
-            final override def submit[T](callable: Callable[T]) = asExecutorService.submit(callable)
-            final override def submit[T](runnable: Runnable, t: T) = asExecutorService.submit(runnable, t)
-            final override def submit(runnable: Runnable) = asExecutorService.submit(runnable)
-            final override def invokeAll[T](callables: Collection[_ <: Callable[T]]) = asExecutorService.invokeAll(callables)
-            final override def invokeAll[T](callables: Collection[_ <: Callable[T]], l: Long, timeUnit: TimeUnit) = asExecutorService.invokeAll(callables, l, timeUnit)
-            final override def invokeAny[T](callables: Collection[_ <: Callable[T]]) = asExecutorService.invokeAny(callables)
-            final override def invokeAny[T](callables: Collection[_ <: Callable[T]], l: Long, timeUnit: TimeUnit) = asExecutorService.invokeAny(callables, l, timeUnit)
-          }
-        }
+    ExecutionContextExecutorService =
+      new ExecutionContextImpl(es, reporter) with ExecutionContextExecutorService {
+        private[this] final def asExecutorService: ExecutorService = executor.asInstanceOf[ExecutorService]
+        final override def shutdown() = asExecutorService.shutdown()
+        final override def shutdownNow() = asExecutorService.shutdownNow()
+        final override def isShutdown = asExecutorService.isShutdown
+        final override def isTerminated = asExecutorService.isTerminated
+        final override def awaitTermination(l: Long, timeUnit: TimeUnit) = asExecutorService.awaitTermination(l, timeUnit)
+        final override def submit[T](callable: Callable[T]) = asExecutorService.submit(callable)
+        final override def submit[T](runnable: Runnable, t: T) = asExecutorService.submit(runnable, t)
+        final override def submit(runnable: Runnable) = asExecutorService.submit(runnable)
+        final override def invokeAll[T](callables: Collection[_ <: Callable[T]]) = asExecutorService.invokeAll(callables)
+        final override def invokeAll[T](callables: Collection[_ <: Callable[T]], l: Long, timeUnit: TimeUnit) = asExecutorService.invokeAll(callables, l, timeUnit)
+        final override def invokeAny[T](callables: Collection[_ <: Callable[T]]) = asExecutorService.invokeAny(callables)
+        final override def invokeAny[T](callables: Collection[_ <: Callable[T]], l: Long, timeUnit: TimeUnit) = asExecutorService.invokeAny(callables, l, timeUnit)
+      }
 }

--- a/src/library/scala/concurrent/impl/ExecutionContextImpl.scala
+++ b/src/library/scala/concurrent/impl/ExecutionContextImpl.scala
@@ -116,11 +116,16 @@ private[concurrent] object ExecutionContextImpl {
   }
 
   def fromExecutor(e: Executor, reporter: Throwable => Unit = ExecutionContext.defaultReporter): ExecutionContextExecutor =
-    new ExecutionContextImpl(e, reporter)
+    e match {
+      case null =>  throw new IllegalArgumentException("Executor is null")
+      case _ => new ExecutionContextImpl (e, reporter)
+    }
 
 
   def fromExecutorService(es: ExecutorService, reporter: Throwable => Unit = ExecutionContext.defaultReporter):
-    ExecutionContextExecutorService =
+    ExecutionContextExecutorService = es match {
+    case null =>  throw new IllegalArgumentException("ExecutorService is null")
+    case _ => {
       new ExecutionContextImpl(es, reporter) with ExecutionContextExecutorService {
         private[this] final def asExecutorService: ExecutorService = executor.asInstanceOf[ExecutorService]
         final override def shutdown() = asExecutorService.shutdown()
@@ -136,4 +141,6 @@ private[concurrent] object ExecutionContextImpl {
         final override def invokeAny[T](callables: Collection[_ <: Callable[T]]) = asExecutorService.invokeAny(callables)
         final override def invokeAny[T](callables: Collection[_ <: Callable[T]], l: Long, timeUnit: TimeUnit) = asExecutorService.invokeAny(callables, l, timeUnit)
       }
+    }
+  }
 }

--- a/test/files/jvm/future-spec/FutureTests.scala
+++ b/test/files/jvm/future-spec/FutureTests.scala
@@ -230,7 +230,7 @@ class FutureTests extends MinimalScalaTest {
     import ExecutionContext.Implicits._
     "report uncaught exceptions" in {
       val p = Promise[Throwable]()
-      val ec: ExecutionContextExecutorService = ExecutionContext.fromExecutorService(null, p.trySuccess(_))
+      val ec: ExecutionContextExecutorService = ExecutionContext.global
       val t = new Exception()
       try {
         ec.execute(() => throw t)


### PR DESCRIPTION
I wondered use a null value to executionContext.global 
argument.
And match null for `impl.ExecutionContextImpl.fromExecutor(null: Executor)`

I thought it could be improved.

