### PR TITLE
Upgrade to JLine 3.17.1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -9,5 +9,5 @@ starr.version=2.13.3
 scala-asm.version=7.3.1-scala-1
 
 # jna.version must be updated together with jline-terminal-jna
-jline.version=3.16.0
+jline.version=3.17.1
 jna.version=5.3.1


### PR DESCRIPTION
The JNA version still matches.

~This is in prep for the 2.13.4 release.~  The only other dependenncy in versions.properties is scala-asm, which is latest.