### PR TITLE
fix never-released 2.12.13 regression where Array[Unit].empty caused NPE

### DIFF
--- a/src/library/scala/reflect/ClassTag.scala
+++ b/src/library/scala/reflect/ClassTag.scala
@@ -53,7 +53,7 @@ trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serial
 
   @transient private[scala] lazy val emptyArray       : Array[T]                = {
     val componentType =
-      if (runtimeClass eq classOf[Void]) classOf[BoxedUnit] else runtimeClass
+      if (runtimeClass eq java.lang.Void.TYPE) classOf[BoxedUnit] else runtimeClass
     java.lang.reflect.Array.newInstance(componentType, 0).asInstanceOf[Array[T]]
   }
   @transient private[scala] lazy val emptyWrappedArray: mutable.WrappedArray[T] =

--- a/test/junit/scala/ArrayTest.scala
+++ b/test/junit/scala/ArrayTest.scala
@@ -1,17 +1,20 @@
 package scala
 
-import org.junit.Assert.{ assertArrayEquals, assertFalse, assertTrue }
+import org.junit.Assert.{ assertFalse, assertTrue }
 import org.junit.Test
-
-import scala.runtime.BoxedUnit
 
 class ArrayTest {
 
   @Test
   def testArrayIsEmpty(): Unit = {
     assertTrue(Array[Int]().isEmpty)
+    assertTrue(Array.empty[Int].isEmpty)
     assertTrue(Array[Char]().isEmpty) // scala/bug#12172
+    assertTrue(Array.empty[Char].isEmpty)
     assertTrue(Array[String]().isEmpty)
+    assertTrue(Array.empty[String].isEmpty)
+    assertTrue(Array[Unit]().isEmpty)
+    assertTrue(Array.empty[Unit].isEmpty)
 
     assertFalse(Array(1).isEmpty)
     assertFalse(Array[Char](1).isEmpty)


### PR DESCRIPTION
this regressed in #9091

the problem turned up in the Scala 2.12 community build -- when Scala 3 support was added to the scala-collection-compat repo, a test case there was altered in a way that happened to tickle this

even though the bug doesn't exist in 2.13, the change to the test should be merged forward