### PR TITLE
Tasty: block scala.Tuple

### DIFF
--- a/src/compiler/scala/tools/nsc/tasty/TastyModes.scala
+++ b/src/compiler/scala/tools/nsc/tasty/TastyModes.scala
@@ -33,7 +33,7 @@ object TastyModes {
   /** When not at the package scope */
   final val InnerScope: TastyMode = TastyMode(1 << 5)
 
-  /** The union of [[IndexStats]] and [[InnerScope]] */
+  /** The union of `IndexStats` and `InnerScope` */
   final val IndexScopedStats: TastyMode = IndexStats | InnerScope
 
   case class TastyMode(val toInt: Int) extends AnyVal { mode =>

--- a/src/compiler/scala/tools/nsc/tasty/TastyUniverse.scala
+++ b/src/compiler/scala/tools/nsc/tasty/TastyUniverse.scala
@@ -14,7 +14,7 @@ package scala.tools.nsc.tasty
 
 import bridge._
 
-/**A facade to [[scala.tools.nsc.symbtab.SymbolTable]], providing operations that map from the language of TASTy to the
+/**A facade to `scala.tools.nsc.symbtab.SymbolTable`, providing operations that map from the language of TASTy to the
  * nsc compiler, e.g. to create trees, resolve types and symbols.
  */
 abstract class TastyUniverse extends TastyCore

--- a/src/compiler/scala/tools/nsc/tasty/TastyUnpickler.scala
+++ b/src/compiler/scala/tools/nsc/tasty/TastyUnpickler.scala
@@ -20,9 +20,9 @@ import TastyName._
 import scala.annotation.nowarn
 import scala.reflect.io.AbstractFile
 
-/**The entry point to TASTy unpickling for nsc, initialises a [[TastyUniverse#Context]] with the root symbols of a
+/**The entry point to TASTy unpickling for nsc, initialises a `TastyUniverse#Context` with the root symbols of a
  * top-level class, then parses the header and names from a TASTy file, before entering symbols from the `ASTs` section
- * with [[TreeUnpickler]]
+ * with `TreeUnpickler`
  */
 object TastyUnpickler {
 

--- a/src/compiler/scala/tools/nsc/tasty/TreeUnpickler.scala
+++ b/src/compiler/scala/tools/nsc/tasty/TreeUnpickler.scala
@@ -20,16 +20,16 @@ import scala.reflect.io.AbstractFile
 import scala.reflect.internal.Variance
 import scala.util.chaining._
 
-/**[[TreeUnpickler]] is responsible for traversing all trees in the "ASTs" section of a TASTy file, which represent the
- * definitions inside the classfile associated with the root class/module. [[TreeUnpickler]] will enter the public api
- * of the TASTy file into the symbolTable of [[TastyUniverse]]. "Public API" includes annotations when they are
+/**`TreeUnpickler` is responsible for traversing all trees in the "ASTs" section of a TASTy file, which represent the
+ * definitions inside the classfile associated with the root class/module. `TreeUnpickler` will enter the public api
+ * of the TASTy file into the symbolTable of `TastyUniverse`. "Public API" includes annotations when they are
  * simple trees.
  *
- * Where possible, [[TreeUnpickler]] should not directly manipulate values created by the symbolTable, but use
- * operations provided by [[TastyUniverse]]
+ * Where possible, `TreeUnpickler` should not directly manipulate values created by the symbolTable, but use
+ * operations provided by `TastyUniverse`
  *  @param reader    the reader from which to unpickle
  *  @param nameAtRef an index of names from the tasty file of this unpickler
- *  @param tasty     the handle on the [[TastyUniverse]]
+ *  @param tasty     the handle on the `TastyUniverse`
  */
 class TreeUnpickler[Tasty <: TastyUniverse](
     reader: TastyReader,

--- a/src/compiler/scala/tools/nsc/tasty/bridge/AnnotationOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/AnnotationOps.scala
@@ -23,7 +23,8 @@ trait AnnotationOps { self: TastyUniverse =>
       u.AnnotationInfo(tpt.tpe, args, Nil)
     case u.Apply(u.TypeApply(u.Select(u.New(tpt), u.nme.CONSTRUCTOR), tpargs), args) =>
       u.AnnotationInfo(u.appliedType(tpt.tpe, tpargs.map(_.tpe)), args, Nil)
-    case u.New(tpt) => // special case for `val $values: Array[E] @unchecked` for scala 3 enums
+    case u.New(tpt) =>
+      // this is to handle incorrectly formatted annotations in dotty - https://github.com/lampepfl/dotty/issues/10113
       u.AnnotationInfo(tpt.tpe, Nil, Nil)
     case _ =>
       throw new Exception(s"unexpected annotation kind from TASTy: ${u.showRaw(tree)}")

--- a/src/compiler/scala/tools/nsc/tasty/bridge/ContextOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/ContextOps.scala
@@ -20,7 +20,7 @@ import scala.tools.nsc.tasty.{TastyUniverse, TastyModes, SafeEq}, TastyModes._
 import scala.reflect.internal.MissingRequirementError
 import scala.collection.mutable
 
-/**This contains the definition for [[Context]], along with standard error throwing capabilities with user friendly
+/**This contains the definition for `Context`, along with standard error throwing capabilities with user friendly
  * formatted errors that can change their output depending on the context mode.
  */
 trait ContextOps { self: TastyUniverse =>
@@ -104,7 +104,7 @@ trait ContextOps { self: TastyUniverse =>
     inIndexStatsContext(inInnerScopeContext(op)(_))(ctx)
   }
 
-  /**Forces lazy annotations, if one is [[scala.annotation.internal.Child]] then it will add the referenced type as a
+  /**Forces lazy annotations, if one is `scala.annotation.internal.Child` then it will add the referenced type as a
    * sealed child.
    */
   private def analyseAnnotations(sym: Symbol)(implicit ctx: Context): Unit = {
@@ -291,12 +291,12 @@ trait ContextOps { self: TastyUniverse =>
       }
     }
 
-    /** Unsafe to call for creation of a object val, prefer [[delayCompletion]] if info is a LazyType
+    /** Unsafe to call for creation of a object val, prefer `delayCompletion` if info is a LazyType
       */
     final def unsafeNewSymbol(owner: Symbol, name: TastyName, flags: TastyFlagSet, info: Type, privateWithin: Symbol = noSymbol): Symbol =
       adjustSymbol(unsafeNewUntypedSymbol(owner, name, flags), info, privateWithin)
 
-    /** Unsafe to call for creation of a object class, prefer [[delayClassCompletion]] if info is a LazyType
+    /** Unsafe to call for creation of a object class, prefer `delayClassCompletion` if info is a LazyType
       */
     final def unsafeNewClassSymbol(owner: Symbol, typeName: TastyName.TypeName, flags: TastyFlagSet, info: Type, privateWithin: Symbol): Symbol =
       adjustSymbol(unsafeNewUntypedClassSymbol(owner, typeName, flags), info, privateWithin)
@@ -491,7 +491,7 @@ trait ContextOps { self: TastyUniverse =>
     /** Force any lazy annotations collected from declaration statements directly in this scope.
      *
      *  It is important to call this *after* indexing statements in a scope, otherwise calling
-     *  [[ownertree.findOwner]] can fail, this is because [[ownertree.findOwner]] cannot traverse a definition tree at
+     *  `ownertree.findOwner` can fail, this is because `ownertree.findOwner` cannot traverse a definition tree at
      *  a given address before a symbol has been registered to that address.
      */
     private[ContextOps] def forceAnnotations(): Unit = {

--- a/src/compiler/scala/tools/nsc/tasty/bridge/FlagOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/FlagOps.scala
@@ -16,7 +16,7 @@ import scala.tools.tasty.TastyFlags._
 import scala.tools.nsc.tasty.TastyUniverse
 import scala.reflect.internal.{Flags, ModifierFlags}
 
-/**Handles encoding of [[TastyFlagSet]] to [[scala.reflect]] flags and witnessing which flags do not map directly
+/**Handles encoding of `TastyFlagSet` to `scala.reflect` flags and witnessing which flags do not map directly
  * from TASTy.
  */
 trait FlagOps { self: TastyUniverse =>
@@ -35,8 +35,8 @@ trait FlagOps { self: TastyUniverse =>
     val LocalFieldFlags: TastyFlagSet = Private | Local
   }
 
-  /**encodes a [[TastyFlagSet]] as [[scala.reflect]] flags and will ignore flags that can't be converted, such as
-   * members of [[FlagSets.TastyOnlyFlags]]
+  /**encodes a `TastyFlagSet` as `scala.reflect` flags and will ignore flags that can't be converted, such as
+   * members of `FlagSets.TastyOnlyFlags`
    */
   private[bridge] def encodeFlagSet(tflags: TastyFlagSet): u.FlagSet = {
     import u.Flag

--- a/src/compiler/scala/tools/nsc/tasty/bridge/NameOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/NameOps.scala
@@ -51,6 +51,7 @@ trait NameOps { self: TastyUniverse =>
     final val And: String = "&"
     final val AnyKind: String = "AnyKind"
     final val TupleCons: String = "*:"
+    final val Tuple: String = "Tuple"
 
     val ContextFunctionN = raw"ContextFunction(\d+)".r
     val FunctionN        = raw"Function(\d+)".r

--- a/src/compiler/scala/tools/nsc/tasty/bridge/SymbolOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/SymbolOps.scala
@@ -18,7 +18,7 @@ import scala.tools.nsc.tasty.{TastyUniverse, TastyModes}, TastyModes._
 import scala.tools.tasty.{TastyName, Signature, TastyFlags}, TastyName.SignedName, Signature.MethodSignature, TastyFlags._
 import scala.tools.tasty.ErasedTypeRef
 
-/**This layer deals with selecting a member symbol from a type using a [[TastyName]],
+/**This layer deals with selecting a member symbol from a type using a `TastyName`,
  * also contains factories for making type references to symbols.
  */
 trait SymbolOps { self: TastyUniverse =>

--- a/src/compiler/scala/tools/nsc/tasty/bridge/TastyCore.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/TastyCore.scala
@@ -15,7 +15,7 @@ package scala.tools.nsc.tasty.bridge
 import scala.tools.nsc
 import nsc.symtab, nsc.tasty.TastyUniverse
 
-/**The base of the [[TastyUniverse]] cake, providing aliases to types from [[scala.reflect]] at the same import level
+/**The base of the `TastyUniverse` cake, providing aliases to types from `scala.reflect` at the same import level
  * as new TASTy specific types.
  */
 abstract class TastyCore { self: TastyUniverse =>

--- a/src/compiler/scala/tools/nsc/tasty/bridge/TreeOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/TreeOps.scala
@@ -17,7 +17,7 @@ import scala.tools.nsc.tasty.{TastyUniverse, TastyModes}, TastyModes._
 import scala.tools.tasty.TastyName
 import scala.reflect.internal.Flags
 
-/**This layer adds factories that construct typed [[scala.reflect]] Trees in the shapes that TASTy expects
+/**This layer adds factories that construct typed `scala.reflect` Trees in the shapes that TASTy expects
  */
 trait TreeOps { self: TastyUniverse =>
   import self.{symbolTable => u}

--- a/src/compiler/scala/tools/tasty/Signature.scala
+++ b/src/compiler/scala/tools/tasty/Signature.scala
@@ -27,7 +27,7 @@ sealed abstract class Signature[+T] { self =>
 
 object Signature {
 
-  /** Encodes either an [[Int]] which is the size of a type parameter list, or [[T]], which represents a type */
+  /** Encodes either an `Int` which is the size of a type parameter list, or `T`, which represents a type */
   type ParamSig[T] = Either[Int, T]
 
   def merge[T](sb: StringBuilder, sig: Signature[T]): StringBuilder = sig.mergeShow(sb)

--- a/src/compiler/scala/tools/tasty/TastyFlags.scala
+++ b/src/compiler/scala/tools/tasty/TastyFlags.scala
@@ -13,7 +13,7 @@
 package scala.tools.tasty
 
 /**A static type representing a bitset of flags that are encoded in a TASTy file, along with some other flags
- * inferred from context, such as [[Method]] and [[Deferred]].
+ * inferred from context, such as `Method` and `Deferred`.
  */
 object TastyFlags {
 

--- a/src/compiler/scala/tools/tasty/TastyName.scala
+++ b/src/compiler/scala/tools/tasty/TastyName.scala
@@ -165,11 +165,11 @@ object TastyName {
 
 }
 
-/**This is a data structure representing semantic names. [[TastyName]] is the interface that TASTy uses to select
+/**This is a data structure representing semantic names. `TastyName` is the interface that TASTy uses to select
  * members from a type, providing more information than simple strings, such as selecting types over terms,
  * companion module instead of a class, or signals if a term is a default getter.
- * Names can also be a [[SignedName]], which is used to select an overloaded method, and pairs a name with a
- * [[MethodSignature]] with types are represented by [[ErasedTypeRef]].
+ * Names can also be a `SignedName`, which is used to select an overloaded method, and pairs a name with a
+ * `MethodSignature` with types are represented by `ErasedTypeRef`.
  */
 sealed abstract class TastyName extends Product with Serializable { self =>
   import TastyName._

--- a/test/tasty/neg/src-2/TestGenericTuples.check
+++ b/test/tasty/neg/src-2/TestGenericTuples.check
@@ -1,13 +1,22 @@
-TestGenericTuples_fail.scala:4: error: Unsupported Scala 3 generic tuple type *: in result; found in method bigtuple in object tastytest.GenericTuples.
+TestGenericTuples_fail.scala:4: error: Unsupported Scala 3 generic tuple type scala.*: in result; found in method bigtuple in object tastytest.GenericTuples.
   val test1 = GenericTuples.bigtuple // error
                             ^
-TestGenericTuples_fail.scala:6: error: Unsupported Scala 3 generic tuple type *: in result; found in method pair in object tastytest.GenericTuples.
+TestGenericTuples_fail.scala:6: error: Unsupported Scala 3 generic tuple type scala.*: in result; found in method pair in object tastytest.GenericTuples.
   val test3 = GenericTuples.pair // error
                             ^
-TestGenericTuples_fail.scala:7: error: Unsupported Scala 3 generic tuple type *: in result; found in method simpleTuple in object tastytest.GenericTuples.
+TestGenericTuples_fail.scala:7: error: Unsupported Scala 3 generic tuple type scala.*: in result; found in method simpleTuple in object tastytest.GenericTuples.
   val test4 = GenericTuples.simpleTuple // error
                             ^
-TestGenericTuples_fail.scala:9: error: Unsupported Scala 3 generic tuple type *: in bounds of type T; found in method consumeBigTuple in object tastytest.GenericTuples.
+TestGenericTuples_fail.scala:9: error: Unsupported Scala 3 generic tuple type scala.*: in bounds of type T; found in method consumeBigTuple in object tastytest.GenericTuples.
   val test6 = GenericTuples.consumeBigTuple((1, "")) // error
                             ^
-4 errors
+TestGenericTuples_fail.scala:10: error: Unsupported Scala 3 generic tuple type scala.Tuple in result; found in method tuple in object tastytest.GenericTuples.
+  val test7 = GenericTuples.tuple // error
+                            ^
+TestGenericTuples_fail.scala:11: error: Unsupported Scala 3 generic tuple type scala.Tuple in parameter value t; found in parameter t in class tastytest.GenericTuples.ConsumeTuple.
+  val test8 = new GenericTuples.ConsumeTuple(???) // error
+              ^
+TestGenericTuples_fail.scala:12: error: Unsupported Scala 3 generic tuple type scala.Tuple in bounds of type T; found in class tastytest.GenericTuples.ConsumeTupleGen.
+  val test9 = new GenericTuples.ConsumeTupleGen[(Int, String)](???) // error
+                                ^
+7 errors

--- a/test/tasty/neg/src-2/TestGenericTuples_fail.scala
+++ b/test/tasty/neg/src-2/TestGenericTuples_fail.scala
@@ -7,4 +7,7 @@ object TestGenericTuples {
   val test4 = GenericTuples.simpleTuple // error
   val test5 = GenericTuples.emptyTuple // ok
   val test6 = GenericTuples.consumeBigTuple((1, "")) // error
+  val test7 = GenericTuples.tuple // error
+  val test8 = new GenericTuples.ConsumeTuple(???) // error
+  val test9 = new GenericTuples.ConsumeTupleGen[(Int, String)](???) // error
 }

--- a/test/tasty/neg/src-3/GenericTuples.scala
+++ b/test/tasty/neg/src-3/GenericTuples.scala
@@ -7,9 +7,13 @@ object GenericTuples {
   val simpleTuple: Int *: EmptyTuple = 1 *: EmptyTuple                         // *: erases to Product
   val emptyTuple: EmptyTuple = EmptyTuple                                      // statically EmptyTuple.type
 
+  val tuple: Tuple = (1,2,3)
 
   def consumeBigTuple[T <: (Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any)](
     f: T
   ): Any = f(12) // this case tests type trees rather than types
+
+  class ConsumeTupleGen[T <: Tuple](t: T)
+  class ConsumeTuple(t: Tuple)
 
 }


### PR DESCRIPTION
`scala.Tuple` is always erased to `scala.Product` so should also be blocked until it is possible to erase correctly.

Also, this removes `[[link]]` syntax in docs, they were causing extra logs in ci due to not linking