### PR TITLE
No mixin forwarders for known binary incompatible trait overrides

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Mixin.scala
+++ b/src/compiler/scala/tools/nsc/transform/Mixin.scala
@@ -29,32 +29,6 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL with AccessorSynthes
   /** The name of the phase: */
   val phaseName: String = "mixin"
 
-  // See https://github.com/scala/bug/issues/12137#issuecomment-695944076
-  lazy val binaryIncompatibleTraitOverrides: Set[Symbol] = {
-    def meth(path: List[String], cls: Symbol): Symbol = path match {
-      case m :: Nil => cls.map(_.info.member(TermName(m)))
-      case i :: xs  => meth(xs, cls.map(_.info.member(TypeName(i))))
-    }
-    // Trait overrides that were added, list from https://github.com/scala/scala/pull/9260/files
-    // `FloatOrdering.reverse` and `DoubleOrdering.reverse` are trait overrides that were removed (not added)
-    // in 44318c8959, so there's nothing we can do. Compiling with 2.12.0 and running on 2.12.12 is not binary
-    // compatible for super calls to these two methods.
-    enteringTyper{
-      Set(
-        List("scala.math.Ordering.IntOrdering", "reverse"),
-        List("scala.collection.IndexedSeqOptimized", "toList"),
-        List("scala.collection.LinearSeqOptimized", "tails"),
-        List("scala.collection.TraversableViewLike", "Transformed", "last"),
-        List("scala.collection.immutable.SortedSet", "equals"),
-        List("scala.collection.immutable.SortedMap", "equals"),
-        List("scala.math.Ordering.OptionOrdering", "equals"),
-        List("scala.math.Ordering.OptionOrdering", "hashCode"),
-        ).map({
-          case c :: xs => meth(xs, rootMirror.getClassIfDefined(c))
-        }).filterNot(_ == NoSymbol)
-    }
-  }
-
   /** Some trait methods need to be implemented in subclasses, so they cannot be private.
     *
     * We used to publicize during explicitouter (for some reason), so the condition is a bit more involved now it's done here
@@ -309,7 +283,7 @@ abstract class Mixin extends InfoTransform with ast.TreeDSL with AccessorSynthes
 
               if (existsCompetingMethod(clazz.baseClasses) || generateJUnitForwarder || generateSerializationForwarder)
                 genForwarder(required = true)
-              else if (settings.mixinForwarderChoices.isTruthy && !binaryIncompatibleTraitOverrides(member))
+              else if (settings.mixinForwarderChoices.isTruthy)
                 genForwarder(required = false)
             }
 

--- a/src/library/scala/collection/GenMapLike.scala
+++ b/src/library/scala/collection/GenMapLike.scala
@@ -117,6 +117,9 @@ trait GenMapLike[K, +V, +Repr] extends GenIterableLike[(K, V), Repr] with Equals
    *              same mappings, `false` otherwise.
    */
   override def equals(that: Any): Boolean = that match {
+    case _ if this eq that.asInstanceOf[AnyRef] => true
+    case sm: immutable.SortedMap[_, _] if this.isInstanceOf[immutable.SortedMap[_, _]] && sm.ordering == this.asInstanceOf[immutable.SortedMap[_, _]].ordering =>
+      this.asInstanceOf[immutable.SortedMap[_, _]].equalsImpl(sm)
     case that: GenMap[b, _] =>
       (this eq that) ||
       (that canEqual this) &&

--- a/src/library/scala/collection/GenSetLike.scala
+++ b/src/library/scala/collection/GenSetLike.scala
@@ -117,6 +117,9 @@ extends GenIterableLike[A, Repr]
    *              as this set.
    */
   override def equals(that: Any): Boolean = that match {
+    case _ if this eq that.asInstanceOf[AnyRef] => true
+    case ss: immutable.SortedSet[_] if this.isInstanceOf[immutable.SortedSet[_]] && ss.ordering == this.asInstanceOf[immutable.SortedSet[_]].ordering =>
+      this.asInstanceOf[immutable.SortedSet[_]].equalsImpl(ss)
     case that: GenSet[_] =>
       (this eq that) ||
       (that canEqual this) &&

--- a/src/library/scala/collection/LinearSeqOptimized.scala
+++ b/src/library/scala/collection/LinearSeqOptimized.scala
@@ -320,6 +320,9 @@ trait LinearSeqOptimized[+A, +Repr <: LinearSeqOptimized[A, Repr]] extends Linea
     last
   }
 
+  private[collection] final def tailsImpl: Iterator[Repr] =
+    Iterator.iterate(repr)(_.tail).takeWhile(_.nonEmpty) ++ Iterator(newBuilder.result)
+
   override /*TraversableLike*/
-  def tails: Iterator[Repr] = Iterator.iterate(repr)(_.tail).takeWhile(_.nonEmpty) ++ Iterator(newBuilder.result)
+  def tails: Iterator[Repr] = tailsImpl
 }

--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -623,11 +623,14 @@ trait TraversableLike[+A, +Repr] extends Any
     * @return The last element of this $coll.
     * @throws NoSuchElementException If the $coll is empty.
     */
-  def last: A = {
-    var lst = head
-    for (x <- this)
-      lst = x
-    lst
+  def last: A = this match {
+    case t: TraversableViewLike[_, _, _]#Transformed[A] =>
+      t.lastImpl
+    case _ =>
+      var lst = head
+      for (x <- this)
+        lst = x
+      lst
   }
 
   /** Optionally selects the last element.
@@ -751,7 +754,10 @@ trait TraversableLike[+A, +Repr] extends Any
    *  @return   an iterator over all the tails of this $coll
    *  @example  `List(1,2,3).tails = Iterator(List(1,2,3), List(2,3), List(3), Nil)`
    */
-  def tails: Iterator[Repr] = iterateUntilEmpty(_.tail)
+  def tails: Iterator[Repr] = this match {
+    case lso: LinearSeqOptimized[_, Repr] => lso.tailsImpl
+    case _ => iterateUntilEmpty(_.tail)
+  }
 
   /** Iterates over the inits of this $coll. The first value will be this
    *  $coll and the final one will be an empty $coll, with the intervening

--- a/src/library/scala/collection/TraversableOnce.scala
+++ b/src/library/scala/collection/TraversableOnce.scala
@@ -347,7 +347,19 @@ trait TraversableOnce[+A] extends Any with GenTraversableOnce[A] {
 
   def toTraversable: Traversable[A]
 
-  def toList: List[A] = to[List]
+  def toList: List[A] = this match {
+    case iso: IndexedSeqOptimized[_, _] =>
+      var i = iso.length - 1
+      var result: List[A] = Nil
+      while (i >= 0) {
+        result ::= iso.apply(i)
+        i -= 1
+      }
+      result
+
+    case _ =>
+      to[List]
+  }
 
   def toIterable: Iterable[A] = toStream
 

--- a/src/library/scala/collection/TraversableViewLike.scala
+++ b/src/library/scala/collection/TraversableViewLike.scala
@@ -116,7 +116,7 @@ trait TraversableViewLike[+A,
       None
     }
 
-    override def last: B = {
+    private[collection] def lastImpl: B = {
       // (Should be) better than allocating a Some for every element.
       var empty = true
       var result: B = null.asInstanceOf[B]
@@ -126,6 +126,8 @@ trait TraversableViewLike[+A,
       }
       if (empty) throw new NoSuchElementException("last of empty traversable") else result
     }
+
+    override def last: B = lastImpl
 
     override def lastOption: Option[B] = {
       // (Should be) better than allocating a Some for every element.

--- a/src/library/scala/collection/immutable/SortedMap.scala
+++ b/src/library/scala/collection/immutable/SortedMap.scala
@@ -102,18 +102,21 @@ self =>
     override def valuesIteratorFrom(start : A) = self valuesIteratorFrom start map f
   }
 
+  final private[collection] def equalsImpl(sm: SortedMap[_, _]): Boolean = {
+    (sm canEqual this) &&
+      (this.size == sm.size) && {
+      val i1 = this.iterator
+      val i2 = sm.iterator
+      var allEqual = true
+      while (allEqual && i1.hasNext)
+        allEqual = i1.next() == i2.next()
+      allEqual
+    }
+  }
+
   override def equals(that: Any): Boolean = that match {
     case _ if this eq that.asInstanceOf[AnyRef] => true
-    case sm: SortedMap[k, v] if sm.ordering == this.ordering =>
-      (sm canEqual this) &&
-        (this.size == sm.size) && {
-        val i1 = this.iterator
-        val i2 = sm.iterator
-        var allEqual = true
-        while (allEqual && i1.hasNext)
-          allEqual = i1.next() == i2.next()
-        allEqual
-      }
+    case sm: SortedMap[_, _] if sm.ordering == this.ordering => equalsImpl(sm)
     case _ => super.equals(that)
   }
 }

--- a/src/library/scala/collection/immutable/SortedSet.scala
+++ b/src/library/scala/collection/immutable/SortedSet.scala
@@ -29,20 +29,22 @@ trait SortedSet[A] extends Set[A] with scala.collection.SortedSet[A] with Sorted
   /** Needs to be overridden in subclasses. */
   override def empty: SortedSet[A] = SortedSet.empty[A]
 
+  private[collection] def equalsImpl(ss: SortedSet[_]): Boolean = {
+    (ss canEqual this) &&
+      (this.size == ss.size) && {
+      val i1 = this.iterator
+      val i2 = ss.iterator
+      var allEqual = true
+      while (allEqual && i1.hasNext)
+        allEqual = i1.next() == i2.next
+      allEqual
+    }
+  }
+
   override def equals(that: Any): Boolean = that match {
     case _ if this eq that.asInstanceOf[AnyRef] => true
-    case ss: SortedSet[_] if ss.ordering == this.ordering =>
-      (ss canEqual this) &&
-        (this.size == ss.size) && {
-        val i1 = this.iterator
-        val i2 = ss.iterator
-        var allEqual = true
-        while (allEqual && i1.hasNext)
-          allEqual = i1.next() == i2.next
-        allEqual
-      }
-    case _ =>
-      super.equals(that)
+    case ss: SortedSet[_] if ss.ordering == this.ordering => equalsImpl(ss)
+    case _ => super.equals(that)
   }
 }
 /** $factoryInfo

--- a/src/library/scala/collection/immutable/Stream.scala
+++ b/src/library/scala/collection/immutable/Stream.scala
@@ -201,6 +201,7 @@ import scala.language.implicitConversions
  *  @define orderDependentFold
  *  @define willTerminateInf Note: lazily evaluated; will terminate for infinite-sized collections.
  */
+@SerialVersionUID(4897901117128916054L)
 sealed abstract class Stream[+A] extends AbstractSeq[A]
                              with LinearSeq[A]
                              with GenericTraversableTemplate[A, Stream]
@@ -1103,6 +1104,7 @@ object Stream extends SeqFactory[Stream] {
     def result: Stream[A] = parts.toStream flatMap (_.toStream)
   }
 
+  @SerialVersionUID(-7198474341142331012L)
   object Empty extends Stream[Nothing] {
     override def isEmpty = true
     override def head = throw new NoSuchElementException("head of empty stream")

--- a/src/library/scala/collection/mutable/Queue.scala
+++ b/src/library/scala/collection/mutable/Queue.scala
@@ -32,6 +32,7 @@ import generic._
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
  */
+@SerialVersionUID(-5130636723247980089L)
 class Queue[A]
 extends MutableList[A]
    with LinearSeqOptimized[A, Queue[A]]

--- a/src/library/scala/collection/mutable/SynchronizedQueue.scala
+++ b/src/library/scala/collection/mutable/SynchronizedQueue.scala
@@ -27,6 +27,7 @@ package mutable
  *  @define coll synchronized queue
  */
 @deprecated("Synchronization via selective overriding of methods is inherently unreliable. Consider java.util.concurrent.ConcurrentLinkedQueue as an alternative.", "2.11.0")
+@SerialVersionUID(9032322813113599864L)
 class SynchronizedQueue[A] extends Queue[A] {
   /** Checks if the queue is empty.
    *

--- a/src/library/scala/math/Numeric.scala
+++ b/src/library/scala/math/Numeric.scala
@@ -59,7 +59,9 @@ object Numeric {
     def toFloat(x: Int): Float = x.toFloat
     def toDouble(x: Int): Double = x.toDouble
   }
-  implicit object IntIsIntegral extends IntIsIntegral with Ordering.IntOrdering
+  implicit object IntIsIntegral extends IntIsIntegral with Ordering.IntOrdering {
+    override def reverse: Ordering[Int] = Ordering.IntReverse
+  }
 
   trait ShortIsIntegral extends Integral[Short] {
     def plus(x: Short, y: Short): Short = (x + y).toShort


### PR DESCRIPTION
New overrides added to traits are not forwards binary compatible
(scala/bug#12137).

For those overrides that were added since 2.12.0, a new special case
in Mixin avoids generating the mixin forwarder, so compiling with
2.12.13 will emit code that is binary compatible with 2.12.0.

Tested with this code:

```
object A extends scala.math.Ordering.IntOrdering   // `reverse` override was added
object B extends scala.math.Ordering.FloatOrdering // `reverse` override was removed

object Test {
  def main(args: Array[String]): Unit = {
    println(A.reverse)
    println(B.reverse)
  }
}
```

Code compiled with 2.12.13 (qsc/qs) works with all 2.12 libraries
thanks to this fix.

```
qsc Test.scala && sv 2.12.0 Test && sv 2.12.12 Test && qs Test
```

Code compiled with 2.12.0 fails on 2.12.12. The super call in the
generated mixin forwarder `B.reverse` invokes the static method
`FloatOrdering.reverse$` that no longer exists. This will be the same
in 2.12.13.

```
scv 2.12.0 Test.scala && sv 2.12.12 Test
java.lang.NoSuchMethodError: scala.math.Ordering$FloatOrdering.reverse$
```