### PR TITLE
Make `ArrayBuffer`'s iterator fail fast when buffer is mutated

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -31,6 +31,29 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.Predef#ArrayCharSequence.isEmpty"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.ArrayCharSequence.isEmpty"),
 
+    // #9425 Node is private[collection]
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.mutable.HashMap#Node.foreachEntry"),
+
+    // Fixes for scala/bug#12009
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.mutable.ArrayBufferView.this"),                  // private[mutable]
+    ProblemFilters.exclude[FinalClassProblem]("scala.collection.IndexedSeqView$IndexedSeqViewIterator"),                  // private[collection]
+    ProblemFilters.exclude[FinalClassProblem]("scala.collection.IndexedSeqView$IndexedSeqViewReverseIterator"),           // private[collection]
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.mutable.CheckedIndexedSeqView"),                        // private[mutable]
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.mutable.CheckedIndexedSeqView$"),                       // private[mutable]
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.mutable.CheckedIndexedSeqView$CheckedIterator"),        // private[mutable]
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.mutable.CheckedIndexedSeqView$CheckedReverseIterator"), // private[mutable]
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.mutable.CheckedIndexedSeqView$Id"),                     // private[mutable]
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.mutable.CheckedIndexedSeqView$Appended"),               // private[mutable]
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.mutable.CheckedIndexedSeqView$Prepended"),              // private[mutable]
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.mutable.CheckedIndexedSeqView$Concat"),                 // private[mutable]
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.mutable.CheckedIndexedSeqView$Take"),                   // private[mutable]
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.mutable.CheckedIndexedSeqView$TakeRight"),              // private[mutable]
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.mutable.CheckedIndexedSeqView$Drop"),                   // private[mutable]
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.mutable.CheckedIndexedSeqView$DropRight"),              // private[mutable]
+    ProblemFilters.exclude[MissingClassProblem](s"scala.collection.mutable.CheckedIndexedSeqView$$Map"),                  // private[mutable]
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.mutable.CheckedIndexedSeqView$Reverse"),                // private[mutable]
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.mutable.CheckedIndexedSeqView$Slice"),                  // private[mutable]
+
     // #8835
     ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.reflect.runtime.SynchronizedOps#SynchronizedBaseTypeSeq.scala$reflect$runtime$SynchronizedOps$SynchronizedBaseTypeSeq$$super$maxDepthOfElems"),
 
@@ -42,7 +65,7 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.reflect.io.FileZipArchive#LeakyEntry.this"),
     ProblemFilters.exclude[MissingClassProblem]("scala.reflect.io.FileZipArchive$zipFilePool$"),
 
-    )
+  )
 
   override val buildSettings = Seq(
     mimaFailOnNoPrevious := false, // we opt everything out, knowing we only check library/reflect

--- a/src/library/scala/collection/IndexedSeq.scala
+++ b/src/library/scala/collection/IndexedSeq.scala
@@ -47,15 +47,7 @@ trait IndexedSeqOps[+A, +CC[_], +C] extends Any with SeqOps[A, CC, C] { self =>
     s.asInstanceOf[S with EfficientSplit]
   }
 
-  override def reverseIterator: Iterator[A] = new AbstractIterator[A] {
-    private[this] var i = self.length
-    def hasNext: Boolean = 0 < i
-    def next(): A =
-      if (0 < i) {
-        i -= 1
-        self(i)
-      } else Iterator.empty.next()
-  }
+  override def reverseIterator: Iterator[A] = view.reverseIterator
 
   override def foldRight[B](z: B)(op: (A, B) => B): B = {
     val it = reverseIterator

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -167,6 +167,10 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
         size0 = size0 + elemsLength
         elems match {
           case elems: ArrayBuffer[_] =>
+            // if `elems eq this`, this works because `elems.array eq this.array`,
+            // we didn't overwrite the values being inserted after moving them in
+            // the previous copy a few lines up, and `System.arraycopy` will
+            // effectively "read" all the values before overwriting any of them.
             Array.copy(elems.array, 0, array, index, elemsLength)
           case _ =>
             var i = 0

--- a/src/library/scala/collection/mutable/CheckedIndexedSeqView.scala
+++ b/src/library/scala/collection/mutable/CheckedIndexedSeqView.scala
@@ -1,0 +1,117 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package collection
+package mutable
+
+private[mutable] trait CheckedIndexedSeqView[+A] extends IndexedSeqView[A] {
+  protected val mutationCount: () => Int
+
+  override def iterator: Iterator[A] = new CheckedIndexedSeqView.CheckedIterator(this, mutationCount())
+  override def reverseIterator: Iterator[A] = new CheckedIndexedSeqView.CheckedReverseIterator(this, mutationCount())
+
+  override def appended[B >: A](elem: B): IndexedSeqView[B] = new CheckedIndexedSeqView.Appended(this, elem)(mutationCount)
+  override def prepended[B >: A](elem: B): IndexedSeqView[B] = new CheckedIndexedSeqView.Prepended(elem, this)(mutationCount)
+  override def take(n: Int): IndexedSeqView[A] = new CheckedIndexedSeqView.Take(this, n)(mutationCount)
+  override def takeRight(n: Int): IndexedSeqView[A] = new CheckedIndexedSeqView.TakeRight(this, n)(mutationCount)
+  override def drop(n: Int): IndexedSeqView[A] = new CheckedIndexedSeqView.Drop(this, n)(mutationCount)
+  override def dropRight(n: Int): IndexedSeqView[A] = new CheckedIndexedSeqView.DropRight(this, n)(mutationCount)
+  override def map[B](f: A => B): IndexedSeqView[B] = new CheckedIndexedSeqView.Map(this, f)(mutationCount)
+  override def reverse: IndexedSeqView[A] = new CheckedIndexedSeqView.Reverse(this)(mutationCount)
+  override def slice(from: Int, until: Int): IndexedSeqView[A] = new CheckedIndexedSeqView.Slice(this, from, until)(mutationCount)
+  override def tapEach[U](f: A => U): IndexedSeqView[A] = new CheckedIndexedSeqView.Map(this, { (a: A) => f(a); a})(mutationCount)
+
+  override def concat[B >: A](suffix: IndexedSeqView.SomeIndexedSeqOps[B]): IndexedSeqView[B] = new CheckedIndexedSeqView.Concat(this, suffix)(mutationCount)
+  override def appendedAll[B >: A](suffix: IndexedSeqView.SomeIndexedSeqOps[B]): IndexedSeqView[B] = new CheckedIndexedSeqView.Concat(this, suffix)(mutationCount)
+  override def prependedAll[B >: A](prefix: IndexedSeqView.SomeIndexedSeqOps[B]): IndexedSeqView[B] = new CheckedIndexedSeqView.Concat(prefix, this)(mutationCount)
+}
+
+private[mutable] object CheckedIndexedSeqView {
+  import IndexedSeqView.SomeIndexedSeqOps
+
+  @SerialVersionUID(3L)
+  private[mutable] class CheckedIterator[A](self: IndexedSeqView[A], mutationCount: => Int)
+    extends IndexedSeqView.IndexedSeqViewIterator[A](self) {
+    private[this] val expectedCount = mutationCount
+    override def hasNext: Boolean = {
+      MutationTracker.checkMutationsForIteration(expectedCount, mutationCount)
+      super.hasNext
+    }
+  }
+
+  @SerialVersionUID(3L)
+  private[mutable] class CheckedReverseIterator[A](self: IndexedSeqView[A], mutationCount: => Int)
+    extends IndexedSeqView.IndexedSeqViewReverseIterator[A](self) {
+    private[this] val expectedCount = mutationCount
+    override def hasNext: Boolean = {
+      MutationTracker.checkMutationsForIteration(expectedCount, mutationCount)
+      super.hasNext
+    }
+  }
+
+  @SerialVersionUID(3L)
+  class Id[+A](underlying: SomeIndexedSeqOps[A])(protected val mutationCount: () => Int)
+    extends IndexedSeqView.Id(underlying) with CheckedIndexedSeqView[A]
+
+  @SerialVersionUID(3L)
+  class Appended[+A](underlying: SomeIndexedSeqOps[A], elem: A)(protected val mutationCount: () => Int)
+    extends IndexedSeqView.Appended(underlying, elem) with CheckedIndexedSeqView[A]
+
+  @SerialVersionUID(3L)
+  class Prepended[+A](elem: A, underlying: SomeIndexedSeqOps[A])(protected val mutationCount: () => Int)
+    extends IndexedSeqView.Prepended(elem, underlying) with CheckedIndexedSeqView[A]
+
+  @SerialVersionUID(3L)
+  class Concat[A](prefix: SomeIndexedSeqOps[A], suffix: SomeIndexedSeqOps[A])(protected val mutationCount: () => Int)
+    extends IndexedSeqView.Concat[A](prefix, suffix) with CheckedIndexedSeqView[A]
+
+  @SerialVersionUID(3L)
+  class Take[A](underlying: SomeIndexedSeqOps[A], n: Int)(protected val mutationCount: () => Int)
+    extends IndexedSeqView.Take(underlying, n) with CheckedIndexedSeqView[A]
+
+  @SerialVersionUID(3L)
+  class TakeRight[A](underlying: SomeIndexedSeqOps[A], n: Int)(protected val mutationCount: () => Int)
+    extends IndexedSeqView.TakeRight(underlying, n) with CheckedIndexedSeqView[A]
+
+  @SerialVersionUID(3L)
+  class Drop[A](underlying: SomeIndexedSeqOps[A], n: Int)(protected val mutationCount: () => Int)
+    extends IndexedSeqView.Drop[A](underlying, n) with CheckedIndexedSeqView[A]
+
+  @SerialVersionUID(3L)
+  class DropRight[A](underlying: SomeIndexedSeqOps[A], n: Int)(protected val mutationCount: () => Int)
+    extends IndexedSeqView.DropRight[A](underlying, n) with CheckedIndexedSeqView[A]
+
+  @SerialVersionUID(3L)
+  class Map[A, B](underlying: SomeIndexedSeqOps[A], f: A => B)(protected val mutationCount: () => Int)
+    extends IndexedSeqView.Map(underlying, f) with CheckedIndexedSeqView[B]
+
+  @SerialVersionUID(3L)
+  class Reverse[A](underlying: SomeIndexedSeqOps[A])(protected val mutationCount: () => Int)
+    extends IndexedSeqView.Reverse[A](underlying) with CheckedIndexedSeqView[A] {
+    override def reverse: IndexedSeqView[A] = underlying match {
+      case x: IndexedSeqView[A] => x
+      case _ => super.reverse
+    }
+  }
+
+  @SerialVersionUID(3L)
+  class Slice[A](underlying: SomeIndexedSeqOps[A], from: Int, until: Int)(protected val mutationCount: () => Int)
+    extends AbstractIndexedSeqView[A] with CheckedIndexedSeqView[A] {
+    protected val lo = from max 0
+    protected val hi = (until max 0) min underlying.length
+    protected val len = (hi - lo) max 0
+    @throws[IndexOutOfBoundsException]
+    def apply(i: Int): A = underlying(lo + i)
+    def length: Int = len
+  }
+}

--- a/test/benchmarks/src/main/scala/scala/collection/mutable/ArrayBufferBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/mutable/ArrayBufferBenchmark.scala
@@ -1,0 +1,97 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection.mutable
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra._
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 15)
+@Measurement(iterations = 15)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class ArrayBufferBenchmark {
+  @Param(Array(/*"0", "1",*/ "10", "100", "1000", "10000"))
+  var size: Int = _
+
+  var ref: ArrayBuffer[Int] = _
+
+  @Setup(Level.Trial) def init: Unit = {
+    ref = new ArrayBuffer
+    for(i <- 0 until size) ref += i
+  }
+
+  @Benchmark def filterInPlace(bh: Blackhole): Unit = {
+    val b = ref.clone()
+    b.filterInPlace(_ % 2 == 0)
+    bh.consume(b)
+  }
+
+  @Benchmark def update(bh: Blackhole): Unit = {
+    val b = ref.clone()
+    var i = 0
+    while(i < size) {
+      b.update(i, -1)
+      i += 2
+    }
+    bh.consume(b)
+  }
+
+  @Benchmark def addAll(bh: Blackhole): Unit = {
+    val b1 = ref.clone()
+    val b2 = ref.clone()
+    var i = 0
+    b1.addAll(b2)
+    bh.consume(b1)
+  }
+
+  @Benchmark def flatMapInPlace1(bh: Blackhole): Unit = {
+    val b = ref.clone()
+    val seq = Seq(0,0)
+    b.flatMapInPlace { _ => seq }
+    bh.consume(b)
+  }
+
+  @Benchmark def iteratorA(bh: Blackhole): Unit = {
+    val b = ref.clone()
+    var n = 0
+    for (x <- b.iterator) n += x
+    bh.consume(n)
+    bh.consume(b)
+  }
+
+  @Benchmark def iteratorB(bh: Blackhole): Unit = {
+    val b = ref.clone()
+    bh.consume(b.iterator.toVector)
+    bh.consume(b)
+  }
+
+  @Benchmark def reverseIteratorA(bh: Blackhole): Unit = {
+    val b = ref.clone()
+    var n = 0
+    for (x <- b.reverseIterator) n += x
+    bh.consume(n)
+    bh.consume(b)
+  }
+
+  @Benchmark def reverseIteratorB(bh: Blackhole): Unit = {
+    val b = ref.clone()
+    bh.consume(b.reverseIterator.toVector)
+    bh.consume(b)
+  }
+
+}

--- a/test/junit/scala/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBufferTest.scala
@@ -4,7 +4,7 @@ import org.junit.Test
 import org.junit.Assert.{assertEquals, assertTrue}
 
 import scala.annotation.nowarn
-import scala.tools.testkit.AssertUtil.{assertThrows, fail}
+import scala.tools.testkit.AssertUtil.{assertSameElements, assertThrows, fail}
 import scala.tools.testkit.ReflectUtil.{getMethodAccessible, _}
 
 class ArrayBufferTest {
@@ -446,5 +446,13 @@ class ArrayBufferTest {
     assertEquals(17, resizeDown(17, 3))
     assertEquals(32, resizeDown(64, 30))
     assertEquals(21, resizeDown(42, 17))
+  }
+
+  // scala/bug#12121
+  @Test
+  def insertAll_self(): Unit = {
+    val buf = ArrayBuffer(1, 2, 3)
+    buf.insertAll(1, buf)
+    assertSameElements(List(1, 1, 2, 3, 2, 3), buf)
   }
 }


### PR DESCRIPTION
Make `ArrayBuffer`'s iterator fail-fast when the buffer is mutated after the iterator's creation.

Fix inserting an `ArrayBuffer` into itself (scala/bug#12121).

Partially addresses scala/bug#12121 and scala/bug#12009