### PR TITLE
Add linting of unused context bounds (via `-Wunused:synthetics` or `-Wunused:params`)

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -124,8 +124,9 @@ trait Warnings {
     val Locals    = Choice("locals",    "Warn if a local definition is unused.")
     val Explicits = Choice("explicits", "Warn if an explicit parameter is unused.")
     val Implicits = Choice("implicits", "Warn if an implicit parameter is unused.")
+    val Synthetics = Choice("synthetics", "Warn if a synthetic implicit parameter (context bound) is unused.")
     val Nowarn    = Choice("nowarn",    "Warn if a @nowarn annotation does not suppress any warnings.")
-    val Params    = Choice("params",    "Enable -Wunused:explicits,implicits.", expandsTo = List(Explicits, Implicits))
+    val Params    = Choice("params",    "Enable -Wunused:explicits,implicits,synthetics.", expandsTo = List(Explicits, Implicits, Synthetics))
     val Linted    = Choice("linted",    "-Xlint:unused.", expandsTo = List(Imports, Privates, Locals, Implicits, Nowarn))
   }
 
@@ -142,9 +143,10 @@ trait Warnings {
   def warnUnusedPatVars   = warnUnused contains UnusedWarnings.PatVars
   def warnUnusedPrivates  = warnUnused contains UnusedWarnings.Privates
   def warnUnusedLocals    = warnUnused contains UnusedWarnings.Locals
-  def warnUnusedParams    = warnUnusedExplicits || warnUnusedImplicits
+  def warnUnusedParams    = warnUnusedExplicits || warnUnusedImplicits || warnUnusedSynthetics
   def warnUnusedExplicits = warnUnused contains UnusedWarnings.Explicits
   def warnUnusedImplicits = warnUnused contains UnusedWarnings.Implicits
+  def warnUnusedSynthetics = warnUnused contains UnusedWarnings.Synthetics
   def warnUnusedNowarn    = warnUnused contains UnusedWarnings.Nowarn
 
   val warnExtraImplicit   = BooleanSetting("-Wextra-implicit", "Warn when more than one implicit parameter section is defined.") withAbbreviation "-Ywarn-extra-implicit"

--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -597,7 +597,9 @@ trait TypeDiagnostics {
           case nme.CONSTRUCTOR => sym.owner.companion.isCaseClass
           case nme.copy        => sym.owner.typeSignature.member(nme.copy).isSynthetic
         }
-      sym.isDefaultGetter && !privateSyntheticDefault
+      def defaultGetterOK = sym.isDefaultGetter && !privateSyntheticDefault
+      def contextBoundOK = sym.isImplicit && settings.warnUnusedSynthetics
+      contextBoundOK || defaultGetterOK
     }
     def isUnusedTerm(m: Symbol): Boolean = (
       m.isTerm

--- a/test/files/neg/warn-unused-explicits.check
+++ b/test/files/neg/warn-unused-explicits.check
@@ -1,0 +1,6 @@
+warn-unused-explicits.scala:9: warning: parameter value x in method warn is never used
+  def warn(x: Int) = 42
+           ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/warn-unused-explicits.scala
+++ b/test/files/neg/warn-unused-explicits.scala
@@ -1,0 +1,10 @@
+// scalac: -Wunused:explicits -Werror
+//
+trait Context[A]
+trait ExplicitsOnly {
+  def i(implicit s: String) = 42
+  def f[A](implicit ctx: Context[A]) = 42
+  def g[A: Context] = 42
+
+  def warn(x: Int) = 42
+}

--- a/test/files/neg/warn-unused-params.check
+++ b/test/files/neg/warn-unused-params.check
@@ -28,6 +28,15 @@ warn-unused-params.scala:89: warning: parameter value i in anonymous function is
 warn-unused-params.scala:95: warning: parameter value i in anonymous function is never used
   def g = for (i <- List(1)) yield 42    // warn map.(i => 42)
                ^
+warn-unused-params.scala:99: warning: parameter value ctx in method f is never used
+  def f[A](implicit ctx: Context[A]) = 42
+                    ^
+warn-unused-params.scala:100: warning: parameter value evidence$1 in method g is never used
+  def g[A: Context] = 42
+      ^
+warn-unused-params.scala:102: warning: parameter value evidence$2 in class Bound is never used
+class Bound[A: Context]
+             ^
 error: No warnings can be incurred under -Werror.
-10 warnings
+13 warnings
 1 error

--- a/test/files/neg/warn-unused-params.scala
+++ b/test/files/neg/warn-unused-params.scala
@@ -1,4 +1,4 @@
-// scalac: -Ywarn-unused:params -Xfatal-warnings
+// scalac: -Wunused:params -Werror
 //
 
 trait InterFace {
@@ -13,7 +13,7 @@ trait BadAPI extends InterFace {
     println(c)
     a
   }
-  @deprecated ("no warn in deprecated API", since="yesterday")
+  @deprecated("no warn in deprecated API", since="yesterday")
   def g(a: Int,
         b: String,               // no warn
         c: Double): Int = {
@@ -94,3 +94,9 @@ trait Anonymous {
 
   def g = for (i <- List(1)) yield 42    // warn map.(i => 42)
 }
+trait Context[A]
+trait Implicits {
+  def f[A](implicit ctx: Context[A]) = 42
+  def g[A: Context] = 42
+}
+class Bound[A: Context]


### PR DESCRIPTION
Warn under `-Wunused:synthetics` which is included by `-Wunused:params`.

Warnings for unused value parameters can be selectively enabled. `-Xlint` enables `-Wunused:implicits` to warn about unused implicit parameters. Warnings about ordinary parameters can be enabled with `-Wunused:explicits`; that is deemed noisy for ordinary use, so it is not enabled by `-Xlint`. Now, "unused context bounds", which are synthetic parameters, can be detected by enabling `-Wunused:synthetics`. All three warnings are enabled by `-Wunused:params`.
```
  def f[A](implicit ctx: Context[A]) = ???  // -Wunused:implicits
  def g[A: Context] = ???                   // -Wunused:synthetics
```
Fixes scala/bug#10349