### PR TITLE
Catch exceptions for the InlineInfoAttribute reader

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/ByteCodeRepository.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/ByteCodeRepository.scala
@@ -17,6 +17,7 @@ package opt
 
 import scala.collection.JavaConverters._
 import scala.collection.{concurrent, mutable}
+import scala.reflect.internal.util.NoPosition
 import scala.tools.asm
 import scala.tools.asm.Attribute
 import scala.tools.asm.tree._
@@ -33,7 +34,7 @@ abstract class ByteCodeRepository extends PerRunInit {
 
   import postProcessor.{bTypes, bTypesFromClassfile, callGraph}
   import bTypes._
-  import frontendAccess.{backendClassPath, recordPerRunCache}
+  import frontendAccess.{backendReporting, backendClassPath, recordPerRunCache}
 
   /**
    * Contains ClassNodes and the canonical path of the source file path of classes being compiled in
@@ -295,7 +296,9 @@ abstract class ByteCodeRepository extends PerRunInit {
         removeLineNumbersAndAddLMFImplMethods(classNode)
         Some(classNode)
       } catch {
-        case e: Exception =>
+        case ex: Exception =>
+          if (frontendAccess.compilerSettings.debug) ex.printStackTrace()
+          backendReporting.warning(NoPosition, s"Error while reading InlineInfoAttribute from ${fullName}\n${ex.getMessage}")
           None
       }
     } match {


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/11247

Verified via `sbt publishLocal`on this PR and `sbt compile` using the snapshot Scala version on https://github.com/sadhen/bug_12229

For logging:
```
        if (frontendAccess.compilerSettings.debug) ex.printStackTrace()
        backendReporting.warning(NoPosition, s"Error while reading InlineInfoAttribute from ${fullName}\n${ex.getMessage}")
```

And here is the logging tested (`"-Ydebug", "-Ylog:jvm"`):
```
java.lang.ArrayIndexOutOfBoundsException: 821
        at scala.tools.asm.ClassReader.readUtf(ClassReader.java:3671)
        at scala.tools.asm.ClassReader.readUtf(ClassReader.java:3651)
        at scala.tools.asm.ClassReader.readUTF8(ClassReader.java:3632)
        at scala.tools.nsc.backend.jvm.opt.InlineInfoAttribute.nextUTF8$1(InlineInfoAttribute.scala:98)
  | => bat scala.tools.nsc.backend.jvm.opt.InlineInfoAttribute.$anonfun$read$1(InlineInfoAttribute.scala:118)
        at scala.tools.nsc.backend.jvm.opt.InlineInfoAttribute.$anonfun$read$1$adapted(InlineInfoAttribute.scala:117)
        at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:286)
        at scala.collection.immutable.Range.foreach(Range.scala:158)
        at scala.collection.TraversableLike.map(TraversableLike.scala:286)
        at scala.collection.TraversableLike.map$(TraversableLike.scala:279)
        at scala.collection.AbstractTraversable.map(Traversable.scala:108)
        at scala.tools.nsc.backend.jvm.opt.InlineInfoAttribute.read(InlineInfoAttribute.scala:117)
        at scala.tools.nsc.backend.jvm.opt.InlineInfoAttribute.read(InlineInfoAttribute.scala:40)
        at scala.tools.asm.ClassReader.readAttribute(ClassReader.java:3507)
        at scala.tools.asm.ClassReader.accept(ClassReader.java:526)
        at scala.tools.nsc.backend.jvm.opt.ByteCodeRepository.$anonfun$parseClass$1(ByteCodeRepository.scala:288)
        at scala.Option.flatMap(Option.scala:271)
        at scala.tools.nsc.backend.jvm.opt.ByteCodeRepository.parseClass(ByteCodeRepository.scala:278)
        at scala.tools.nsc.backend.jvm.opt.ByteCodeRepository.$anonfun$parsedClassNode$1(ByteCodeRepository.scala:72)
        at scala.collection.mutable.MapLike.getOrElseUpdate(MapLike.scala:209)
        at scala.collection.mutable.MapLike.getOrElseUpdate$(MapLike.scala:206)
        at scala.collection.mutable.AbstractMap.getOrElseUpdate(Map.scala:84)
        at scala.tools.nsc.backend.jvm.opt.ByteCodeRepository.parsedClassNode(ByteCodeRepository.scala:72)
        at scala.tools.nsc.backend.jvm.opt.ByteCodeRepository.classNode(ByteCodeRepository.scala:93)
        at scala.tools.nsc.backend.jvm.BTypesFromSymbols.buildInlineInfo(BTypesFromSymbols.scala:533)
        at scala.tools.nsc.backend.jvm.BTypesFromSymbols.computeClassInfo(BTypesFromSymbols.scala:445)
        at scala.tools.nsc.backend.jvm.BTypesFromSymbols.$anonfun$classBTypeFromSymbol$5(BTypesFromSymbols.scala:109)
        at scala.tools.nsc.backend.jvm.BTypes$ClassBType$.apply(BTypes.scala:826)
        at scala.tools.nsc.backend.jvm.BTypesFromSymbols.classBTypeFromSymbol(BTypesFromSymbols.scala:106)
        at scala.tools.nsc.backend.jvm.BTypesFromSymbols.$anonfun$typeToBType$1(BTypesFromSymbols.scala:164)
        at scala.collection.immutable.HashMap$HashTrieMap.getOrElse0(HashMap.scala:593)
        at scala.collection.immutable.HashMap.getOrElse(HashMap.scala:73)
        at scala.tools.nsc.backend.jvm.BTypesFromSymbols.primitiveOrClassToBType$1(BTypesFromSymbols.scala:164)
        at scala.tools.nsc.backend.jvm.BTypesFromSymbols.typeToBType(BTypesFromSymbols.scala:179)
        at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder.tpeTK(BCodeSkelBuilder.scala:86)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoad(BCodeBodyBuilder.scala:256)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoadQualifier(BCodeBodyBuilder.scala:908)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genApply(BCodeBodyBuilder.scala:672)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoad(BCodeBodyBuilder.scala:303)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoad(BCodeBodyBuilder.scala:256)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoadQualifier(BCodeBodyBuilder.scala:908)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genApply(BCodeBodyBuilder.scala:672)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoad(BCodeBodyBuilder.scala:303)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoad(BCodeBodyBuilder.scala:256)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoadQualifier(BCodeBodyBuilder.scala:908)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genApply(BCodeBodyBuilder.scala:672)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoad(BCodeBodyBuilder.scala:303)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.$anonfun$genLoadArguments$1(BCodeBodyBuilder.scala:943)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.$anonfun$genLoadArguments$1$adapted(BCodeBodyBuilder.scala:943)
        at scala.reflect.internal.util.Collections.foreach2(Collections.scala:255)
        at scala.reflect.internal.util.Collections.foreach2$(Collections.scala:251)
        at scala.reflect.internal.SymbolTable.foreach2(SymbolTable.scala:28)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoadArguments(BCodeBodyBuilder.scala:943)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genApply(BCodeBodyBuilder.scala:673)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoad(BCodeBodyBuilder.scala:303)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genArrayValue(BCodeBodyBuilder.scala:748)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoad(BCodeBodyBuilder.scala:384)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoad(BCodeBodyBuilder.scala:256)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoadQualifier(BCodeBodyBuilder.scala:908)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genTypeApply$1(BCodeBodyBuilder.scala:532)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genApply(BCodeBodyBuilder.scala:563)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoad(BCodeBodyBuilder.scala:303)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.$anonfun$genLoadArguments$1(BCodeBodyBuilder.scala:943)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.$anonfun$genLoadArguments$1$adapted(BCodeBodyBuilder.scala:943)
        at scala.reflect.internal.util.Collections.foreach2(Collections.scala:255)
        at scala.reflect.internal.util.Collections.foreach2$(Collections.scala:251)
        at scala.reflect.internal.SymbolTable.foreach2(SymbolTable.scala:28)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoadArguments(BCodeBodyBuilder.scala:943)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genApply(BCodeBodyBuilder.scala:673)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoad(BCodeBodyBuilder.scala:303)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.$anonfun$genLoadArguments$1(BCodeBodyBuilder.scala:943)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.$anonfun$genLoadArguments$1$adapted(BCodeBodyBuilder.scala:943)
        at scala.reflect.internal.util.Collections.foreach2(Collections.scala:255)
        at scala.reflect.internal.util.Collections.foreach2$(Collections.scala:251)
        at scala.reflect.internal.SymbolTable.foreach2(SymbolTable.scala:28)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoadArguments(BCodeBodyBuilder.scala:943)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genApply(BCodeBodyBuilder.scala:673)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoad(BCodeBodyBuilder.scala:303)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoad(BCodeBodyBuilder.scala:256)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoadQualifier(BCodeBodyBuilder.scala:908)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genTypeApply$1(BCodeBodyBuilder.scala:532)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genApply(BCodeBodyBuilder.scala:563)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoad(BCodeBodyBuilder.scala:303)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genStat(BCodeBodyBuilder.scala:73)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.$anonfun$genBlock$1(BCodeBodyBuilder.scala:820)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.$anonfun$genBlock$1$adapted(BCodeBodyBuilder.scala:820)
        at scala.collection.immutable.List.foreach(List.scala:431)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genBlock(BCodeBodyBuilder.scala:820)
        at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoad(BCodeBodyBuilder.scala:373)
        at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder.emitNormalMethodBody$1(BCodeSkelBuilder.scala:610)
        at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder.genDefDef(BCodeSkelBuilder.scala:642)
        at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder.gen(BCodeSkelBuilder.scala:515)
        at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder.$anonfun$gen$7(BCodeSkelBuilder.scala:517)
        at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder.$anonfun$gen$7$adapted(BCodeSkelBuilder.scala:517)
        at scala.collection.immutable.List.foreach(List.scala:431)
        at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder.gen(BCodeSkelBuilder.scala:517)
        at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder.genPlainClass(BCodeSkelBuilder.scala:117)
        at scala.tools.nsc.backend.jvm.CodeGen.genClass(CodeGen.scala:81)
        at scala.tools.nsc.backend.jvm.CodeGen.genClassDef$1(CodeGen.scala:42)
        at scala.tools.nsc.backend.jvm.CodeGen.$anonfun$genUnit$3(CodeGen.scala:66)
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
        at scala.tools.nsc.backend.jvm.PostProcessorFrontendAccess.frontendSynch(PostProcessorFrontendAccess.scala:34)
        at scala.tools.nsc.backend.jvm.CodeGen.genClassDefs$1(CodeGen.scala:66)
        at scala.tools.nsc.backend.jvm.CodeGen.$anonfun$genUnit$2(CodeGen.scala:65)
        at scala.tools.nsc.backend.jvm.CodeGen.$anonfun$genUnit$2$adapted(CodeGen.scala:65)
        at scala.collection.immutable.List.foreach(List.scala:431)
        at scala.tools.nsc.backend.jvm.CodeGen.genClassDefs$1(CodeGen.scala:65)
        at scala.tools.nsc.backend.jvm.CodeGen.$anonfun$genUnit$4(CodeGen.scala:70)
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
        at scala.reflect.internal.util.Statistics.timed(Statistics.scala:333)
        at scala.tools.nsc.backend.jvm.CodeGen.genUnit(CodeGen.scala:70)
        at scala.tools.nsc.backend.jvm.GenBCode$BCodePhase.apply(GenBCode.scala:74)
        at scala.tools.nsc.Global$GlobalPhase.applyPhase(Global.scala:453)
        at scala.tools.nsc.Global$GlobalPhase.run(Global.scala:400)
        at scala.tools.nsc.backend.jvm.GenBCode$BCodePhase.super$run(GenBCode.scala:80)
        at scala.tools.nsc.backend.jvm.GenBCode$BCodePhase.$anonfun$run$1(GenBCode.scala:80)
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
        at scala.reflect.internal.util.Statistics.timed(Statistics.scala:333)
        at scala.tools.nsc.backend.jvm.GenBCode$BCodePhase.run(GenBCode.scala:78)
        at scala.tools.nsc.Global$Run.compileUnitsInternal(Global.scala:1511)
        at scala.tools.nsc.Global$Run.compileUnits(Global.scala:1495)
        at scala.tools.nsc.Global$Run.compileSources(Global.scala:1488)
        at scala.tools.nsc.Global$Run.compile(Global.scala:1617)
        at xsbt.CachedCompiler0.run(CompilerInterface.scala:153)
        at xsbt.CachedCompiler0.run(CompilerInterface.scala:125)
        at xsbt.CompilerInterface.run(CompilerInterface.scala:39)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at sbt.internal.inc.AnalyzingCompiler.call(AnalyzingCompiler.scala:248)
        at sbt.internal.inc.AnalyzingCompiler.compile(AnalyzingCompiler.scala:122)
        at sbt.internal.inc.AnalyzingCompiler.compile(AnalyzingCompiler.scala:95)
        at sbt.internal.inc.MixedAnalyzingCompiler.$anonfun$compile$4(MixedAnalyzingCompiler.scala:91)
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
        at sbt.internal.inc.MixedAnalyzingCompiler.timed(MixedAnalyzingCompiler.scala:186)
        at sbt.internal.inc.MixedAnalyzingCompiler.$anonfun$compile$3(MixedAnalyzingCompiler.scala:82)
        at sbt.internal.inc.MixedAnalyzingCompiler.$anonfun$compile$3$adapted(MixedAnalyzingCompiler.scala:77)
        at sbt.internal.inc.JarUtils$.withPreviousJar(JarUtils.scala:215)
        at sbt.internal.inc.MixedAnalyzingCompiler.compileScala$1(MixedAnalyzingCompiler.scala:77)
        at sbt.internal.inc.MixedAnalyzingCompiler.compile(MixedAnalyzingCompiler.scala:146)
        at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileInternal$1(IncrementalCompilerImpl.scala:343)
        at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileInternal$1$adapted(IncrementalCompilerImpl.scala:343)
        at sbt.internal.inc.Incremental$.doCompile(Incremental.scala:120)
        at sbt.internal.inc.Incremental$.$anonfun$compile$4(Incremental.scala:100)
        at sbt.internal.inc.IncrementalCommon.recompileClasses(IncrementalCommon.scala:180)
        at sbt.internal.inc.IncrementalCommon.cycle(IncrementalCommon.scala:98)
        at sbt.internal.inc.Incremental$.$anonfun$compile$3(Incremental.scala:102)
        at sbt.internal.inc.Incremental$.manageClassfiles(Incremental.scala:155)
        at sbt.internal.inc.Incremental$.compile(Incremental.scala:92)
        at sbt.internal.inc.IncrementalCompile$.apply(Compile.scala:75)
        at sbt.internal.inc.IncrementalCompilerImpl.compileInternal(IncrementalCompilerImpl.scala:348)
        at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileIncrementally$1(IncrementalCompilerImpl.scala:301)
        at sbt.internal.inc.IncrementalCompilerImpl.handleCompilationError(IncrementalCompilerImpl.scala:168)
        at sbt.internal.inc.IncrementalCompilerImpl.compileIncrementally(IncrementalCompilerImpl.scala:248)
        at sbt.internal.inc.IncrementalCompilerImpl.compile(IncrementalCompilerImpl.scala:74)
        at sbt.Defaults$.compileIncrementalTaskImpl(Defaults.scala:1765)
        at sbt.Defaults$.$anonfun$compileIncrementalTask$1(Defaults.scala:1738)
        at scala.Function1.$anonfun$compose$1(Function1.scala:49)
        at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:62)
        at sbt.std.Transform$$anon$4.work(Transform.scala:67)
        at sbt.Execute.$anonfun$submit$2(Execute.scala:281)
        at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:19)
        at sbt.Execute.work(Execute.scala:290)
        at sbt.Execute.$anonfun$submit$1(Execute.scala:281)
        at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:178)
        at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
[warn] Error while reading InlineInfoAttribute from org.apache.spark.sql.functions$
[warn] 821

```