### PR TITLE
Dealias val aliases to modules so they're =:=

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4558,9 +4558,9 @@ trait Types
     if (isRawType(tp)) rawToExistential(tp)
     else tp.normalize match {
       // Unify the representations of module classes
-      case st@SingleType(_, sym) if sym.isModule => st.underlying.normalize
-      case st@ThisType(sym) if sym.isModuleClass => normalizePlus(st.underlying)
-      case _ => tp.normalize
+      case st @ SingleType(_, _) if st.typeSymbol.isModuleClass => st.underlying.normalize
+      case st @ ThisType(sym) if sym.isModuleClass              => normalizePlus(st.underlying)
+      case tpNorm                                               => tpNorm
     }
   }
 

--- a/test/files/pos/t12186.scala
+++ b/test/files/pos/t12186.scala
@@ -1,0 +1,29 @@
+// scalac: -Werror
+
+// this is remodeling of the scala package object and scala.collection.immutable.{ List, ::, Nil }
+// in order to:
+// * avoid the scala package, which is auto-imported
+// * avoid List, which is rewritten/fudged in the pattern matcher
+package skala.collect {
+  sealed trait Xs[+A]
+  final case class  Cons[+A](head: A, tail: Xs[A]) extends Xs[A]
+  final case object Done                           extends Xs[Nothing]
+  object Xs
+}
+package object skala {
+  type Cons[+A]                     = skala.collect.Cons[A]
+  type Xs[+A]                       = skala.collect.Xs[A]
+  val Cons                          = skala.collect.Cons
+  val Done: skala.collect.Done.type = skala.collect.Done
+  val Xs                            = skala.collect.Xs
+}
+
+import skala._
+
+class Test {
+  def test(xs: Xs[Int]): Boolean = xs match {
+    case Cons(_, _)                 => true
+    case _: Done.type               => false
+  //case _: skala.collect.Done.type => false // done this way it already works
+  }
+}


### PR DESCRIPTION
This changes the definition of `=:=` in the smallest possible way:
if you have a singleton type that widens to a module,
then widen to that module.

Fixes scala/bug#12186.