### PR TITLE
remove some allocations from RedBlackTree

### DIFF
--- a/test/junit/scala/collection/immutable/TreeMapTest.scala
+++ b/test/junit/scala/collection/immutable/TreeMapTest.scala
@@ -228,4 +228,12 @@ class TreeMapTest extends AllocationTest {
     assertEquals(Map("A" -> "2"), r)
 
   }
+
+  @Test def removeNonContent(): Unit = {
+    val src: Map[Int, String] = TreeMap(Range(0, 100, 2).map((_, "")) :_*)
+    for (i <- Range(-1, 101, 2)) {
+      src - i
+      assertSame(i.toString, src, nonAllocating(src - i, text = i.toString))
+    }
+  }
 }

--- a/test/junit/scala/collection/immutable/TreeSetTest.scala
+++ b/test/junit/scala/collection/immutable/TreeSetTest.scala
@@ -288,4 +288,10 @@ class TreeSetTest extends AllocationTest{
       assertEquals(expected, src filter set)
     }
   }
+  @Test def removeNonContent(): Unit = {
+    val src      = TreeSet(Range(0, 100, 2) :_*)
+    for (i <- Range(-1, 101, 2)) {
+      assertSame(src, nonAllocating(src - i))
+    }
+  }
 }


### PR DESCRIPTION
Deletion from a TreeSet/TreeMap of a key that doesn't exist should not allocate

pass the tree into balance/balLeft/balRight methods so that is can be reused is unchanged

prefer use of isBlack/isRed to isRedTree when we know the tree is not null
