### PR TITLE
Make StringOps mkString surrogate pair aware

### DIFF
--- a/src/library/scala/collection/StringOps.scala
+++ b/src/library/scala/collection/StringOps.scala
@@ -594,12 +594,11 @@ final class StringOps(private val s: String) extends AnyVal {
       if (sep.isEmpty) jsb.append(s)
       else {
         jsb.ensureCapacity(jsb.length + len + end.length + (len - 1) * sep.length)
-        jsb.append(s.charAt(0))
-        var i = 1
-        while (i < len) {
+        val it = codePointStepper.iterator
+        jsb.appendCodePoint(it.next())
+        while(it.hasNext){
           jsb.append(sep)
-          jsb.append(s.charAt(i))
-          i += 1
+          jsb.appendCodePoint(it.next())
         }
       }
     }

--- a/test/junit/scala/collection/StringOpsTest.scala
+++ b/test/junit/scala/collection/StringOpsTest.scala
@@ -16,6 +16,7 @@ class StringOpsTest {
     assert("a".mkString(",") == "a")
     assert("ab".mkString(",") == "a,b")
     assert("ab".mkString("foo", ",", "bar") == "fooa,bbar")
+    assert("👏👏👏".mkString("keep", "them", "together") == "keep👏them👏them👏together")
   }
 
   @Test def addString(): Unit = {


### PR DESCRIPTION
Don't insert separators between a surrogate pair, as an alternative to the note in https://github.com/scala/scala/pull/9339 on mkString

I can't imagine any situation where people rely on the behaviour that a string created with mkString is used for some purpose where it's intentional surrogate pairs get split up.

