### PR TITLE
Allow annotated literals inside as annotation args

### DIFF
--- a/test/files/neg/annotated-literal-annotation-arg.check
+++ b/test/files/neg/annotated-literal-annotation-arg.check
@@ -1,0 +1,7 @@
+annotated-literal-annotation-arg.scala:14: error: $foo
+  implicitly[Foo]
+            ^
+annotated-literal-annotation-arg.scala:15: error: bar
+  implicitly[Bar]
+            ^
+two errors found

--- a/test/files/neg/annotated-literal-annotation-arg.scala
+++ b/test/files/neg/annotated-literal-annotation-arg.scala
@@ -1,0 +1,16 @@
+
+import annotation.implicitNotFound
+import scala.annotation.nowarn
+
+// Ensure that an annotation doesn't break the message
+@implicitNotFound("$foo": @nowarn)
+trait Foo
+
+// Ensure that a type ascription doesn't break the message
+@implicitNotFound("bar": String)
+trait Bar
+
+object Example {
+  implicitly[Foo]
+  implicitly[Bar]
+}


### PR DESCRIPTION
This notably allows for silencing warnings inside annotation
arguments (see scala-js/scala-js#3737, ghik/silencer#32).

Fixes https://github.com/scala/bug/issues/11932