### PR TITLE
Un-deprecate useful `StringOps` methods, despite Unicode concerns

### DIFF
--- a/src/library/scala/collection/StringOps.scala
+++ b/src/library/scala/collection/StringOps.scala
@@ -1443,7 +1443,6 @@ final class StringOps(private val s: String) extends AnyVal {
     *                ''n'' times in `that`, then the first ''n'' occurrences of `x` will not form
     *                part of the result, but any following occurrences will.
     */
-  @deprecated("Use `s.toSeq.diff(...).unwrap` instead of `s.diff(...)`", "2.13.0")
   def diff[B >: Char](that: Seq[B]): String = new WrappedString(s).diff(that).unwrap
 
   /** Computes the multiset intersection between this string and another sequence.
@@ -1455,11 +1454,9 @@ final class StringOps(private val s: String) extends AnyVal {
     *                ''n'' times in `that`, then the first ''n'' occurrences of `x` will be retained
     *                in the result, but any following occurrences will be omitted.
     */
-  @deprecated("Use `s.toSeq.intersect(...).unwrap` instead of `s.intersect(...)`", "2.13.0")
   def intersect[B >: Char](that: Seq[B]): String = new WrappedString(s).intersect(that).unwrap
 
   /** Selects all distinct chars of this string ignoring the duplicates. */
-  @deprecated("Use `s.toSeq.distinct.unwrap` instead of `s.distinct`", "2.13.0")
   def distinct: String = new WrappedString(s).distinct.unwrap
 
   /** Selects all distinct chars of this string ignoring the duplicates as determined by `==` after applying
@@ -1469,7 +1466,6 @@ final class StringOps(private val s: String) extends AnyVal {
     * @tparam B the type of the elements after being transformed by `f`
     * @return a new string consisting of all the chars of this string without duplicates.
     */
-  @deprecated("Use `s.toSeq.distinctBy(...).unwrap` instead of `s.distinctBy(...)`", "2.13.0")
   def distinctBy[B](f: Char => B): String = new WrappedString(s).distinctBy(f).unwrap
 
   /** Sorts the characters of this string according to an Ordering.
@@ -1483,7 +1479,6 @@ final class StringOps(private val s: String) extends AnyVal {
     *  @return     a string consisting of the chars of this string
     *              sorted according to the ordering `ord`.
     */
-  @deprecated("Use `s.toSeq.sorted.unwrap` instead of `s.sorted`", "2.13.0")
   def sorted[B >: Char](implicit ord: Ordering[B]): String = new WrappedString(s).sorted(ord).unwrap
 
   /** Sorts this string according to a comparison function.
@@ -1497,7 +1492,6 @@ final class StringOps(private val s: String) extends AnyVal {
     *  @return     a string consisting of the elements of this string
     *              sorted according to the comparison function `lt`.
     */
-  @deprecated("Use `s.toSeq.sortWith(...).unwrap` instead of `s.sortWith(...)`", "2.13.0")
   def sortWith(lt: (Char, Char) => Boolean): String = new WrappedString(s).sortWith(lt).unwrap
 
   /** Sorts this string according to the Ordering which results from transforming
@@ -1516,7 +1510,6 @@ final class StringOps(private val s: String) extends AnyVal {
     *           sorted according to the ordering where `x < y` if
     *           `ord.lt(f(x), f(y))`.
     */
-  @deprecated("Use `s.toSeq.sortBy(...).unwrap` instead of `s.sortBy(...)`", "2.13.0")
   def sortBy[B](f: Char => B)(implicit ord: Ordering[B]): String = new WrappedString(s).sortBy(f)(ord).unwrap
 
   /** Partitions this string into a map of strings according to some discriminator function.
@@ -1531,7 +1524,6 @@ final class StringOps(private val s: String) extends AnyVal {
     *               for which `f(x)` equals `k`.
     *
     */
-  @deprecated("Use `s.toSeq.groupBy(...).view.mapValues(_.unwrap)` instead of `s.groupBy(...)`", "2.13.0")
   def groupBy[K](f: Char => K): immutable.Map[K, String] = new WrappedString(s).groupBy(f).view.mapValues(_.unwrap).toMap
 
   /** Groups chars in fixed size blocks by passing a "sliding window"
@@ -1544,7 +1536,6 @@ final class StringOps(private val s: String) extends AnyVal {
     *          last element (which may be the only element) will be truncated
     *          if there are fewer than `size` chars remaining to be grouped.
     */
-  @deprecated("Use `s.toSeq.sliding(...).map(_.unwrap)` instead of `s.sliding(...)`", "2.13.0")
   def sliding(size: Int, step: Int = 1): Iterator[String] = new WrappedString(s).sliding(size, step).map(_.unwrap)
 
   /** Iterates over combinations.  A _combination_ of length `n` is a subsequence of
@@ -1560,7 +1551,6 @@ final class StringOps(private val s: String) extends AnyVal {
     *  @return   An Iterator which traverses the possible n-element combinations of this string.
     *  @example  `"abbbc".combinations(2) = Iterator(ab, ac, bb, bc)`
     */
-  @deprecated("Use `s.toSeq.combinations(...).map(_.unwrap)` instead of `s.combinations(...)`", "2.13.0")
   def combinations(n: Int): Iterator[String] = new WrappedString(s).combinations(n).map(_.unwrap)
 
   /** Iterates over distinct permutations.
@@ -1568,7 +1558,6 @@ final class StringOps(private val s: String) extends AnyVal {
     *  @return   An Iterator which traverses the distinct permutations of this string.
     *  @example  `"abb".permutations = Iterator(abb, bab, bba)`
     */
-  @deprecated("Use `s.toSeq.permutations(...).map(_.unwrap)` instead of `s.permutations(...)`", "2.13.0")
   def permutations: Iterator[String] = new WrappedString(s).permutations.map(_.unwrap)
 }
 


### PR DESCRIPTION
Namely: `diff`, `intersect`, `distinct`, `distinctBy`, `sorted`, `sortWith`, `sortBy`, `groupBy`, `sliding`, `combinations`, permutations`

referring to discussion in issue https://github.com/scala/bug/issues/11676 and on gitter https://gitter.im/scala/contributors?at=5f84ccb4e6840119ec83d0dd