### PR TITLE
further speed up Travis-CI PR validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,6 @@ jobs:
           - set -e
           - STARR=$(sed -n 's/^maven\.version\.number=//p' buildcharacter.properties) && echo $STARR
           - sbt -Dstarr.version=$STARR -warn setupValidateTest Test/compile info testAll1
-          - sbt -Dscala.build.compileWithDotty=true library/compile
 
       - name: testAll2
         if: type = pull_request OR repo != scala/scala
@@ -78,6 +77,15 @@ jobs:
           - set -e
           - STARR=$(sed -n 's/^maven\.version\.number=//p' buildcharacter.properties) && echo $STARR
           - sbt -Dstarr.version=$STARR -warn setupValidateTest info testAll2
+
+      - name: testDotty
+        if: type = pull_request OR repo != scala/scala
+        workspaces:
+          use: published-local
+        script:
+          - set -e
+          - STARR=$(sed -n 's/^maven\.version\.number=//p' buildcharacter.properties) && echo $STARR
+          - sbt -Dscala.build.compileWithDotty=true library/compile
 
       - stage: build
         name: build the spec using jekyll

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,9 @@ jobs:
         if: type = pull_request OR repo != scala/scala
         script:
           - set -e
-          - sbt -warn setupPublishCore generateBuildCharacterPropertiesFile headerCheck publishLocal
+          - sbt setupPublishCore generateBuildCharacterPropertiesFile headerCheck publishLocal
           - STARR=$(sed -n 's/^maven\.version\.number=//p' buildcharacter.properties) && echo $STARR
-          - sbt -Dstarr.version=$STARR -warn setupValidateTest compile
+          - sbt -Dstarr.version=$STARR setupValidateTest compile
         workspaces:
           create:
             name: published-local
@@ -67,7 +67,7 @@ jobs:
         script:
           - set -e
           - STARR=$(sed -n 's/^maven\.version\.number=//p' buildcharacter.properties) && echo $STARR
-          - sbt -Dstarr.version=$STARR -warn setupValidateTest Test/compile info testAll1
+          - sbt -Dstarr.version=$STARR setupValidateTest Test/compile testAll1
 
       - name: testAll2
         if: type = pull_request OR repo != scala/scala
@@ -76,7 +76,7 @@ jobs:
         script:
           - set -e
           - STARR=$(sed -n 's/^maven\.version\.number=//p' buildcharacter.properties) && echo $STARR
-          - sbt -Dstarr.version=$STARR -warn setupValidateTest info testAll2
+          - sbt -Dstarr.version=$STARR setupValidateTest testAll2
 
       - name: testDotty
         if: type = pull_request OR repo != scala/scala

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,16 +44,20 @@ jobs:
           - sbt -warn setupPublishCore generateBuildCharacterPropertiesFile headerCheck publishLocal
           - STARR=$(sed -n 's/^maven\.version\.number=//p' buildcharacter.properties) && echo $STARR
           - sbt -Dstarr.version=$STARR -warn setupValidateTest compile
-          # as per discussion on #9332, caching the new STARR only goes halfway.
-          # we should also cache the products of the bootstrapped build. currently all three stages
-          # (build, testAll1, testAll2) end up recompiling core projects like `library` and `compiler`.
-          # fixing that will take some care to satisfy sbt/zinc.
         workspaces:
           create:
             name: published-local
             paths:
-              - "$PWD/buildcharacter.properties"
+              # so new STARR will be available
+              - "buildcharacter.properties"
               - "$HOME/.ivy2/local/org.scala-lang"
+              # so build products built using new STARR are kept
+              - "target"
+              - "project/target"
+              - "project/project/target"
+              - "project/project/project/target"
+              - "dist"
+              - "build"
 
       - stage: testAll
         name: testAll1

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: scala
 
 stages:
   - build
-  - testAll
+  - test
 
 jobs:
     include:
@@ -37,7 +37,7 @@ jobs:
       # the bootstrap above is older historically; this way of doing it is newer
       # and also simpler. we should aim to reduce/eliminate the duplication.
       - stage: build
-        name: bootstrap and publishLocal
+        name: build, publishLocal, build again
         if: type = pull_request OR repo != scala/scala
         script:
           - set -e
@@ -46,7 +46,7 @@ jobs:
           - sbt -Dstarr.version=$STARR setupValidateTest compile
         workspaces:
           create:
-            name: published-local
+            name: bootstrapped
             paths:
               # so new STARR will be available
               - "buildcharacter.properties"
@@ -59,36 +59,36 @@ jobs:
               - "dist"
               - "build"
 
-      - stage: testAll
-        name: testAll1
+      - stage: test
+        name: tests (junit, scalacheck, et al)
         if: type = pull_request OR repo != scala/scala
         workspaces:
-          use: published-local
+          use: bootstrapped
         script:
           - set -e
           - STARR=$(sed -n 's/^maven\.version\.number=//p' buildcharacter.properties) && echo $STARR
           - sbt -Dstarr.version=$STARR setupValidateTest Test/compile testAll1
 
-      - name: testAll2
+      - name: tests (partest)
         if: type = pull_request OR repo != scala/scala
         workspaces:
-          use: published-local
+          use: bootstrapped
         script:
           - set -e
           - STARR=$(sed -n 's/^maven\.version\.number=//p' buildcharacter.properties) && echo $STARR
           - sbt -Dstarr.version=$STARR setupValidateTest testAll2
 
-      - name: testDotty
+      - name: ensure standard library is buildable by Scala 3
         if: type = pull_request OR repo != scala/scala
         workspaces:
-          use: published-local
+          use: bootstrapped
         script:
           - set -e
           - STARR=$(sed -n 's/^maven\.version\.number=//p' buildcharacter.properties) && echo $STARR
           - sbt -Dscala.build.compileWithDotty=true library/compile
 
       - stage: build
-        name: build the spec using jekyll
+        name: language spec (Jekyll)
         language: ruby
         install:
           - ruby -v


### PR DESCRIPTION
by caching all build products after bootstrap, to avoid recompilation
in testing stages

sequel to #9332, where there is some discussion