### PR TITLE
Fix ArrayBuffer incorrectly reporting the upper bound in IndexOutOfBoundsException

### DIFF
--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -95,7 +95,7 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
 
   @inline private def checkWithinBounds(lo: Int, hi: Int) = {
     if (lo < 0) throw new IndexOutOfBoundsException(s"$lo is out of bounds (min 0, max ${size0-1})")
-    if (hi > size0) throw new IndexOutOfBoundsException(s"$hi is out of bounds (min 0, max ${size0 - 1})")
+    if (hi > size0) throw new IndexOutOfBoundsException(s"${hi - 1} is out of bounds (min 0, max ${size0 - 1})")
   }
 
   def apply(n: Int): A = {

--- a/test/junit/scala/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBufferTest.scala
@@ -4,7 +4,7 @@ import org.junit.Test
 import org.junit.Assert.assertEquals
 
 import scala.annotation.nowarn
-import scala.tools.testkit.AssertUtil.assertThrows
+import scala.tools.testkit.AssertUtil.{assertThrows, fail}
 
 class ArrayBufferTest {
 
@@ -362,4 +362,22 @@ class ArrayBufferTest {
 
   @Test def t11482_allowNegativeInitialSize(): Unit =
     new ArrayBuffer(-1)
+
+  @Test def t12176_indexOutOfBoundsExceptionMessage(): Unit = {
+    def newAB = ArrayBuffer('a', 'b', 'c')
+    def iiobe[A](f: => A, msg: String) =
+      try {
+        f; fail("Did not throw IndexOutOfBoundsException")
+      } catch {
+        case ex: IndexOutOfBoundsException => assertEquals(ex.getMessage, msg)
+      }
+
+    iiobe( newAB.insert(-1, 'x'), "-1 is out of bounds (min 0, max 2)" )
+    iiobe( newAB.insertAll(-2, Array('x', 'y', 'z')), "-2 is out of bounds (min 0, max 2)" )
+    iiobe( newAB.update(-3, 'u'), "-3 is out of bounds (min 0, max 2)" )
+    iiobe( newAB.update(-1, 'u'), "-1 is out of bounds (min 0, max 2)" )
+    iiobe( newAB.update(3, 'u'), "3 is out of bounds (min 0, max 2)" )
+    iiobe( newAB(3), "3 is out of bounds (min 0, max 2)" )
+    iiobe( newAB.remove(2, 2), "3 is out of bounds (min 0, max 2)" )
+  }
 }

--- a/test/junit/scala/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBufferTest.scala
@@ -378,6 +378,7 @@ class ArrayBufferTest {
     iiobe( newAB.update(-1, 'u'), "-1 is out of bounds (min 0, max 2)" )
     iiobe( newAB.update(3, 'u'), "3 is out of bounds (min 0, max 2)" )
     iiobe( newAB(3), "3 is out of bounds (min 0, max 2)" )
+    iiobe( newAB.remove(3), "3 is out of bounds (min 0, max 2)" )
     iiobe( newAB.remove(2, 2), "3 is out of bounds (min 0, max 2)" )
   }
 }


### PR DESCRIPTION
This is the fix scala/bug#12176.
~The solution suggested there seems to work~ , so I've just applied it and added partest for this.

Thanks in advance for reviewing!