### PR TITLE
Restore Global.reporter()Reporter

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -87,7 +87,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
   private[this] var currentReporter: FilteringReporter = null
   locally { reporter = reporter0 }
 
-  def reporter: FilteringReporter = currentReporter
+  def reporter: Reporter = currentReporter
   def reporter_=(newReporter: Reporter): Unit =
     currentReporter = newReporter match {
       case f: FilteringReporter => f


### PR DESCRIPTION
It's an important binary API:

    [scala-rewrites] [error] java.lang.NoSuchMethodError: scala.tools.nsc.Global.reporter()Lscala/tools/nsc/reporters/Reporter;
    [scala-rewrites] [error] 	at scala.meta.internal.semanticdb.scalac.SemanticdbPlugin.init(SemanticdbPlugin.scala:25)
    [scala-rewrites] [error] 	at scala.tools.nsc.plugins.Plugins.$anonfun$loadPlugins$9(Plugins.scala:162)