### PR TITLE
Validate (and fix) the RedBlackTree invariants

### DIFF
--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -261,11 +261,6 @@ private[collection] object NewRedBlackTree {
       }
     }
 
-    def leftBlackHeight(tree: Tree[_, _], h: Int): Int = {
-      if (tree eq null) h
-      else leftBlackHeight(tree.left, h + (if (tree.isBlack) 1 else 0))
-    }
-
     def validateBlackHeight(tree: Tree[_, _], h: Int, expected: Int): Unit = {
       if (tree eq null)
         if (h != 0) throw new IllegalStateException(s"at red tree ${tree.key} tree is has a black height of ${expected -h} while expecting $expected")
@@ -279,7 +274,7 @@ private[collection] object NewRedBlackTree {
       try {
         checkImmutable(generated)
         checkAdjacentRed(generated)
-        val h = leftBlackHeight(generated, 0)
+        val h = blackHeight(generated, 0)
         validateBlackHeight(generated, h, h)
       } catch {
         case e: IllegalStateException => {
@@ -1277,12 +1272,13 @@ private[collection] object NewRedBlackTree {
       else mkTree(trBlack, tr.key, tr.value, ttl, tr.right)
     }
   }
+  @tailrec private def blackHeight(tree: Tree[_, _], heightSoFar: Int): Int =
+    if (tree eq null) heightSoFar + 1
+    else blackHeight(tree.left, if (tree.isBlack) heightSoFar + 1 else heightSoFar)
 
   private[this] def join[A, B](tl: Tree[A, B], k: A, v: B, tr: Tree[A, B]): Tree[A, B] = {
-    @tailrec def h(t: Tree[_, _], i: Int): Int =
-      if(t eq null) i+1 else h(t.left, if(isBlackTree(t)) i+1 else i)
-    val bhtl = h(tl, 0)
-    val bhtr = h(tr, 0)
+    val bhtl = blackHeight(tl, 0)
+    val bhtr = blackHeight(tr, 0)
     if(bhtl > bhtr) {
       val tt = joinRight(tl, k, v, tr, bhtl, rank(tr, bhtr))
       if(isRedTree(tt) && isRedTree(tt.right)) tt.black

--- a/test/junit/scala/collection/immutable/TreeMapTest.scala
+++ b/test/junit/scala/collection/immutable/TreeMapTest.scala
@@ -8,6 +8,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import scala.tools.testing.AllocationTest
+import scala.util.Random
 
 @RunWith(classOf[JUnit4])
 class TreeMapTest extends AllocationTest {
@@ -227,5 +228,147 @@ class TreeMapTest extends AllocationTest {
     // as keys are retained
     assertEquals(Map("A" -> "2"), r)
 
+  }
+
+  def validate[A, B](original: TreeMap[A, B], result: TreeMap[A, B]): TreeMap[A, B] = {
+    NewRedBlackTree.validate(original.tree0, result.tree0)
+    result
+  }
+  @Test
+  def randomTreePlusMinus() {
+    val r = new Random(0)
+    var m = TreeMap[Int, String]()
+    for (i <- 1 to 100000) {
+      m = validate(m, m + ((r.nextInt(1000), "")))
+      m = validate(m, m - r.nextInt(1000))
+    }
+  }
+  @Test
+  def randomTreeBuild() {
+    val r = new Random(0)
+    var m = TreeMap[Int, String]()
+    for (i <- 1 to 100000) {
+      m = validate(m, m + ((r.nextInt(1000), "")))
+      m = validate(m, m - r.nextInt(1000))
+      
+      val builder = TreeMap.newBuilder[Int, String]
+      builder ++= r.shuffle(m.toList)
+      val res = validate(m, builder.result())
+      
+      assertEquals(m, res)
+    }
+  }
+  @Test
+  def randomTreeSplit() {
+    val r = new Random(0)
+    var m = TreeMap[Int, String]()
+    for (i <- 1 to 100000) {
+      m = validate(m, m + ((r.nextInt(1000), "")))
+      m = validate(m, m - r.nextInt(1000))
+
+      val (m1,m2) = m.splitAt(r.nextInt(1000))
+
+      validate(m, m1)
+      validate(m, m2)
+    }
+  }
+  @Test
+  def randomTreeDrop() {
+    val r = new Random(0)
+    var m = TreeMap[Int, String]()
+    for (i <- 1 to 100000) {
+      m = validate(m, m + ((r.nextInt(1000), "")))
+      m = validate(m, m - r.nextInt(1000))
+
+      validate(m, m.drop(r.nextInt(1000)))
+    }
+  }
+  @Test
+  def randomTreeTake() {
+    val r = new Random(0)
+    var m = TreeMap[Int, String]()
+    for (i <- 1 to 100000) {
+      m = validate(m, m + ((r.nextInt(1000), "")))
+      m = validate(m, m - r.nextInt(1000))
+
+      validate(m, m.take(r.nextInt(1000)))
+    }
+  }
+  @Test
+  def randomTreeSlice() {
+    val r = new Random(0)
+    var m = TreeMap[Int, String]()
+    for (i <- 1 to 100000) {
+      m = validate(m, m + ((r.nextInt(1000), "")))
+      m = validate(m, m - r.nextInt(1000))
+
+      validate(m, m.slice(r.nextInt(1000),r.nextInt(1000)))
+    }
+  }
+  @Test
+  def randomTreeInit() {
+    val r = new Random(0)
+    var m = TreeMap[Int, String]()
+    for (i <- 1 to 100000) {
+      m = validate(m, m + ((r.nextInt(1000), "")))
+      m = validate(m, m - r.nextInt(1000))
+
+      validate(m, m.init)
+    }
+  }
+  @Test
+  def randomTreeTail() {
+    val r = new Random(0)
+    var m = TreeMap[Int, String]()
+    for (i <- 1 to 100000) {
+      m = validate(m, m + ((r.nextInt(1000), "")))
+      m = validate(m, m - r.nextInt(1000))
+
+      validate(m, m.tail)
+    }
+  }
+  @Test
+  def randomTreeFrom() {
+    val r = new Random(0)
+    var m = TreeMap[Int, String]()
+    for (i <- 1 to 100000) {
+      m = validate(m, m + ((r.nextInt(1000), "")))
+      m = validate(m, m - r.nextInt(1000))
+
+      validate(m, m.from(r.nextInt(1000)))
+    }
+  }
+  @Test
+  def randomTreeTo() {
+    val r = new Random(0)
+    var m = TreeMap[Int, String]()
+    for (i <- 1 to 100000) {
+      m = validate(m, m + ((r.nextInt(1000), "")))
+      m = validate(m, m - r.nextInt(1000))
+
+      validate(m, m.to(r.nextInt(1000)))
+    }
+  }
+  @Test
+  def randomTreeUntil() {
+    val r = new Random(0)
+    var m = TreeMap[Int, String]()
+    for (i <- 1 to 100000) {
+      m = validate(m, m + ((r.nextInt(1000), "")))
+      m = validate(m, m - r.nextInt(1000))
+
+      validate(m, m.until(r.nextInt(1000)))
+    }
+  }
+  @Test
+  def randomTreeRange() {
+    val r = new Random(0)
+    var m = TreeMap[Int, String]()
+    for (i <- 1 to 100000) {
+      m = validate(m, m + ((r.nextInt(1000), "")))
+      m = validate(m, m - r.nextInt(1000))
+
+      validate(m, m.range(r.nextInt(1000), r.nextInt(1000)))
+    }
   }
 }

--- a/test/junit/scala/collection/immutable/TreeMapTest.scala
+++ b/test/junit/scala/collection/immutable/TreeMapTest.scala
@@ -230,8 +230,12 @@ class TreeMapTest extends AllocationTest {
 
   }
 
-  def validate[A, B](original: TreeMap[A, B], result: TreeMap[A, B]): TreeMap[A, B] = {
+  private def validateMap[A, B](original: TreeMap[A, B], result: TreeMap[A, B]): TreeMap[A, B] = {
     NewRedBlackTree.validate(original.tree0, result.tree0)
+    result
+  }
+  private def validateSet[A](original: TreeSet[A], result: TreeSet[A]): TreeSet[A] = {
+    NewRedBlackTree.validate(original.tree, result.tree)
     result
   }
   @Test
@@ -239,8 +243,8 @@ class TreeMapTest extends AllocationTest {
     val r = new Random(0)
     var m = TreeMap[Int, String]()
     for (i <- 1 to 100000) {
-      m = validate(m, m + ((r.nextInt(1000), "")))
-      m = validate(m, m - r.nextInt(1000))
+      m = validateMap(m, m + ((r.nextInt(1000), "")))
+      m = validateMap(m, m - r.nextInt(1000))
     }
   }
   @Test
@@ -248,13 +252,13 @@ class TreeMapTest extends AllocationTest {
     val r = new Random(0)
     var m = TreeMap[Int, String]()
     for (i <- 1 to 100000) {
-      m = validate(m, m + ((r.nextInt(1000), "")))
-      m = validate(m, m - r.nextInt(1000))
-      
+      m = validateMap(m, m + ((r.nextInt(1000), "")))
+      m = validateMap(m, m - r.nextInt(1000))
+
       val builder = TreeMap.newBuilder[Int, String]
       builder ++= r.shuffle(m.toList)
-      val res = validate(m, builder.result())
-      
+      val res = validateMap(m, builder.result())
+
       assertEquals(m, res)
     }
   }
@@ -263,13 +267,13 @@ class TreeMapTest extends AllocationTest {
     val r = new Random(0)
     var m = TreeMap[Int, String]()
     for (i <- 1 to 100000) {
-      m = validate(m, m + ((r.nextInt(1000), "")))
-      m = validate(m, m - r.nextInt(1000))
+      m = validateMap(m, m + ((r.nextInt(1000), "")))
+      m = validateMap(m, m - r.nextInt(1000))
 
       val (m1,m2) = m.splitAt(r.nextInt(1000))
 
-      validate(m, m1)
-      validate(m, m2)
+      validateMap(m, m1)
+      validateMap(m, m2)
     }
   }
   @Test
@@ -277,10 +281,10 @@ class TreeMapTest extends AllocationTest {
     val r = new Random(0)
     var m = TreeMap[Int, String]()
     for (i <- 1 to 100000) {
-      m = validate(m, m + ((r.nextInt(1000), "")))
-      m = validate(m, m - r.nextInt(1000))
+      m = validateMap(m, m + ((r.nextInt(1000), "")))
+      m = validateMap(m, m - r.nextInt(1000))
 
-      validate(m, m.drop(r.nextInt(1000)))
+      validateMap(m, m.drop(r.nextInt(1000)))
     }
   }
   @Test
@@ -288,10 +292,10 @@ class TreeMapTest extends AllocationTest {
     val r = new Random(0)
     var m = TreeMap[Int, String]()
     for (i <- 1 to 100000) {
-      m = validate(m, m + ((r.nextInt(1000), "")))
-      m = validate(m, m - r.nextInt(1000))
+      m = validateMap(m, m + ((r.nextInt(1000), "")))
+      m = validateMap(m, m - r.nextInt(1000))
 
-      validate(m, m.take(r.nextInt(1000)))
+      validateMap(m, m.take(r.nextInt(1000)))
     }
   }
   @Test
@@ -299,10 +303,10 @@ class TreeMapTest extends AllocationTest {
     val r = new Random(0)
     var m = TreeMap[Int, String]()
     for (i <- 1 to 100000) {
-      m = validate(m, m + ((r.nextInt(1000), "")))
-      m = validate(m, m - r.nextInt(1000))
+      m = validateMap(m, m + ((r.nextInt(1000), "")))
+      m = validateMap(m, m - r.nextInt(1000))
 
-      validate(m, m.slice(r.nextInt(1000),r.nextInt(1000)))
+      validateMap(m, m.slice(r.nextInt(1000), r.nextInt(1000)))
     }
   }
   @Test
@@ -310,10 +314,10 @@ class TreeMapTest extends AllocationTest {
     val r = new Random(0)
     var m = TreeMap[Int, String]()
     for (i <- 1 to 100000) {
-      m = validate(m, m + ((r.nextInt(1000), "")))
-      m = validate(m, m - r.nextInt(1000))
+      m = validateMap(m, m + ((r.nextInt(1000), "")))
+      m = validateMap(m, m - r.nextInt(1000))
 
-      validate(m, m.init)
+      validateMap(m, m.init)
     }
   }
   @Test
@@ -321,10 +325,10 @@ class TreeMapTest extends AllocationTest {
     val r = new Random(0)
     var m = TreeMap[Int, String]()
     for (i <- 1 to 100000) {
-      m = validate(m, m + ((r.nextInt(1000), "")))
-      m = validate(m, m - r.nextInt(1000))
+      m = validateMap(m, m + ((r.nextInt(1000), "")))
+      m = validateMap(m, m - r.nextInt(1000))
 
-      validate(m, m.tail)
+      validateMap(m, m.tail)
     }
   }
   @Test
@@ -332,10 +336,10 @@ class TreeMapTest extends AllocationTest {
     val r = new Random(0)
     var m = TreeMap[Int, String]()
     for (i <- 1 to 100000) {
-      m = validate(m, m + ((r.nextInt(1000), "")))
-      m = validate(m, m - r.nextInt(1000))
+      m = validateMap(m, m + ((r.nextInt(1000), "")))
+      m = validateMap(m, m - r.nextInt(1000))
 
-      validate(m, m.from(r.nextInt(1000)))
+      validateMap(m, m.from(r.nextInt(1000)))
     }
   }
   @Test
@@ -343,10 +347,10 @@ class TreeMapTest extends AllocationTest {
     val r = new Random(0)
     var m = TreeMap[Int, String]()
     for (i <- 1 to 100000) {
-      m = validate(m, m + ((r.nextInt(1000), "")))
-      m = validate(m, m - r.nextInt(1000))
+      m = validateMap(m, m + ((r.nextInt(1000), "")))
+      m = validateMap(m, m - r.nextInt(1000))
 
-      validate(m, m.to(r.nextInt(1000)))
+      validateMap(m, m.to(r.nextInt(1000)))
     }
   }
   @Test
@@ -354,10 +358,10 @@ class TreeMapTest extends AllocationTest {
     val r = new Random(0)
     var m = TreeMap[Int, String]()
     for (i <- 1 to 100000) {
-      m = validate(m, m + ((r.nextInt(1000), "")))
-      m = validate(m, m - r.nextInt(1000))
+      m = validateMap(m, m + ((r.nextInt(1000), "")))
+      m = validateMap(m, m - r.nextInt(1000))
 
-      validate(m, m.until(r.nextInt(1000)))
+      validateMap(m, m.until(r.nextInt(1000)))
     }
   }
   @Test
@@ -365,10 +369,183 @@ class TreeMapTest extends AllocationTest {
     val r = new Random(0)
     var m = TreeMap[Int, String]()
     for (i <- 1 to 100000) {
-      m = validate(m, m + ((r.nextInt(1000), "")))
-      m = validate(m, m - r.nextInt(1000))
+      m = validateMap(m, m + ((r.nextInt(1000), "")))
+      m = validateMap(m, m - r.nextInt(1000))
 
-      validate(m, m.range(r.nextInt(1000), r.nextInt(1000)))
+      validateMap(m, m.range(r.nextInt(1000), r.nextInt(1000)))
     }
   }
+  @Test
+  def randomTreeUnion() {
+    val r = new Random(0)
+    var m1 = TreeMap[Int, String]()
+    var m2 = TreeMap[Int, String]()
+    for (i <- 1 to 100000) {
+      m1 = validateMap(m1, m1 +((r.nextInt(1000), "")))
+      m1 = validateMap(m1, m1 - r.nextInt(1000))
+
+      m2 = validateMap(m2, m2 + ((r.nextInt(1000), "")))
+      m2 = validateMap(m2, m2 - r.nextInt(1000))
+
+      validateMap(m1, m1 ++ m2)
+
+      var m3 = m1
+      m3 = validateMap(m3, m3 - r.nextInt(1000))
+      m3 = validateMap(m3, m3 - r.nextInt(1000))
+      m3 = validateMap(m3, m3 - r.nextInt(1000))
+      //subset
+      validateMap(m1, m1 ++ m3)
+
+      m3 = m1
+      m3 = validateMap(m3, m3 + ((r.nextInt(1000), "")))
+      m3 = validateMap(m3, m3 + ((r.nextInt(1000), "")))
+      m3 = validateMap(m3, m3 + ((r.nextInt(1000), "")))
+      //superset
+      validateMap(m1, m1 ++ m3)
+
+      m3 = validateMap(m3, m3 - r.nextInt(1000))
+      m3 = validateMap(m3, m3 - r.nextInt(1000))
+      m3 = validateMap(m3, m3 - r.nextInt(1000))
+      //overlap
+      validateMap(m1, m1 ++ m3)
+    }
+  }
+  @Test
+  def randomTreeDiff() {
+    val r = new Random(0)
+    var m1 = TreeMap[Int, String]()
+    var m2 = TreeSet[Int]()
+    for (i <- 1 to 100000) {
+      m1 = validateMap(m1, m1 + ((r.nextInt(1000), "")))
+      m1 = validateMap(m1, m1 - r.nextInt(1000))
+
+      m2 = validateSet(m2, m2 + r.nextInt(1000))
+      m2 = validateSet(m2, m2 - r.nextInt(1000))
+
+      validateMap(m1, m1 -- m2)
+
+      var m3 = m1.keySet.asInstanceOf[TreeSet[Int]]
+      m3 = validateSet(m3, m3 - r.nextInt(1000))
+      m3 = validateSet(m3, m3 - r.nextInt(1000))
+      m3 = validateSet(m3, m3 - r.nextInt(1000))
+      //subset
+      validateMap(m1, m1 -- m2)
+
+      m3 = m1.keySet.asInstanceOf[TreeSet[Int]]
+      m3 = validateSet(m3, m3 + r.nextInt(1000))
+      m3 = validateSet(m3, m3 + r.nextInt(1000))
+      m3 = validateSet(m3, m3 + r.nextInt(1000))
+      //superset
+      validateMap(m1, m1 -- m2)
+
+      m3 = validateSet(m3, m3 - r.nextInt(1000))
+      m3 = validateSet(m3, m3 - r.nextInt(1000))
+      m3 = validateSet(m3, m3 - r.nextInt(1000))
+      //overlap
+      validateMap(m1, m1 -- m2)
+    }
+  }
+  @Test
+  def randomTreeFilter() {
+    val r = new Random(0)
+    var m1 = TreeMap[Int, String]()
+    var m2 = HashSet[Int]()
+    for (i <- 1 to 100000) {
+      m1 = validateMap(m1, m1 + ((r.nextInt(1000), "")))
+      m1 = validateMap(m1, m1 - r.nextInt(1000))
+
+      m2 = m2 + r.nextInt(1000)
+      m2 = m2 - r.nextInt(1000)
+
+      //we want this as a function, avoid any special optimised code
+      validateMap(m1, m1.filter(x => m2 contains x._1))
+
+      var m3 = m1
+      m3 = validateMap(m3, m3 - r.nextInt(1000))
+      m3 = validateMap(m3, m3 - r.nextInt(1000))
+      m3 = validateMap(m3, m3 - r.nextInt(1000))
+      //subset
+      validateMap(m1, m1.filter(x => m3 contains x._1))
+
+      m3 = m1
+      m3 = validateMap(m3, m3 + ((r.nextInt(1000), "")))
+      m3 = validateMap(m3, m3 + ((r.nextInt(1000), "")))
+      m3 = validateMap(m3, m3 + ((r.nextInt(1000), "")))
+      //superset
+      validateMap(m1, m1.filter(x => m3 contains x._1))
+
+      m3 = validateMap(m3, m3 - r.nextInt(1000))
+      m3 = validateMap(m3, m3 - r.nextInt(1000))
+      m3 = validateMap(m3, m3 - r.nextInt(1000))
+      //overlap
+      validateMap(m1, m1.filter(x => m3 contains x._1))
+    }
+  }
+  @Test
+  def randomTreeTransform() {
+    val r = new Random(0)
+    var m1 = TreeMap[Int, String]()
+    for (i <- 1 to 100000) {
+      m1 = validateMap(m1, m1 + ((r.nextInt(1000), "")))
+      m1 = validateMap(m1, m1 - r.nextInt(1000))
+
+      validateMap(m1, m1.transform((k, v) => if (r.nextBoolean()) "" else "z"))
+    }
+  }
+  @Test
+  def randomTreePartition() {
+    val r = new Random(0)
+    var m1 = TreeMap[Int, String]()
+    var m2 = TreeSet[Int]()
+    for (i <- 1 to 100000) {
+      m1 = validateMap(m1, m1 + ((r.nextInt(1000), "")))
+      m1 = validateMap(m1, m1 - r.nextInt(1000))
+
+      m2 = m2 + r.nextInt(1000)
+      m2 = m2 - r.nextInt(1000)
+
+      //we want this as a function, avoid any special optimised code
+      {
+        val (p1, p2) = m1.partition(x => m2 contains x._1)
+        validateMap(m1, p1)
+        validateMap(m1, p2)
+      }
+
+      var m3 = m1
+      m3 = m3 - r.nextInt(1000)
+      m3 = m3 - r.nextInt(1000)
+      m3 = m3 - r.nextInt(1000)
+
+      //subset
+      {
+        val (p1, p2) = m1.partition(x => m3 contains x._1)
+        validateMap(m1, p1)
+        validateMap(m1, p2)
+      }
+
+      m3 = m1
+      m3 = m3 + ((r.nextInt(1000), ""))
+      m3 = m3 + ((r.nextInt(1000), ""))
+      m3 = m3 + ((r.nextInt(1000), ""))
+
+      //superset
+      {
+        val (p1, p2) = m1.partition(x => m3 contains x._1)
+        validateMap(m1, p1)
+        validateMap(m1, p2)
+      }
+
+      m3 = m3 - r.nextInt(1000)
+      m3 = m3 - r.nextInt(1000)
+      m3 = m3 - r.nextInt(1000)
+
+      //overlap
+      {
+        val (p1, p2) = m1.partition(x => m3 contains x._1)
+        validateMap(m1, p1)
+        validateMap(m1, p2)
+      }
+    }
+  }
+
 }

--- a/test/junit/scala/collection/immutable/TreeSetTest.scala
+++ b/test/junit/scala/collection/immutable/TreeSetTest.scala
@@ -431,4 +431,30 @@ class TreeSetTest extends AllocationTest{
       validate(m, m.range(r.nextInt(1000), r.nextInt(1000)))
     }
   }
+
+  @Test
+  def toStructuralSharing() {
+    def check(input: Seq[Int], expectedSharedNodes: Int)(operation: TreeSet[Int] => TreeSet[Int]): Unit = {
+      val s1 = TreeSet(input: _*)
+      val s2 = operation(s1)
+      val debugString = s2.tree.debugToString(Some(s1.tree))
+      val regex = """\[shared\]""".r
+      val sharedNodes = regex.findAllIn(debugString).size
+      // could be >=, but let's start with an exact assertion.
+      assertEquals("Structural sharing changed. Final tree: " + debugString, expectedSharedNodes, sharedNodes)
+    }
+    check((1 to 64), 64)(_.to(64))
+    check((1 to 64), 64)(_.until(64 + 1))
+    check((1 to 64), 64)(_.from(1))
+    check((1 to 64), 64)(_.range(1, 64 + 1))
+
+    check((1 to 64), 52)(_.to(63))
+    check((1 to 64), 52)(_.until(63 + 1))
+    check((1 to 64), 52)(_.range(1, 63 + 1))
+
+    check((1 to 64), 53)(_.from(2))
+    check((1 to 64), 53)(_.range(2, 64 + 1))
+
+    check((1 to 64), 44)(_.range(2, 63 + 1))
+  }
 }

--- a/test/junit/scala/collection/immutable/TreeSetTest.scala
+++ b/test/junit/scala/collection/immutable/TreeSetTest.scala
@@ -9,6 +9,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import scala.tools.testing.AllocationTest
+import scala.util.Random
 
 @RunWith(classOf[JUnit4])
 class TreeSetTest extends AllocationTest{
@@ -286,6 +287,148 @@ class TreeSetTest extends AllocationTest{
     for (set <- List(keepISS, keepMSS, keepIBS, keepMBS)) {
       assertEquals(expected, src intersect set)
       assertEquals(expected, src filter set)
+    }
+  }
+  def validate[A, B](original: TreeSet[Int], result: TreeSet[Int]): TreeSet[Int] = {
+    NewRedBlackTree.validate(original.tree, result.tree)
+    result
+  }
+
+  @Test
+  def randomTreePlusMinus() {
+    val r = new Random(0)
+    var m = TreeSet[Int]()
+    for (i <- 1 to 100000) {
+      m = validate(m, m + r.nextInt(1000))
+      m = validate(m, m - r.nextInt(1000))
+    }
+  }
+  @Test
+  def randomTreeBuild() {
+    val r = new Random(0)
+    var m = TreeSet[Int]()
+    for (i <- 1 to 100000) {
+      m = validate(m, m + r.nextInt(1000))
+      m = validate(m, m - r.nextInt(1000))
+
+      val builder = TreeSet.newBuilder[Int]
+      builder ++= r.shuffle(m.toList)
+      val res = validate(m, builder.result())
+
+      assertEquals(m, res)
+    }
+  }
+  @Test
+  def randomTreeSplit() {
+    val r = new Random(0)
+    var m = TreeSet[Int]()
+    for (i <- 1 to 100000) {
+      m = validate(m, m + r.nextInt(1000))
+      m = validate(m, m - r.nextInt(1000))
+
+      val (m1,m2) = m.splitAt(r.nextInt(1000))
+
+      validate(m, m1)
+      validate(m, m2)
+    }
+  }
+  @Test
+  def randomTreeDrop() {
+    val r = new Random(0)
+    var m = TreeSet[Int]()
+    for (i <- 1 to 100000) {
+      m = validate(m, m + r.nextInt(1000))
+      m = validate(m, m - r.nextInt(1000))
+
+      validate(m, m.drop(r.nextInt(1000)))
+    }
+  }
+  @Test
+  def randomTreeTake() {
+    val r = new Random(0)
+    var m = TreeSet[Int]()
+    for (i <- 1 to 100000) {
+      m = validate(m, m + r.nextInt(1000))
+      m = validate(m, m - r.nextInt(1000))
+
+      validate(m, m.take(r.nextInt(1000)))
+    }
+  }
+  @Test
+  def randomTreeSlice() {
+    val r = new Random(0)
+    var m = TreeSet[Int]()
+    for (i <- 1 to 100000) {
+      m = validate(m, m + r.nextInt(1000))
+      m = validate(m, m - r.nextInt(1000))
+
+      validate(m, m.slice(r.nextInt(1000),r.nextInt(1000)))
+    }
+  }
+  @Test
+  def randomTreeInit() {
+    val r = new Random(0)
+    var m = TreeSet[Int]()
+    for (i <- 1 to 100000) {
+      m = validate(m, m + r.nextInt(1000))
+      m = validate(m, m - r.nextInt(1000))
+
+      validate(m, m.init)
+    }
+  }
+  @Test
+  def randomTreeTail() {
+    val r = new Random(0)
+    var m = TreeSet[Int]()
+    for (i <- 1 to 100000) {
+      m = validate(m, m + r.nextInt(1000))
+      m = validate(m, m - r.nextInt(1000))
+
+      validate(m, m.tail)
+    }
+  }
+  @Test
+  def randomTreeFrom() {
+    val r = new Random(0)
+    var m = TreeSet[Int]()
+    for (i <- 1 to 100000) {
+      m = validate(m, m + r.nextInt(1000))
+      m = validate(m, m - r.nextInt(1000))
+
+      validate(m, m.from(r.nextInt(1000)))
+    }
+  }
+  @Test
+  def randomTreeTo() {
+    val r = new Random(0)
+    var m = TreeSet[Int]()
+    for (i <- 1 to 100000) {
+      m = validate(m, m + r.nextInt(1000))
+      m = validate(m, m - r.nextInt(1000))
+
+      validate(m, m.to(r.nextInt(1000)))
+    }
+  }
+  @Test
+  def randomTreeUntil() {
+    val r = new Random(0)
+    var m = TreeSet[Int]()
+    for (i <- 1 to 100000) {
+      m = validate(m, m + r.nextInt(1000))
+      m = validate(m, m - r.nextInt(1000))
+
+      validate(m, m.until(r.nextInt(1000)))
+    }
+  }
+  @Test
+  def randomTreeRange() {
+    val r = new Random(0)
+    var m = TreeSet[Int]()
+    for (i <- 1 to 100000) {
+      m = validate(m, m + r.nextInt(1000))
+      m = validate(m, m - r.nextInt(1000))
+
+      validate(m, m.range(r.nextInt(1000), r.nextInt(1000)))
     }
   }
 }

--- a/test/junit/scala/collection/immutable/TreeSetTest.scala
+++ b/test/junit/scala/collection/immutable/TreeSetTest.scala
@@ -431,6 +431,203 @@ class TreeSetTest extends AllocationTest{
       validate(m, m.range(r.nextInt(1000), r.nextInt(1000)))
     }
   }
+  @Test
+  def randomTreeUnion() {
+    val r = new Random(0)
+    var m1 = TreeSet[Int]()
+    var m2 = TreeSet[Int]()
+    for (i <- 1 to 100000) {
+      m1 = validate(m1, m1 + r.nextInt(1000))
+      m1 = validate(m1, m1 - r.nextInt(1000))
+
+      m2 = validate(m2, m2 + r.nextInt(1000))
+      m2 = validate(m2, m2 - r.nextInt(1000))
+
+      validate(m1, m1.union(m2))
+
+      var m3 = m1
+      m3 = validate(m3, m3 - r.nextInt(1000))
+      m3 = validate(m3, m3 - r.nextInt(1000))
+      m3 = validate(m3, m3 - r.nextInt(1000))
+      //subset
+      validate(m1, m1.union(m3))
+
+      m3 = m1
+      m3 = validate(m3, m3 + r.nextInt(1000))
+      m3 = validate(m3, m3 + r.nextInt(1000))
+      m3 = validate(m3, m3 + r.nextInt(1000))
+      //superset
+      validate(m1, m1.union(m3))
+
+      m3 = validate(m3, m3 - r.nextInt(1000))
+      m3 = validate(m3, m3 - r.nextInt(1000))
+      m3 = validate(m3, m3 - r.nextInt(1000))
+      //overlap
+      validate(m1, m1.union(m3))
+    }
+  }
+  @Test
+  def randomTreeIntersect() {
+    val r = new Random(0)
+    var m1 = TreeSet[Int]()
+    var m2 = TreeSet[Int]()
+    for (i <- 1 to 100000) {
+      m1 = validate(m1, m1 + r.nextInt(1000))
+      m1 = validate(m1, m1 - r.nextInt(1000))
+
+      m2 = validate(m2, m2 + r.nextInt(1000))
+      m2 = validate(m2, m2 - r.nextInt(1000))
+
+      validate(m1, m1.intersect(m2))
+
+      var m3 = m1
+      m3 = validate(m3, m3 - r.nextInt(1000))
+      m3 = validate(m3, m3 - r.nextInt(1000))
+      m3 = validate(m3, m3 - r.nextInt(1000))
+      //subset
+      validate(m1, m1.intersect(m3))
+
+      m3 = m1
+      m3 = validate(m3, m3 + r.nextInt(1000))
+      m3 = validate(m3, m3 + r.nextInt(1000))
+      m3 = validate(m3, m3 + r.nextInt(1000))
+      //superset
+      validate(m1, m1.intersect(m3))
+
+      m3 = validate(m3, m3 - r.nextInt(1000))
+      m3 = validate(m3, m3 - r.nextInt(1000))
+      m3 = validate(m3, m3 - r.nextInt(1000))
+      //overlap
+      validate(m1, m1.intersect(m3))
+    }
+  }
+  @Test
+  def randomTreeDiff() {
+    val r = new Random(0)
+    var m1 = TreeSet[Int]()
+    var m2 = TreeSet[Int]()
+    for (i <- 1 to 100000) {
+      m1 = validate(m1, m1 + r.nextInt(1000))
+      m1 = validate(m1, m1 - r.nextInt(1000))
+
+      m2 = validate(m2, m2 + r.nextInt(1000))
+      m2 = validate(m2, m2 - r.nextInt(1000))
+
+      validate(m1, m1.diff(m2))
+
+      var m3 = m1
+      m3 = validate(m3, m3 - r.nextInt(1000))
+      m3 = validate(m3, m3 - r.nextInt(1000))
+      m3 = validate(m3, m3 - r.nextInt(1000))
+      //subset
+      validate(m1, m1.diff(m3))
+
+      m3 = m1
+      m3 = validate(m3, m3 + r.nextInt(1000))
+      m3 = validate(m3, m3 + r.nextInt(1000))
+      m3 = validate(m3, m3 + r.nextInt(1000))
+      //superset
+      validate(m1, m1.diff(m3))
+
+      m3 = validate(m3, m3 - r.nextInt(1000))
+      m3 = validate(m3, m3 - r.nextInt(1000))
+      m3 = validate(m3, m3 - r.nextInt(1000))
+      //overlap
+      validate(m1, m1.diff(m3))
+    }
+  }
+  @Test
+  def randomTreeFilter() {
+    val r = new Random(0)
+    var m1 = TreeSet[Int]()
+    var m2 = HashSet[Int]()
+    for (i <- 1 to 100000) {
+      m1 = validate(m1, m1 + r.nextInt(1000))
+      m1 = validate(m1, m1 - r.nextInt(1000))
+
+      m2 = m2 + r.nextInt(1000)
+      m2 = m2 - r.nextInt(1000)
+
+      //we want this as a function, avoid any special optimised code
+      validate(m1, m1.filter(x => m2 contains x))
+
+      var m3 = m1
+      m3 = validate(m3, m3 - r.nextInt(1000))
+      m3 = validate(m3, m3 - r.nextInt(1000))
+      m3 = validate(m3, m3 - r.nextInt(1000))
+      //subset
+      validate(m1, m1.filter(x => m3 contains x))
+
+      m3 = m1
+      m3 = validate(m3, m3 + r.nextInt(1000))
+      m3 = validate(m3, m3 + r.nextInt(1000))
+      m3 = validate(m3, m3 + r.nextInt(1000))
+      //superset
+      validate(m1, m1.filter(x => m3 contains x))
+
+      m3 = validate(m3, m3 - r.nextInt(1000))
+      m3 = validate(m3, m3 - r.nextInt(1000))
+      m3 = validate(m3, m3 - r.nextInt(1000))
+      //overlap
+      validate(m1, m1.filter(x => m3 contains x))
+    }
+  }
+
+  @Test
+  def randomTreePartition() {
+    val r = new Random(0)
+    var m1 = TreeSet[Int]()
+    var m2 = TreeSet[Int]()
+    for (i <- 1 to 100000) {
+      m1 = validate(m1, m1 + r.nextInt(1000))
+      m1 = validate(m1, m1 - r.nextInt(1000))
+
+      m2 = m2 + r.nextInt(1000)
+      m2 = m2 - r.nextInt(1000)
+
+      //we want this as a function, avoid any special optimised code
+      {
+        val (p1, p2) = m1.partition(x => m2 contains x)
+        validate(m1, p1)
+        validate(m1, p2)
+      }
+      var m3 = m1
+      m3 = m3 - r.nextInt(1000)
+      m3 = m3 - r.nextInt(1000)
+      m3 = m3 - r.nextInt(1000)
+
+      //subset
+      {
+        val (p1, p2) = m1.partition(x => m3 contains x)
+        validate(m1, p1)
+        validate(m1, p2)
+      }
+
+      m3 = m1
+      m3 = m3 + r.nextInt(1000)
+      m3 = m3 + r.nextInt(1000)
+      m3 = m3 + r.nextInt(1000)
+
+      //superset
+      {
+        val (p1, p2) = m1.partition(x => m3 contains x)
+        validate(m1, p1)
+        validate(m1, p2)
+      }
+
+      m3 = m3 - r.nextInt(1000)
+      m3 = m3 - r.nextInt(1000)
+      m3 = m3 - r.nextInt(1000)
+
+      //overlap
+      {
+        val (p1, p2) = m1.partition(x => m3 contains x)
+        validate(m1, p1)
+        validate(m1, p2)
+      }
+    }
+  }
+
 
   @Test
   def toStructuralSharing() {


### PR DESCRIPTION
It seems that we were generating invalid RedBlack trees

This PR add validation to test RedBlackTrees against the rules, fixes the trees that were invalid, and adds some debug support for detecting errors during development (commented out)

Other PRs will optimise these generated trees

Thanks to @retronym I have incorporated some of the debugging utilities from https://github.com/retronym/scala/pull/107