### PR TITLE
Tab-complete relative partest paths (eg pos/t<TAB>)

### DIFF
--- a/project/ParserUtil.scala
+++ b/project/ParserUtil.scala
@@ -6,49 +6,37 @@ import sbt.complete.Parsers._
 import sbt.complete._
 
 object ParserUtil {
-  def notStartingWith(parser: Parser[String], c: Char): Parser[String] = parser & not(c ~> any.*, "value cannot start with " + c + ".")
-  def concat(p: Parser[(String, String)]): Parser[String] = {
-    p.map(x => x._1 + x._2)
-  }
-
+  def notStartingWith(parser: Parser[String], c: Char): Parser[String] = parser & not(c ~> any.*, s"value cannot start with $c.")
+  def concat(p: Parser[(String, String)]): Parser[String] = p.map { case (a, b) => a + b }
   def Opt(a: Parser[String]) = a.?.map(_.getOrElse(""))
 
   val StringBasicNotStartingWithDash = notStartingWith(StringBasic, '-')
-  val IsDirectoryFilter = new SimpleFileFilter(_.isDirectory)
-  val JarOrDirectoryParser = FileParser(GlobFilter("*.jar") || IsDirectoryFilter)
+  val IsDirectoryFilter              = new SimpleFileFilter(_.isDirectory)
+  val JarOrDirectoryParser           = FileParser(GlobFilter("*.jar") || IsDirectoryFilter)
+
   def FileParser(fileFilter: FileFilter, dirFilter: FileFilter = AllPassFilter, base: File = file(".")) = {
+    val childFilter = IsDirectoryFilter && dirFilter || fileFilter
+    def ensureSuffix(s: String, suffix: String) = if (s.endsWith(suffix)) s else s"$s$suffix"
     def matching(prefix: String): List[String] = {
-      val preFile = file(prefix)
-      val cwd = base
-      val parent = Option(preFile.getParentFile).getOrElse(cwd)
-      if (preFile.exists) {
-        if (preFile.isDirectory) {
-          preFile.*(IsDirectoryFilter.&&(dirFilter) || fileFilter).get.map(_.getPath).toList
-        } else {
-          List(preFile).filter(fileFilter.accept).map(_.getPath)
-        }
+      val prefixFile            = new File(prefix)
+      val prefixIsAbsolute      = prefixFile.isAbsolute
+      val preFile               = if (prefixIsAbsolute) prefixFile else new File(base, prefix)
+      val basePrefix            = if (prefixIsAbsolute) "" else ensureSuffix(base.getPath, "/")
+      def relativize(p: String) = p.stripPrefix(basePrefix)
+      def pathOf(f: File)       = if (f.isDirectory() && !fileFilter.accept(f)) ensureSuffix(f.getPath, "/") else f.getPath
+      val finder = if (preFile.isDirectory()) {
+        preFile.glob(childFilter)
+      } else if (preFile.exists()) {
+        PathFinder(preFile).filter(fileFilter.accept)
+      } else {
+        preFile.getParentFile.glob(GlobFilter(s"${preFile.getName}*") && childFilter)
       }
-      else if (parent != null) {
-        def ensureSuffix(s: String, suffix: String) = if (s.endsWith(suffix)) s else s + suffix
-        def pathOf(f: File): String = {
-          val f1 = if (preFile.getParentFile == null) f.relativeTo(cwd).getOrElse(f) else f
-          if (f1.isDirectory && !fileFilter.accept(f1)) ensureSuffix(f1.getPath, "/") else f1.getPath
-        }
-        val childFilter = GlobFilter(preFile.name + "*") && ((IsDirectoryFilter && dirFilter) || fileFilter)
-        val children = parent.*(childFilter).get
-        children.map(pathOf).toList
-      } else Nil
+      finder.get().toList.map(pathOf).map(relativize)
     }
     def displayPath = Completions.single(Completion.displayOnly("<path>"))
-    token(StringBasic, TokenCompletions.fixed((seen, level) => if (seen.isEmpty) displayPath else matching(seen) match {
+    token(StringBasic, TokenCompletions.fixed((prefix, _) => if (prefix.isEmpty) displayPath else matching(prefix) match {
       case Nil => displayPath
-      case x :: Nil =>
-        if (fileFilter.accept(file(x)))
-          Completions.strict(Set(Completion.tokenDisplay(x.stripPrefix(seen), x)))
-        else
-          Completions.strict(Set(Completion.suggestion(x.stripPrefix(seen))))
-      case xs =>
-        Completions.strict(xs.map(x => Completion.tokenDisplay(x.stripPrefix(seen), x)).toSet)
+      case xs  => Completions.strict(xs.map(x => Completion.tokenDisplay(x.stripPrefix(prefix), x)).toSet)
     })).filter(!_.startsWith("-"), x => x)
   }
 }

--- a/project/src/test/scala/PartestUtilTest.scala
+++ b/project/src/test/scala/PartestUtilTest.scala
@@ -1,0 +1,69 @@
+package scala.build
+
+import sbt._
+import sbt.complete._, Completion._
+
+import scala.Console.{ GREEN, RED, RESET, err }
+
+// This doesn't get run automatically
+// but it was handy when tweaking PartestUtil
+// so it may be handy down the line.
+//
+// Run it manually like so:
+//      > reload plugins
+//      ...
+//      [info] loading project definition from /d/scala/project
+//      > Test/runMain scala.build.PartestUtilTest
+//      [info] running scala.build.PartestUtilTest
+//
+//      = base=/d/scala
+//      = path=pos/t177
+//      + completions partest pos/t177 OK
+//      + completions partest test/files/pos/t177 OK
+//      ...
+object PartestUtilTest {
+  def main(args: Array[String]): Unit = {
+    def test(base: File, str: String, expected: Completions) = {
+      print(s"+ completions partest $str ")
+      val P = PartestUtil.partestParser(base, base / "test")
+      val completions = Parser.completions(P, s" $str", 9).filterS(_.nonEmpty)
+      def pp(c: Completions, pre: String) = c.get.iterator.map(x => s"\n$pre  $x)$RESET").mkString
+      def ppStr = s"($RED-obtained$RESET/$GREEN+expected$RESET):${pp(completions, s"$RED-")}${pp(expected, s"$GREEN+")}"
+      if (completions == expected) {
+        println(s"${GREEN}OK$RESET")
+        //println(s"Completions $ppStr")
+      } else {
+        println(s"${RED}KO$RESET")
+        err.println(s"Completions $ppStr")
+        throw new AssertionError("Completions mismatch")
+      }
+    }
+
+    def prependTokens(completions: Completions, prefix: String) = completions.map {
+      case t: Token => new Token(s"$prefix${t.display}", t.append)
+      case x        => x
+    }
+
+    def testGen(base: File, path: String, res: Completions) = {
+      println(s"= path=$path")
+      test(base, s"$path",                  prependTokens(res, ""))
+      test(base, s"test/files/$path",       prependTokens(res, "test/files/"))
+      test(base, s"./test/files/$path",     prependTokens(res, "./test/files/"))
+      if (base.isAbsolute) // a prerequisite as this is to test absolute path tab-completion
+        test(base, s"$base/test/files/$path", prependTokens(res, s"$base/test/files/"))
+    }
+
+    def tests(base: File) = {
+      println(s"\n= base=$base")
+      testGen(base, "pos/t177",        Completions(Set(token("pos/t177", ".scala"))))
+      testGen(base, "pos/t177.scala",  Completions(Set(suggestion(" "))))
+      testGen(base, "pos/t1786",       Completions(Set(token("pos/t1786", "-counter.scala"), token("pos/t1786", "-cycle.scala"))))
+      testGen(base, "pos/t1786.scala", Completions(Set()))
+    }
+
+    tests(file(sys.props("user.dir")))
+    tests(file(".").getAbsoluteFile)
+    tests(file("."))
+    tests(file("./"))
+  }
+}


### PR DESCRIPTION
For example:

    > partest pos/t17<TAB>
    pos/t1711                 pos/t1722-A.scala         pos/t1748.scala           pos/t1751                 pos/t177.scala            pos/t1785.scala           pos/t1786-cycle.scala     pos/t1798.scala
    pos/t1722                 pos/t1745                 pos/t175.scala            pos/t1756.scala           pos/t1782                 pos/t1786-counter.scala   pos/t1789.scala

I wrote a little build test, which you can manually run (see commit for instructions).

Fixes https://github.com/scala/bug/issues/11184