### PR TITLE
Make annotation typechecking lazier

### DIFF
--- a/src/reflect/scala/reflect/internal/AnnotationInfos.scala
+++ b/src/reflect/scala/reflect/internal/AnnotationInfos.scala
@@ -110,6 +110,9 @@ trait AnnotationInfos extends api.Annotations { self: SymbolTable =>
     def lazily(lazyInfo: => AnnotationInfo) =
       new LazyAnnotationInfo(lazyInfo)
 
+    def lazily(lazySymbol: => Symbol, lazyInfo: => AnnotationInfo) =
+      new ExtraLazyAnnotationInfo(lazySymbol, lazyInfo)
+
     def apply(atp: Type, args: List[Tree], assocs: List[(Name, ClassfileAnnotArg)]): AnnotationInfo =
       new CompleteAnnotationInfo(atp, args, assocs)
 
@@ -154,7 +157,7 @@ trait AnnotationInfos extends api.Annotations { self: SymbolTable =>
   /** Symbol annotations parsed in `Namer` (typeCompleter of
    *  definitions) have to be lazy (#1782)
    */
-  final class LazyAnnotationInfo(lazyInfo: => AnnotationInfo) extends AnnotationInfo {
+  class LazyAnnotationInfo(lazyInfo: => AnnotationInfo) extends AnnotationInfo {
     private[this] var forced = false
     private lazy val forcedInfo = try lazyInfo finally forced = true
 
@@ -170,6 +173,11 @@ trait AnnotationInfos extends api.Annotations { self: SymbolTable =>
     override def pos: Position = if (forced) forcedInfo.pos else NoPosition
 
     override def completeInfo(): Unit = forcedInfo
+  }
+
+  final class ExtraLazyAnnotationInfo(sym: => Symbol, lazyInfo: => AnnotationInfo) extends LazyAnnotationInfo(lazyInfo) {
+    private[this] lazy val typeSymbol = sym
+    override def symbol: Symbol = typeSymbol
   }
 
   /** Typed information about an annotation. It can be attached to either

--- a/test/files/pos/annotation-cycle.scala
+++ b/test/files/pos/annotation-cycle.scala
@@ -1,0 +1,7 @@
+import scala.annotation.StaticAnnotation
+
+class anno(attr: Boolean) extends StaticAnnotation
+
+object Test {
+  @anno(attr = true) def attr: Int = 1
+}

--- a/test/files/pos/t11870.scala
+++ b/test/files/pos/t11870.scala
@@ -1,0 +1,60 @@
+class Annot(arg: Any) extends scala.annotation.StaticAnnotation
+
+abstract class Demo1 {
+  @Annot(x)
+  def x: String = "foo"
+}
+
+abstract class Demo2 {
+  @Annot(y)
+  def x: String = "foo"
+
+  @Annot(x)
+  def y: String = "bar"
+}
+
+class Annot1(arg: Any) extends scala.annotation.StaticAnnotation
+class Annot2(arg: Any) extends scala.annotation.StaticAnnotation
+
+abstract class Demo3 {
+  @Annot1(y)
+  def x: String = "foo"
+
+  @Annot2(x)
+  def y: String = "bar"
+}
+
+// test annotations without argument
+import scala.annotation.unchecked
+
+class C {
+  class D
+}
+
+class Test {
+  locally {
+    val c = new C
+    import c._
+    new D
+  }
+
+  locally {
+    import unchecked.uncheckedStable
+    @uncheckedStable def c = new C
+    import c._
+    new D
+  }
+
+  locally {
+    @unchecked.uncheckedStable def c = new C
+    import c._
+    new D
+  }
+
+  locally {
+    import unchecked.{uncheckedStable => uc}
+    @uc def c = new C
+    import c._
+    new D
+  }
+}

--- a/test/files/pos/unchecked-stable-cyclic-error.scala
+++ b/test/files/pos/unchecked-stable-cyclic-error.scala
@@ -1,0 +1,8 @@
+import scala.annotation.StaticAnnotation
+
+class anno(a: Any) extends StaticAnnotation
+
+object Test {
+  def foo = attr
+  @anno(foo) def attr: Int = foo
+}


### PR DESCRIPTION
Make annotation typechecking lazier

Now that `Typer.stabilize` ends up checking for `@uncheckedStable` annotations to support defs's as stable paths, new opportunities arise for cyclic errors.

This PR reduces the likelihood of cycles by typechecking the only core of an annotation (_not_ the full application to the annotation arguments) to determine its type symbol.

pos/unchecked-stable-cyclic-error.scala test case started to fail since #8338 with:

```
|-- object Test BYVALmode-EXPRmode (site: package <empty>)
|    |-- super APPSELmode-EXPRmode-POLYmode-QUALmode (silent: <init> in Test)
|    |    |-- this EXPRmode (silent: <init> in Test)
|    |    |    \-> Test.type
|    |    \-> Test.type
|    |-- def foo BYVALmode-EXPRmode (site: object Test)
|    |    |-- attr EXPRmode (site: method foo in Test)
|    |    |    |-- Int TYPEmode (site: method attr in Test)
|    |    |    |    \-> Int
|    |    |    |-- new anno APPSELmode-BYVALmode-EXPRmode-FUNmode-POLYmode (site: object Test)
|    |    |    |    |-- new anno APPSELmode-EXPRmode-POLYmode-QUALmode (site: object Test)
|    |    |    |    |    |-- anno FUNmode-TYPEmode (site: object Test)
|    |    |    |    |    |    \-> anno
|    |    |    |    |    \-> anno
|    |    |    |    \-> (a: Any): anno
|    |    |    |-- (a: Any): anno : pt=anno EXPRmode (site: value <local Test> in Test)
|    |    |    |    |-- foo : pt=Any BYVALmode-EXPRmode (site: value <local Test> in Test)
|    |    |    |    |    caught scala.reflect.internal.Symbols$CyclicReference: illegal cyclic reference involving method foo: while typing foo
/Users/jz/code/scala/sandbox/test.scala:7: error: recursive method foo needs result type
  @anno(foo) def attr: Int = foo
        ^
|    |    |    |    \-> anno
```

Another variant, pos/annotation-cycle.scala, fails only on 2.12.x (after the backport of #8338). Backporting this fix makes that test start passing on 2.12.x.

References https://github.com/scala/bug/issues/12216 (which will be fixed after this is backported to 2.12.x)

Fixes scala/bug#11870
