### PR TITLE
Travis CI: make a command error fatal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ jobs:
         name: bootstrap and publishLocal
         if: type = pull_request OR repo != scala/scala
         script:
+          - set -e
           - sbt -warn setupPublishCore generateBuildCharacterPropertiesFile headerCheck publishLocal
           - STARR=$(sed -n 's/^maven\.version\.number=//p' buildcharacter.properties) && echo $STARR
           - sbt -Dstarr.version=$STARR -warn setupValidateTest test:compile info testOsgi
@@ -56,6 +57,7 @@ jobs:
         workspaces:
           use: published-local
         script:
+          - set -e
           - STARR=$(sed -n 's/^maven\.version\.number=//p' buildcharacter.properties) && echo $STARR
           - sbt -Dstarr.version=$STARR -warn setupValidateTest test:compile info testAll1
           - sbt -Dscala.build.compileWithDotty=true library/compile
@@ -65,6 +67,7 @@ jobs:
         workspaces:
           use: published-local
         script:
+          - set -e
           - STARR=$(sed -n 's/^maven\.version\.number=//p' buildcharacter.properties) && echo $STARR
           - sbt -Dstarr.version=$STARR -warn setupValidateTest test:compile info testAll2
 


### PR DESCRIPTION
I saw a CI log where the failure to build and bootstrap didn't kill the
job, trying to fetch that starr version to testOsgi did...  Previously
this wasn't the case because there was a "set -e" (aka "-o errexit")
present which I just recently removed, because I confused it with "set
-x" (which is "-o xtrace"). -.-

There's a bit of an holy war on "set -e" usage but I (still?) tend to
lean on the "don't rely on it" side.  I'd initially gone with my "append
everything important with `|| travis_terminate 1`" solution, but I found
this other "make it one big command with `&&`" to be perhaps better
because I think it's harder to not do the wrong thing that way (i.e.
forget to append travis_terminate).  I think the downside is a failure
reports the entire chain of commands rather than explicitly which one
failed...