### PR TITLE
Disable fatal warnings in the library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -727,6 +727,7 @@ lazy val library = configureAsSubproject(project)
   .settings(
     name := "scala-library",
     description := "Scala Standard Library",
+    fatalWarnings := false,
     Compile / scalacOptions ++= Seq("-sourcepath", (Compile / scalaSource).value.toString),
     Compile / scalacOptions ++= Seq("-Xlint", "-feature"),
     Compile / doc / scalacOptions ++= {


### PR DESCRIPTION
The fatal warnings PR (for library) was merged prematurely as it is
impacting my exhaustivity PR ([1](https://github.com/scala/scala/pull/9140)).  Rather do anything (like rebase or tweak)
to the 12 commits that my PR consists of and therefore causing CI to
rebuild each commit, I'm separately going to PR disabling fatal
warnings, so I can merge my PR without it instantly breaking the 2.13.x
branch.

I'll do the same for the reflect and compiler PRs, and once we've
re-STARR'd we can re-enable fatal warnings by either resolving all the
exhaustivity warnings or opting out of them (or a mix of both).

cc @NthPortal