### PR TITLE
Fix compiler crosstalk w/ an empty package reset

### DIFF
--- a/test/junit/scala/CrossTalkTest.scala
+++ b/test/junit/scala/CrossTalkTest.scala
@@ -1,0 +1,19 @@
+package scala
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.tools.testkit.BytecodeTesting
+
+@RunWith(classOf[JUnit4])
+class CrossTalkTest extends BytecodeTesting {
+  import compiler.compileClasses
+
+  @Test def eins(): Unit = compileClasses("class A; class B  extends A; class C extends B ")
+  @Test def zwei(): Unit = compileClasses("         trait B  extends A; class C extends B ", List("interface A {}" -> "A.java"))
+  @Test def zwey(): Unit = compileClasses("         trait B1 extends A; class C extends B1", List("interface A {}" -> "A.java"))
+
+  @Test def a(): Unit = compileClasses("                   class C extends T", List("interface T {}" -> "T.java"))
+  @Test def b(): Unit = compileClasses("trait T extends A; class C extends T", List("interface A {}" -> "A.java"))
+}

--- a/test/junit/scala/tools/nsc/backend/jvm/IndyLambdaTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/IndyLambdaTest.scala
@@ -13,7 +13,7 @@ class IndyLambdaTest extends BytecodeTesting {
 
   @Test def boxingBridgeMethodUsedSelectively(): Unit = {
     def implMethodDescriptorFor(code: String): String = {
-      val method = compileAsmMethods(s"""def f = $code """).find(_.name == "f").get
+      val method = compileAsmMethods(s"""def f = $code """, reuseEmptyPkg = true).find(_.name == "f").get
       val x = method.instructions.iterator.asScala.toList
       x.flatMap {
         case insn : InvokeDynamicInsnNode => insn.bsmArgs.collect { case h : Handle => h.getDesc }
@@ -49,14 +49,14 @@ class IndyLambdaTest extends BytecodeTesting {
     compileToBytes("class VC(private val i: Int) extends AnyVal; trait FunVC { def apply(a: VC): VC }")
     assertEquals("(I)I", implMethodDescriptorFor("((x: VC) => x): FunVC"))
 
-    compileToBytes("trait Fun1[T, U] { def apply(a: T): U }")
+    compileToBytes("trait Fun1[T, U] { def apply(a: T): U }", reuseEmptyPkg = true)
     assertEquals(s"($obj)$str", implMethodDescriptorFor("(x => x.toString): Fun1[Int, String]"))
     assertEquals(s"($obj)$obj", implMethodDescriptorFor("(x => println(x)): Fun1[Int, Unit]"))
     assertEquals(s"($obj)$str", implMethodDescriptorFor("((x: VC) => \"\") : Fun1[VC, String]"))
     assertEquals(s"($str)$obj", implMethodDescriptorFor("((x: String) => new VC(0)) : Fun1[String, VC]"))
 
     compileToBytes("trait Coll[A, Repr] extends Any")
-    compileToBytes("final class ofInt(val repr: Array[Int]) extends AnyVal with Coll[Int, Array[Int]]")
+    compileToBytes("final class ofInt(val repr: Array[Int]) extends AnyVal with Coll[Int, Array[Int]]", reuseEmptyPkg = true)
 
     assertEquals(s"([I)$obj", implMethodDescriptorFor("((xs: Array[Int]) => new ofInt(xs)): Array[Int] => Coll[Int, Array[Int]]"))
   }

--- a/test/junit/scala/tools/nsc/backend/jvm/IndySammyTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/IndySammyTest.scala
@@ -40,7 +40,7 @@ class IndySammyTest extends BytecodeTesting {
           (expectedSig: String, lamBody: List[Instruction], appArgs: List[Instruction], ret: Instruction)
           (allowMessage: StoreReporter.Info => Boolean = _ => false) = {
     val List(funClass, vcClass, vcCompanion) = compileClasses(s"${classPrologue(from, to)}")
-    val c = compileClass(s"class C { ${lamDef(from, to, body)}; ${appDef(arg)} }", allowMessage = allowMessage)
+    val c = compileClass(s"class C { ${lamDef(from, to, body)}; ${appDef(arg)} }", allowMessage = allowMessage, reuseEmptyPkg = true)
 
     val applySig = getAsmMethod(funClass, "apply").desc
     val anonfun = getMethod(c, "$anonfun$lam$1")


### PR DESCRIPTION
The point of using a "resident" compiler is to hold on to a single
Global which initialises a bunch of expensive things, so you save that
cost when you execute multiple compile Run's on various code.  One of
those things is constructing and populating various data structures
based on the runtime that the compiler finds itself executing on, the
standard library and JDK, for instance.  For instance constructing the
Symbol's and Scope's for various important parts of the classpath.

Wiping out all of that would (I predict - the mechanics aren't there and
I didn't get far enough to build and test it) negate the intent of
reusing a Global.  So instead I just wipe out the empty package, which
works well because production code doesn't (shouldn't) live there but
test code frequently does.  Fortunately it's logic that lives in
testkit-land so its imperfections don't cascade into production usage.

Fixes https://github.com/scala/scala-dev/issues/214