### PR TITLE
Java imports compete with level 4 definitions

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -712,7 +712,7 @@ trait Contexts { self: Analyzer =>
         c(TypeConstructorAllowed) = false
 
       registerContext(c.asInstanceOf[analyzer.Context])
-      debuglog("[context] ++ " + c.unit + " / " + (if (tree == null) "" else tree.summaryString))
+      debuglog(s"[context] ++ ${c.unit} / ${if (tree == null) "" else tree.summaryString}")
       c
     }
 
@@ -1499,26 +1499,41 @@ trait Contexts { self: Analyzer =>
        *     as the reference, have lowest precedence. Also "root" imports added implicitly.
        */
       def foreignDefined = defSym.exists && thisContext.isPackageOwnedInDifferentUnit(defSym)  // SI-2458
-      // can an import at this depth possibly shadow the definition found in scope if any?
-      def importCanShadowAtDepth(imp: ImportInfo) = imp.depth > symbolDepth || (
-        if (thisContext.unit.isJava) imp.depth == symbolDepth && imp.isExplicitImport(name)
-        else foreignDefined
-      )
 
-      while (!impSym.exists && importCursor.imp1Exists && importCanShadowAtDepth(importCursor.imp1)) {
-        val (sel, sym) = lookupImport(imp1, requireExplicit = false)
-        impSel = sel
-        impSym = sym
-        if (!impSym.exists)
-          importCursor.advanceImp1Imp2()
+      // Find the first candidate import
+      def advanceCursorToNextImport(): Unit = {
+        val defIsLevel4 = foreignDefined
+        // can the import at this depth compete with the definition?
+        // If not, we can stop inspecting outer scopes (including more imports).
+        // A competing import can either shadow the definition or render it ambiguous.
+        //
+        @inline def importCanShadowAtDepth(imp: ImportInfo) = {
+          @inline def importCompetesWithDefinition =
+            if (thisContext.unit.isJava) imp.depth == symbolDepth && defIsLevel4
+            else defIsLevel4
+          imp.depth > symbolDepth || importCompetesWithDefinition
+        }
+
+        while (!impSym.exists && importCursor.imp1Exists && importCanShadowAtDepth(importCursor.imp1)) {
+          val javaRule = thisContext.unit.isJava && defIsLevel4
+          val (sel, sym) = lookupImport(imp1, requireExplicit = javaRule)
+          impSel = sel
+          impSym = sym
+          if (!impSym.exists)
+            importCursor.advanceImp1Imp2()
+        }
       }
+      advanceCursorToNextImport()
 
       val preferDef: Boolean = defSym.exists && (!impSym.exists || {
         // 4) root imported symbols have same (lowest) precedence as package-owned symbols in different compilation units.
         if (imp1.depth < symbolDepth && imp1.isRootImport && foreignDefined)
           true
         // 4) imported symbols have higher precedence than package-owned symbols in different compilation units.
-        else if (imp1.depth >= symbolDepth && foreignDefined)
+        //    except that in Java, the import must be "explicit" (level 2)
+        else if (thisContext.unit.isJava && imp1.depth == symbolDepth && foreignDefined)
+          !importCursor.imp1Explicit
+        else if (!thisContext.unit.isJava && imp1.depth >= symbolDepth && foreignDefined)
           false
         // Defined symbols take precedence over erroneous imports.
         else if (impSym.isError || impSym.name == nme.CONSTRUCTOR)
@@ -1531,8 +1546,8 @@ trait Contexts { self: Analyzer =>
           return ambiguousDefnAndImport(defSym.alternatives.head.owner, imp1)
       })
 
-      // If the defSym is at 4, and there is a def at 1 in scope, then the reference is ambiguous.
-      if (foreignDefined && !defSym.isPackage) {
+      // If the defSym is at 4, and there is a def at 1 in scope due to packaging, then the reference is ambiguous.
+      if (foreignDefined && !defSym.isPackage && !thisContext.unit.isJava) {
         val defSym0 = defSym
         val pre0    = pre
         val cx0     = cx
@@ -1919,7 +1934,7 @@ trait Contexts { self: Analyzer =>
     def sameDepth: Boolean = imp1.depth == imp2.depth
 
     private def imp2Exists = imp2Ctx.importOrNull != null
-    private def imp1Explicit = imp1 isExplicitImport name
+    def imp1Explicit = imp1 isExplicitImport name
     private def imp2Explicit = imp2 isExplicitImport name
   }
 

--- a/test/files/pos/t7232e/Foo.java
+++ b/test/files/pos/t7232e/Foo.java
@@ -1,0 +1,10 @@
+package pack;
+
+import java.util.List;   // does shadow
+import java.awt.*;       // doesn't shadow, keep looking
+import java.util.function.Supplier;  // irrelevant, keep looking
+
+public class Foo {
+    // should be java.util.List.
+    public static List list() { throw new Error(); }
+}

--- a/test/files/pos/t7232e/List.java
+++ b/test/files/pos/t7232e/List.java
@@ -1,0 +1,5 @@
+package pack;
+
+public class List {
+    public void packList() {}
+}

--- a/test/files/pos/t7232e/Test.scala
+++ b/test/files/pos/t7232e/Test.scala
@@ -1,0 +1,7 @@
+// scalac: -Werror
+object Test {
+  import pack._
+
+  // java.util.List not java.awt.List or pack.List
+  Foo.list().listIterator()
+}

--- a/test/files/pos/t7232f/C.java
+++ b/test/files/pos/t7232f/C.java
@@ -1,0 +1,8 @@
+
+import p.D;
+
+import java.util.function.Supplier;
+
+public class C {
+    public final D d = new D();
+}

--- a/test/files/pos/t7232f/D.java
+++ b/test/files/pos/t7232f/D.java
@@ -1,0 +1,4 @@
+
+public class D {
+    public void notok() { }
+}

--- a/test/files/pos/t7232f/Test.scala
+++ b/test/files/pos/t7232f/Test.scala
@@ -1,0 +1,8 @@
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val c = new C()
+    val x = c.d
+    x.ok()
+  }
+}

--- a/test/files/pos/t7232f/q.scala
+++ b/test/files/pos/t7232f/q.scala
@@ -1,0 +1,6 @@
+
+package p
+
+class D {
+  def ok() = ()
+}

--- a/test/files/pos/t7232g/Foo.java
+++ b/test/files/pos/t7232g/Foo.java
@@ -1,0 +1,8 @@
+package pack;
+
+import java.util.*;
+
+public class Foo {
+    // should be java.util.List obviously.
+    public static List list() { throw new Error(); }
+}

--- a/test/files/pos/t7232g/Test.scala
+++ b/test/files/pos/t7232g/Test.scala
@@ -1,0 +1,6 @@
+// scalac: -Werror
+object Test {
+  import pack._
+
+  Foo.list().listIterator()
+}

--- a/test/files/run/t12195/C.java
+++ b/test/files/run/t12195/C.java
@@ -1,0 +1,8 @@
+
+import p.D;
+
+import java.util.function.Supplier;
+
+public class C {
+    public final D d = new D();
+}

--- a/test/files/run/t12195/D.java
+++ b/test/files/run/t12195/D.java
@@ -1,0 +1,3 @@
+
+public class D {
+}

--- a/test/files/run/t12195/Test.scala
+++ b/test/files/run/t12195/Test.scala
@@ -1,0 +1,13 @@
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val c = new C()
+    val x = c.d
+    assert(x.toString == "ok")
+  }
+}
+/* Because scalac used wrong class D in C.java, was:
+ * java.lang.NoSuchFieldError: d
+ *   at Test$.main(Test.scala:5)
+ *   at Test.main(Test.scala)
+ */

--- a/test/files/run/t12195/q.scala
+++ b/test/files/run/t12195/q.scala
@@ -1,0 +1,6 @@
+
+package p
+
+class D {
+  override def toString = "ok"
+}


### PR DESCRIPTION
Like Scala, an import in Java can shadow a definition
in another file, if it is not import-on-demand.

The implementation bailed too quickly from searching
enclosing contexts while testing this condition.

Fixes scala/bug#12195