### PR TITLE
Travis-CI: don't compile tests during initial build stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,11 @@ jobs:
           - set -e
           - sbt -warn setupPublishCore generateBuildCharacterPropertiesFile headerCheck publishLocal
           - STARR=$(sed -n 's/^maven\.version\.number=//p' buildcharacter.properties) && echo $STARR
-          - sbt -Dstarr.version=$STARR -warn setupValidateTest test:compile info testOsgi
+          - sbt -Dstarr.version=$STARR -warn setupValidateTest compile
+          # as per discussion on #9332, caching the new STARR only goes halfway.
+          # we should also cache the products of the bootstrapped build. currently all three stages
+          # (build, testAll1, testAll2) end up recompiling core projects like `library` and `compiler`.
+          # fixing that will take some care to satisfy sbt/zinc.
         workspaces:
           create:
             name: published-local
@@ -59,7 +63,7 @@ jobs:
         script:
           - set -e
           - STARR=$(sed -n 's/^maven\.version\.number=//p' buildcharacter.properties) && echo $STARR
-          - sbt -Dstarr.version=$STARR -warn setupValidateTest test:compile info testAll1
+          - sbt -Dstarr.version=$STARR -warn setupValidateTest Test/compile info testAll1
           - sbt -Dscala.build.compileWithDotty=true library/compile
 
       - name: testAll2
@@ -69,7 +73,7 @@ jobs:
         script:
           - set -e
           - STARR=$(sed -n 's/^maven\.version\.number=//p' buildcharacter.properties) && echo $STARR
-          - sbt -Dstarr.version=$STARR -warn setupValidateTest test:compile info testAll2
+          - sbt -Dstarr.version=$STARR -warn setupValidateTest info testAll2
 
       - stage: build
         name: build the spec using jekyll

--- a/build.sbt
+++ b/build.sbt
@@ -963,8 +963,7 @@ lazy val root: Project = (project in file("."))
     testJarSize := TestJarSize.testJarSizeImpl.value,
 
     // Wasn't sure if findRootCauses would work if I just aggregated testAll1/etc, so a little duplication..
-    testAll  := runTests(unitTests ::: partests ::: osgiTests ::: remainingTests).value,
-    testOsgi := runTests(osgiTests).value,
+    testAll  := runTests(unitTests ::: partests ::: remainingTests).value,
     // splitting this in two parts allows them to run in parallel on CI.
     // partest takes the longest, so "partest vs. everything else" is a roughly equal split
     testAll1 := runTests(unitTests ::: remainingTests).value,
@@ -998,13 +997,9 @@ lazy val partests = List(
   (tasty / Test / Keys.test).result.map(_ -> "tasty/test"),
 )
 
-// failed in CI? :( https://travis-ci.com/github/dwijnand/scala/jobs/403646205
-lazy val osgiTests = List(
+lazy val remainingTests = List(
   (osgiTestFelix   / Test / Keys.test).result.map(_ -> "osgiTestFelix/test"),
   (osgiTestEclipse / Test / Keys.test).result.map(_ -> "osgiTestEclipse/test"),
-)
-
-lazy val remainingTests = List(
   (mimaReportBinaryIssues                ).result.map(_ -> "mimaReportBinaryIssues"),
   (testJDeps                             ).result.map(_ -> "testJDeps"),
   (testJarSize                           ).result.map(_ -> "testJarSize"),
@@ -1124,7 +1119,6 @@ lazy val mkBin = taskKey[Seq[File]]("Generate shell script (bash or Windows batc
 lazy val mkQuick = taskKey[File]("Generate a full build, including scripts, in build/quick")
 lazy val mkPack = taskKey[File]("Generate a full build, including scripts, in build/pack")
 lazy val testAll = taskKey[Unit]("Run all test tasks sequentially")
-lazy val testOsgi = taskKey[Unit]("Run OSGI test tasks sequentially")
 lazy val testAll1 = taskKey[Unit]("Run 1/2 test tasks sequentially")
 lazy val testAll2 = taskKey[Unit]("Run 2/2 test tasks sequentially")
 


### PR DESCRIPTION
this gets the build stage over with sooner, so the parallelized
test jobs can start sooner

as far as I can see, it makes sense to do it this way, because
`testAll2` (== partest) doesn't need the non-partest test code
compiled at all