### PR TITLE
[nomerge] Emit warnings in the REPL

### DIFF
--- a/test/files/jvm/interpreter.check
+++ b/test/files/jvm/interpreter.check
@@ -93,6 +93,7 @@ scala> case class Bar(n: Int)
 defined class Bar
 
 scala> implicit def foo2bar(foo: Foo) = Bar(foo.n)
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 foo2bar: (foo: Foo)Bar
 
 scala> val bar: Bar = Foo(3)
@@ -266,6 +267,7 @@ scala> xs map (x => x)
 res6: Array[_] = Array(1, 2)
 
 scala> xs map (x => (x, x))
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 res7: Array[(_$1, _$1)] forSome { type _$1 } = Array((1,1), (2,2))
 
 scala> 
@@ -351,6 +353,10 @@ defined class Term
 scala> def f(e: Exp) = e match {  // non-exhaustive warning here
   case _:Fact => 3
 }
+<console>:18: warning: match may not be exhaustive.
+It would fail on the following inputs: Exp(), Term()
+def f(e: Exp) = e match {  // non-exhaustive warning here
+                ^
 f: (e: Exp)Int
 
 scala> :quit

--- a/test/files/run/constrained-types.check
+++ b/test/files/run/constrained-types.check
@@ -69,9 +69,11 @@ scala> var four = "four"
 four: String = four
 
 scala> val four2 = m(four) // should have an existential bound
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 four2: String @Annot(x) forSome { val x: String } = four
 
 scala> val four3 = four2   // should have the same type as four2
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 four3: String @Annot(x) forSome { val x: String } = four
 
 scala> val stuff = m("stuff") // should not crash
@@ -94,6 +96,7 @@ scala> def m = {
   val y : String @Annot(x) = x
   y
 } // x should not escape the local scope with a narrow type
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 m: String @Annot(x) forSome { val x: String }
 
 scala> 
@@ -107,6 +110,7 @@ scala> def n(y: String) = {
   }
   m("stuff".stripMargin)
 } // x should be existentially bound
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 n: (y: String)String @Annot(x) forSome { val x: String }
 
 scala> 

--- a/test/files/run/reflection-magicsymbols-repl.check
+++ b/test/files/run/reflection-magicsymbols-repl.check
@@ -19,6 +19,7 @@ scala> def test(n: Int): Unit = {
   val x = sig.asInstanceOf[MethodType].params.head
   println(x.info)
 }
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 test: (n: Int)Unit
 
 scala> for (i <- 1 to 8) test(i)

--- a/test/files/run/repl-bare-expr.check
+++ b/test/files/run/repl-bare-expr.check
@@ -1,14 +1,32 @@
 
 scala> 2 ; 3
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+2 ;;
+^
 res0: Int = 3
 
 scala> { 2 ; 3 }
+<console>:12: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
+{ 2 ; 3 }
+  ^
 res1: Int = 3
 
 scala> 5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
   1 +
   2 +
   3 } ; bippy+88+11
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+    ^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+                           ^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+                                                                                  ^
 defined object Cow
 defined class Moo
 bippy: Int

--- a/test/files/run/repl-class-based-outer-pointers.check
+++ b/test/files/run/repl-class-based-outer-pointers.check
@@ -8,6 +8,9 @@ defined class Value
 defined object Value
 
 scala> class C { final case class Num(value: Double) } // here it should still warn
+<console>:11: warning: The outer reference in this type test cannot be checked at run time.
+class C { final case class Num(value: Double) } // here it should still warn
+                           ^
 defined class C
 
 scala> :quit

--- a/test/files/run/repl-no-imports-no-predef-power.check
+++ b/test/files/run/repl-no-imports-no-predef-power.check
@@ -7,9 +7,11 @@ Try :help or completions for vals._ and power._
 scala> // guarding against "error: reference to global is ambiguous"
 
 scala> global.emptyValDef  // "it is imported twice in the same scope by ..."
+warning: one deprecation (since 2.11.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res0: $r.global.noSelfType.type = private val _ = _
 
 scala> val tp = ArrayClass[scala.util.Random]    // magic with tags
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 tp: $r.global.Type = Array[scala.util.Random]
 
 scala> tp.memberType(Array_apply)                // evidence

--- a/test/files/run/repl-no-imports-no-predef.check
+++ b/test/files/run/repl-no-imports-no-predef.check
@@ -76,9 +76,15 @@ y: Int = 13
 scala> 
 
 scala> 2 ; 3
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+2 ;;
+^
 res14: Int = 3
 
 scala> { 2 ; 3 }
+<console>:12: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
+{ 2 ; 3 }
+  ^
 res15: Int = 3
 
 scala> 5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
@@ -86,6 +92,18 @@ bippy = {
   1 +
   2 +
   3 } ; bippy+88+11
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
+^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
+    ^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
+                           ^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
+                                                                                  ^
 defined object Cow
 defined class Moo
 bippy: Int
@@ -125,6 +143,12 @@ scala>   (  (2 + 2 )  )
 res24: Int = 4
 
 scala> 5 ;   (  (2 + 2 )  ) ; ((5))
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ;   (  (2 + 2 )  ) ;;
+^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ;   (  (2 + 2 )  ) ;;
+            ^
 res25: Int = 5
 
 scala> (((2 + 2)), ((2 + 2)))
@@ -139,9 +163,18 @@ res28: String = 4423
 scala> 
 
 scala> 55 ; ((2 + 2)) ; (1, 2, 3)
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ; ((2 + 2)) ;;
+^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ; ((2 + 2)) ;;
+         ^
 res29: (Int, Int, Int) = (1,2,3)
 
 scala> 55 ; (x: scala.Int) => x + 1 ; () => ((5))
+<console>:12: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ; (x: scala.Int) => x + 1 ;;
+^
 res30: () => Int = <function>
 
 scala> 
@@ -150,6 +183,9 @@ scala> () => 5
 res31: () => Int = <function>
 
 scala> 55 ; () => 5
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ;;
+^
 res32: () => Int = <function>
 
 scala> () => { class X ; new X }

--- a/test/files/run/repl-parens.check
+++ b/test/files/run/repl-parens.check
@@ -18,6 +18,12 @@ scala>   (  (2 + 2 )  )
 res5: Int = 4
 
 scala> 5 ;   (  (2 + 2 )  ) ; ((5))
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ;   (  (2 + 2 )  ) ;;
+^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ;   (  (2 + 2 )  ) ;;
+            ^
 res6: Int = 5
 
 scala> (((2 + 2)), ((2 + 2)))
@@ -32,9 +38,18 @@ res9: String = 4423
 scala> 
 
 scala> 55 ; ((2 + 2)) ; (1, 2, 3)
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ; ((2 + 2)) ;;
+^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ; ((2 + 2)) ;;
+         ^
 res10: (Int, Int, Int) = (1,2,3)
 
 scala> 55 ; (x: Int) => x + 1 ; () => ((5))
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ; (x: Int) => x + 1 ;;
+^
 res11: () => Int = <function>
 
 scala> 
@@ -43,6 +58,9 @@ scala> () => 5
 res12: () => Int = <function>
 
 scala> 55 ; () => 5
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ;;
+^
 res13: () => Int = <function>
 
 scala> () => { class X ; new X }

--- a/test/files/run/repl-power.check
+++ b/test/files/run/repl-power.check
@@ -7,9 +7,11 @@ Try :help or completions for vals._ and power._
 scala> // guarding against "error: reference to global is ambiguous"
 
 scala> global.emptyValDef  // "it is imported twice in the same scope by ..."
+warning: one deprecation (since 2.11.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res0: $r.global.noSelfType.type = private val _ = _
 
 scala> val tp = ArrayClass[scala.util.Random]    // magic with tags
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 tp: $r.global.Type = Array[scala.util.Random]
 
 scala> tp.memberType(Array_apply)                // evidence

--- a/test/files/run/t11402.check
+++ b/test/files/run/t11402.check
@@ -1,0 +1,14 @@
+
+scala> import scala.concurrent.duration._; val t = 1 second
+<console>:11: warning: postfix operator second should be enabled
+by making the implicit value scala.language.postfixOps visible.
+This can be achieved by adding the import clause 'import scala.language.postfixOps'
+or by setting the compiler option -language:postfixOps.
+See the Scaladoc for value scala.language.postfixOps for a discussion
+why the feature should be explicitly enabled.
+import scala.concurrent.duration._; val t = 1 second
+                                              ^
+import scala.concurrent.duration._
+t: scala.concurrent.duration.FiniteDuration = 1 second
+
+scala> :quit

--- a/test/files/run/t11402.scala
+++ b/test/files/run/t11402.scala
@@ -1,0 +1,12 @@
+import scala.tools.nsc.Settings
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  override def transformSettings(ss: Settings) = {
+    ss.feature.value = true
+    ss
+  }
+
+  // From zinc's InteractiveConsoleInterfaceSpecification "should evaluate postfix op with a warning"
+  override def code = "import scala.concurrent.duration._; val t = 1 second"
+}

--- a/test/files/run/t4172.check
+++ b/test/files/run/t4172.check
@@ -1,5 +1,6 @@
 
 scala> val c = { class C { override def toString = "C" }; ((new C, new C { def f = 2 })) }
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 c: (C, C{def f: Int}) forSome { type C <: AnyRef } = (C,C)
 
 scala> :quit

--- a/test/files/run/t4542.check
+++ b/test/files/run/t4542.check
@@ -5,6 +5,9 @@ scala> @deprecated("foooo", "ReplTest version 1.0-FINAL") class Foo() {
 defined class Foo
 
 scala> val f = new Foo
+<console>:12: warning: class Foo is deprecated (since ReplTest version 1.0-FINAL): foooo
+val f = new Foo
+            ^
 f: Foo = Bippy
 
 scala> :quit

--- a/test/files/run/t4594-repl-settings.check
+++ b/test/files/run/t4594-repl-settings.check
@@ -3,11 +3,15 @@ scala> @deprecated(message="Please don't do that.", since="Time began.") def dep
 depp: String
 
 scala> def a = depp
+warning: one deprecation (since Time began.); for details, enable `:setting -deprecation' or `:replay -deprecation'
 a: String
 
 scala> :settings -deprecation
 
 scala> def b = depp
+<console>:12: warning: method depp is deprecated (since Time began.): Please don't do that.
+def b = depp
+        ^
 b: String
 
 scala> :quit

--- a/test/files/run/t4710.check
+++ b/test/files/run/t4710.check
@@ -1,5 +1,6 @@
 
 scala> def method : String = { implicit def f(s: Symbol) = "" ; 'symbol }
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 method: String
 
 scala> :quit

--- a/test/files/run/t6329_repl.check
+++ b/test/files/run/t6329_repl.check
@@ -3,24 +3,28 @@ scala> import scala.reflect.classTag
 import scala.reflect.classTag
 
 scala> classManifest[scala.List[_]]
+warning: one deprecation (since 2.10.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res0: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List[<?>]
 
 scala> classTag[scala.List[_]]
 res1: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List
 
 scala> classManifest[scala.collection.immutable.List[_]]
+warning: one deprecation (since 2.10.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res2: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List[<?>]
 
 scala> classTag[scala.collection.immutable.List[_]]
 res3: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List
 
 scala> classManifest[Predef.Set[_]]
+warning: one deprecation (since 2.10.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res4: scala.reflect.ClassTag[scala.collection.immutable.Set[_]] = scala.collection.immutable.Set[<?>]
 
 scala> classTag[Predef.Set[_]]
 res5: scala.reflect.ClassTag[scala.collection.immutable.Set[_]] = scala.collection.immutable.Set
 
 scala> classManifest[scala.collection.immutable.Set[_]]
+warning: one deprecation (since 2.10.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res6: scala.reflect.ClassTag[scala.collection.immutable.Set[_]] = scala.collection.immutable.Set[<?>]
 
 scala> classTag[scala.collection.immutable.Set[_]]

--- a/test/files/run/t6329_repl_bug.check
+++ b/test/files/run/t6329_repl_bug.check
@@ -6,6 +6,7 @@ scala> import scala.reflect.runtime._
 import scala.reflect.runtime._
 
 scala> classManifest[List[_]]
+warning: one deprecation (since 2.10.0); for details, enable `:setting -deprecation' or `:replay -deprecation'
 res0: scala.reflect.ClassTag[List[_]] = scala.collection.immutable.List[<?>]
 
 scala> scala.reflect.classTag[List[_]]

--- a/test/files/run/t7319.check
+++ b/test/files/run/t7319.check
@@ -3,12 +3,15 @@ scala> class M[A]
 defined class M
 
 scala> implicit def ma0[A](a: A): M[A] = null
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 ma0: [A](a: A)M[A]
 
 scala> implicit def ma1[A](a: A): M[A] = null
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 ma1: [A](a: A)M[A]
 
 scala> def convert[F[X <: F[X]]](builder: F[_ <: F[_]]) = 0
+warning: one feature warning; for details, enable `:setting -feature' or `:replay -feature'
 convert: [F[X <: F[X]]](builder: F[_ <: F[_]])Int
 
 scala> convert(Some[Int](0))

--- a/test/files/run/t7747-repl.check
+++ b/test/files/run/t7747-repl.check
@@ -15,15 +15,33 @@ scala> val z = x * y
 z: Int = 156
 
 scala> 2 ; 3
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+2 ;;
+^
 res0: Int = 3
 
 scala> { 2 ; 3 }
+<console>:12: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
+{ 2 ; 3 }
+  ^
 res1: Int = 3
 
 scala> 5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
   1 +
   2 +
   3 } ; bippy+88+11
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+    ^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+                           ^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+                                                                                  ^
 defined object Cow
 defined class Moo
 bippy: Int
@@ -63,6 +81,12 @@ scala>   (  (2 + 2 )  )
 res10: Int = 4
 
 scala> 5 ;   (  (2 + 2 )  ) ; ((5))
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ;   (  (2 + 2 )  ) ;;
+^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+5 ;   (  (2 + 2 )  ) ;;
+            ^
 res11: Int = 5
 
 scala> (((2 + 2)), ((2 + 2)))
@@ -77,9 +101,18 @@ res14: String = 4423
 scala> 
 
 scala> 55 ; ((2 + 2)) ; (1, 2, 3)
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ; ((2 + 2)) ;;
+^
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ; ((2 + 2)) ;;
+         ^
 res15: (Int, Int, Int) = (1,2,3)
 
 scala> 55 ; (x: Int) => x + 1 ; () => ((5))
+<console>:12: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ; (x: Int) => x + 1 ;;
+^
 res16: () => Int = <function>
 
 scala> 
@@ -88,6 +121,9 @@ scala> () => 5
 res17: () => Int = <function>
 
 scala> 55 ; () => 5
+<console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+55 ;;
+^
 res18: () => Int = <function>
 
 scala> () => { class X ; new X }

--- a/test/files/run/xMigration.check
+++ b/test/files/run/xMigration.check
@@ -10,6 +10,10 @@ res1: Iterable[String] = MapLike.DefaultValuesIterable(eis)
 scala> :setting -Xmigration:any
 
 scala> Map(1 -> "eis").values    // warn
+<console>:12: warning: method values in trait MapLike has changed semantics in version 2.8.0:
+`values` returns `Iterable[V]` rather than `Iterator[V]`.
+Map(1 -> "eis").values    // warn
+                ^
 res2: Iterable[String] = MapLike.DefaultValuesIterable(eis)
 
 scala> :setting -Xmigration:2.8
@@ -20,6 +24,10 @@ res3: Iterable[String] = MapLike.DefaultValuesIterable(eis)
 scala> :setting -Xmigration:2.7
 
 scala> Map(1 -> "eis").values    // warn
+<console>:12: warning: method values in trait MapLike has changed semantics in version 2.8.0:
+`values` returns `Iterable[V]` rather than `Iterator[V]`.
+Map(1 -> "eis").values    // warn
+                ^
 res4: Iterable[String] = MapLike.DefaultValuesIterable(eis)
 
 scala> :setting -Xmigration:2.11
@@ -30,6 +38,10 @@ res5: Iterable[String] = MapLike.DefaultValuesIterable(eis)
 scala> :setting -Xmigration      // same as :any
 
 scala> Map(1 -> "eis").values    // warn
+<console>:12: warning: method values in trait MapLike has changed semantics in version 2.8.0:
+`values` returns `Iterable[V]` rather than `Iterator[V]`.
+Map(1 -> "eis").values    // warn
+                ^
 res6: Iterable[String] = MapLike.DefaultValuesIterable(eis)
 
 scala> :quit


### PR DESCRIPTION
My attempt to backport https://github.com/scala/scala/pull/7756, but it doesn't fix the tests.  (I hand-rolled their checkfiles so don't take them as canon.)

@som-snytt I think I'm right in thinking that you aren't that interested in sinking time in 2.12's REPL.  But in the interest of getting 2.12 and 2.13 released, could you spend a second seeing if you can see what's missing to fix this?  It might be a blocker for the 2.12 release...