### PR TITLE
reword warning about `equals` and cooperative equality

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1148,7 +1148,7 @@ abstract class RefChecks extends Transform {
       val actual   = underlyingClass(other.tpe)
       def typesString = "" + normalizeAll(qual.tpe.widen) + " and " + normalizeAll(other.tpe.widen)
       def nonSensiblyEquals() = {
-        refchecksWarning(pos, s"comparing values of types $typesString using `${name.decode}` is unsafe due to cooperative equality; use `==` instead", WarningCategory.OtherNonCooperativeEquals)
+        refchecksWarning(pos, s"comparing values of types $typesString using `${name.decode}` unsafely bypasses cooperative equality; use `==` instead", WarningCategory.OtherNonCooperativeEquals)
       }
       def isScalaNumber(s: Symbol) = s isSubClass ScalaNumberClass
       def isJavaNumber(s: Symbol)  = s isSubClass JavaNumberClass

--- a/src/library/scala/math/BigInt.scala
+++ b/src/library/scala/math/BigInt.scala
@@ -126,7 +126,7 @@ final class BigInt(val bigInteger: BigInteger)
   /** Compares this BigInt with the specified value for equality. */
   // TODO: switch to `cat`-based after 2.13.4 re-STARR
   // @nowarn("cat=other-non-cooperative-equals")
-  @nowarn("msg=comparing values .* is unsafe due to cooperative equality")
+  @nowarn("msg=comparing values .* unsafely bypasses cooperative equality")
   override def equals(that: Any): Boolean = that match {
     case that: BigInt     => this equals that
     case that: BigDecimal => that equals this

--- a/src/reflect/scala/reflect/internal/Constants.scala
+++ b/src/reflect/scala/reflect/internal/Constants.scala
@@ -112,7 +112,7 @@ trait Constants extends api.Constants {
             case _ =>
               // we do not want cooperative equality for determining if constants are equal
               // TODO: switch to `cat`-based after 2.13.4 re-STARR // : @nowarn("cat=other-non-cooperative-equals")
-              this.value.equals(that.value): @nowarn("msg=comparing values .* is unsafe due to cooperative equality")
+              this.value.equals(that.value): @nowarn("msg=comparing values .* unsafely bypasses cooperative equality")
           }
         }
       case _ => false

--- a/test/files/jvm/serialization-new.check
+++ b/test/files/jvm/serialization-new.check
@@ -1,13 +1,13 @@
-serialization-new.scala:24: warning: comparing values of types A and B using `equals` is unsafe due to cooperative equality; use `==` instead
+serialization-new.scala:24: warning: comparing values of types A and B using `equals` unsafely bypasses cooperative equality; use `==` instead
     println("x equals y: " + (x equals y) + ", y equals x: " + (y equals x))
                                 ^
-serialization-new.scala:24: warning: comparing values of types B and A using `equals` is unsafe due to cooperative equality; use `==` instead
+serialization-new.scala:24: warning: comparing values of types B and A using `equals` unsafely bypasses cooperative equality; use `==` instead
     println("x equals y: " + (x equals y) + ", y equals x: " + (y equals x))
                                                                   ^
-serialization-new.scala:25: warning: comparing values of types A and B using `equals` is unsafe due to cooperative equality; use `==` instead
+serialization-new.scala:25: warning: comparing values of types A and B using `equals` unsafely bypasses cooperative equality; use `==` instead
     assert((x equals y) && (y equals x))
               ^
-serialization-new.scala:25: warning: comparing values of types B and A using `equals` is unsafe due to cooperative equality; use `==` instead
+serialization-new.scala:25: warning: comparing values of types B and A using `equals` unsafely bypasses cooperative equality; use `==` instead
     assert((x equals y) && (y equals x))
                               ^
 warning: 4 deprecations (since 2.13.0); re-run with -deprecation for details

--- a/test/files/jvm/serialization.check
+++ b/test/files/jvm/serialization.check
@@ -1,13 +1,13 @@
-serialization.scala:24: warning: comparing values of types A and B using `equals` is unsafe due to cooperative equality; use `==` instead
+serialization.scala:24: warning: comparing values of types A and B using `equals` unsafely bypasses cooperative equality; use `==` instead
     println("x equals y: " + (x equals y) + ", y equals x: " + (y equals x))
                                 ^
-serialization.scala:24: warning: comparing values of types B and A using `equals` is unsafe due to cooperative equality; use `==` instead
+serialization.scala:24: warning: comparing values of types B and A using `equals` unsafely bypasses cooperative equality; use `==` instead
     println("x equals y: " + (x equals y) + ", y equals x: " + (y equals x))
                                                                   ^
-serialization.scala:25: warning: comparing values of types A and B using `equals` is unsafe due to cooperative equality; use `==` instead
+serialization.scala:25: warning: comparing values of types A and B using `equals` unsafely bypasses cooperative equality; use `==` instead
     assert((x equals y) && (y equals x))
               ^
-serialization.scala:25: warning: comparing values of types B and A using `equals` is unsafe due to cooperative equality; use `==` instead
+serialization.scala:25: warning: comparing values of types B and A using `equals` unsafely bypasses cooperative equality; use `==` instead
     assert((x equals y) && (y equals x))
                               ^
 warning: 4 deprecations (since 2.13.0); re-run with -deprecation for details

--- a/test/files/neg/checksensible.check
+++ b/test/files/neg/checksensible.check
@@ -100,19 +100,19 @@ checksensible.scala:86: warning: comparing values of types EqEqRefTest.this.C3 a
 checksensible.scala:97: warning: comparing values of types Unit and Int using `!=` will always yield true
     while ((c = in.read) != -1)
                          ^
-checksensible.scala:105: warning: comparing values of types Long and Int using `equals` is unsafe due to cooperative equality; use `==` instead
+checksensible.scala:105: warning: comparing values of types Long and Int using `equals` unsafely bypasses cooperative equality; use `==` instead
   1L equals 1
      ^
-checksensible.scala:112: warning: comparing values of types Any and Int using `equals` is unsafe due to cooperative equality; use `==` instead
+checksensible.scala:112: warning: comparing values of types Any and Int using `equals` unsafely bypasses cooperative equality; use `==` instead
   (1L: Any) equals 1
             ^
-checksensible.scala:113: warning: comparing values of types AnyVal and Int using `equals` is unsafe due to cooperative equality; use `==` instead
+checksensible.scala:113: warning: comparing values of types AnyVal and Int using `equals` unsafely bypasses cooperative equality; use `==` instead
   (1L: AnyVal) equals 1
                ^
-checksensible.scala:114: warning: comparing values of types AnyVal and AnyVal using `equals` is unsafe due to cooperative equality; use `==` instead
+checksensible.scala:114: warning: comparing values of types AnyVal and AnyVal using `equals` unsafely bypasses cooperative equality; use `==` instead
   (1L: AnyVal) equals (1: AnyVal)
                ^
-checksensible.scala:117: warning: comparing values of types A and Int using `equals` is unsafe due to cooperative equality; use `==` instead
+checksensible.scala:117: warning: comparing values of types A and Int using `equals` unsafely bypasses cooperative equality; use `==` instead
   def foo[A](a: A) = a.equals(1)
                              ^
 error: No warnings can be incurred under -Werror.


### PR DESCRIPTION
this is a small adjustment to @eed3si9n's #8120

it's no big deal, but the old wording kind of made cooperative equality sound like what we need rescuing from, rather than what will rescue us