### PR TITLE
Allow using classOf with object type

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4752,7 +4752,7 @@ trait Types
   /** def isNonValueType(tp: Type) = !isValueElseNonValue(tp) */
 
   def isNonRefinementClassType(tpe: Type) = tpe match {
-    case SingleType(_, sym) => sym.isModuleClass
+    case SingleType(_, sym) => sym.isModuleOrModuleClass
     case TypeRef(_, sym, _) => sym.isClass && !sym.isRefinementClass
     case ErrorType          => true
     case _                  => false

--- a/test/files/pos/classOfObjectType/AnnotationWithClassType.java
+++ b/test/files/pos/classOfObjectType/AnnotationWithClassType.java
@@ -1,0 +1,10 @@
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AnnotationWithClassType {
+    Class<?> cls();
+}

--- a/test/files/pos/classOfObjectType/Foo.scala
+++ b/test/files/pos/classOfObjectType/Foo.scala
@@ -1,0 +1,7 @@
+
+object Bar
+
+trait Foo {
+  @AnnotationWithClassType(cls = classOf[Bar.type])
+  def function: Any = ???
+}

--- a/test/files/run/classOfObjectType.scala
+++ b/test/files/run/classOfObjectType.scala
@@ -1,0 +1,7 @@
+
+object Test {
+  object Bar
+  def main(args: Array[String]): Unit = {
+    assert(Bar.getClass == classOf[Bar.type] )
+  }
+}


### PR DESCRIPTION
This is a fix for https://github.com/scala/bug/issues/2453. 

It makes it possible to write the following: 

```scala
object Bar 

val cls = classOf[Bar.type]
```

