### PR TITLE
Always Emit mixin forwarders for readResolve/writeReplace

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Mixin.scala
+++ b/src/compiler/scala/tools/nsc/transform/Mixin.scala
@@ -17,6 +17,7 @@ import symtab._
 import Flags._
 import scala.annotation.tailrec
 import scala.collection.mutable
+import scala.reflect.internal.util.ListOfNil
 
 
 abstract class Mixin extends InfoTransform with ast.TreeDSL with AccessorSynthesis {
@@ -276,7 +277,11 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL with AccessorSynthes
                   JUnitAnnotations.exists(annot => annot.exists && member.hasAnnotation(annot))
               }
 
-              if (existsCompetingMethod(clazz.baseClasses) || generateJUnitForwarder)
+              def generateSerializationForwarder: Boolean = {
+                (member.name == nme.readResolve || member.name == nme.writeReplace) && member.info.paramss == ListOfNil
+              }
+
+              if (existsCompetingMethod(clazz.baseClasses) || generateJUnitForwarder || generateSerializationForwarder)
                 genForwarder(required = true)
               else if (settings.mixinForwarderChoices.isTruthy)
                 genForwarder(required = false)

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -852,6 +852,7 @@ trait StdNames {
     val values : NameType              = "values"
     val wait_ : NameType               = "wait"
     val withFilter: NameType           = "withFilter"
+    val writeReplace: NameType         = "writeReplace"
     val xml: NameType                  = "xml"
     val zero: NameType                 = "zero"
 

--- a/test/files/run/defaults-serizaliable-no-forwarders.flags
+++ b/test/files/run/defaults-serizaliable-no-forwarders.flags
@@ -1,0 +1,1 @@
+-Xmixin-force-forwarders:false

--- a/test/files/run/defaults-serizaliable-no-forwarders.scala
+++ b/test/files/run/defaults-serizaliable-no-forwarders.scala
@@ -1,0 +1,26 @@
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
+
+trait T1 extends Serializable {
+  def writeReplace(): AnyRef = new SerializationProxy(this.asInstanceOf[C].s)
+}
+trait T2 {
+  def readResolve: AnyRef = new C(this.asInstanceOf[SerializationProxy].s.toLowerCase)
+}
+class C(val s: String) extends T1
+class SerializationProxy(val s: String) extends T2 with Serializable
+
+object Test {
+  def serializeDeserialize[T <: AnyRef](obj: T) = {
+    val buffer = new ByteArrayOutputStream
+    val out = new ObjectOutputStream(buffer)
+    out.writeObject(obj)
+    val in = new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray))
+    in.readObject.asInstanceOf[T]
+  }
+
+  def main(args: Array[String]): Unit = {
+    val c1 = new C("TEXT")
+    val c2 = serializeDeserialize(c1)
+    assert(c2.s == "text")
+  }
+}

--- a/test/files/run/defaults-serizaliable-with-forwarders.scala
+++ b/test/files/run/defaults-serizaliable-with-forwarders.scala
@@ -1,0 +1,26 @@
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
+
+trait T1 extends Serializable {
+  def writeReplace(): AnyRef = new SerializationProxy(this.asInstanceOf[C].s)
+}
+trait T2 {
+  def readResolve: AnyRef = new C(this.asInstanceOf[SerializationProxy].s.toLowerCase)
+}
+class C(val s: String) extends T1
+class SerializationProxy(val s: String) extends T2 with Serializable
+
+object Test {
+  def serializeDeserialize[T <: AnyRef](obj: T) = {
+    val buffer = new ByteArrayOutputStream
+    val out = new ObjectOutputStream(buffer)
+    out.writeObject(obj)
+    val in = new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray))
+    in.readObject.asInstanceOf[T]
+  }
+
+  def main(args: Array[String]): Unit = {
+    val c1 = new C("TEXT")
+    val c2 = serializeDeserialize(c1)
+    assert(c2.s == "text")
+  }
+}


### PR DESCRIPTION
Java's serialization implementation does not consider default methods
as inheritible for readResolve/writeReplace.

See:

https://github.com/openjdk/jdk/blob/dd032b7fa67186e59446061aebe451d9d9daecd5/src/java.base/share/classes/java/io/ObjectStreamClass.java#L555-L558