### PR TITLE
Allow -Wconf configuration of non-cooperative equals warning

### DIFF
--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -336,6 +336,7 @@ object Reporting {
     object OtherMatchAnalysis extends Other; add(OtherMatchAnalysis)
     object OtherDebug extends Other; add(OtherDebug)
     object OtherNullaryOverride extends Other; add(OtherNullaryOverride)
+    object OtherNonCooperativeEquals extends Other; add(OtherNonCooperativeEquals)
 
     sealed trait WFlag extends WarningCategory { override def summaryCategory: WarningCategory = WFlag }
     object WFlag extends WFlag { override def includes(o: WarningCategory): Boolean = o.isInstanceOf[WFlag] }; add(WFlag)

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1148,7 +1148,7 @@ abstract class RefChecks extends Transform {
       val actual   = underlyingClass(other.tpe)
       def typesString = normalizeAll(qual.tpe.widen)+" and "+normalizeAll(other.tpe.widen)
       def nonSensiblyEquals() = {
-        reporter.warning(pos, s"comparing values of types $typesString using `${name.decode}` is unsafe due to cooperative equality; use `==` instead")
+        refchecksWarning(pos, s"comparing values of types $typesString using `${name.decode}` is unsafe due to cooperative equality; use `==` instead", WarningCategory.OtherNonCooperativeEquals)
       }
       def isScalaNumber(s: Symbol) = s isSubClass ScalaNumberClass
       def isJavaNumber(s: Symbol)  = s isSubClass JavaNumberClass


### PR DESCRIPTION
Add `other-non-cooperative-equals` warning category.

Follow-up to #8120