### PR TITLE
fix ClassTag#cache leak

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -567,6 +567,7 @@ val mimaFilterSettings = Seq {
 
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.api.Internals#InternalApi.markForAsyncTransform"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.io.ZipArchive.RootEntry"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.reflect.ClassTag$cache$"),
   )
 }
 

--- a/src/library/scala/reflect/ClassTag.scala
+++ b/src/library/scala/reflect/ClassTag.scala
@@ -137,16 +137,19 @@ object ClassTag {
   val Nothing : ClassTag[scala.Nothing]    = Manifest.Nothing
   val Null    : ClassTag[scala.Null]       = Manifest.Null
 
-  private[this] val cache = new ClassValue[jWeakReference[ClassTag[_]]] {
-    override def computeValue(runtimeClass: jClass[_]): jWeakReference[ClassTag[_]] = {
-      new jWeakReference(runtimeClass match {
+  private val cacheDisabledProp = scala.sys.Prop[String]("scala.reflect.classtag.cache.disable")
+  private[this] object cache extends ClassValue[jWeakReference[ClassTag[_]]] {
+    override def computeValue(runtimeClass: jClass[_]): jWeakReference[ClassTag[_]] =
+      new jWeakReference(computeTag(runtimeClass))
+
+    def computeTag(runtimeClass: jClass[_]): ClassTag[_] =
+      runtimeClass match {
         case x if x.isPrimitive => primitiveClassTag(runtimeClass)
         case ObjectTYPE         => ClassTag.Object
         case NothingTYPE        => ClassTag.Nothing
         case NullTYPE           => ClassTag.Null
         case _                  => new GenericClassTag[AnyRef](runtimeClass)
-      })
-    }
+     }
 
     private def primitiveClassTag[T](runtimeClass: Class[_]): ClassTag[_] = runtimeClass match {
       case java.lang.Byte.TYPE      => ClassTag.Byte
@@ -170,13 +173,17 @@ object ClassTag {
   }
 
   def apply[T](runtimeClass1: jClass[_]): ClassTag[T] = {
-    val ref = cache.get(runtimeClass1).asInstanceOf[jWeakReference[ClassTag[T]]]
-    var tag = ref.get
-    if (tag == null) {
-      cache.remove(runtimeClass1)
-      tag = cache.get(runtimeClass1).asInstanceOf[jWeakReference[ClassTag[T]]].get
+    if (cacheDisabledProp.isSet)
+      cache.computeTag(runtimeClass1).asInstanceOf[ClassTag[T]]
+    else {
+      val ref = cache.get(runtimeClass1).asInstanceOf[jWeakReference[ClassTag[T]]]
+      var tag = ref.get
+      if (tag == null) {
+        cache.remove(runtimeClass1)
+        tag = cache.computeTag(runtimeClass1).asInstanceOf[ClassTag[T]]
+      }
+      tag
     }
-    tag
   }
 
   def unapply[T](ctag: ClassTag[T]): Option[Class[_]] = Some(ctag.runtimeClass)


### PR DESCRIPTION
I was diagnosing some classloader leaks and the profiler pointed to `ClassTag#cache`

JDK issues about the problem:
* https://bugs.openjdk.java.net/browse/JDK-8136353

Also this is not a problem in 2.13.x because the cache does not exist there. See gitter question https://gitter.im/scala/contributors?at=5f941163a0a3072b43a099b7