### PR TITLE
Make more annotations extend `ConstantAnnotation`

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -17,7 +17,7 @@ object MimaFilters extends AutoPlugin {
   )
 
   val mimaFilters: Seq[ProblemFilter] = Seq[ProblemFilter](
-    // KEEP: we don't the reflect internal API isn't public API
+    // KEEP: the reflect internal API isn't public API
     ProblemFilters.exclude[Problem]("scala.reflect.internal.*"),
 
     // KEEP: java.util.Enumeration.asIterator only exists in later JDK versions (11 at least).  If you build
@@ -25,6 +25,14 @@ object MimaFilters extends AutoPlugin {
     // don't publish the artifact built with JDK 11 anyways
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.convert.JavaCollectionWrappers#IteratorWrapper.asIterator"),
 
+    // PR: https://github.com/scala/scala/pull/9336; remove after re-STARR
+    ProblemFilters.exclude[MissingTypesProblem]("scala.deprecatedOverriding"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.deprecatedInheritance"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.deprecated"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.annotation.elidable"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.annotation.implicitAmbiguous"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.annotation.implicitNotFound"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.annotation.migration"),
   )
 
   override val buildSettings = Seq(

--- a/src/library/scala/annotation/elidable.scala
+++ b/src/library/scala/annotation/elidable.scala
@@ -76,7 +76,7 @@ package scala.annotation
  *   }
  * }}}
  */
-final class elidable(final val level: Int) extends scala.annotation.StaticAnnotation
+final class elidable(final val level: Int) extends scala.annotation.ConstantAnnotation
 
 /** This useless appearing code was necessary to allow people to use
  *  named constants for the elidable annotation.  This is what it takes

--- a/src/library/scala/annotation/implicitAmbiguous.scala
+++ b/src/library/scala/annotation/implicitAmbiguous.scala
@@ -39,4 +39,4 @@ package scala.annotation
   * }}}
   */
 @meta.getter
-final class implicitAmbiguous(msg: String) extends scala.annotation.StaticAnnotation
+final class implicitAmbiguous(msg: String) extends scala.annotation.ConstantAnnotation

--- a/src/library/scala/annotation/implicitNotFound.scala
+++ b/src/library/scala/annotation/implicitNotFound.scala
@@ -53,4 +53,4 @@ package scala.annotation
  *      ^
  * </pre>
  */
-final class implicitNotFound(msg: String) extends scala.annotation.StaticAnnotation {}
+final class implicitNotFound(msg: String) extends scala.annotation.ConstantAnnotation

--- a/src/library/scala/annotation/migration.scala
+++ b/src/library/scala/annotation/migration.scala
@@ -27,4 +27,4 @@ package scala.annotation
  * @param changedIn The version, in which the behaviour change was
  * introduced.
  */
-private[scala] final class migration(message: String, changedIn: String) extends scala.annotation.StaticAnnotation
+private[scala] final class migration(message: String, changedIn: String) extends scala.annotation.ConstantAnnotation

--- a/src/library/scala/deprecated.scala
+++ b/src/library/scala/deprecated.scala
@@ -58,4 +58,4 @@ import scala.annotation.meta._
  */
 @getter @setter @beanGetter @beanSetter @field
 @deprecatedInheritance("Scheduled for being final in the future", "2.13.0")
-class deprecated(message: String = "", since: String = "") extends scala.annotation.StaticAnnotation
+class deprecated(message: String = "", since: String = "") extends scala.annotation.ConstantAnnotation

--- a/src/library/scala/deprecatedInheritance.scala
+++ b/src/library/scala/deprecatedInheritance.scala
@@ -47,4 +47,4 @@ import scala.annotation.meta._
  *  @see    [[scala.deprecatedName]]
  */
 @getter @setter @beanGetter @beanSetter
-final class deprecatedInheritance(message: String = "", since: String = "") extends scala.annotation.StaticAnnotation
+final class deprecatedInheritance(message: String = "", since: String = "") extends scala.annotation.ConstantAnnotation

--- a/src/library/scala/deprecatedName.scala
+++ b/src/library/scala/deprecatedName.scala
@@ -14,7 +14,6 @@ package scala
 
 import scala.annotation.meta._
 
-
  /** An annotation that designates that the name of a parameter is deprecated.
   *
   *  Using this name in a named argument generates a deprecation warning.
@@ -43,6 +42,8 @@ import scala.annotation.meta._
 @param
 @deprecatedInheritance("Scheduled for being final in the future", "2.13.0")
 class deprecatedName(name: String = "<none>", since: String = "") extends scala.annotation.StaticAnnotation {
+  // at the time we remove these constructors, we should also change this from a StaticAnnotation to
+  // a ConstantAnnotation; for now, the presence of auxiliary constructors blocks that change
   @deprecated("The parameter name should be a String, not a symbol.", "2.13.0") def this(name: Symbol, since: String) = this(name.name, since)
   @deprecated("The parameter name should be a String, not a symbol.", "2.13.0") def this(name: Symbol) = this(name.name, "")
 }

--- a/src/library/scala/deprecatedOverriding.scala
+++ b/src/library/scala/deprecatedOverriding.scala
@@ -49,4 +49,4 @@ import scala.annotation.meta._
  */
 @getter @setter @beanGetter @beanSetter
 @deprecatedInheritance("Scheduled for being final in the future", "2.13.0")
-class deprecatedOverriding(message: String = "", since: String = "") extends scala.annotation.StaticAnnotation
+class deprecatedOverriding(message: String = "", since: String = "") extends scala.annotation.ConstantAnnotation

--- a/test/files/run/t5225_2.check
+++ b/test/files/run/t5225_2.check
@@ -1,4 +1,4 @@
 {
-  def foo(@new elidable(0) x: Int) = "";
+  def foo(@new elidable(level = 0) x: Int) = "";
   ()
 }


### PR DESCRIPTION
This makes it clearer that any custom error messages (e.g. on `implicitNotFound`) must be literal values.

Fixes https://github.com/scala/bug/issues/10424