### PR TITLE
[backport] always keep a field for `private[this] var` class parameters

### DIFF
--- a/test/files/run/t12002.check
+++ b/test/files/run/t12002.check
@@ -1,1 +1,10 @@
 good boy!
+List()
+List()
+List()
+List(private int D.x)
+List(private int E.x)
+List(private int F.x)
+List(private int G.x)
+List(private final int H.x)
+List(private int I.x)

--- a/test/files/run/t12002.check
+++ b/test/files/run/t12002.check
@@ -1,7 +1,7 @@
 good boy!
 List()
 List()
-List()
+List(private int C.x)
 List(private int D.x)
 List(private int E.x)
 List(private int F.x)

--- a/test/files/run/t12002.scala
+++ b/test/files/run/t12002.scala
@@ -1,12 +1,24 @@
-class C(private[this] var c: String) {
+class C0(private[this] var c: String) {
   private[this] var x: String = _
   c = "good"
   x = c + " boy!"
   override def toString = x
 }
 
+class A(x: Int) { assert(x == 1) } // elided
+class B(private[this] val x: Int) { assert(x == 1) } // elided
+class C(private[this] var x: Int) { } // elided
+class D(private[this] var x: Int) { assert(x == 1) } // kept
+class E(private[this] var x: Int) { x = 2 } // kept
+class F(private[this] var x: Int) { x = 2; assert(x == 2) } // kept
+class G(private[this] var x: Int) { x = 2; assert(x == 2); def m() = assert(x == 2, "m" + x); m() } // kept
+class H(private val x: Int) { } // kept
+class I(private var x: Int) { } // kept
+
 object Test {
-  def main(args: Array[String]) = println {
-    new C("bad")
+  def fs(o: AnyRef) = println(o.getClass.getDeclaredFields.toList)
+  def main(args: Array[String]): Unit = {
+    println(new C0("bad"))
+    List(new A(1), new B(1), new C(1), new D(1), new E(1), new F(1), new G(1), new H(1), new I(1)).foreach(fs)
   }
 }

--- a/test/files/run/t12002.scala
+++ b/test/files/run/t12002.scala
@@ -7,7 +7,7 @@ class C0(private[this] var c: String) {
 
 class A(x: Int) { assert(x == 1) } // elided
 class B(private[this] val x: Int) { assert(x == 1) } // elided
-class C(private[this] var x: Int) { } // elided
+class C(private[this] var x: Int) { } // kept
 class D(private[this] var x: Int) { assert(x == 1) } // kept
 class E(private[this] var x: Int) { x = 2 } // kept
 class F(private[this] var x: Int) { x = 2; assert(x == 2) } // kept


### PR DESCRIPTION
Backport of https://github.com/scala/scala/pull/9226

Fixes https://github.com/scala/bug/issues/12096