### PR TITLE
[after #9141] optimised ListMap.head

### DIFF
--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -96,6 +96,15 @@ sealed class ListMap[A, +B] extends AbstractMap[A, B]
     }
   }
 
+  override def head: (A, B) = {
+    @tailrec def headImpl(curr: ListMap[A, B]): (A, B) = {
+      val n = curr.next
+      if (n.isEmpty) (curr.key, curr.value)
+      else headImpl(n)
+    }
+    headImpl(this)
+  }
+
   override def hashCode(): Int = {
     if (isEmpty) {
       MurmurHash3.emptyMapHash


### PR DESCRIPTION
Addressing the `head` part of https://github.com/scala/bug/issues/11752

Mima issue 
```

[error] scala-library: Failed binary compatibility check against org.scala-lang:scala-library:2.12.0! Found 1 potential problems (filtered 858)
[error]  * method head()scala.Tuple2 in class scala.collection.immutable.ListMap does not have a correspondent in other version
[error]    filter with: ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.ListMap.head")

```

@lrytz is this a candidate for https://github.com/scala/scala/pull/9141?