### PR TITLE
Use unmixed backticks more uniformly

### DIFF
--- a/src/compiler/scala/tools/nsc/javac/JavaScanners.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaScanners.scala
@@ -213,12 +213,10 @@ trait JavaScanners extends ast.parser.ScannersCommon {
       case SLASHEQ    => "`/=`"
       case TILDE      => "`~`"
       case _ =>
-        try ("`" + tokenName(token) + "'")
+        try s"`${tokenName(token)}`"
         catch {
-          case _: ArrayIndexOutOfBoundsException =>
-            "`<" + token + ">'"
-          case _: NullPointerException =>
-            "`<(" + token + ")>'"
+          case _: ArrayIndexOutOfBoundsException => s"`<$token>`"
+          case _: NullPointerException           => s"`<($token)>`"
         }
     }
   }

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -271,7 +271,7 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
   val YcacheMacroClassLoader   = CachePolicy.setting("macro", "macros")
   val YmacroClasspath = PathSetting       ("-Ymacro-classpath", "The classpath used to reflectively load macro implementations, default is the compilation classpath.", "")
 
-  val Youtline        = BooleanSetting    ("-Youtline", "Don't compile method bodies. Use together with `-Ystop-after:pickler to generate the pickled signatures for all source files.").internalOnly()
+  val Youtline        = BooleanSetting    ("-Youtline", "Don't compile method bodies. Use together with `-Ystop-after:pickler` to generate the pickled signatures for all source files.").internalOnly()
 
   val exposeEmptyPackage = BooleanSetting ("-Yexpose-empty-package", "Internal only: expose the empty package.").internalOnly()
   val Ydelambdafy        = ChoiceSetting  ("-Ydelambdafy", "strategy", "Strategy used for translating lambdas into JVM code.", List("inline", "method"), "method")

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -1346,10 +1346,10 @@ trait ContextErrors {
             "`override` modifier not allowed for constructors"
 
           case AbstractOverride =>
-            "`abstract override' modifier only allowed for members of traits"
+            "`abstract override` modifier only allowed for members of traits"
 
           case AbstractOverrideOnTypeMember =>
-            "`abstract override' modifier not allowed for type members"
+            "`abstract override` modifier not allowed for type members"
 
           case LazyAndEarlyInit =>
             "`lazy` definitions may not be initialized early"

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -403,7 +403,7 @@ abstract class RefChecks extends Transform {
             if (!(memberOverrides || other.isDeferred) && !member.isSynthetic) {
               overrideErrorConcreteMissingOverride()
             } else if (other.isAbstractOverride && other.isIncompleteIn(clazz) && !member.isAbstractOverride) {
-              overrideErrorWithMemberInfo("`abstract override' modifiers required to override:")
+              overrideErrorWithMemberInfo("`abstract override` modifiers required to override:")
             }
             else if (memberOverrides && (other hasFlag ACCESSOR) && !(other hasFlag STABLE | DEFERRED)) {
               // TODO: this is not covered by the spec.
@@ -414,7 +414,7 @@ abstract class RefChecks extends Transform {
                      !member.isDeferred && !other.isDeferred &&
                      intersectionIsEmpty(member.extendedOverriddenSymbols, other.extendedOverriddenSymbols)) {
               overrideErrorWithMemberInfo("cannot override a concrete member without a third member that's overridden by both " +
-                                          "(this rule is designed to prevent ``accidental overrides'')")
+                                          "(this rule is designed to prevent accidental overrides)")
             } else if (other.isStable && !member.isStable) { // (1.4)
               overrideErrorWithMemberInfo("stable, immutable value required to override:")
             } else if (member.isValue && member.isLazy &&
@@ -1775,7 +1775,7 @@ abstract class RefChecks extends Transform {
             tree
 
           case treeInfo.WildcardStarArg(_) if !isRepeatedParamArg(tree) =>
-            reporter.error(tree.pos, "no `: _*' annotation allowed here\n"+
+            reporter.error(tree.pos, "no `: _*` annotation allowed here\n"+
               "(such annotations are only allowed in arguments to *-parameters)")
             tree
 

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/Reporter.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/Reporter.scala
@@ -227,7 +227,7 @@ class ReplReporterImpl(val config: ShellConfig, val settings: Settings = new Set
     }
 
   override def rerunWithDetails(setting: reflect.internal.settings.MutableSettings#Setting, name: String): String =
-    s"; for details, enable `:setting $name' or `:replay $name'"
+    s"; for details, enable `:setting $name` or `:replay $name`"
 
   override def finish() = {
     if (hasWarnings) printMessage(s"${StringOps.countElementsAsString(warningCount, label(WARNING))} found")

--- a/test/files/jvm/interpreter.check
+++ b/test/files/jvm/interpreter.check
@@ -87,7 +87,7 @@ scala> case class Bar(n: Int)
 class Bar
 
 scala> implicit def foo2bar(foo: Foo) = Bar(foo.n)
-warning: 1 feature warning; for details, enable `:setting -feature' or `:replay -feature'
+warning: 1 feature warning; for details, enable `:setting -feature` or `:replay -feature`
 def foo2bar(foo: Foo): Bar
 
 scala> val bar: Bar = Foo(3)
@@ -261,7 +261,7 @@ scala> xs map (x => x)
 val res6: Array[_] = Array(1, 2)
 
 scala> xs map (x => (x, x))
-warning: 1 feature warning; for details, enable `:setting -feature' or `:replay -feature'
+warning: 1 feature warning; for details, enable `:setting -feature` or `:replay -feature`
 val res7: Array[(_$1, _$1)] forSome { type _$1 } = Array((1,1), (2,2))
 
 scala> 

--- a/test/files/neg/sd128.check
+++ b/test/files/neg/sd128.check
@@ -4,7 +4,7 @@ Test.scala:4: error: class C1 inherits conflicting members:
   (note: this can be resolved by declaring an `override` in class C1.)
 class C1 extends A with T // error
       ^
-Test.scala:5: error: cannot override a concrete member without a third member that's overridden by both (this rule is designed to prevent ``accidental overrides'')
+Test.scala:5: error: cannot override a concrete member without a third member that's overridden by both (this rule is designed to prevent accidental overrides)
 def f: Int (defined in trait T)
   with <defaultmethod> def f(): Int (defined in trait A)
 class C2 extends T with A // error

--- a/test/files/neg/t2497.check
+++ b/test/files/neg/t2497.check
@@ -1,4 +1,4 @@
-t2497.scala:21: error: cannot override a concrete member without a third member that's overridden by both (this rule is designed to prevent ``accidental overrides'')
+t2497.scala:21: error: cannot override a concrete member without a third member that's overridden by both (this rule is designed to prevent accidental overrides)
 def eval: Int (defined in class Foo)
   with absoverride def eval: Int (defined in trait DebugNode)
   (new Foo with DebugNode).eval

--- a/test/files/neg/t2497b.check
+++ b/test/files/neg/t2497b.check
@@ -1,4 +1,4 @@
-t2497b.scala:6: error: cannot override a concrete member without a third member that's overridden by both (this rule is designed to prevent ``accidental overrides'')
+t2497b.scala:6: error: cannot override a concrete member without a third member that's overridden by both (this rule is designed to prevent accidental overrides)
 def f: Int (defined in trait B)
   with override def f: Int (defined in trait AAA)
 class C extends B with AAA

--- a/test/files/neg/t6795.check
+++ b/test/files/neg/t6795.check
@@ -1,4 +1,4 @@
-t6795.scala:3: error: `abstract override' modifier not allowed for type members
+t6795.scala:3: error: `abstract override` modifier not allowed for type members
 trait T1 extends T { abstract override type U = Int }
                                             ^
 1 error

--- a/test/files/neg/t835.check
+++ b/test/files/neg/t835.check
@@ -1,8 +1,8 @@
-t835.scala:2: error: no `: _*' annotation allowed here
+t835.scala:2: error: no `: _*` annotation allowed here
 (such annotations are only allowed in arguments to *-parameters)
   Console.println(List(List(1, 2, 3) : _*, List(4, 5, 6) : _*))
                                      ^
-t835.scala:2: error: no `: _*' annotation allowed here
+t835.scala:2: error: no `: _*` annotation allowed here
 (such annotations are only allowed in arguments to *-parameters)
   Console.println(List(List(1, 2, 3) : _*, List(4, 5, 6) : _*))
                                                          ^

--- a/test/files/neg/t875.check
+++ b/test/files/neg/t875.check
@@ -1,16 +1,16 @@
-t875.scala:3: error: no `: _*' annotation allowed here
+t875.scala:3: error: no `: _*` annotation allowed here
 (such annotations are only allowed in arguments to *-parameters)
   val ys = List(1, 2, 3, xs: _*)
                            ^
-t875.scala:6: error: no `: _*' annotation allowed here
+t875.scala:6: error: no `: _*` annotation allowed here
 (such annotations are only allowed in arguments to *-parameters)
   mkList1(xs: _*)
             ^
-t875.scala:15: error: no `: _*' annotation allowed here
+t875.scala:15: error: no `: _*` annotation allowed here
 (such annotations are only allowed in arguments to *-parameters)
   f(true, 1, xs: _*)
                ^
-t875.scala:16: error: no `: _*' annotation allowed here
+t875.scala:16: error: no `: _*` annotation allowed here
 (such annotations are only allowed in arguments to *-parameters)
   g(1, xs:_*)
          ^

--- a/test/files/run/constrained-types.check
+++ b/test/files/run/constrained-types.check
@@ -69,11 +69,11 @@ scala> var four = "four"
 var four: String = four
 
 scala> val four2 = m(four) // should have an existential bound
-warning: 1 feature warning; for details, enable `:setting -feature' or `:replay -feature'
+warning: 1 feature warning; for details, enable `:setting -feature` or `:replay -feature`
 val four2: String @Annot(x) forSome { val x: String } = four
 
 scala> val four3 = four2   // should have the same type as four2
-warning: 1 feature warning; for details, enable `:setting -feature' or `:replay -feature'
+warning: 1 feature warning; for details, enable `:setting -feature` or `:replay -feature`
 val four3: String @Annot(x) forSome { val x: String } = four
 
 scala> val stuff = m("stuff") // should not crash
@@ -96,7 +96,7 @@ scala> def m = {
   val y : String @Annot(x) = x
   y
 } // x should not escape the local scope with a narrow type
-warning: 1 feature warning; for details, enable `:setting -feature' or `:replay -feature'
+warning: 1 feature warning; for details, enable `:setting -feature` or `:replay -feature`
 def m: String @Annot(x) forSome { val x: String }
 
 scala> 
@@ -110,7 +110,7 @@ scala> def n(y: String) = {
   }
   m("stuff".stripMargin)
 } // x should be existentially bound
-warning: 1 feature warning; for details, enable `:setting -feature' or `:replay -feature'
+warning: 1 feature warning; for details, enable `:setting -feature` or `:replay -feature`
 def n(y: String): String @Annot(x) forSome { val x: String }
 
 scala> 

--- a/test/files/run/macro-expand-varargs-explicit-over-nonvarargs-bad.check
+++ b/test/files/run/macro-expand-varargs-explicit-over-nonvarargs-bad.check
@@ -1,4 +1,4 @@
 reflective compilation has failed:
 
-no `: _*' annotation allowed here
+no `: _*` annotation allowed here
 (such annotations are only allowed in arguments to *-parameters)

--- a/test/files/run/repl-no-imports-no-predef-power.check
+++ b/test/files/run/repl-no-imports-no-predef-power.check
@@ -7,11 +7,11 @@ Try :help or completions for vals._ and power._
 scala> // guarding against "error: reference to global is ambiguous"
 
 scala> global.emptyValDef  // "it is imported twice in the same scope by ..."
-warning: 1 deprecation (since 2.11.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
+warning: 1 deprecation (since 2.11.0); for details, enable `:setting -deprecation` or `:replay -deprecation`
 val res0: $r.global.noSelfType.type = private val _ = _
 
 scala> val tp = ArrayClass[scala.util.Random]    // magic with tags
-warning: 1 feature warning; for details, enable `:setting -feature' or `:replay -feature'
+warning: 1 feature warning; for details, enable `:setting -feature` or `:replay -feature`
 val tp: $r.global.Type = Array[scala.util.Random]
 
 scala> tp.memberType(Array_apply)                // evidence

--- a/test/files/run/repl-paste-2.check
+++ b/test/files/run/repl-paste-2.check
@@ -30,7 +30,7 @@ res10: Int = 12
 // Replaying 8 commands from transcript.
 
 scala> 999l
-warning: 1 deprecation (since 2.13.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
+warning: 1 deprecation (since 2.13.0); for details, enable `:setting -deprecation` or `:replay -deprecation`
 val res0: Long = 999
 
 scala> val res5 = { 123 }

--- a/test/files/run/repl-power.check
+++ b/test/files/run/repl-power.check
@@ -7,11 +7,11 @@ Try :help or completions for vals._ and power._
 scala> // guarding against "error: reference to global is ambiguous"
 
 scala> global.emptyValDef  // "it is imported twice in the same scope by ..."
-warning: 1 deprecation (since 2.11.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
+warning: 1 deprecation (since 2.11.0); for details, enable `:setting -deprecation` or `:replay -deprecation`
 val res0: $r.global.noSelfType.type = private val _ = _
 
 scala> val tp = ArrayClass[scala.util.Random]    // magic with tags
-warning: 1 feature warning; for details, enable `:setting -feature' or `:replay -feature'
+warning: 1 feature warning; for details, enable `:setting -feature` or `:replay -feature`
 val tp: $r.global.Type = Array[scala.util.Random]
 
 scala> tp.memberType(Array_apply)                // evidence

--- a/test/files/run/t1931.check
+++ b/test/files/run/t1931.check
@@ -3,7 +3,7 @@ scala> val x: Any = 42
 val x: Any = 42
 
 scala> x + " works"
-warning: 1 deprecation (since 2.13.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
+warning: 1 deprecation (since 2.13.0); for details, enable `:setting -deprecation` or `:replay -deprecation`
 val res0: String = 42 works
 
 scala> import Predef.{ any2stringadd => _, _ }
@@ -17,7 +17,7 @@ scala> import Predef._
 import Predef._
 
 scala> x + " works"
-warning: 1 deprecation (since 2.13.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
+warning: 1 deprecation (since 2.13.0); for details, enable `:setting -deprecation` or `:replay -deprecation`
 val res2: String = 42 works
 
 scala> object Predef { def f = 42 }

--- a/test/files/run/t4172.check
+++ b/test/files/run/t4172.check
@@ -1,6 +1,6 @@
 
 scala> val c = { class C { override def toString = "C" }; ((new C, new C { def f = 2 })) }
-warning: 1 feature warning; for details, enable `:setting -feature' or `:replay -feature'
+warning: 1 feature warning; for details, enable `:setting -feature` or `:replay -feature`
 val c: (C, C{def f: Int}) forSome { type C <: AnyRef } = (C,C)
 
 scala> :quit

--- a/test/files/run/t4594-repl-settings.check
+++ b/test/files/run/t4594-repl-settings.check
@@ -3,7 +3,7 @@ scala> @deprecated(message="Please don't do that.", since="Time began.") def dep
 def depp: String
 
 scala> def a = depp
-warning: 1 deprecation (since Time began.); for details, enable `:setting -deprecation' or `:replay -deprecation'
+warning: 1 deprecation (since Time began.); for details, enable `:setting -deprecation` or `:replay -deprecation`
 def a: String
 
 scala> :settings -deprecation

--- a/test/files/run/t4710.check
+++ b/test/files/run/t4710.check
@@ -1,7 +1,7 @@
 
 scala> def method : String = { implicit def f(s: Symbol) = "" ; 'symbol }
-warning: 1 deprecation (since 2.13.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
-warning: 1 feature warning; for details, enable `:setting -feature' or `:replay -feature'
+warning: 1 deprecation (since 2.13.0); for details, enable `:setting -deprecation` or `:replay -deprecation`
+warning: 1 feature warning; for details, enable `:setting -feature` or `:replay -feature`
 def method: String
 
 scala> :quit

--- a/test/files/run/t6329_repl.check
+++ b/test/files/run/t6329_repl.check
@@ -3,28 +3,28 @@ scala> import scala.reflect.{ClassManifest, classTag}
 import scala.reflect.{ClassManifest, classTag}
 
 scala> implicitly[ClassManifest[scala.List[_]]]
-warning: 1 deprecation (since 2.10.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
+warning: 1 deprecation (since 2.10.0); for details, enable `:setting -deprecation` or `:replay -deprecation`
 val res0: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List[<?>]
 
 scala> classTag[scala.List[_]]
 val res1: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List
 
 scala> implicitly[ClassManifest[scala.collection.immutable.List[_]]]
-warning: 1 deprecation (since 2.10.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
+warning: 1 deprecation (since 2.10.0); for details, enable `:setting -deprecation` or `:replay -deprecation`
 val res2: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List[<?>]
 
 scala> classTag[scala.collection.immutable.List[_]]
 val res3: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List
 
 scala> implicitly[ClassManifest[Predef.Set[_]]]
-warning: 1 deprecation (since 2.10.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
+warning: 1 deprecation (since 2.10.0); for details, enable `:setting -deprecation` or `:replay -deprecation`
 val res4: scala.reflect.ClassTag[scala.collection.immutable.Set[_]] = scala.collection.immutable.Set[<?>]
 
 scala> classTag[Predef.Set[_]]
 val res5: scala.reflect.ClassTag[scala.collection.immutable.Set[_]] = scala.collection.immutable.Set
 
 scala> implicitly[ClassManifest[scala.collection.immutable.Set[_]]]
-warning: 1 deprecation (since 2.10.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
+warning: 1 deprecation (since 2.10.0); for details, enable `:setting -deprecation` or `:replay -deprecation`
 val res6: scala.reflect.ClassTag[scala.collection.immutable.Set[_]] = scala.collection.immutable.Set[<?>]
 
 scala> classTag[scala.collection.immutable.Set[_]]

--- a/test/files/run/t6329_repl_bug.check
+++ b/test/files/run/t6329_repl_bug.check
@@ -6,7 +6,7 @@ scala> import scala.reflect.runtime._
 import scala.reflect.runtime._
 
 scala> implicitly[scala.reflect.ClassManifest[List[_]]]
-warning: 1 deprecation (since 2.10.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
+warning: 1 deprecation (since 2.10.0); for details, enable `:setting -deprecation` or `:replay -deprecation`
 val res0: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List[<?>]
 
 scala> scala.reflect.classTag[List[_]]

--- a/test/files/run/t6549.check
+++ b/test/files/run/t6549.check
@@ -3,7 +3,7 @@ scala> case class `X"`(var xxx: Any)
 class X$u0022
 
 scala> val m = Map(("": Any) -> `X"`("\""), ('s: Any) -> `X"`("\""))
-warning: 1 deprecation (since 2.13.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
+warning: 1 deprecation (since 2.13.0); for details, enable `:setting -deprecation` or `:replay -deprecation`
 val m: scala.collection.immutable.Map[Any,X"] = Map("" -> X"("), Symbol(s) -> X"("))
 
 scala> m("")
@@ -19,7 +19,7 @@ scala> m("").xxx = "\""
 // mutated m("").xxx
 
 scala> m('s).xxx = 's
-warning: 2 deprecations (since 2.13.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
+warning: 2 deprecations (since 2.13.0); for details, enable `:setting -deprecation` or `:replay -deprecation`
 // mutated m(scala.Symbol("s")).xxx
 
 scala> val `"` = 0

--- a/test/files/run/t7319.check
+++ b/test/files/run/t7319.check
@@ -3,11 +3,11 @@ scala> class M[A]
 class M
 
 scala> implicit def ma0[A](a: A): M[A] = null
-warning: 1 feature warning; for details, enable `:setting -feature' or `:replay -feature'
+warning: 1 feature warning; for details, enable `:setting -feature` or `:replay -feature`
 def ma0[A](a: A): M[A]
 
 scala> implicit def ma1[A](a: A): M[A] = null
-warning: 1 feature warning; for details, enable `:setting -feature' or `:replay -feature'
+warning: 1 feature warning; for details, enable `:setting -feature` or `:replay -feature`
 def ma1[A](a: A): M[A]
 
 scala> def convert[F[X <: F[X]]](builder: F[_ <: F[_]]) = 0


### PR DESCRIPTION
I was disturbed again, hopefully for the last time, by the highlighting of
```scala
error: no `: _*' annotation allowed here
```
Because Halloween is nigh, one might regret losing the frightfully scary scare quotes at
```scala
``accidental overrides''
```