### PR TITLE
Fix type signature for specialized Function0

### DIFF
--- a/src/library/scala/runtime/java8/JFunction0$mcB$sp.scala
+++ b/src/library/scala/runtime/java8/JFunction0$mcB$sp.scala
@@ -13,6 +13,6 @@
 package scala.runtime.java8
 
 @FunctionalInterface trait JFunction0$mcB$sp extends Function0[Any] with Serializable {
-  def apply$mcB$sp: Byte
-  override def apply(): Any = scala.runtime.BoxesRunTime.boxToByte(apply$mcB$sp)
+  def apply$mcB$sp(): Byte
+  override def apply(): Any = scala.runtime.BoxesRunTime.boxToByte(apply$mcB$sp())
 }

--- a/src/library/scala/runtime/java8/JFunction0$mcC$sp.scala
+++ b/src/library/scala/runtime/java8/JFunction0$mcC$sp.scala
@@ -13,6 +13,6 @@
 package scala.runtime.java8
 
 @FunctionalInterface trait JFunction0$mcC$sp extends Function0[Any] with Serializable {
-  def apply$mcC$sp: Char
-  override def apply(): Any = scala.runtime.BoxesRunTime.boxToCharacter(apply$mcC$sp)
+  def apply$mcC$sp(): Char
+  override def apply(): Any = scala.runtime.BoxesRunTime.boxToCharacter(apply$mcC$sp())
 }

--- a/src/library/scala/runtime/java8/JFunction0$mcD$sp.scala
+++ b/src/library/scala/runtime/java8/JFunction0$mcD$sp.scala
@@ -13,6 +13,6 @@
 package scala.runtime.java8
 
 @FunctionalInterface trait JFunction0$mcD$sp extends Function0[Any] with Serializable {
-  def apply$mcD$sp: Double
-  override def apply(): Any = scala.runtime.BoxesRunTime.boxToDouble(apply$mcD$sp)
+  def apply$mcD$sp(): Double
+  override def apply(): Any = scala.runtime.BoxesRunTime.boxToDouble(apply$mcD$sp())
 }

--- a/src/library/scala/runtime/java8/JFunction0$mcF$sp.scala
+++ b/src/library/scala/runtime/java8/JFunction0$mcF$sp.scala
@@ -13,6 +13,6 @@
 package scala.runtime.java8
 
 @FunctionalInterface trait JFunction0$mcF$sp extends Function0[Any] with Serializable {
-  def apply$mcF$sp: Float
-  override def apply(): Any = scala.runtime.BoxesRunTime.boxToFloat(apply$mcF$sp)
+  def apply$mcF$sp(): Float
+  override def apply(): Any = scala.runtime.BoxesRunTime.boxToFloat(apply$mcF$sp())
 }

--- a/src/library/scala/runtime/java8/JFunction0$mcI$sp.scala
+++ b/src/library/scala/runtime/java8/JFunction0$mcI$sp.scala
@@ -13,6 +13,6 @@
 package scala.runtime.java8
 
 @FunctionalInterface trait JFunction0$mcI$sp extends Function0[Any] with Serializable {
-  def apply$mcI$sp: Int
-  override def apply(): Any = scala.runtime.BoxesRunTime.boxToInteger(apply$mcI$sp)
+  def apply$mcI$sp(): Int
+  override def apply(): Any = scala.runtime.BoxesRunTime.boxToInteger(apply$mcI$sp())
 }

--- a/src/library/scala/runtime/java8/JFunction0$mcJ$sp.scala
+++ b/src/library/scala/runtime/java8/JFunction0$mcJ$sp.scala
@@ -13,6 +13,6 @@
 package scala.runtime.java8
 
 @FunctionalInterface trait JFunction0$mcJ$sp extends Function0[Any] with Serializable {
-  def apply$mcJ$sp: Long
-  override def apply(): Any = scala.runtime.BoxesRunTime.boxToLong(apply$mcJ$sp)
+  def apply$mcJ$sp(): Long
+  override def apply(): Any = scala.runtime.BoxesRunTime.boxToLong(apply$mcJ$sp())
 }

--- a/src/library/scala/runtime/java8/JFunction0$mcS$sp.scala
+++ b/src/library/scala/runtime/java8/JFunction0$mcS$sp.scala
@@ -13,6 +13,6 @@
 package scala.runtime.java8
 
 @FunctionalInterface trait JFunction0$mcS$sp extends Function0[Any] with Serializable {
-  def apply$mcS$sp: Short
-  override def apply(): Any = scala.runtime.BoxesRunTime.boxToShort(apply$mcS$sp)
+  def apply$mcS$sp(): Short
+  override def apply(): Any = scala.runtime.BoxesRunTime.boxToShort(apply$mcS$sp())
 }

--- a/src/library/scala/runtime/java8/JFunction0$mcZ$sp.scala
+++ b/src/library/scala/runtime/java8/JFunction0$mcZ$sp.scala
@@ -13,6 +13,6 @@
 package scala.runtime.java8
 
 @FunctionalInterface trait JFunction0$mcZ$sp extends Function0[Any] with Serializable {
-  def apply$mcZ$sp: Boolean
-  override def apply(): Any = scala.runtime.BoxesRunTime.boxToBoolean(apply$mcZ$sp)
+  def apply$mcZ$sp(): Boolean
+  override def apply(): Any = scala.runtime.BoxesRunTime.boxToBoolean(apply$mcZ$sp())
 }


### PR DESCRIPTION
Dotty is more strict in overriding check: `()Int` cannot
be overridden by parameterless `=> Int`.