### PR TITLE
Revert "Restore Global.reporter()Reporter"

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -87,7 +87,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
   private[this] var currentReporter: FilteringReporter = null
   locally { reporter = reporter0 }
 
-  def reporter: Reporter = currentReporter
+  def reporter: FilteringReporter = currentReporter
   def reporter_=(newReporter: Reporter): Unit =
     currentReporter = newReporter match {
       case f: FilteringReporter => f


### PR DESCRIPTION
This reverts commit 8662d4aebb56a0763383f2773d22ffaa8ca62736 / #9297.

It is a very important API, but the compiler's binary API isn't stable.

This got confused because scala-rewrites is special in the
community-build as it uses binary dependencies (for scalafix/scalameta
dependency graph problems).  Additionally I optimistically "fix"
semanticdb-scalac-core's cross version when consuming Scala nightlies...