### PR TITLE
ListMap is reverse oriented, so use that for foldRight (forward-port)

### DIFF
--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -107,6 +107,7 @@ sealed class ListMap[K, +V]
   private[immutable] def value: V = throw new NoSuchElementException("value of empty map")
   private[immutable] def next: ListMap[K, V] = throw new NoSuchElementException("next of empty map")
 
+  override def foldRight[Z](z: Z)(op: ((K, V), Z) => Z): Z = ListMap.foldRightInternal(this, z, op)
   override protected[this] def className = "ListMap"
 
 }
@@ -272,6 +273,11 @@ object ListMap extends MapFactory[ListMap] {
     * @tparam V the map value type
     */
   def newBuilder[K, V]: ReusableBuilder[(K, V), ListMap[K, V]] = new ListMapBuilder[K, V]
+
+  @tailrec private def foldRightInternal[K, V, Z](map: ListMap[K, V], prevValue: Z, op: ((K, V), Z) => Z): Z = {
+    if (map.isEmpty) prevValue
+    else foldRightInternal(map.init, op(map.last, prevValue), op)
+  }
 }
 
 /** Builder for ListMap.

--- a/test/junit/scala/collection/immutable/ListMapTest.scala
+++ b/test/junit/scala/collection/immutable/ListMapTest.scala
@@ -5,8 +5,11 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
+import scala.runtime.AbstractFunction2
+import scala.tools.testkit.AllocationTest
+
 @RunWith(classOf[JUnit4])
-class ListMapTest {
+class ListMapTest extends AllocationTest {
 
   @Test
   def t7445(): Unit = {
@@ -51,4 +54,55 @@ class ListMapTest {
     val m = ListMap("a" -> "1", "b" -> "2", "c" -> "3", "d" -> "4", "e" -> "5")
     assertEquals(List("A", "B", "C", "D", "E"), m.keys.map(_.toUpperCase).toList)
   }
+
+  @Test
+  def foldRightAllocations(): Unit = {
+    var m = ListMap.empty[Int, Int]
+    object acc extends AbstractFunction2[(Int, Int), String, String] {
+      def dataFrom(m: ListMap[Int, Int]): Unit = {
+        data = m.toArray.reverse
+        strings = data map (x => x.toString+"XX")
+      }
+
+      var data = m.toArray
+      var strings = new Array[String](0)
+      var index = -1
+      var last = ""
+
+      def reset = {
+        index = -1
+        last = "INIT"
+        last
+      }
+      override def apply(v1: (Int, Int), v2: String): String = {
+        assert (v2 eq last)
+        index += 1
+        if (v1 != data(index))
+          throw new AssertionError(s"index: $index expected ${data(index)} but was $v1")
+        last = strings(index)
+        last
+      }
+    }
+    acc.dataFrom(m)
+    assertEquals("INIT", nonAllocating(m.foldRight(acc.reset)(acc)))
+
+    m = ListMap(1 -> 1)
+    acc.dataFrom(m)
+    assertEquals("(1,1)XX", exactAllocates(tuples(m.size))(m.foldRight(acc.reset)(acc)))
+
+    m = ListMap(1 -> 1, 2 -> 2)
+    acc.dataFrom(m)
+    assertEquals("(1,1)XX", exactAllocates(tuples(m.size))(m.foldRight(acc.reset)(acc)))
+
+    m = ListMap(1 -> 1, 2 -> 2, 3 -> 3)
+    acc.dataFrom(m)
+    assertEquals("(1,1)XX", exactAllocates(tuples(m.size))(m.foldRight(acc.reset)(acc)))
+  }
+
+  /** we base the result on tuples of strings as ListMap is not specialised */
+  private def tuples(n: Int) = ListMapTest.tupleStringCost * n
+}
+
+object ListMapTest {
+  val tupleStringCost = AllocationTest.sizeOf(("1","1"), "a tuple of Strings")
 }


### PR DESCRIPTION
(cherry picked from commit 2103368a92faea671c15e67e330aa9af6c0cc467)
Forward-port of #9218
Refs https://github.com/scala/scala-dev/issues/721