### PR TITLE
Scaladoc member permalinks now get us to destination, not to neighbors

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
@@ -361,10 +361,14 @@ trait EntityPage extends HtmlPage {
     indentation: Int = 0
   ): Elems = {
     // Sometimes it's same, do we need signatureCompat still?
-    val sig = if (mbr.signature == mbr.signatureCompat) {
-      A(id= mbr.signature) :: NoElems
-    } else {
-      A(id= mbr.signature) :: A(id= mbr.signatureCompat) :: NoElems
+    val sig = {
+      val anchorToMember = "anchorToMember"
+
+      if (mbr.signature == mbr.signatureCompat) {
+        A(id= mbr.signature, `class` = anchorToMember) :: NoElems
+      } else {
+        A(id= mbr.signature, `class` = anchorToMember) :: A(id= mbr.signatureCompat, `class` = anchorToMember) :: NoElems
+      }
     }
 
     val memberComment = memberToCommentHtml(mbr, inTpl, isSelf = false)

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.css
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.css
@@ -479,7 +479,7 @@ div#content-container > div#content {
   margin: 4em auto 0;
 }
 
-div#content-container > div#content > div#template > div#allMembers > div.members > ol > li > a.anchorToMember {
+a.anchorToMember {
   display: inline-block;
   position: relative;
   top: -5em;

--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.css
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/index.css
@@ -479,6 +479,13 @@ div#content-container > div#content {
   margin: 4em auto 0;
 }
 
+div#content-container > div#content > div#template > div#allMembers > div.members > ol > li > a.anchorToMember {
+  display: inline-block;
+  position: relative;
+  top: -5em;
+  width: 0;
+}
+
 div#content-container > div#subpackage-spacer {
   float: right;
   height: 100%;


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/11805 .

This problem seems to be just because the fixed header which is identified with `search` had be hiding other elements.