### PR TITLE
Enable -Werror for even more modules (particularly junit)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -668,10 +668,11 @@ lazy val testkit = configureAsSubproject(project)
   .dependsOn(compiler)
   .settings(Osgi.settings)
   .settings(AutomaticModuleName.settings("scala.testkit"))
+  .settings(fatalWarningsSettings)
   .settings(
     name := "scala-testkit",
     description := "Scala Compiler Testkit",
-    Compile / scalacOptions += "-feature",
+    Compile / scalacOptions ++= Seq("-feature", "-Xlint"),
     libraryDependencies ++= Seq(junitDep, asmDep),
     Compile / unmanagedSourceDirectories := List(baseDirectory.value),
     fixPom(

--- a/build.sbt
+++ b/build.sbt
@@ -591,10 +591,12 @@ lazy val partest = configureAsSubproject(project)
   .dependsOn(library, reflect, compiler, replFrontend, scalap, scaladoc, testkit)
   .settings(Osgi.settings)
   .settings(AutomaticModuleName.settings("scala.partest"))
+  .settings(fatalWarningsSettings)
   .settings(
     name := "scala-partest",
     description := "Scala Compiler Testing Tool",
     libraryDependencies ++= List(testInterfaceDep, diffUtilsDep, junitDep),
+    Compile / scalacOptions ++= Seq("-feature", "-Xlint"),
     pomDependencyExclusions ++= List((organization.value, "scala-repl-frontend"), (organization.value, "scala-compiler-doc")),
     fixPom(
       "/project/name" -> <name>Scala Partest</name>,

--- a/build.sbt
+++ b/build.sbt
@@ -692,8 +692,6 @@ lazy val testkit = configureAsSubproject(project)
 lazy val junit = project.in(file("test") / "junit")
   .dependsOn(testkit, compiler, replFrontend, scaladoc)
   .settings(commonSettings)
-  .settings(Compile / scalacOptions += "-Xlint:-adapted-args,-nullary-unit,_")
-  .settings(Compile / javacOptions ++= Seq("-Xlint"))
   .settings(disableDocs)
   .settings(publish / skip := true)
   .settings(
@@ -701,7 +699,8 @@ lazy val junit = project.in(file("test") / "junit")
     Test / javaOptions += "-Xss1M",
     (Test / forkOptions) := (Test / forkOptions).value.withWorkingDirectory((ThisBuild / baseDirectory).value),
     (Test / testOnly / forkOptions) := (Test / testOnly / forkOptions).value.withWorkingDirectory((ThisBuild / baseDirectory).value),
-    Compile / scalacOptions += "-feature",
+    Compile / scalacOptions ++= Seq("-feature", "-Xlint"),
+    Compile / javacOptions ++= Seq("-Xlint"),
     libraryDependencies ++= Seq(junitInterfaceDep, jolDep, diffUtilsDep),
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),
     Compile / unmanagedSourceDirectories := Nil,

--- a/build.sbt
+++ b/build.sbt
@@ -608,11 +608,13 @@ lazy val partest = configureAsSubproject(project)
 lazy val tastytest = configureAsSubproject(project)
   .dependsOn(library, reflect, compiler)
   .settings(disableDocs)
+  .settings(fatalWarningsSettings)
   .settings(publish / skip := true)
   .settings(
     name := "scala-tastytest",
     description := "Scala TASTy Integration Testing Tool",
     libraryDependencies ++= List(diffUtilsDep, TastySupport.scala3Compiler),
+    Compile / scalacOptions ++= Seq("-feature", "-Xlint"),
   )
 
 // An instrumented version of BoxesRunTime and ScalaRunTime for partest's "specialized" test category

--- a/build.sbt
+++ b/build.sbt
@@ -622,6 +622,7 @@ lazy val specLib = project.in(file("test") / "instrumented")
   .dependsOn(library, reflect, compiler)
   .settings(commonSettings)
   .settings(disableDocs)
+  .settings(fatalWarningsSettings)
   .settings(publish / skip := true)
   .settings(
     Compile / sourceGenerators += Def.task {
@@ -643,7 +644,8 @@ lazy val specLib = project.in(file("test") / "instrumented")
         patch("BoxesRunTime.java", "boxes.patch"),
         patch("ScalaRunTime.scala", "srt.patch")
       )
-    }.taskValue
+    }.taskValue,
+    Compile / scalacOptions ++= Seq("-feature", "-Xlint"),
   )
 
 // The scala version used by the benchmark suites, leave undefined to use the ambient version.")

--- a/build.sbt
+++ b/build.sbt
@@ -699,7 +699,12 @@ lazy val junit = project.in(file("test") / "junit")
     Test / javaOptions += "-Xss1M",
     (Test / forkOptions) := (Test / forkOptions).value.withWorkingDirectory((ThisBuild / baseDirectory).value),
     (Test / testOnly / forkOptions) := (Test / testOnly / forkOptions).value.withWorkingDirectory((ThisBuild / baseDirectory).value),
-    Compile / scalacOptions ++= Seq("-feature", "-Xlint"),
+    Compile / scalacOptions ++= Seq(
+      "-feature",
+      "-Xlint:-valpattern,_",
+      "-Wconf:msg=match may not be exhaustive:s", // if we missed a case, all that happens is the test fails
+      "-Ypatmat-exhaust-depth", "40", // despite not caring about patmat exhaustiveness, we still get warnings for this
+    ),
     Compile / javacOptions ++= Seq("-Xlint"),
     libraryDependencies ++= Seq(junitInterfaceDep, jolDep, diffUtilsDep),
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),

--- a/build.sbt
+++ b/build.sbt
@@ -693,6 +693,7 @@ lazy val junit = project.in(file("test") / "junit")
   .dependsOn(testkit, compiler, replFrontend, scaladoc)
   .settings(commonSettings)
   .settings(disableDocs)
+  .settings(fatalWarningsSettings)
   .settings(publish / skip := true)
   .settings(
     Test / fork := true,

--- a/src/partest/scala/tools/partest/IcodeTest.scala
+++ b/src/partest/scala/tools/partest/IcodeTest.scala
@@ -35,7 +35,7 @@ abstract class IcodeTest extends DirectTest {
     compile("-d" :: testOutput.path :: args.toList : _*)
     val icodeFiles = testOutput.files.toList filter (_ hasExtension "icode")
 
-    try     icodeFiles sortBy (_.name) flatMap (f => f.lines.toList)
+    try     icodeFiles sortBy (_.name) flatMap (f => f.lines().toList)
     finally icodeFiles foreach (f => f.delete())
   }
 

--- a/src/partest/scala/tools/partest/MemoryTest.scala
+++ b/src/partest/scala/tools/partest/MemoryTest.scala
@@ -31,7 +31,7 @@ abstract class MemoryTest {
       var i = 0
       while (i < calcsPerIter) { calc(); i += 1 }
       1 to 5 foreach (_ => rt.gc())
-      history += memUsage
+      history += memUsage()
     }
 
     1 to 5 foreach (_ => stressTestIter())

--- a/src/partest/scala/tools/partest/ReplTest.scala
+++ b/src/partest/scala/tools/partest/ReplTest.scala
@@ -108,7 +108,7 @@ object StackCleaner {
  */
 abstract class SessionTest extends ReplTest  {
   /** Session transcript. */
-  def session: String = testPath.changeExtension("check").toFile.slurp
+  def session: String = testPath.changeExtension("check").toFile.slurp()
 
   /** Expected output, as an iterator, optionally marginally stripped. */
   def expected = if (stripMargins) session.stripMargin.linesIterator else session.linesIterator

--- a/src/partest/scala/tools/partest/ScriptTest.scala
+++ b/src/partest/scala/tools/partest/ScriptTest.scala
@@ -21,7 +21,7 @@ abstract class ScriptTest extends DirectTest {
   def testmain = "TestMain"
   override def extraSettings = s"-usejavacp -Xscript $testmain"
   def scriptPath = testPath changeExtension "script"
-  def code = scriptPath.toFile.slurp
+  def code = scriptPath.toFile.slurp()
   def argv = Seq.empty[String]
   def show() = {
     compile()

--- a/src/partest/scala/tools/partest/async/OutputAwait.scala
+++ b/src/partest/scala/tools/partest/async/OutputAwait.scala
@@ -53,7 +53,7 @@ object Output {
     val mutableMap = collection.mutable.HashMap[K, mutable.Builder[V, Vector[V]]]()
     for ((k, v) <- written) mutableMap.getOrElseUpdate(k, Vector.newBuilder[V]) += v
     val immutableMapBuilder = collection.immutable.HashMap.newBuilder[K, Vector[V]]
-    immutableMapBuilder ++= mutableMap.mapValues(_.result())
+    immutableMapBuilder ++= mutableMap.view.mapValues(_.result())
     immutableMapBuilder.result()
   }
 }

--- a/src/partest/scala/tools/partest/nest/AbstractRunner.scala
+++ b/src/partest/scala/tools/partest/nest/AbstractRunner.scala
@@ -175,7 +175,7 @@ class AbstractRunner(val config: RunnerSpec.Config, protected final val testSour
 
   /** Run the tests and return the success status */
   def run(): Boolean = {
-    setUncaughtHandler
+    setUncaughtHandler()
 
     if (config.optVersion) echo(versionMsg)
     else if (config.optHelp) {

--- a/src/partest/scala/tools/partest/nest/FileManager.scala
+++ b/src/partest/scala/tools/partest/nest/FileManager.scala
@@ -54,7 +54,7 @@ object FileManager {
   def mapFile(file: File, replace: String => String): Unit = {
     val f = SFile(file)
 
-    f.printlnAll(f.lines.toList map replace: _*)
+    f.printlnAll(f.lines().toList map replace: _*)
   }
 
   def jarsWithPrefix(dir: Directory, name: String): Iterator[SFile] =

--- a/src/partest/scala/tools/partest/nest/Instance.scala
+++ b/src/partest/scala/tools/partest/nest/Instance.scala
@@ -12,6 +12,8 @@
 
 package scala.tools.partest.nest
 
+import scala.language.implicitConversions
+
 /** The trait mixed into each instance of a specification.
  *
  *  @see    Reference

--- a/src/partest/scala/tools/partest/nest/Reference.scala
+++ b/src/partest/scala/tools/partest/nest/Reference.scala
@@ -13,6 +13,7 @@
 package scala.tools.partest.nest
 
 import scala.collection.mutable.ListBuffer
+import scala.language.implicitConversions
 import scala.tools.nsc.Properties.envOrNone
 
 /** Mixes in the specification trait and uses the vals therein to

--- a/src/partest/scala/tools/partest/nest/RunnerSpec.scala
+++ b/src/partest/scala/tools/partest/nest/RunnerSpec.scala
@@ -13,6 +13,7 @@
 package scala.tools.partest.nest
 
 import language.postfixOps
+import scala.annotation.nowarn
 
 trait RunnerSpec extends Spec with Meta.StdOpts with Interpolation {
   def referenceSpec       = RunnerSpec
@@ -66,5 +67,7 @@ object RunnerSpec extends RunnerSpec with Reference {
   type ThisCommandLine = CommandLine
   def creator(args: List[String]): ThisCommandLine = new CommandLine(RunnerSpec, args)
 
+  // TODO: restructure to avoid using early initializers
+  @nowarn("cat=deprecation&msg=early initializers")
   def forArgs(args: Array[String]): Config = new { val parsed = creator(args.toList) } with Config
 }

--- a/src/partest/scala/tools/partest/nest/Spec.scala
+++ b/src/partest/scala/tools/partest/nest/Spec.scala
@@ -12,6 +12,7 @@
 
 package scala.tools.partest.nest
 
+import scala.language.implicitConversions
 import scala.util.chaining._
 
 /** This trait works together with others in scala.tools.cmd to allow

--- a/src/partest/scala/tools/partest/sbt/Framework.scala
+++ b/src/partest/scala/tools/partest/sbt/Framework.scala
@@ -52,7 +52,7 @@ case class PartestTask(taskDef: TaskDef, args: Array[String]) extends Task {
     if (Runtime.getRuntime().maxMemory() / (1024*1024) < 800)
       loggers foreach (_.warn(s"""Low heap size detected (~ ${Runtime.getRuntime().maxMemory() / (1024*1024)}M). Please add the following to your build.sbt: javaOptions in Test += "-Xmx1G""""))
 
-    try runner.run
+    try runner.run()
     catch {
       case ex: ClassNotFoundException =>
         loggers foreach { l => l.error("Please make sure partest is running in a forked VM by including the following line in build.sbt:\nfork in Test := true") }

--- a/src/tastytest/scala/tools/tastytest/Dotc.scala
+++ b/src/tastytest/scala/tools/tastytest/Dotc.scala
@@ -47,7 +47,7 @@ object Dotc extends Script.Command {
       println(red(s"please provide two arguments in sub-command: $describe"))
       return 1
     }
-    val Seq(out, src) = args
+    val Seq(out, src) = args: @unchecked
     val success = dotc(out, out, Nil, src).get
     if (success) 0 else 1
   }

--- a/src/tastytest/scala/tools/tastytest/DotcDecompiler.scala
+++ b/src/tastytest/scala/tools/tastytest/DotcDecompiler.scala
@@ -1,8 +1,6 @@
 package scala.tools.tastytest
 
-import scala.util.{ Try, Success }
-
-import java.lang.reflect.Modifier
+import scala.util.Try
 
 object DotcDecompiler extends Script.Command {
 
@@ -19,7 +17,7 @@ object DotcDecompiler extends Script.Command {
       println(red(s"please provide at least 1 argument in sub-command: $describe"))
       return 1
     }
-    val Seq(tasty, additionalSettings @ _*) = args
+    val Seq(tasty, additionalSettings @ _*) = args: @unchecked
     val success = decompile(tasty, additionalSettings).get
     if (success) 0 else 1
   }

--- a/src/tastytest/scala/tools/tastytest/Files.scala
+++ b/src/tastytest/scala/tools/tastytest/Files.scala
@@ -2,7 +2,7 @@ package scala.tools.tastytest
 
 import scala.io.{ Source, BufferedSource }
 import scala.jdk.CollectionConverters._
-import scala.util.{ Try, Success, Failure }
+import scala.util.Try
 
 import java.{ lang => jl, util => ju }
 import java.nio.file.{ Files => JFiles, Paths => JPaths, Path => JPath, PathMatcher, FileSystems }
@@ -61,7 +61,7 @@ object Files {
     var source: BufferedSource = null
     try {
       source = Source.fromResource(resource)
-      op(() => source.getLines.asJava)
+      op(() => source.getLines().asJava)
     }
     finally if (source != null) {
       source.close()

--- a/src/tastytest/scala/tools/tastytest/Javac.scala
+++ b/src/tastytest/scala/tools/tastytest/Javac.scala
@@ -1,5 +1,6 @@
 package scala.tools.tastytest
 
+import scala.collection.immutable.ArraySeq
 import scala.util.{Try, Success, Properties}
 
 import javax.tools.ToolProvider
@@ -23,7 +24,7 @@ object Javac extends Script.Command {
         "-d", out,
         "-classpath", classpath,
       ) ++ sources
-      compile(settings:_*)
+      compile(ArraySeq.unsafeWrapArray(settings):_*)
     }
   }
 
@@ -35,7 +36,7 @@ object Javac extends Script.Command {
       println(red(s"please provide two arguments in sub-command: $describe"))
       return 1
     }
-    val Seq(out, src) = args
+    val Seq(out, src) = args: @unchecked
     val success = javac(out, src).get
     if (success) 0 else 1
   }

--- a/src/tastytest/scala/tools/tastytest/Runner.scala
+++ b/src/tastytest/scala/tools/tastytest/Runner.scala
@@ -6,11 +6,10 @@ import scala.util.Try
 
 import java.nio.file.Paths
 import java.io.{ OutputStream, ByteArrayOutputStream }
-import java.{ lang => jl, util => ju }
+import java.{ lang => jl }
 import jl.reflect.Modifier
 import scala.util.control.NonFatal
 import java.lang.reflect.Method
-import java.net.URLClassLoader
 
 import Files._
 import java.net.URL
@@ -79,7 +78,7 @@ object Runner extends Script.Command {
       println(red(s"please provide 2 arguments in sub-command: $describe"))
       return 1
     }
-    val Seq(classpath, className) = args
+    val Seq(classpath, className) = args: @unchecked
     classloadFrom(classpath).map(run(_, className)).get
     0
   }

--- a/src/tastytest/scala/tools/tastytest/Scalac.scala
+++ b/src/tastytest/scala/tools/tastytest/Scalac.scala
@@ -1,5 +1,6 @@
 package scala.tools.tastytest
 
+import scala.collection.immutable.ArraySeq
 import scala.util.{ Try, Success, chaining }, chaining._
 import scala.tools.nsc.{Global, Settings, reporters}, reporters.ConsoleReporter
 
@@ -35,7 +36,7 @@ object Scalac extends Script.Command {
         "-Xfatal-warnings",
         "-usejavacp"
       ) ++ additionalSettings
-      compile(settings:_*)
+      compile(ArraySeq.unsafeWrapArray(settings):_*)
     }
   }
 
@@ -47,7 +48,7 @@ object Scalac extends Script.Command {
       println(red(s"please provide at least 2 arguments in sub-command: $describe"))
       return 1
     }
-    val Seq(out, src, additionalArgs @ _*) = args
+    val Seq(out, src, additionalArgs @ _*) = args: @unchecked
     val success = scalac(out, additionalArgs, src).get
     if (success) 0 else 1
   }

--- a/src/tastytest/scala/tools/tastytest/Script.scala
+++ b/src/tastytest/scala/tools/tastytest/Script.scala
@@ -9,7 +9,7 @@ trait Script extends Script.Command {
       println(red("Please provide at least one sub-command"))
       return 1
     }
-    val Seq(command, args0 @ _*) = args
+    val Seq(command, args0 @ _*) = args: @unchecked
     subcommands.collectFirst {
       case subcommand if subcommand.commandName == command => subcommand.process(args0:_*)
     }.getOrElse {

--- a/src/tastytest/scala/tools/tastytest/TastyTest.scala
+++ b/src/tastytest/scala/tools/tastytest/TastyTest.scala
@@ -11,7 +11,6 @@ import java.{ util => ju }
 
 import SourceKind._
 import Files._
-import scala.util.Properties
 
 object TastyTest {
 
@@ -172,7 +171,7 @@ object TastyTest {
   private def getMovePreChangeSources(root: String,
     preAFilters: Set[SourceKind] = Set(Scala),
     preBFilters: Set[SourceKind] = Set(Scala),
-    src2Filters: Set[SourceKind] = Set(Scala),
+    src2Filters: Set[SourceKind] /*= Set(Scala)*/,
     src3Filters: Set[SourceKind] = Set(Scala)
   ): Try[(Seq[String], Seq[String], Seq[String], Seq[String])] = {
     for {
@@ -181,7 +180,7 @@ object TastyTest {
     } yield (filterByKind(preAFilters, preA:_*), filterByKind(preBFilters, preB:_*), src2, src3)
   }
 
-  private def get2And3Sources(root: String, src2Filters: Set[SourceKind] = Set(Scala),
+  private def get2And3Sources(root: String, src2Filters: Set[SourceKind] /*= Set(Scala)*/,
     src3Filters: Set[SourceKind] = Set(Scala)
   ): Try[(Seq[String], Seq[String])] = {
     for {
@@ -190,8 +189,8 @@ object TastyTest {
     } yield (filterByKind(src2Filters, src2:_*), filterByKind(src3Filters, src3:_*))
   }
 
-  private def getPreChangeSources(root: String, preAFilters: Set[SourceKind] = Set(Scala),
-    preBFilters: Set[SourceKind] = Set(Scala)
+  private def getPreChangeSources(root: String, preAFilters: Set[SourceKind] /*= Set(Scala)*/,
+    preBFilters: Set[SourceKind] /*= Set(Scala)*/
   ): Try[(Seq[String], Seq[String])] = {
     for {
       preA <- getFiles(root/"pre-a")
@@ -199,7 +198,7 @@ object TastyTest {
     } yield (filterByKind(preAFilters, preA:_*), filterByKind(preBFilters, preB:_*))
   }
 
-  private def getNegIsolatedSources(root: String, src2Filters: Set[SourceKind] = Set(Scala),
+  private def getNegIsolatedSources(root: String, src2Filters: Set[SourceKind] /*= Set(Scala)*/,
     src3Filters: Set[SourceKind] = Set(Scala)
   ): Try[(Seq[String], Seq[String], Seq[String])] = {
     for {

--- a/src/tastytest/scala/tools/tastytest/package.scala
+++ b/src/tastytest/scala/tools/tastytest/package.scala
@@ -2,11 +2,9 @@ package scala.tools
 
 package object tastytest {
 
-import java.nio.file.FileSystems
+  import scala.util.Try
 
-import scala.util.Try
-
-import Files.{pathSep, classpathSep}
+  import Files.{pathSep, classpathSep}
 
   def printerrln(str: String): Unit = System.err.println(red(str))
   def printwarnln(str: String): Unit = System.err.println(yellow(str))

--- a/src/testkit/scala/tools/testkit/AllocationTest.scala
+++ b/src/testkit/scala/tools/testkit/AllocationTest.scala
@@ -17,6 +17,7 @@ import java.lang.management.ManagementFactory
 
 import org.junit.Assert.{assertEquals, assertTrue, fail}
 
+import scala.annotation.nowarn
 import scala.reflect.{ClassTag, classTag}
 
 object AllocationTest {
@@ -41,6 +42,7 @@ object AllocationTest {
 
     def double = 1D
 
+    @nowarn("cat=lint-nullary-unit")
     def unit = ()
 
     def sizeOf[T <: AnyRef](fn: => T): T = fn

--- a/src/testkit/scala/tools/testkit/BytecodeTesting.scala
+++ b/src/testkit/scala/tools/testkit/BytecodeTesting.scala
@@ -97,7 +97,7 @@ class Compiler(val global: Global) {
   }
 
   def compileClass(code: String, javaCode: List[(String, String)] = Nil, allowMessage: StoreReporter.Info => Boolean = _ => false): ClassNode = {
-    val List(c) = compileClasses(code, javaCode, allowMessage)
+    val List(c) = compileClasses(code, javaCode, allowMessage): @unchecked
     c
   }
 
@@ -127,7 +127,7 @@ class Compiler(val global: Global) {
   }
 
   def compileAsmMethod(code: String, allowMessage: StoreReporter.Info => Boolean = _ => false): MethodNode = {
-    val List(m) = compileAsmMethods(code, allowMessage)
+    val List(m) = compileAsmMethods(code, allowMessage): @unchecked
     m
   }
 
@@ -135,12 +135,12 @@ class Compiler(val global: Global) {
     compileAsmMethods(code, allowMessage).map(convertMethod)
 
   def compileMethod(code: String, allowMessage: StoreReporter.Info => Boolean = _ => false): Method = {
-    val List(m) = compileMethods(code, allowMessage = allowMessage)
+    val List(m) = compileMethods(code, allowMessage = allowMessage): @unchecked
     m
   }
 
   def compileInstructions(code: String, allowMessage: StoreReporter.Info => Boolean = _ => false): List[Instruction] = {
-    val List(m) = compileMethods(code, allowMessage = allowMessage)
+    val List(m) = compileMethods(code, allowMessage = allowMessage): @unchecked
     m.instructions
   }
 }
@@ -276,7 +276,7 @@ object BytecodeTesting {
   }
 
   def findClass(cs: List[ClassNode], name: String): ClassNode = {
-    val List(c) = cs.filter(_.name == name)
+    val List(c) = cs.filter(_.name == name): @unchecked
     c
   }
 
@@ -329,7 +329,7 @@ object BytecodeTesting {
    * If `query` starts with a `+`, the next instruction is returned.
    */
   def findInstr(method: MethodNode, query: String): AbstractInsnNode = {
-    val List(i) = findInstrs(method, query)
+    val List(i) = findInstrs(method, query): @unchecked
     i
   }
 

--- a/src/testkit/scala/tools/testkit/TempDir.scala
+++ b/src/testkit/scala/tools/testkit/TempDir.scala
@@ -13,7 +13,7 @@
 package scala.tools.testkit
 
 import java.io.{IOException, File}
-import java.nio.file.{Files, FileVisitor, FileVisitResult, SimpleFileVisitor, Path}, FileVisitResult.{CONTINUE => Continue}
+import java.nio.file.{Files, FileVisitResult, SimpleFileVisitor, Path}, FileVisitResult.{CONTINUE => Continue}
 import java.nio.file.attribute._
 
 import scala.util.Properties

--- a/test/junit/scala/AdaptedArrowAssocWorkaround.scala
+++ b/test/junit/scala/AdaptedArrowAssocWorkaround.scala
@@ -1,0 +1,26 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+
+object AdaptedArrowAssocWorkaround {
+  // Factory for arbitrary-sized tuples, to avoid argument list adaptation
+  // warnings for `->`. If there comes a point when that warning no longer
+  // exists, then it is easy to remove all traces of this workaround using
+  // find/replace, which would not be the case for wrapping all of the
+  // affected tuples in extra sets of parentheses.
+  object Tx {
+    def apply[A, B](a:A, b: B): (A, B) = (a, b)
+    def apply[A, B, C](a:A, b: B, c: C): (A, B, C) = (a, b, c)
+    def apply[A, B, C, D](a:A, b: B, c: C, d: D): (A, B, C, D) = (a, b, c, d)
+  }
+}

--- a/test/junit/scala/CollectTest.scala
+++ b/test/junit/scala/CollectTest.scala
@@ -27,41 +27,41 @@ class CollectTest {
   }
 
   @Test
-  def testListCollect: Unit =
+  def testListCollect(): Unit =
     testing(Seq(1, 2), List(1))(List(1, 2) collect { case x if f(x) && x < 2 => x})
 
   @Test
-  def testListCollectFirst: Unit =
+  def testListCollectFirst(): Unit =
     testing(Seq(1), Some(1))(List(1, 2) collectFirst { case x if f(x) && x < 2 => x})
 
   @Test
-  def testOptionCollect1: Unit =
+  def testOptionCollect1(): Unit =
     testing(Seq(1), Some(1))(Some(1) collect { case x if f(x) && x < 2 => x})
 
   @Test
-  def testOptionCollect2: Unit =
+  def testOptionCollect2(): Unit =
     testing(Seq(2), None)(Some(2) collect { case x if f(x) && x < 2 => x})
 
   @deprecated("Tests deprecated Stream", since="2.13")
   @Test
-  def testStreamCollect: Unit =
+  def testStreamCollect(): Unit =
     testing(Seq(1, 2), List(1))((Stream(1, 2).collect { case x if f(x) && x < 2 => x}).toList)
 
   @deprecated("Tests deprecated Stream", since="2.13")
   @Test
-  def testStreamCollectFirst: Unit =
+  def testStreamCollectFirst(): Unit =
     testing(Seq(1), Some(1))(Stream.continually(1) collectFirst { case x if f(x) && x < 2 => x})
 
   @Ignore @Test
-  def testIteratorCollect: Unit =
+  def testIteratorCollect(): Unit =
     testing(???)((Iterator(1, 2) collect { case x if f(x) && x < 2 => x}).toList)
 
   @Ignore @Test
-  def testListViewCollect: Unit =
+  def testListViewCollect(): Unit =
     testing(???)((Iterator(1, 2) collect { case x if f(x) && x < 2 => x}).toList)
 
   @Ignore @Test
-  def testFutureCollect: Unit = {
+  def testFutureCollect(): Unit = {
     // This would do the trick in Future.collect, but I haven't added this yet as there is a tradeoff
     // with extra allocations to consider.
     //

--- a/test/junit/scala/EnumerationTest.scala
+++ b/test/junit/scala/EnumerationTest.scala
@@ -8,7 +8,7 @@ import org.junit.runners.JUnit4
 @RunWith(classOf[JUnit4])
 class EnumerationTest {
 
-  @Test def t10906: Unit = {
+  @Test def t10906(): Unit = {
     object A extends Enumeration
     val s1 = A.values.map(x => 42)
     assertEquals(Set.empty, (s1: scala.collection.immutable.SortedSet[Int]))
@@ -20,7 +20,7 @@ class EnumerationTest {
     assertEquals(Set.empty, (s4: A.ValueSet))
   }
 
-  @Test def implicitOrderingIsSameAsEnumerationOrdering: Unit = {
+  @Test def implicitOrderingIsSameAsEnumerationOrdering(): Unit = {
     object MyEnum extends Enumeration {
       val a, b, c = Value
     }

--- a/test/junit/scala/MatchErrorSerializationTest.scala
+++ b/test/junit/scala/MatchErrorSerializationTest.scala
@@ -11,7 +11,7 @@ import org.junit.runners.JUnit4
 class MatchErrorSerializationTest {
 
   @Test
-  def canSerializeMatchError = {
+  def canSerializeMatchError(): Unit = {
     import java.io._
     val matchError = new MatchError(new Object)
     val barrayOut = new ByteArrayOutputStream()

--- a/test/junit/scala/OptionTest.scala
+++ b/test/junit/scala/OptionTest.scala
@@ -6,24 +6,24 @@ import org.junit.Test
 import scala.tools.testkit.RunTesting
 
 class OptionTest extends RunTesting {
-  @Test def testSomeZipSome: Unit = assertEquals(Some("foo") zip Some("bar"), Some(("foo", "bar")))
-  @Test def testSomeZipNone: Unit = assertEquals(Some("foo") zip None, None)
-  @Test def testNoneZipSome: Unit = assertEquals(None zip Some("bar"), None)
-  @Test def testNoneZipNone: Unit = assertEquals(None zip None, None)
+  @Test def testSomeZipSome(): Unit = assertEquals(Some("foo") zip Some("bar"), Some(("foo", "bar")))
+  @Test def testSomeZipNone(): Unit = assertEquals(Some("foo") zip None, None)
+  @Test def testNoneZipSome(): Unit = assertEquals(None zip Some("bar"), None)
+  @Test def testNoneZipNone(): Unit = assertEquals(None zip None, None)
 
-  @Test def testSomeUnzipToSomePair: Unit = assertEquals(Some(("foo", "bar")).unzip, (Some("foo"), Some("bar")))
-  @Test def testSomeUnzipToSomeNone: Unit = assertEquals(Some(("foo", null)).unzip, (Some("foo"), Some(null)))
-  @Test def testNoneUnzipToNonePair: Unit = assertEquals(None.unzip, (None, None))
+  @Test def testSomeUnzipToSomePair(): Unit = assertEquals(Some(("foo", "bar")).unzip, (Some("foo"), Some("bar")))
+  @Test def testSomeUnzipToSomeNone(): Unit = assertEquals(Some(("foo", null)).unzip, (Some("foo"), Some(null)))
+  @Test def testNoneUnzipToNonePair(): Unit = assertEquals(None.unzip, (None, None))
 
-  @Test def testSomeUnzip3ToSomeTriple: Unit = assertEquals(Some(("foo", "bar", "z")).unzip3, (Some("foo"), Some("bar"), Some("z")))
-  @Test def testSomeUnzip3ToSomeNone: Unit = assertEquals(Some(("foo", null, null)).unzip3, (Some("foo"), Some(null), Some(null)))
-  @Test def testNoneUnzip3ToNoneTriple: Unit = assertEquals(None.unzip3, (None, None, None))
+  @Test def testSomeUnzip3ToSomeTriple(): Unit = assertEquals(Some(("foo", "bar", "z")).unzip3, (Some("foo"), Some("bar"), Some("z")))
+  @Test def testSomeUnzip3ToSomeNone(): Unit = assertEquals(Some(("foo", null, null)).unzip3, (Some("foo"), Some(null), Some(null)))
+  @Test def testNoneUnzip3ToNoneTriple(): Unit = assertEquals(None.unzip3, (None, None, None))
 
   import runner._
   import scala.tools.reflect.{ ToolBoxError => E }
 
-  @Test(expected = classOf[E]) def testSomeZipList: Unit = run("""Some("foo") zip List("bar", "baz")""")
-  @Test(expected = classOf[E]) def testSomeZipNil: Unit = run("""Some("foo") zip Nil""")
-  @Test(expected = classOf[E]) def testNoneZipList: Unit = run("""None zip List("bar")""")
-  @Test(expected = classOf[E]) def testNoneZipNil: Unit = run("""None zip Nil""")
+  @Test(expected = classOf[E]) def testSomeZipList(): Unit = run("""Some("foo") zip List("bar", "baz")""")
+  @Test(expected = classOf[E]) def testSomeZipNil(): Unit = run("""Some("foo") zip Nil""")
+  @Test(expected = classOf[E]) def testNoneZipList(): Unit = run("""None zip List("bar")""")
+  @Test(expected = classOf[E]) def testNoneZipNil(): Unit = run("""None zip Nil""")
 }

--- a/test/junit/scala/PartialFunctionSerializationTest.scala
+++ b/test/junit/scala/PartialFunctionSerializationTest.scala
@@ -15,15 +15,15 @@ class PartialFunctionSerializationTest {
     new ObjectOutputStream(new ByteArrayOutputStream()).writeObject(fn)
   }
 
-  @Test def canSerializeLiteral = assertSerializable(pf1)
+  @Test def canSerializeLiteral(): Unit = assertSerializable(pf1)
 
-  @Test def canSerializeLifted = assertSerializable(pf1.lift)
+  @Test def canSerializeLifted(): Unit = assertSerializable(pf1.lift)
 
-  @Test def canSerializeOrElse = assertSerializable(pf1 orElse pf2)
+  @Test def canSerializeOrElse(): Unit = assertSerializable(pf1 orElse pf2)
 
-  @Test def canSerializeUnlifted = assertSerializable(Function.unlift((x: Int) => Some(x)))
+  @Test def canSerializeUnlifted(): Unit = assertSerializable(Function.unlift((x: Int) => Some(x)))
 
-  @Test def canSerializeAndThen = assertSerializable(pf1.andThen((x: Int) => x))
+  @Test def canSerializeAndThen(): Unit = assertSerializable(pf1.andThen((x: Int) => x))
 
-  @Test def canSerializeEmpty = assertSerializable(PartialFunction.empty)
+  @Test def canSerializeEmpty(): Unit = assertSerializable(PartialFunction.empty)
 }

--- a/test/junit/scala/PredefTest.scala
+++ b/test/junit/scala/PredefTest.scala
@@ -6,7 +6,7 @@ import org.junit.Test
 
 class PredefTest {
   @Test
-  def testTuple2Alias: Unit = {
+  def testTuple2Alias(): Unit = {
     val tup = "foobar" -> 3
     val char = tup match {
       case str -> i => str.charAt(i)

--- a/test/junit/scala/collection/ArrayOpsTest.scala
+++ b/test/junit/scala/collection/ArrayOpsTest.scala
@@ -28,13 +28,13 @@ class ArrayOpsTest {
   }
 
   @Test
-  def reverseIterator: Unit = {
+  def reverseIterator(): Unit = {
     val a = Array(1,2,3)
     assertEquals(List(3,2,1), a.reverseIterator.toList)
   }
 
   @Test
-  def folds: Unit = {
+  def folds(): Unit = {
     val a = Array(1,2,3)
     assertEquals(6, a.foldLeft(0){ (a, b) => a+b })
     assertEquals(6, a.foldRight(0){ (a, b) => a+b })
@@ -78,7 +78,7 @@ class ArrayOpsTest {
   }
 
   @Test
-  def startsWith: Unit = {
+  def startsWith(): Unit = {
     val l0 = Nil
     val l1 = 1 :: Nil
     val a0 = Array[Int]()
@@ -105,14 +105,14 @@ class ArrayOpsTest {
   }
 
   @Test
-  def slice: Unit = {
+  def slice(): Unit = {
     assertArrayEquals(Array[Int](2), Array[Int](1, 2).slice(1, 2))
     assertArrayEquals(Array[Int](), Array[Int](1).slice(1052471512, -1496048404))
     assertArrayEquals(Array[Int](), Array[Int](1).slice(2, 3))
   }
 
   @Test
-  def copyToArrayOutOfBoundsTest: Unit = {
+  def copyToArrayOutOfBoundsTest(): Unit = {
     val target = Array[Int]()
     assertEquals(0, Array(1,2).copyToArray(target, 1, 0))
   }

--- a/test/junit/scala/collection/GenericTest.scala
+++ b/test/junit/scala/collection/GenericTest.scala
@@ -41,7 +41,7 @@ object Parse {
 class GenericTest {
 
   @Test
-  def genericTest: Unit = {
+  def genericTest(): Unit = {
     assert(Parse.parseCollection[Int, immutable.List[Int]].parse("1|2|3").contains(1 :: 2 :: 3 :: immutable.Nil))
     assert(Parse.parseCollection[(Int, Int), immutable.HashMap[Int, Int]].parse("1-2|3-4").contains(immutable.HashMap((1, 2), (3, 4))))
   }

--- a/test/junit/scala/collection/IndexedSeqTest.scala
+++ b/test/junit/scala/collection/IndexedSeqTest.scala
@@ -32,7 +32,7 @@ abstract class IndexedTest[T, E] {
   /**
     * check some simple indexed access
     */
-  @Test def checkIndexedAccess: Unit = {
+  @Test def checkIndexedAccess(): Unit = {
     val test = underTest(size)
     for (i <- 0 until size) {
       assertEquals(s" at index $i", expectedValueAtIndex(i), get(test, i))
@@ -49,7 +49,7 @@ abstract class IndexedTest[T, E] {
     * check simple equality of the initial data.
     * More a test of the infra that we use in this est than a full test of equality
     */
-  @Test def checkEquals: Unit = {
+  @Test def checkEquals(): Unit = {
     val test1 = underTest(size)
     val test2 = underTest(size)
     doAssertEquals("", test1, test2)
@@ -73,7 +73,7 @@ abstract class IndexedTest[T, E] {
   /**
     * check the operation of {{{take}}} when the parameter is less than the size of the test data
     */
-  @Test def checkTakeNormal: Unit = {
+  @Test def checkTakeNormal(): Unit = {
     val orig = underTest(size)
     for (len <- 0 until size) {
       val taken = take(orig, len)
@@ -84,7 +84,7 @@ abstract class IndexedTest[T, E] {
   /**
     * check the operation of {{{slice}}} within the bounds of the source
     */
-  @Test def checkSliceNormal: Unit = {
+  @Test def checkSliceNormal(): Unit = {
     val orig = underTest(size)
     for (
       from <- 0 until size;
@@ -99,7 +99,7 @@ abstract class IndexedTest[T, E] {
     * check the operation of {{{take}}} works for size of 0
     * There is a special case that for some implementations empty will be a singleton
     */
-  @Test def checkTakeEmpty: Unit = {
+  @Test def checkTakeEmpty(): Unit = {
     val orig = underTest(size)
     val empty1 = take(orig, 0)
     val empty2 = take(orig, 0)
@@ -111,7 +111,7 @@ abstract class IndexedTest[T, E] {
     * check the operation of {{{slice}}} works for size of 0
     * There is a special case that for some implementations empty will be a singleton
     */
-  @Test def checkSliceEmpty: Unit = {
+  @Test def checkSliceEmpty(): Unit = {
     val orig = underTest(size)
     for (start <- 0 until size) {
       val empty1 = slice(orig, start, start)
@@ -125,7 +125,7 @@ abstract class IndexedTest[T, E] {
     * check the operation of {{{take}}} works for the entire content
     * There is a special case that for some immutable implementations they can share the result
     */
-  @Test def checkTakeAll: Unit = {
+  @Test def checkTakeAll(): Unit = {
     val orig = underTest(size)
     val all = take(orig, size)
     assertEquals(size, length(all))
@@ -140,7 +140,7 @@ abstract class IndexedTest[T, E] {
     * check the operation of {{{slice}}} works for the entire content
     * There is a special case that for some immutable implementations they can share the result
     */
-  @Test def checkSliceAll: Unit = {
+  @Test def checkSliceAll(): Unit = {
     val orig = underTest(size)
     val all = slice(orig, 0, size)
     assertEquals(size, length(all))
@@ -155,7 +155,7 @@ abstract class IndexedTest[T, E] {
     * check that take operates appropriately for negative values
     * take and slice should be lenient and silently ignore any data outside valid ranges
     */
-  @Test def checkTakeNeg: Unit = {
+  @Test def checkTakeNeg(): Unit = {
     val orig = underTest(size)
     val e = take(orig, 0)
     for (len <- List(-1, -10, -99, Int.MinValue)) {
@@ -169,7 +169,7 @@ abstract class IndexedTest[T, E] {
     * check that take operates appropriately for lengths that exceed the input size
     * take and slice should be lenient and silently ignore any data outside valid ranges
     */
-  @Test def checkTakeTooBig: Unit = {
+  @Test def checkTakeTooBig(): Unit = {
     val orig = underTest(size)
     val e = take(orig, 0)
     assertNotNull(e)
@@ -184,7 +184,7 @@ abstract class IndexedTest[T, E] {
     * check that slice operates appropriately for negative start point
     * take and slice should be lenient and silently ignore any data outside valid ranges
     */
-  @Test def checkSliceFromNeg: Unit = {
+  @Test def checkSliceFromNeg(): Unit = {
     val orig = underTest(size)
     for (
       from <- List(-1, -10, -99, Int.MinValue);
@@ -198,7 +198,7 @@ abstract class IndexedTest[T, E] {
     * check that slice operates appropriately for out of range end values
     * take and slice should be lenient and silently ignore any data outside valid ranges
     */
-  @Test def checkSliceToTooBig: Unit = {
+  @Test def checkSliceToTooBig(): Unit = {
     val orig = underTest(size)
     for (
       from <- List(-1, -10, -99, Int.MinValue, 0, 1, 5);
@@ -214,7 +214,7 @@ abstract class IndexedTest[T, E] {
     * check that slice operates appropriately for negative values start and ends too large
     * take and slice should be lenient and silently ignore any data outside valid ranges
     */
-  @Test def checkSliceFromNegAndToTooBig: Unit = {
+  @Test def checkSliceFromNegAndToTooBig(): Unit = {
     val orig = underTest(size)
     for (
       from <- List(-1, -10, -99, Int.MinValue);

--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -660,11 +660,11 @@ class IteratorTest {
       case _ => ???
     }
 
-    def noop = ()
+    def noop(): Unit = ()
 
-    def check() = assertNotReachable(seq1.get, it)(noop)
+    def check(): Unit = assertNotReachable(seq1.get, it)(noop())
 
-    def checkHasElement() = assertNotReachable(Option(seq1.get).map(_.apply(1)).orNull, it)(noop)
+    def checkHasElement(): Unit = assertNotReachable(Option(seq1.get).map(_.apply(1)).orNull, it)(noop())
 
     assert(it.hasNext)
     assertEquals("first", it.next())

--- a/test/junit/scala/collection/LazyZipOpsTest.scala
+++ b/test/junit/scala/collection/LazyZipOpsTest.scala
@@ -5,6 +5,8 @@ import org.junit.Assert._
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+
+import scala.AdaptedArrowAssocWorkaround.Tx
 import scala.collection.immutable._
 
 @RunWith(classOf[JUnit4])
@@ -84,19 +86,19 @@ class LazyZipOpsTest {
 
   @Test
   def lazyZip2_withMap(): Unit = {
-    val res: Map[Int, (String, String)] = map.lazyZip(ys).map { case ((k, v), s) => k -> (s, v) }
+    val res: Map[Int, (String, String)] = map.lazyZip(ys).map { case ((k, v), s) => k -> Tx(s, v) }
 
     assertThat(res, either(
-      is(Map(1 -> ("a", "foo"), 2 -> ("b", "bar"))))
-      .or(is(Map(1 -> ("b", "foo"), 2 -> ("a", "bar"))))
+      is(Map(1 -> Tx("a", "foo"), 2 -> Tx("b", "bar"))))
+      .or(is(Map(1 -> Tx("b", "foo"), 2 -> Tx("a", "bar"))))
     )
   }
 
   @Test
   def lazyZip2_withSortedMap(): Unit = {
-    val res: TreeMap[Int, (String, String)] = sortedMap.lazyZip(ys).map { case ((k, v), s) => k -> (s, v) }
+    val res: TreeMap[Int, (String, String)] = sortedMap.lazyZip(ys).map { case ((k, v), s) => k -> Tx(s, v) }
 
-    assertEquals(Map(1 -> ("a", "foo"), 2 -> ("b", "bar")), res)
+    assertEquals(Map(1 -> Tx("a", "foo"), 2 -> Tx("b", "bar")), res)
   }
 
   @Test
@@ -162,20 +164,20 @@ class LazyZipOpsTest {
 
   @Test
   def lazyZip3_withMap(): Unit = {
-    val res: Map[Int, (Int, String, String)] = map.lazyZip(ws).lazyZip(ys).map { case ((k, v), w, y) => k -> (w, y, v) }
+    val res: Map[Int, (Int, String, String)] = map.lazyZip(ws).lazyZip(ys).map { case ((k, v), w, y) => k -> Tx(w, y, v) }
 
     assertThat(res, either(
-      is(Map(1 -> (1, "a", "foo"), 2 -> (2, "b", "bar"))))
-      .or(is(Map(1 -> (2, "b", "foo"), 2 -> (1, "a", "bar"))))
+      is(Map(1 -> Tx(1, "a", "foo"), 2 -> Tx(2, "b", "bar"))))
+      .or(is(Map(1 -> Tx(2, "b", "foo"), 2 -> Tx(1, "a", "bar"))))
     )
   }
 
   @Test
   def lazyZip3_withSortedMap(): Unit = {
     val res: TreeMap[Int, (Int, String, String)] = sortedMap.lazyZip(ws).lazyZip(ys)
-      .map { case ((k, v), w, y) => k -> (w, y, v) }
+      .map { case ((k, v), w, y) => k -> Tx(w, y, v) }
 
-    assertEquals(Map(1 -> (1, "a", "foo"), 2 -> (2, "b", "bar")), res)
+    assertEquals(Map(1 -> Tx(1, "a", "foo"), 2 -> Tx(2, "b", "bar")), res)
   }
 
   @Test
@@ -242,20 +244,20 @@ class LazyZipOpsTest {
   @Test
   def lazyZip4_withMap(): Unit = {
     val res: Map[Int, (Int, Int, String, String)] = map.lazyZip(ws).lazyZip(xs).lazyZip(ys)
-      .map { case ((k, v), w, x, y) => k -> (w, x, y, v) }
+      .map { case ((k, v), w, x, y) => k -> Tx(w, x, y, v) }
 
     assertThat(res, either(
-      is(Map(1 -> (1, 1, "a", "foo"), 2 -> (2, 2, "b", "bar"))))
-      .or(is(Map(1 -> (2, 2, "b", "foo"), 2 -> (1, 1, "a", "bar"))))
+      is(Map(1 -> Tx(1, 1, "a", "foo"), 2 -> Tx(2, 2, "b", "bar"))))
+      .or(is(Map(1 -> Tx(2, 2, "b", "foo"), 2 -> Tx(1, 1, "a", "bar"))))
     )
   }
 
   @Test
   def lazyZip4_withSortedMap(): Unit = {
     val res: TreeMap[Int, (Int, Int, String, String)] = sortedMap.lazyZip(ws).lazyZip(xs).lazyZip(ys)
-      .map { case ((k, v), w, x, y) => k -> (w, x, y, v) }
+      .map { case ((k, v), w, x, y) => k -> Tx(w, x, y, v) }
 
-    assertEquals(Map(1 -> (1, 1, "a", "foo"), 2 -> (2, 2, "b", "bar")), res)
+    assertEquals(Map(1 -> Tx(1, 1, "a", "foo"), 2 -> Tx(2, 2, "b", "bar")), res)
   }
 
   @Test

--- a/test/junit/scala/collection/LazyZipOpsTest.scala
+++ b/test/junit/scala/collection/LazyZipOpsTest.scala
@@ -1,7 +1,8 @@
 package scala.collection
 
 import org.hamcrest.CoreMatchers._
-import org.junit.Assert._
+import org.hamcrest.MatcherAssert._
+import org.junit.Assert.{assertThat => _, _}
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4

--- a/test/junit/scala/collection/LazyZipOpsTest.scala
+++ b/test/junit/scala/collection/LazyZipOpsTest.scala
@@ -261,14 +261,14 @@ class LazyZipOpsTest {
   }
 
   @Test
-  def lazyZipArray: Unit = {
+  def lazyZipArray(): Unit = {
     val a = Array(1,2,3).lazyZip(List(4,5,6)).map(_ + _)
     val at: Array[Int] = a
     assertArrayEquals(Array(5, 7, 9), at)
   }
 
   @Test
-  def lazyZipString: Unit = {
+  def lazyZipString(): Unit = {
     val v = "abc".lazyZip(List(1,2,3)).map((a, b) => a.toInt + b.toInt)
     val vt: IndexedSeq[Int] = v
     assertEquals(Vector(98, 100, 102), vt)

--- a/test/junit/scala/collection/LinearSeqTest.scala
+++ b/test/junit/scala/collection/LinearSeqTest.scala
@@ -7,7 +7,7 @@ import org.junit.runners.JUnit4
 @RunWith(classOf[JUnit4])
 class LinearSeqTest {
   // Tests regression on issue 11262
-  @Test def extensionIteratorTest: Unit = {
+  @Test def extensionIteratorTest(): Unit = {
     class ConstantLinearSeq[A](len: Int, elt: A) extends scala.collection.LinearSeq[A] {
       override val isEmpty: Boolean = len == 0
       override val head = elt

--- a/test/junit/scala/collection/SeqTest.scala
+++ b/test/junit/scala/collection/SeqTest.scala
@@ -96,7 +96,7 @@ class SeqTest extends AllocationTest {
     nonAllocating(Seq())
   }
 
-  @Test def smallSeqAllocation: Unit = {
+  @Test def smallSeqAllocation(): Unit = {
     if (CompileTime.versionNumberString == "2.13.2") return
     exactAllocates(Sizes.list * 1, "collection seq  size 1")(Seq("0"))
     exactAllocates(Sizes.list * 2, "collection seq  size 2")(Seq("0", "1"))
@@ -107,7 +107,7 @@ class SeqTest extends AllocationTest {
     exactAllocates(Sizes.list * 7, "collection seq  size 7")(Seq("0", "1", "2", "3", "4", "5", "6"))
   }
 
-  @Test def largeSeqAllocation: Unit = {
+  @Test def largeSeqAllocation(): Unit = {
     def expected(n: Int) = Sizes.list * n + Sizes.wrappedRefArray(n) + Sizes.wrappedRefArrayIterator
     exactAllocates(expected(10) , "collection seq size 10")(
       Seq("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"))

--- a/test/junit/scala/collection/SetMapRulesTest.scala
+++ b/test/junit/scala/collection/SetMapRulesTest.scala
@@ -210,83 +210,83 @@ class SetMapRulesTest {
 
   // Immutable maps
 
-  @Test def testImmutableMap: Unit =
+  @Test def testImmutableMap(): Unit =
     mapdata.foreach(d => checkImmutableMap(() => immutable.Map.from(d)))
 
-  @Test def testImmutableListMap: Unit =
+  @Test def testImmutableListMap(): Unit =
     mapdata.foreach(d => checkImmutableMap(() => immutable.ListMap.from(d)))
 
-  @Test def testImmutableVectorMap: Unit =
+  @Test def testImmutableVectorMap(): Unit =
     mapdata.foreach(d => checkImmutableMap(() => immutable.VectorMap.from(d)))
 
-  @Test def testImmutableTreeMap: Unit =
+  @Test def testImmutableTreeMap(): Unit =
     mapdata.foreach(d => checkImmutableMap(() => immutable.TreeMap.from(d)))
 
-  @Test def testImmutableHashMap: Unit =
+  @Test def testImmutableHashMap(): Unit =
     mapdata.foreach(d => checkImmutableMap(() => immutable.HashMap.from(d)))
 
   // Mutable maps
 
-  @Test def testMutableMap: Unit =
+  @Test def testMutableMap(): Unit =
     mapdata.foreach(d => checkMutableMap(() => mutable.Map.from(d)))
 
-  @Test def testMutableHashMap: Unit =
+  @Test def testMutableHashMap(): Unit =
     mapdata.foreach(d => checkMutableMap(() => mutable.HashMap.from(d)))
 
   @deprecated("Uses OpenHashMap", since="2.13")
-  @Test def testMutableOpenHashMap: Unit =
+  @Test def testMutableOpenHashMap(): Unit =
     mapdata.foreach(d => checkMutableMap(() => mutable.OpenHashMap.from(d)))
 
-  @Test def testMutableAnyRefMap: Unit =
+  @Test def testMutableAnyRefMap(): Unit =
     mapdata.foreach(d => checkMutableMap(() => mutable.AnyRefMap.from(d)))
 
-  @Test def testMutableTreeMap: Unit =
+  @Test def testMutableTreeMap(): Unit =
     mapdata.foreach(d => checkMutableMap(() => mutable.TreeMap.from(d)))
 
-  @Test def testMutableLinkedHashMap: Unit =
+  @Test def testMutableLinkedHashMap(): Unit =
     mapdata.foreach(d => checkMutableMap(() => mutable.LinkedHashMap.from(d)))
 
-  @Test def testMutableSeqMap: Unit =
+  @Test def testMutableSeqMap(): Unit =
     mapdata.foreach(d => checkMutableMap(() => mutable.SeqMap.from(d)))
 
   @deprecated("Uses ListMap", since="2.13")
-  @Test def testMutableListMap: Unit =
+  @Test def testMutableListMap(): Unit =
     mapdata.foreach(d => checkMutableMap(() => mutable.ListMap.from(d)))
 
-  @Test def testConcurrentTrieMap: Unit =
+  @Test def testConcurrentTrieMap(): Unit =
     mapdata.foreach(d => checkMutableMap(() => concurrent.TrieMap.from(d)))
 
-  @Test def testJavaHashMap: Unit =
+  @Test def testJavaHashMap(): Unit =
     mapdata.foreach(d => checkMutableMap(() => new java.util.HashMap[Value, Value].asScala.addAll(d)))
 
   // Immutable sets
 
-  @Test def testImmutableSet: Unit =
+  @Test def testImmutableSet(): Unit =
     setdata.foreach(d => checkImmutableSet(() => immutable.Set.from(d)))
 
-  @Test def testImmutableHashSet: Unit =
+  @Test def testImmutableHashSet(): Unit =
     setdata.foreach(d => checkImmutableSet(() => immutable.HashSet.from(d)))
 
-  @Test def testImmutableListSet: Unit =
+  @Test def testImmutableListSet(): Unit =
     setdata.foreach(d => checkImmutableSet(() => immutable.ListSet.from(d)))
 
-  @Test def testImmutableTreeSet: Unit =
+  @Test def testImmutableTreeSet(): Unit =
     setdata.foreach(d => checkImmutableSet(() => immutable.TreeSet.from(d)))
 
   // Mutable sets
 
-  @Test def testMutableSet: Unit =
+  @Test def testMutableSet(): Unit =
     setdata.foreach(d => checkMutableSet(() => mutable.Set.from(d)))
 
-  @Test def testMutableHashSet: Unit =
+  @Test def testMutableHashSet(): Unit =
     setdata.foreach(d => checkMutableSet(() => mutable.HashSet.from(d)))
 
-  @Test def testMutableLinkedHashSet: Unit =
+  @Test def testMutableLinkedHashSet(): Unit =
     setdata.foreach(d => checkMutableSet(() => mutable.LinkedHashSet.from(d)))
 
-  @Test def testMutableTreeSet: Unit =
+  @Test def testMutableTreeSet(): Unit =
     setdata.foreach(d => checkMutableSet(() => mutable.TreeSet.from(d)))
 
-  @Test def testJavaHashSet: Unit =
+  @Test def testJavaHashSet(): Unit =
     setdata.foreach(d => checkMutableSet(() => new java.util.HashSet[Value].asScala.addAll(d)))
 }

--- a/test/junit/scala/collection/Sizes.scala
+++ b/test/junit/scala/collection/Sizes.scala
@@ -18,26 +18,26 @@ object Sizes {
 class Sizes {
   import JOL._
   @Test
-  def list: Unit = {
+  def list(): Unit = {
     assertTotalSize(Sizes.list, JOL.netLayout(null :: Nil, Nil))
   }
   @Test
-  def listBuffer: Unit = {
+  def listBuffer(): Unit = {
     assertTotalSize(Sizes.listBuffer, JOL.netLayout(new ListBuffer[String], Nil))
   }
   @Test
-  def rawArray: Unit = {
+  def rawArray(): Unit = {
     for (length <- 0 to 10) {
       assertTotalSize(Sizes.refArray(length), JOL.netLayout(new Array[String](length), Nil))
     }
   }
   @Test @deprecated("Tests deprecated API", since="2.13.3")
-  def wrappedArray2: Unit =
+  def wrappedArray2(): Unit =
     for (length <- 1 to 10)
       assertTotalSize(Sizes.wrappedRefArray(length), JOL.netLayout(mutable.WrappedArray.make[String](new Array[String](length)), Nil))
 
   @Test
-  def wrappedArray: Unit = {
+  def wrappedArray(): Unit = {
     val wrapped = Array[String]("")
     assertTotalSize(16, JOL.netLayout(mutable.ArraySeq.make[String](wrapped), wrapped))
     assertTotalSize(16, JOL.netLayout(immutable.ArraySeq.unsafeWrapArray[String](wrapped), wrapped))

--- a/test/junit/scala/collection/StrictOptimizedSeqTest.scala
+++ b/test/junit/scala/collection/StrictOptimizedSeqTest.scala
@@ -10,12 +10,12 @@ import scala.collection.immutable.Vector
 class StrictOptimizedSeqTest {
 
   @Test
-  def hasCorrectDistinct: Unit = {
+  def hasCorrectDistinct(): Unit = {
     assertEquals(Vector(1, 2, 3, 4, 5), Vector(1, 1, 2, 3, 3, 3, 4, 5, 5).distinct)
   }
 
   @Test
-  def hasCorrectDistinctBy: Unit = {
+  def hasCorrectDistinctBy(): Unit = {
     val result = Vector("a", "aa", "aaa", "b", "bb", "bbb", "bbbb", "c").distinctBy(_.length)
 
     assertEquals(Vector("a", "aa", "aaa", "bbbb"), result)

--- a/test/junit/scala/collection/StringOpsTest.scala
+++ b/test/junit/scala/collection/StringOpsTest.scala
@@ -98,7 +98,7 @@ class StringOpsTest {
     assertEquals("hello".withFilter(_ != 'e').map(_.toUpper), "HLLO")
   }
 
-  @Test def collect: Unit = {
+  @Test def collect(): Unit = {
     assertEquals("de", "abcdef".collect { case c @ ('b' | 'c') => (c+2).toChar })
     assertEquals(Seq('d'.toInt, 'e'.toInt), "abcdef".collect { case c @ ('b' | 'c') => (c+2).toInt })
   }

--- a/test/junit/scala/collection/StringParsersTest.scala
+++ b/test/junit/scala/collection/StringParsersTest.scala
@@ -272,45 +272,45 @@ class StringParsersTest {
   )
 
   @Test
-  def doubleSpecificTest: Unit = doubleExamples.foreach(doubleOK)
+  def doubleSpecificTest(): Unit = doubleExamples.foreach(doubleOK)
 
   @Test
-  def doubleGeneralTest: Unit = forAllExamples.foreach(doubleOK)
+  def doubleGeneralTest(): Unit = forAllExamples.foreach(doubleOK)
 
   @Test
-  def floatSpecificTest: Unit = doubleExamples.foreach(floatOK)
+  def floatSpecificTest(): Unit = doubleExamples.foreach(floatOK)
 
   @Test
-  def floatGeneralTest: Unit = forAllExamples.foreach(floatOK)
+  def floatGeneralTest(): Unit = forAllExamples.foreach(floatOK)
 
   @Test
-  def byteTest: Unit = (forAllExamples ::: nearOverflow).foreach(byteOK)
+  def byteTest(): Unit = (forAllExamples ::: nearOverflow).foreach(byteOK)
 
   @Test
-  def shortTest: Unit = (forAllExamples ::: nearOverflow).foreach(shortOK)
+  def shortTest(): Unit = (forAllExamples ::: nearOverflow).foreach(shortOK)
 
   @Test
-  def intTest: Unit = (forAllExamples ::: nearOverflow).foreach(intOK)
+  def intTest(): Unit = (forAllExamples ::: nearOverflow).foreach(intOK)
 
   @Test
-  def longTest: Unit = (forAllExamples ::: longNearOverflow).foreach(longOK)
+  def longTest(): Unit = (forAllExamples ::: longNearOverflow).foreach(longOK)
 
   @Test
-  def nullByte: Unit = assertThrows[NullPointerException](nullstring.toByteOption)
+  def nullByte(): Unit = assertThrows[NullPointerException](nullstring.toByteOption)
 
   @Test
-  def nullShort: Unit = assertThrows[NullPointerException](nullstring.toShortOption)
+  def nullShort(): Unit = assertThrows[NullPointerException](nullstring.toShortOption)
 
   @Test
-  def nullInt: Unit = assertThrows[NullPointerException](nullstring.toIntOption)
+  def nullInt(): Unit = assertThrows[NullPointerException](nullstring.toIntOption)
   
   @Test
-  def nullLong: Unit = assertThrows[NullPointerException](nullstring.toLongOption)
+  def nullLong(): Unit = assertThrows[NullPointerException](nullstring.toLongOption)
 
   @Test
-  def nullFloat: Unit = assertThrows[NullPointerException](nullstring.toFloatOption)
+  def nullFloat(): Unit = assertThrows[NullPointerException](nullstring.toFloatOption)
 
   @Test
-  def nullDouble: Unit = assertThrows[NullPointerException](nullstring.toDoubleOption)
+  def nullDouble(): Unit = assertThrows[NullPointerException](nullstring.toDoubleOption)
 
 }

--- a/test/junit/scala/collection/generic/DecoratorsTest.scala
+++ b/test/junit/scala/collection/generic/DecoratorsTest.scala
@@ -2,6 +2,7 @@ package scala.collection.generic
 
 import org.junit.Test
 
+import scala.AdaptedArrowAssocWorkaround.Tx
 import scala.annotation.unused
 import scala.collection.immutable.{BitSet, IntMap, LongMap, TreeMap, TreeSet}
 import scala.collection.{BuildFrom, View, mutable}
@@ -164,14 +165,14 @@ class DecoratorsTest {
       def leftOuterJoin[W, That](other: Map[map.K, W])(implicit bf: BuildFrom[C, (map.K, (map.V, Option[W])), That]): That = {
         val b = bf.newBuilder(coll)
         for ((k, v) <- map(coll)) {
-          b += k -> (v, other.get(k))
+          b += k -> Tx(v, other.get(k))
         }
         b.result()
       }
       def rightOuterJoin[W, That](other: Map[map.K, W])(implicit bf: BuildFrom[C, (map.K, (Option[map.V], W)), That]): That = {
         val b = bf.newBuilder(coll)
         for ((k, w) <- other) {
-          b += k -> (map(coll).get(k), w)
+          b += k -> Tx(map(coll).get(k), w)
         }
         b.result()
       }

--- a/test/junit/scala/collection/immutable/HashSetTest.scala
+++ b/test/junit/scala/collection/immutable/HashSetTest.scala
@@ -238,7 +238,7 @@ class HashSetTest extends AllocationTest {
     override def toString: String = s"$hashCode-$other"
   }
   @Ignore // TODO Port {HashMap, HashSet}.concat allocation reduction
-  @Test def collidingAdd: Unit = {
+  @Test def collidingAdd(): Unit = {
     val initial = generateWithCollisions(1, 1000)
     assertEquals(1000, initial.size)
     assertEquals(1000, initial.toList.size)

--- a/test/junit/scala/collection/immutable/IndexedSeqTest.scala
+++ b/test/junit/scala/collection/immutable/IndexedSeqTest.scala
@@ -9,7 +9,7 @@ import scala.tools.testkit.AllocationTest
 
 class IndexedSeqTest extends AllocationTest {
 
-  @Test def testEqualsSimple: Unit = {
+  @Test def testEqualsSimple(): Unit = {
     assertTrue(Vector.empty == Vector.empty)
     assertTrue(Vector(1, 2, 3) == Vector(1, 2, 3))
     assertTrue(Vector(1, 2, 3, 4, 5, 6, 7, 8, 9) == Vector(1, 2, 3, 4, 5, 6, 7, 8, 9))
@@ -19,7 +19,7 @@ class IndexedSeqTest extends AllocationTest {
     assertTrue(ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9) == ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9))
   }
 
-  @Test def testNotEqualsSimple1: Unit = {
+  @Test def testNotEqualsSimple1(): Unit = {
     assertTrue(Vector.empty != Vector(1, 2, 3))
     assertTrue(Vector(3, 2, 1) != Vector(1, 2, 3))
     assertTrue(Vector(1, 2, 3) != Vector(1, 2))
@@ -27,7 +27,7 @@ class IndexedSeqTest extends AllocationTest {
     assertTrue(Vector(1, 2, 3, 4, 5, 6, 7, 8, 9) != Vector(1, 2, 3, 4, 5, 6, 7, 8, 99))
   }
 
-  @Test def testNotEqualsSimple2: Unit = {
+  @Test def testNotEqualsSimple2(): Unit = {
     assertTrue(ArraySeq.empty != ArraySeq(1, 2, 3))
     assertTrue(ArraySeq(3, 2, 1) != ArraySeq(1, 2, 3))
     assertTrue(ArraySeq(1, 2, 3) != ArraySeq(1, 2))
@@ -35,7 +35,7 @@ class IndexedSeqTest extends AllocationTest {
     assertTrue(ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9) != ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 99))
   }
 
-  @Test def testNotEqualsSimple3: Unit = {
+  @Test def testNotEqualsSimple3(): Unit = {
     assertTrue(ArraySeq.empty != Vector(1, 2, 3))
     assertTrue(ArraySeq(3, 2, 1) != Vector(1, 2, 3))
     assertTrue(ArraySeq(1, 2, 3) != Vector(1, 2))
@@ -43,7 +43,7 @@ class IndexedSeqTest extends AllocationTest {
     assertTrue(ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9) != Vector(1, 2, 3, 4, 5, 6, 7, 8, 99))
   }
 
-  @Test def testNotEqualsEdges: Unit = {
+  @Test def testNotEqualsEdges(): Unit = {
     assertTrue(ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9) != Vector(10, 2, 3, 4, 5, 6, 7, 8, 9))
     assertTrue(ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9) != Vector(1, 20, 3, 4, 5, 6, 7, 8, 9))
     assertTrue(ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9) != Vector(1, 2, 30, 4, 5, 6, 7, 8, 9))
@@ -55,34 +55,34 @@ class IndexedSeqTest extends AllocationTest {
     assertTrue(ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9) != Vector(1, 2, 3, 4, 5, 6, 7, 8, 90))
   }
 
-  @Test def testEqualsSimpleNonAllocatingEmpty: Unit = {
+  @Test def testEqualsSimpleNonAllocatingEmpty(): Unit = {
     nonAllocatingEqual(true, Vector.empty, Vector.empty)
     nonAllocatingEqual(true, ArraySeq.empty, ArraySeq.empty)
     nonAllocatingEqual(true, Vector.empty, ArraySeq.empty)
   }
 
-  @Test def testEqualsSimpleNonAllocatingSmall: Unit = {
+  @Test def testEqualsSimpleNonAllocatingSmall(): Unit = {
     nonAllocatingEqual(true, Vector(1, 2, 3), Vector(1, 2, 3))
     nonAllocatingEqual(true, ArraySeq(1, 2, 3), ArraySeq(1, 2, 3))
     nonAllocatingEqual(true, Vector(1, 2, 3), ArraySeq(1, 2, 3))
   }
 
-  @Test def testEqualsSimpleNonAllocatingDiffSize: Unit = {
+  @Test def testEqualsSimpleNonAllocatingDiffSize(): Unit = {
     nonAllocatingEqual(false, Vector(1, 2, 3, 4, 5, 6, 7, 8, 9), Vector(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
     nonAllocatingEqual(false, ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
     nonAllocatingEqual(false, Vector(1, 2, 3, 4, 5, 6, 7, 8, 9), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
   }
 
-  @Test def testEqualsSimpleNonAllocatingDiffInFirstFew: Unit = {
+  @Test def testEqualsSimpleNonAllocatingDiffInFirstFew(): Unit = {
     nonAllocatingEqual(false, Vector(1, 2, 3, 14, 5, 6, 7, 8, 9), Vector(1, 2, 3, 4, 5, 6, 7, 8, 9))
     nonAllocatingEqual(false, ArraySeq(1, 2, 3, 14, 5, 6, 7, 8, 9), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9))
     nonAllocatingEqual(false, Vector(1, 2, 3, 14, 5, 6, 7, 8, 9), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9))
   }
 
-  @Test def testEqualsArraySeqSpecialised1: Unit = {
+  @Test def testEqualsArraySeqSpecialised1(): Unit = {
     nonAllocatingEqual(true, ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9), ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9))
   }
-  @Test def testEqualsArraySeqSpecialised2: Unit = {
+  @Test def testEqualsArraySeqSpecialised2(): Unit = {
     nonAllocatingEqual(true, ArraySeq(1, 2, 3, 4, 5, 6, 7, 8, 9), Range(1,10))
   }
 

--- a/test/junit/scala/collection/immutable/LazyListTest.scala
+++ b/test/junit/scala/collection/immutable/LazyListTest.scala
@@ -25,7 +25,7 @@ class LazyListTest {
   }
 
   @Test // scala/bug#8990
-  def withFilter_can_retry_after_exception_thrown_in_filter: Unit = {
+  def withFilter_can_retry_after_exception_thrown_in_filter(): Unit = {
     // use mutable state to control an intermittent failure in filtering the LazyList
     var shouldThrow = true
 
@@ -41,7 +41,7 @@ class LazyListTest {
   }
 
   @Test // scala/bug#6881
-  def test_reference_equality: Unit = {
+  def test_reference_equality(): Unit = {
     // Make sure we're tested with reference equality
     val s = LazyList.from(0)
     assert(s == s, "Referentially identical LazyLists should be equal (==)")
@@ -51,13 +51,13 @@ class LazyListTest {
   }
 
   @Test
-  def t9886: Unit = {
+  def t9886(): Unit = {
     assertEquals(LazyList(None, Some(1)), None #:: LazyList(Some(1)))
     assertEquals(LazyList(None, Some(1)), LazyList(None) #::: LazyList(Some(1)))
   }
 
   @Test
-  def testLazyListDoesNotForceHead: Unit = {
+  def testLazyListDoesNotForceHead(): Unit = {
     var i = 0
     def f: Int = { i += 1; i }
     @unused val s = LazyList.empty.#::(f).#::(f).#::(f)
@@ -70,20 +70,20 @@ class LazyListTest {
   }
 
   @Test
-  def testLazyListToStringWhenHeadAndTailBothAreNotEvaluated = {
+  def testLazyListToStringWhenHeadAndTailBothAreNotEvaluated(): Unit = {
     val l = LazyList(1, 2, 3, 4, 5)
     assertEquals("LazyList(<not computed>)", l.toString)
   }
 
   @Test
-  def testLazyListToStringWhenOnlyHeadIsEvaluated = {
+  def testLazyListToStringWhenOnlyHeadIsEvaluated(): Unit = {
     val l = LazyList(1, 2, 3, 4, 5)
     l.head
     assertEquals("LazyList(1, <not computed>)", l.toString)
   }
 
   @Test
-  def testLazyListToStringWhenHeadAndTailIsEvaluated = {
+  def testLazyListToStringWhenHeadAndTailIsEvaluated(): Unit = {
     val l = LazyList(1, 2, 3, 4, 5)
     l.head
     l.tail
@@ -91,7 +91,7 @@ class LazyListTest {
   }
 
   @Test
-  def testLazyListToStringWhenHeadAndTailHeadIsEvaluated = {
+  def testLazyListToStringWhenHeadAndTailHeadIsEvaluated(): Unit = {
     val l = LazyList(1, 2, 3, 4, 5)
     l.head
     l.tail.head
@@ -99,42 +99,42 @@ class LazyListTest {
   }
 
   @Test
-  def testLazyListToStringWhenHeadIsNotEvaluatedAndOnlyTailIsEvaluated = {
+  def testLazyListToStringWhenHeadIsNotEvaluatedAndOnlyTailIsEvaluated(): Unit = {
     val l = LazyList(1, 2, 3, 4, 5)
     l.tail
     assertEquals("LazyList(1, <not computed>)", l.toString)
   }
 
   @Test
-  def testLazyListToStringWhenHeadIsNotEvaluatedAndTailHeadIsEvaluated = {
+  def testLazyListToStringWhenHeadIsNotEvaluatedAndTailHeadIsEvaluated(): Unit = {
     val l = LazyList(1, 2, 3, 4, 5)
     l.tail.head
     assertEquals("LazyList(1, 2, <not computed>)", l.toString)
   }
 
   @Test
-  def testLazyListToStringWhenHeadIsNotEvaluatedAndTailTailIsEvaluated = {
+  def testLazyListToStringWhenHeadIsNotEvaluatedAndTailTailIsEvaluated(): Unit = {
     val l = LazyList(1, 2, 3, 4, 5)
     l.tail.tail
     assertEquals("LazyList(1, 2, <not computed>)", l.toString)
   }
 
   @Test
-  def testLazyListToStringWhendHeadIsNotEvaluatedAndTailTailHeadIsEvaluated = {
+  def testLazyListToStringWhendHeadIsNotEvaluatedAndTailTailHeadIsEvaluated(): Unit = {
     val l = LazyList(1, 2, 3, 4, 5)
     l.tail.tail.head
     assertEquals("LazyList(1, 2, 3, <not computed>)", l.toString)
   }
 
   @Test
-  def testLazyListToStringWhenLazyListIsForcedToList: Unit = {
+  def testLazyListToStringWhenLazyListIsForcedToList(): Unit = {
     val l = 1 #:: 2 #:: 3 #:: 4 #:: LazyList.empty
     l.toList
     assertEquals("LazyList(1, 2, 3, 4)", l.toString)
   }
 
   @Test
-  def testLazyListToStringWhenLazyListIsEmpty: Unit = {
+  def testLazyListToStringWhenLazyListIsEmpty(): Unit = {
     // cached empty
     val l1 = LazyList.empty
     assertEquals("LazyList()", l1.toString)
@@ -144,14 +144,14 @@ class LazyListTest {
   }
 
   @Test
-  def testLazyListToStringForSingleElementList: Unit = {
+  def testLazyListToStringForSingleElementList(): Unit = {
     val l = LazyList(1)
     l.force
     assertEquals("LazyList(1)", l.toString)
   }
 
   @Test
-  def testLazyListToStringWhenLazyListHasCyclicReference: Unit = {
+  def testLazyListToStringWhenLazyListHasCyclicReference(): Unit = {
     lazy val cyc: LazyList[Int] = 1 #:: 2 #:: 3 #:: 4 #:: cyc
     assertEquals("LazyList(<not computed>)", cyc.toString)
     cyc.head
@@ -266,7 +266,7 @@ class LazyListTest {
   }
 
   @Test
-  def t8680: Unit = {
+  def t8680(): Unit = {
     def pre(n: Int) = (-n to -1).to(LazyList)
 
     def cyc(m: Int) = {

--- a/test/junit/scala/collection/immutable/ListMapTest.scala
+++ b/test/junit/scala/collection/immutable/ListMapTest.scala
@@ -44,13 +44,13 @@ class ListMapTest extends AllocationTest {
   }
 
   @Test
-  def hasCorrectIterator: Unit = {
+  def hasCorrectIterator(): Unit = {
     val m = ListMap(1 -> 1, 2 -> 2, 3 -> 3, 5 -> 5, 4 -> 4)
     assertEquals(List(1 -> 1, 2 -> 2, 3 -> 3, 5 -> 5, 4 -> 4), m.iterator.toList)
   }
 
   @Test
-  def keysShouldPreserveOrderAsInserted: Unit = {
+  def keysShouldPreserveOrderAsInserted(): Unit = {
     val m = ListMap("a" -> "1", "b" -> "2", "c" -> "3", "d" -> "4", "e" -> "5")
     assertEquals(List("A", "B", "C", "D", "E"), m.keys.map(_.toUpperCase).toList)
   }

--- a/test/junit/scala/collection/immutable/ListSetTest.scala
+++ b/test/junit/scala/collection/immutable/ListSetTest.scala
@@ -46,7 +46,7 @@ class ListSetTest {
   }
 
   @Test
-  def hasCorrectIterator: Unit = {
+  def hasCorrectIterator(): Unit = {
     val s = ListSet(1, 2, 3, 5, 4)
     assertEquals(List(1, 2, 3, 5, 4), s.iterator.toList)
   }

--- a/test/junit/scala/collection/immutable/ListTest.scala
+++ b/test/junit/scala/collection/immutable/ListTest.scala
@@ -76,7 +76,7 @@ class ListTest extends AllocationTest{
     assertSame(ls, List.from(ls))
   }
 
-  @Test def checkSearch: Unit = SeqTests.checkSearch(List(0 to 1000: _*), 15,  implicitly[Ordering[Int]])
+  @Test def checkSearch(): Unit = SeqTests.checkSearch(List(0 to 1000: _*), 15,  implicitly[Ordering[Int]])
 
 
   @Test def colonColonColon(): Unit = {
@@ -107,7 +107,7 @@ class ListTest extends AllocationTest{
   }
 
 
-  @Test def smallListAllocation: Unit = {
+  @Test def smallListAllocation(): Unit = {
     if (CompileTime.versionNumberString == "2.13.2") return
     exactAllocates(Sizes.list * 1, "list  size 1")(List("0"))
     exactAllocates(Sizes.list * 2, "list  size 2")(List("0", "1"))
@@ -118,7 +118,7 @@ class ListTest extends AllocationTest{
     exactAllocates(Sizes.list * 7, "list  size 7")(List("0", "1", "2", "3", "4", "5", "6"))
   }
 
-  @Test def largeListAllocation: Unit = {
+  @Test def largeListAllocation(): Unit = {
     def expected(n: Int) = Sizes.list * n + Sizes.wrappedRefArray(n) + Sizes.wrappedRefArrayIterator
     exactAllocates(expected(10), "list  size 10")(
       List("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"))

--- a/test/junit/scala/collection/immutable/MapTest.scala
+++ b/test/junit/scala/collection/immutable/MapTest.scala
@@ -5,7 +5,7 @@ import org.junit.Test
 
 class MapTest {
 
-  @Test def builderCompare1: Unit = {
+  @Test def builderCompare1(): Unit = {
     for (size <- 0 to 100;
          start <- 0 to 10;
          overwrite <- List(true, false)) {
@@ -39,7 +39,7 @@ class MapTest {
 
     }
   }
-  @Test def builderCompare2: Unit = {
+  @Test def builderCompare2(): Unit = {
     for (size <- 0 to 100;
          start <- 0 to 10;
          overwrite <- List(true, false)) {
@@ -68,7 +68,7 @@ class MapTest {
     }
   }
 
-  @Test def addition: Unit = {
+  @Test def addition(): Unit = {
     for (size <- 0 to 100;
          start <- 0 to 10) {
       val tBuilder = TreeMap.newBuilder[String, String]

--- a/test/junit/scala/collection/immutable/NumericRangeTest.scala
+++ b/test/junit/scala/collection/immutable/NumericRangeTest.scala
@@ -11,13 +11,13 @@ import scala.tools.testkit.AssertUtil.assertThrows
 class NumericRangeTest {
 
   @Test
-  def emptyiterator: Unit = {
+  def emptyiterator(): Unit = {
     assertFalse(NumericRange(1, 0, 1).iterator.hasNext)
     assertFalse(NumericRange(0, 10, -1).iterator.hasNext)
   }
 
   @Test
-  def nonEmptyiterator: Unit = {
+  def nonEmptyiterator(): Unit = {
     val it = NumericRange(0, 3, 1).iterator
 
     assertTrue(it.hasNext)
@@ -30,13 +30,13 @@ class NumericRangeTest {
   }
 
   @Test
-  def t11163_BigDecimalSum: Unit = {
+  def t11163_BigDecimalSum(): Unit = {
     val x = (BigDecimal(1) to BigDecimal(3) by 1).sum
     assertEquals(BigDecimal(6), x)
   }
 
   @Test
-  def t11152_BigDecimalMakesProgress: Unit = {
+  def t11152_BigDecimalMakesProgress(): Unit = {
     // Overflow case with default MathContext
     val a = BigDecimal(1)
     val b = a + BigDecimal("1e-30")
@@ -70,7 +70,7 @@ class NumericRangeTest {
   }
 
   @Test
-  def numericRangeIsEmpty: Unit = {
+  def numericRangeIsEmpty(): Unit = {
     //Test Positive Step
     assertFalse((1 to 9).isEmpty)
     assertTrue((9 to 1).isEmpty)
@@ -90,7 +90,7 @@ class NumericRangeTest {
   }
 
   @Test
-  def smallIncrementCount: Unit = {
+  def smallIncrementCount(): Unit = {
     case class TestRange(start: BigDecimal, end: BigDecimal, step: BigDecimal, inclusive: Boolean = false)
     def foldListIncrement(rangeTest: TestRange): List[BigDecimal] = {
       List.unfold(rangeTest. start) { prec =>

--- a/test/junit/scala/collection/immutable/QueueTest.scala
+++ b/test/junit/scala/collection/immutable/QueueTest.scala
@@ -32,7 +32,7 @@ class QueueTest {
   }
 
   @Test
-  def copyToArrayOutOfBounds: Unit = {
+  def copyToArrayOutOfBounds(): Unit = {
     val target = Array[Int]()
     assertEquals(0, Queue(1,2).copyToArray(target, 1, 0))
   }

--- a/test/junit/scala/collection/immutable/SeqTest.scala
+++ b/test/junit/scala/collection/immutable/SeqTest.scala
@@ -15,7 +15,7 @@ class SeqTest extends AllocationTest {
     nonAllocating(Seq())
   }
 
-  @Test def smallSeqAllocation: Unit = {
+  @Test def smallSeqAllocation(): Unit = {
     if (CompileTime.versionNumberString == "2.13.2") return
     exactAllocates(Sizes.list * 1, "immutable seq  size 1")(Seq("0"))
     exactAllocates(Sizes.list * 2, "immutable seq  size 2")(Seq("0", "1"))
@@ -25,7 +25,7 @@ class SeqTest extends AllocationTest {
     exactAllocates(Sizes.list * 6, "immutable seq  size 6")(Seq("0", "1", "2", "3", "4", "5"))
     exactAllocates(Sizes.list * 7, "immutable seq  size 7")(Seq("0", "1", "2", "3", "4", "5", "6"))
   }
-  @Test def largeSeqAllocation: Unit = {
+  @Test def largeSeqAllocation(): Unit = {
     def expected(n: Int) = Sizes.list * n + Sizes.wrappedRefArray(n) + Sizes.wrappedRefArrayIterator
     exactAllocates(expected(10), "immutable seq size 10")(
       Seq("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"))

--- a/test/junit/scala/collection/immutable/SortedMapTest.scala
+++ b/test/junit/scala/collection/immutable/SortedMapTest.scala
@@ -108,14 +108,14 @@ class SortedMapTest extends AllocationTest {
     i => s"$i is not present in this map"
   }
   @Test
-  def testWithDefaultValue: Unit = {
+  def testWithDefaultValue(): Unit = {
     val m1 = SortedMap(1 -> "a", 2 -> "b")
     val m2 = m1.withDefaultValue("missing")
     assertEquals("a", m2(1))
     assertEquals("missing", m2(3))
   }
   @Test
-  def testWithDefault: Unit = {
+  def testWithDefault(): Unit = {
     val m1 = SortedMap(1 -> "a", 2 -> "b")
 
     val m2: Map[Int, String] =
@@ -140,26 +140,26 @@ class SortedMapTest extends AllocationTest {
     assertEquals(m4(100), "101")
   }
 
-  @Test def updatedWithReturnsSortedMap: Unit = {
+  @Test def updatedWithReturnsSortedMap(): Unit = {
     val m1 = SortedMap(1 -> "a")
     val m2 = m1.updatedWith(2) { case Some(v) => Some(v.toUpperCase) case None => Some("DEFAULT") }
     val m3: SortedMap[Int, String] = m2 // check the type returned by `updatedWith`
     assertEquals(SortedMap(1 -> "a", 2 -> "DEFAULT"), m3)
   }
 
-  @Test def empty: Unit = {
+  @Test def empty(): Unit = {
     val ord = Ordering[String]
     exactAllocates(24)(SortedMap.empty[String, String](ord))
   }
-  @Test def apply0: Unit = {
+  @Test def apply0(): Unit = {
     val ord = Ordering[String]
     exactAllocates(24)(SortedMap()(ord))
   }
-  @Test def apply1: Unit = {
+  @Test def apply1(): Unit = {
     val ord = Ordering[String]
     onlyAllocates(200)(SortedMap(("a", "a"))(ord))
   }
-  @Test def apply2: Unit = {
+  @Test def apply2(): Unit = {
     val ord = Ordering[String]
     onlyAllocates(312)(SortedMap(("a", "a"), ("b", "b"))(ord))
   }

--- a/test/junit/scala/collection/immutable/SortedSetTest.scala
+++ b/test/junit/scala/collection/immutable/SortedSetTest.scala
@@ -7,19 +7,19 @@ import scala.tools.testkit.AllocationTest
 
 class SortedSetTest extends AllocationTest{
 
-  @Test def empty: Unit ={
+  @Test def empty(): Unit ={
     val ord = Ordering[String]
     exactAllocates(24)(SortedSet.empty(ord))
   }
-  @Test def apply0: Unit ={
+  @Test def apply0(): Unit ={
     val ord = Ordering[String]
     exactAllocates(24)(SortedSet()(ord))
   }
-  @Test def apply1: Unit ={
+  @Test def apply1(): Unit ={
     val ord = Ordering[String]
     exactAllocates(152)(SortedSet("a")(ord))
   }
-  @Test def apply2: Unit ={
+  @Test def apply2(): Unit ={
     val ord = Ordering[String]
     exactAllocates(216)(SortedSet("a", "b")(ord))
   }

--- a/test/junit/scala/collection/immutable/StreamTest.scala
+++ b/test/junit/scala/collection/immutable/StreamTest.scala
@@ -107,17 +107,17 @@ class StreamTest {
   }
 
   @Test // scala/bug#9134
-  def filter_map_properly_lazy_in_tail: Unit = {
+  def filter_map_properly_lazy_in_tail(): Unit = {
     assertStreamOpLazyInTail(_.filter(_ % 2 == 0).map(identity), List(1, 2))
   }
 
   @Test // scala/bug#9134
-  def withFilter_map_properly_lazy_in_tail: Unit = {
+  def withFilter_map_properly_lazy_in_tail(): Unit = {
     assertStreamOpLazyInTail(_.withFilter(_ % 2 == 0).map(identity), List(1, 2))
   }
 
   @Test // scala/bug#6881
-  def test_reference_equality: Unit = {
+  def test_reference_equality(): Unit = {
     // Make sure we're tested with reference equality
     val s = Stream.from(0)
     assert(s == s, "Referentially identical streams should be equal (==)")
@@ -127,7 +127,7 @@ class StreamTest {
   }
 
   @Test
-  def t9886: Unit = {
+  def t9886(): Unit = {
     assertEquals(Stream(None, Some(1)), None #:: Stream(Some(1)))
     assertEquals(Stream(None, Some(1)), Stream(None) #::: Stream(Some(1)))
   }
@@ -160,20 +160,20 @@ class StreamTest {
   }
 
   @Test
-  def testStreamToStringWhenHeadAndTailBothAreNotEvaluated = {
+  def testStreamToStringWhenHeadAndTailBothAreNotEvaluated(): Unit = {
     val l = Stream(1, 2, 3, 4, 5)
     assertEquals("Stream(1, <not computed>)", l.toString)
   }
 
   @Test
-  def testStreamToStringWhenOnlyHeadIsEvaluated = {
+  def testStreamToStringWhenOnlyHeadIsEvaluated(): Unit = {
     val l = Stream(1, 2, 3, 4, 5)
     l.head
     assertEquals("Stream(1, <not computed>)", l.toString)
   }
 
   @Test
-  def testStreamToStringWhenHeadAndTailIsEvaluated = {
+  def testStreamToStringWhenHeadAndTailIsEvaluated(): Unit = {
     val l = Stream(1, 2, 3, 4, 5)
     l.head
     l.tail
@@ -181,7 +181,7 @@ class StreamTest {
   }
 
   @Test
-  def testStreamToStringWhenHeadAndTailHeadIsEvaluated = {
+  def testStreamToStringWhenHeadAndTailHeadIsEvaluated(): Unit = {
     val l = Stream(1, 2, 3, 4, 5)
     l.head
     l.tail.head
@@ -189,41 +189,41 @@ class StreamTest {
   }
 
   @Test
-  def testStreamToStringWhenHeadIsNotEvaluatedAndOnlyTailIsEvaluated = {
+  def testStreamToStringWhenHeadIsNotEvaluatedAndOnlyTailIsEvaluated(): Unit = {
     val l = Stream(1, 2, 3, 4, 5)
     l.tail
     assertEquals("Stream(1, 2, <not computed>)", l.toString)
   }
 
   @Test
-  def testStreamToStringWhedHeadIsNotEvaluatedAndTailHeadIsEvaluated = {
+  def testStreamToStringWhedHeadIsNotEvaluatedAndTailHeadIsEvaluated(): Unit = {
     val l = Stream(1, 2, 3, 4, 5)
     l.tail.head
     assertEquals("Stream(1, 2, <not computed>)", l.toString)
   }
 
   @Test
-  def testStreamToStringWhenStreamIsForcedToList: Unit = {
+  def testStreamToStringWhenStreamIsForcedToList(): Unit = {
     val l = 1 #:: 2 #:: 3 #:: 4 #:: Stream.empty
     l.toList
     assertEquals("Stream(1, 2, 3, 4)", l.toString)
   }
 
   @Test
-  def testStreamToStringWhenStreamIsEmpty: Unit = {
+  def testStreamToStringWhenStreamIsEmpty(): Unit = {
     val l = Stream.empty
     assertEquals("Stream()", l.toString)
   }
 
   @Test
-  def testStreamToStringWhenStreamHasCyclicReference: Unit = {
+  def testStreamToStringWhenStreamHasCyclicReference(): Unit = {
     lazy val cyc: Stream[Int] = 1 #:: 2 #:: 3 #:: 4 #:: cyc
     cyc.tail.tail.tail.tail
     assertEquals("Stream(1, 2, 3, 4, <cycle>)", cyc.toString)
   }
 
   @Test
-  def testAppendAliasToLazyAppendedAll: Unit = {
+  def testAppendAliasToLazyAppendedAll(): Unit = {
     val l = 1 #:: 2 #:: 3 #:: Stream.Empty
     assertEquals(l.append(l), l.lazyAppendedAll(l))
   }
@@ -235,7 +235,7 @@ class StreamTest {
   }
 
   @Test
-  def testLazyListIterator: Unit = {
+  def testLazyListIterator(): Unit = {
     val it1 = new CountingIt
     val s2 = it1.toStream
     s2.iterator.next()
@@ -247,7 +247,7 @@ class StreamTest {
   }
 
   @Test
-  def t10883: Unit = {
+  def t10883(): Unit = {
     var value: Int = -1
     Stream.iterate(0){ a =>
       val next = a + 1
@@ -265,7 +265,7 @@ class StreamTest {
   }
 
   @Test
-  def t09791: Unit = {
+  def t09791(): Unit = {
     // updated tests
     val x = Stream.continually("*").updated(0, "new value")
     assertEquals(List("new value", "*", "*", "*", "*", "*", "*", "*", "*", "*"), x.take(10).toList)

--- a/test/junit/scala/collection/immutable/StringLikeTest.scala
+++ b/test/junit/scala/collection/immutable/StringLikeTest.scala
@@ -12,7 +12,7 @@ import scala.util.Random
 @RunWith(classOf[JUnit4])
 class StringLikeTest {
   @Test
-  def testStringSplitWithChar: Unit = {
+  def testStringSplitWithChar(): Unit = {
     val chars = (0 to 255).map(_.toChar)
     def randString = Random.nextString(30)
 
@@ -28,7 +28,7 @@ class StringLikeTest {
   }
 
   @Test
-  def testSplitEdgeCases: Unit = {
+  def testSplitEdgeCases(): Unit = {
     val high = 0xD852.toChar
     val low = 0xDF62.toChar
     val surrogatepair = List(high, low).mkString
@@ -44,7 +44,7 @@ class StringLikeTest {
 
   /* Test for scala/bug#9767 */
   @Test
-  def testNumericConversion: Unit = {
+  def testNumericConversion(): Unit = {
     val sOne = " \t\n 1 \n\r\t "
     val sOk  = "2"
     val sNull:String = null

--- a/test/junit/scala/collection/immutable/TreeMapTest.scala
+++ b/test/junit/scala/collection/immutable/TreeMapTest.scala
@@ -28,14 +28,14 @@ class TreeMapTest extends AllocationTest {
     assertSame(m, TreeMap.from(m))
   }
   @Test
-  def testWithDefaultValue: Unit = {
+  def testWithDefaultValue(): Unit = {
     val m1 = TreeMap(1 -> "a", 2 -> "b")
     val m2 = m1.withDefaultValue("missing")
     assertEquals("a", m2(1))
     assertEquals("missing", m2(3))
   }
   @Test
-  def testWithDefault: Unit = {
+  def testWithDefault(): Unit = {
     val m1 = TreeMap(1 -> "a", 2 -> "b")
 
     val m2: Map[Int, String] =
@@ -60,12 +60,12 @@ class TreeMapTest extends AllocationTest {
     assertEquals(m4(100), "101")
   }
 
-  @Test def entriesEqualSimple: Unit = {
+  @Test def entriesEqualSimple(): Unit = {
     val tree1 = TreeMap(1 -> "a", 2 -> "b", 3 -> "c")
     val tree2 = TreeMap(1 -> "a", 2 -> "b", 3 -> "c")
     assertEquals(tree1, tree2)
   }
-  @Test def entriesEqual: Unit = {
+  @Test def entriesEqual(): Unit = {
     val b1 = TreeMap.newBuilder[Int, String]
     for ( i <- 10 to 1000) {
       b1 += i -> s"$i value"
@@ -83,7 +83,7 @@ class TreeMapTest extends AllocationTest {
     assertEquals((tree1+ (9999 -> "zzz")), (tree2+ (9999 -> "zzz")))
     assertNotEquals((tree1+ (9999 -> "zzz")), (tree2+ (9999999 -> "zzz")))
   }
-  @Test def equalFastPath: Unit = {
+  @Test def equalFastPath(): Unit = {
     class V(val s: String) {
       override def equals(obj: Any): Boolean = obj match {
         case v:V => v.s == s
@@ -138,7 +138,7 @@ class TreeMapTest extends AllocationTest {
         assertSame(tree, nonAllocating(tree.updated(k, v)))
     }
   }
-  @Test def consistentEquals: Unit = {
+  @Test def consistentEquals(): Unit = {
     class V(val s: String) {
 
       override def equals(obj: Any): Boolean = obj match {
@@ -235,13 +235,13 @@ class TreeMapTest extends AllocationTest {
     assertEquals(r1, r2)
   }
 
-  @Test def caseIndependent1: Unit = {
+  @Test def caseIndependent1(): Unit = {
     val m = scala.collection.immutable.TreeMap[String, String]()(_ compareToIgnoreCase _)
     val r = m ++ Seq("a" -> "1", "A" -> "2")
     assertMapSameElements(Map("a" -> "2"), r)
   }
 
-  @Test def caseIndependent2: Unit = {
+  @Test def caseIndependent2(): Unit = {
     val m = scala.collection.immutable.TreeMap[String, String]()(_ compareToIgnoreCase _)
     val r = Seq("a" -> "1", "A" -> "2").foldLeft (m) {
       case (acc, t) => acc + t

--- a/test/junit/scala/collection/immutable/TreeSeqMapTest.scala
+++ b/test/junit/scala/collection/immutable/TreeSeqMapTest.scala
@@ -80,20 +80,20 @@ class TreeSeqMapTest {
     assertEquals(TreeSeqMap(4 -> 5, 5 -> 4), (m - 3) - 1 - 2)
   }
   @Test
-  def testIterator: Unit = {
+  def testIterator(): Unit = {
     assertEquals(Nil, TreeSeqMap.empty.iterator.toList)
     assertEquals(List(4 -> 1), TreeSeqMap(4 -> 1).iterator.toList)
     assertEquals(List(4 -> 1, 2 -> 2, 1 -> 3, 5 -> 5, 3 -> 4), TreeSeqMap(4 -> 1, 2 -> 2, 1 -> 3, 5 -> 5, 3 -> 4).iterator.toList)
   }
   @Test
-  def testRemoveIterator: Unit = {
+  def testRemoveIterator(): Unit = {
     val m = TreeSeqMap(3 -> 1, 2 -> 2, 1 -> 3, 4 -> 5, 5 -> 4)
     assertEquals(List(3 -> 1, 2 -> 2, 5 -> 4), ((m - 1) - 4).iterator.toList)
     assertEquals(List(1 -> 3, 5 -> 4), ((m - 3) - 2 - 4).iterator.toList)
     assertEquals(List(4 -> 5, 5 -> 4), ((m - 3) - 1 - 2).iterator.toList)
   }
   @Test
-  def testSlice: Unit = {
+  def testSlice(): Unit = {
     val m = TreeSeqMap(3 -> 1, 2 -> 2, 1 -> 3, 4 -> 5, 5 -> 4)
     assertEquals(List(3 -> 1, 2 -> 2), ((m - 1) - 4).slice(0, 2).iterator.toList)
     assertEquals(List(5 -> 4), ((m - 3) - 2 - 4).slice(1, 2).iterator.toList)
@@ -105,7 +105,7 @@ class TreeSeqMapTest {
   }
 
   @Test
-  def testSplitAt: Unit = {
+  def testSplitAt(): Unit = {
     val m = TreeSeqMap(3 -> 1, 2 -> 2, 1 -> 3, 4 -> 5, 5 -> 4)
     var t = m.splitAt(0)
     assertEquals((List(), List(3 -> 1, 2 -> 2, 1 -> 3, 4 -> 5, 5 -> 4)), (t._1.iterator.toList, t._2.iterator.toList))
@@ -122,7 +122,7 @@ class TreeSeqMapTest {
   }
 
   @Test
-  def testConcatAsSeqs: Unit = {
+  def testConcatAsSeqs(): Unit = {
     val x = TreeSeqMap(3L -> "wish")
     val y = TreeSeqMap(9L -> "nine", 3L -> "three", 7L -> "seven", -1L -> "negative", 42L -> "Adams", 6L -> "vi")
     val xy = x ++ y
@@ -132,7 +132,7 @@ class TreeSeqMapTest {
   }
 
   @Test
-  def testAppend: Unit = {
+  def testAppend(): Unit = {
     import TreeSeqMap._
     import TreeSeqMap.Ordering._
 
@@ -148,7 +148,7 @@ class TreeSeqMapTest {
     }
   }
   @Test
-  def testEmpty: Unit = {
+  def testEmpty(): Unit = {
     {
       val e1 = TreeSeqMap.empty[Int, Int]
       val e2 = e1 + (3 -> 1) + (2 -> 2) + (1 -> 3) + (3 -> 4)

--- a/test/junit/scala/collection/immutable/TreeSetTest.scala
+++ b/test/junit/scala/collection/immutable/TreeSetTest.scala
@@ -58,7 +58,7 @@ class TreeSetTest extends AllocationTest {
   }
 
   @Test
-  def t11637: Unit = {
+  def t11637(): Unit = {
     import scala.collection.immutable.{RedBlackTree => RB}
     val instrs = List[RB.Tree[Int, Null] => RB.Tree[Int, Null]](
       RB.update(_, 18, null, overwrite = false),
@@ -96,7 +96,7 @@ class TreeSetTest extends AllocationTest {
   }
 
 
-  @Test def keysEqualSimple: Unit = {
+  @Test def keysEqualSimple(): Unit = {
     val tree = TreeMap(1 -> "a", 2 -> "b", 3 -> "c")
     assertEquals(Set(1, 2, 3), tree.keySet)
     val tree2 = TreeMap(1 -> "x", 2 -> "y", 3 -> "z")
@@ -106,7 +106,7 @@ class TreeSetTest extends AllocationTest {
     assertEquals(tree.keySet, tree3)
   }
 
-  @Test def valuesEqual: Unit = {
+  @Test def valuesEqual(): Unit = {
     val data = (Array.tabulate(1000) { i => i.toString }).sorted
     val expectedData = data.drop(30)
 
@@ -119,7 +119,7 @@ class TreeSetTest extends AllocationTest {
     assertEquals(tree1, tree2)
   }
 
-  @Test def keysFromMapEqualFastPath: Unit = {
+  @Test def keysFromMapEqualFastPath(): Unit = {
     class V(s: String) {
 
       override def equals(obj: Any): Boolean = {
@@ -136,7 +136,7 @@ class TreeSetTest extends AllocationTest {
     assertEquals(tree1.drop(5).keySet, tree1.drop(5).keySet)
   }
 
-  @Test def equalFastPath: Unit = {
+  @Test def equalFastPath(): Unit = {
     var compareCount = 0
     class K(val s: String) extends Ordered[K] {
       override def toString: String = s"K-$s"
@@ -199,7 +199,7 @@ class TreeSetTest extends AllocationTest {
     }
   }
 
-  @Test def consistentEquals: Unit = {
+  @Test def consistentEquals(): Unit = {
     class K(val s: String) extends Ordered[K] {
       override def toString: String = s"K-$s"
 

--- a/test/junit/scala/collection/immutable/VectorMapTest.scala
+++ b/test/junit/scala/collection/immutable/VectorMapTest.scala
@@ -45,67 +45,67 @@ class VectorMapTest {
   }
 
   @Test
-  def hasCorrectIterator: Unit = {
+  def hasCorrectIterator(): Unit = {
     val m = VectorMap(1 -> 1, 2 -> 2, 3 -> 3, 5 -> 5, 4 -> 4)
     assertEquals(List(1 -> 1, 2 -> 2, 3 -> 3, 5 -> 5, 4 -> 4), m.iterator.toList)
   }
 
   @Test
-  def keysShouldPreserveOrderAsInserted: Unit = {
+  def keysShouldPreserveOrderAsInserted(): Unit = {
     val m = VectorMap("a" -> "1", "b" -> "2", "c" -> "3", "d" -> "4", "e" -> "5")
     assertEquals(List("A", "B", "C", "D", "E"), m.keys.map(_.toUpperCase).toList)
   }
 
   @Test
-  def handlesNullKeys_t11217: Unit = {
+  def handlesNullKeys_t11217(): Unit = {
     val m = VectorMap((null, 1), ("a", 2))
     assertEquals(List(null, "a"), m.keys.toList)
   }
 
   @Test
-  def hasCorrectInit_t11218: Unit = {
+  def hasCorrectInit_t11218(): Unit = {
     val m = VectorMap(1 -> "a", 2 -> "b", 3 -> "c").removed(2).init
     assertEquals(List(1 -> "a"), m.toList)
   }
 
   @Test
-  def removeAllIsEmpty_t11220: Unit = {
+  def removeAllIsEmpty_t11220(): Unit = {
     val m = VectorMap(1 -> "a") - 1 + (2 -> "b") - 2
     assertEquals(List(), m.toList)
   }
 
   @Test
-  def removeLast_t11220: Unit = {
+  def removeLast_t11220(): Unit = {
     val m = VectorMap(1 -> "a", 2 -> "b").removed(2).updated(3, "c")
     assertEquals(List(1 -> "a", 3 -> "c"), m.toList)
   }
 
   @Test
-  def removeLast_t11220_2: Unit = {
+  def removeLast_t11220_2(): Unit = {
     val m = VectorMap(1 -> "a", 2 -> "b").removed(2).updated(3, "c").removed(3)
     assertEquals(List(1 -> "a"), m.toList)
   }
 
   @Test
-  def hasCorrectInit_t11218_2: Unit = {
+  def hasCorrectInit_t11218_2(): Unit = {
     val m = VectorMap(1 -> "a", 2 -> "b", 3 -> "c").removed(3).init
     assertEquals(List(1 -> "a"), m.toList)
   }
 
   @Test
-  def hasCorrectTail: Unit = {
+  def hasCorrectTail(): Unit = {
     val m = VectorMap(1 -> "a", 2 -> "b", 3 -> "c").tail.removed(3)
     assertEquals(List(2 -> "b"), m.toList)
   }
 
   @Test
-  def removeInit: Unit = {
+  def removeInit(): Unit = {
     val m = VectorMap(1 -> "a", 2 -> "b", 3 -> "c").removed(1).init
     assertEquals(List(2 -> "b"), m.toList)
   }
 
   @Test
-  def removeInit_2: Unit = {
+  def removeInit_2(): Unit = {
     val m = VectorMap(1 -> "a", 2 -> "b", 3 -> "c", 4 -> "d", 5 -> "e").removed(1).removed(4).init
     assertEquals(List(2 -> "b", 3 -> "c"), m.toList)
   }

--- a/test/junit/scala/collection/immutable/VectorTest.scala
+++ b/test/junit/scala/collection/immutable/VectorTest.scala
@@ -58,7 +58,7 @@ class VectorTest {
     assertSame(m, Vector.apply(m: _*))
   }
 
-  @Test def checkSearch: Unit = SeqTests.checkSearch(Vector(0 to 1000: _*), 15,  implicitly[Ordering[Int]])
+  @Test def checkSearch(): Unit = SeqTests.checkSearch(Vector(0 to 1000: _*), 15,  implicitly[Ordering[Int]])
 
   @Test
   def emptyIteratorReuse(): Unit = {
@@ -73,12 +73,12 @@ class VectorTest {
   }
 
   @Test
-  def concat: Unit = {
+  def concat(): Unit = {
     assertEquals(Vector.from(1 to 100), Vector.from(1 to 7) concat Vector.from(8 to 100))
   }
 
   @Test
-  def copyToArray: Unit = {
+  def copyToArray(): Unit = {
     val array = Array.fill(100)(2)
     Vector.fill(100)(1).copyToArray(array, 0, 100)
     assertEquals(array.toSeq, Seq.fill(100)(1))
@@ -304,7 +304,7 @@ class VectorTest {
   val verySmallSizes = allSizes.filter(_ <= WIDTH*WIDTH)
 
   @Test
-  def testAligned: Unit = for(size <- smallSizes) {
+  def testAligned(): Unit = for(size <- smallSizes) {
     val v = Vector.range(0, size)
     //println(v.toDebugString)
     validateDebug(v)
@@ -313,7 +313,7 @@ class VectorTest {
   }
 
   @Test
-  def testNonAligned: Unit = for(size <- smallSizes.filter(n => n > 0 && n < WIDTH*WIDTH*WIDTH*WIDTH)) {
+  def testNonAligned(): Unit = for(size <- smallSizes.filter(n => n > 0 && n < WIDTH*WIDTH*WIDTH*WIDTH)) {
     val v0 = Vector.range(1, size)
     val v = 0 +: v0
     //println(v0.toDebugString)
@@ -325,7 +325,7 @@ class VectorTest {
 
 
   @Test
-  def testUpdate: Unit = for(size <- smallSizes) {
+  def testUpdate(): Unit = for(size <- smallSizes) {
     var v = Vector.range(0, size)
     var i = 0
     while(i < size) {
@@ -336,7 +336,7 @@ class VectorTest {
   }
 
   @Test
-  def testSlice1: Unit = for(size <- smallSizes) {
+  def testSlice1(): Unit = for(size <- smallSizes) {
     val step = size/16 max 1
     val v = Vector.range(0, size)
     for {
@@ -353,7 +353,7 @@ class VectorTest {
   }
 
   @Test
-  def testSlice2: Unit = for(size <- Seq(10, 100, 1000, 10000)) {
+  def testSlice2(): Unit = for(size <- Seq(10, 100, 1000, 10000)) {
     val o = new AnyRef
     val coll = Vector.fill(size)(o)
     val inc = size / 10
@@ -373,12 +373,12 @@ class VectorTest {
   }
 
   @Test
-  def testSlice3: Unit = {
+  def testSlice3(): Unit = {
     assertEquals(Vector(1).slice(1, -2147483648), Vector())
   }
 
   @Test
-  def testTail: Unit = for(size <- verySmallSizes) {
+  def testTail(): Unit = for(size <- verySmallSizes) {
     var i = 0
     var v = Vector.range(0, size)
     //println("testTail: "+size)
@@ -390,7 +390,7 @@ class VectorTest {
   }
 
   @Test
-  def testRebuild: Unit = for(size <- smallSizes) {
+  def testRebuild(): Unit = for(size <- smallSizes) {
     for(prependSize <- verySmallSizes) {
       var v = Vector.range(0, size + prependSize)
       for(i <- prependSize to 0 by -1) {
@@ -406,7 +406,7 @@ class VectorTest {
   }
 
   @Test
-  def testAppendAll: Unit = for(size <- smallSizes) {
+  def testAppendAll(): Unit = for(size <- smallSizes) {
     for(appendSize <- smallSizes) {
       val v = Vector.range(0, size)
       val v2 = Vector.range(size, size + appendSize)

--- a/test/junit/scala/collection/mutable/AnyRefMapTest.scala
+++ b/test/junit/scala/collection/mutable/AnyRefMapTest.scala
@@ -9,20 +9,20 @@ import org.junit.Assert._
 @RunWith(classOf[JUnit4])
 class AnyRefMapTest {
 
-  @Test def testAnyRefMapCopy: Unit = {
+  @Test def testAnyRefMapCopy(): Unit = {
     val m1 = AnyRefMap("a" -> "b")
     val m2: AnyRefMap[String, AnyRef] = AnyRefMap.from(m1)
     assertEquals(m1, m2)
   }
 
-  @Test def testAnyRefMapContains: Unit = {
+  @Test def testAnyRefMapContains(): Unit = {
     val m = AnyRefMap("a" -> 1)
     assertEquals(1, m.size)
     assertTrue(m.contains("a"))
   }
 
   @Test
-  def test10540: Unit = {
+  def test10540(): Unit = {
     val badHashCode = -2105619938
     val reported = "K00278:18:H7C2NBBXX:7:1111:7791:21465"
     val equivalent = "JK1C=H"
@@ -35,14 +35,14 @@ class AnyRefMapTest {
 
   @deprecated("Tests deprecated API", since="2.13")
   @Test
-  def t10876: Unit = {
+  def t10876(): Unit = {
     val m = collection.mutable.AnyRefMap("fish" -> 3)
     val m2 = m + (("birds", 2))
     assertEquals(Map("fish" -> 3, "birds" -> 2), (m2: collection.mutable.AnyRefMap[String, Int]))
   }
 
   @Test
-  def testClear: Unit = {
+  def testClear(): Unit = {
     val map = new AnyRefMap[String, String]()
     map("greeting") = "hi"
     map("farewell") = "bye"
@@ -57,7 +57,7 @@ class AnyRefMapTest {
   }
 
   @Test
-  def testClearMemoryReuse: Unit = { // otherwise there's no point to the override
+  def testClearMemoryReuse(): Unit = { // otherwise there's no point to the override
     val map = new AnyRefMap[String, Int]
     def getField[T <: AnyRef](name: String): T =
       reflect.ensureAccessible(map.getClass.getDeclaredField("scala$collection$mutable$AnyRefMap$$" + name)).get(map).asInstanceOf[T]

--- a/test/junit/scala/collection/mutable/ArraySeqTest.scala
+++ b/test/junit/scala/collection/mutable/ArraySeqTest.scala
@@ -37,14 +37,14 @@ class ArraySeqTest {
   }
 
   @Test
-  def testSortInPlaceAnyRef: Unit = {
+  def testSortInPlaceAnyRef(): Unit = {
     val arr = ArraySeq[Integer](3, 2, 1)
     arr.sortInPlace()
     assertEquals(ArraySeq[Integer](1, 2, 3), arr)
   }
 
   @Test
-  def testSortInPlaceInt: Unit = {
+  def testSortInPlaceInt(): Unit = {
     val arr = ArraySeq.make(Array[Int](3, 2, 1))
     arr.sortInPlace()
     assertEquals(ArraySeq.make(Array[Int](1, 2, 3)), arr)

--- a/test/junit/scala/collection/mutable/ArraySortingTest.scala
+++ b/test/junit/scala/collection/mutable/ArraySortingTest.scala
@@ -29,7 +29,7 @@ class ArraySortingTest {
   }
 
   @Test
-  def testSortInPlace: Unit = {
+  def testSortInPlace(): Unit = {
     val arr = Array(3, 2, 1)
     arr.sortInPlace()
 

--- a/test/junit/scala/collection/mutable/BitSetTest.scala
+++ b/test/junit/scala/collection/mutable/BitSetTest.scala
@@ -52,7 +52,7 @@ class BitSetTest {
     assert(bsFromEmptyBitMaskNoCopy.add(0))
   }
 
-  @Test def strawman_508: Unit = {
+  @Test def strawman_508(): Unit = {
     val m = BitSet(1)
     assert(m.map(i => i.toLong).isInstanceOf[TreeSet[Long]])
     assert(m.map(i => i + 1).isInstanceOf[BitSet])
@@ -72,7 +72,7 @@ class BitSetTest {
     assert(im.collect { case i => i + 1 }.isInstanceOf[collection.immutable.BitSet])
   }
 
-  @Test def strawman_507: Unit = {
+  @Test def strawman_507(): Unit = {
     val m = BitSet(1,2,3)
     assert(m.collect{case i if i%2 == 1 => i.toLong}.isInstanceOf[TreeSet[Long]])
     assert(m.collect{case i if i%2 == 1 => i.toLong} == TreeSet(1L, 3L))

--- a/test/junit/scala/collection/mutable/HashSetTest.scala
+++ b/test/junit/scala/collection/mutable/HashSetTest.scala
@@ -6,7 +6,7 @@ import org.junit.Assert._
 class HashSetTest {
   // based on run/hashset.scala partest
   @Test
-  def testPar: Unit = {
+  def testPar(): Unit = {
     val h1 = new HashSet[Int]
     for (i <- 0 until 20) h1 += i
     for (i <- 0 until 20) assertTrue(h1.contains(i))
@@ -28,7 +28,7 @@ class HashSetTest {
   }
 
   @Test
-  def si4894: Unit = {
+  def si4894(): Unit = {
     val hs = HashSet[Int]()
     hs ++= 1 to 10
     hs --= 1 to 10
@@ -49,7 +49,7 @@ class HashSetTest {
   }
 
   @Test
-  def iterator: Unit = {
+  def iterator(): Unit = {
     val hs = HashSet.from(1 to 5)
     val it = hs.iterator
     var s = 0
@@ -58,7 +58,7 @@ class HashSetTest {
   }
 
   @Test
-  def equality: Unit = {
+  def equality(): Unit = {
     val hs = HashSet[Any](1)
     assertTrue(hs.contains(1.0))
   }
@@ -66,7 +66,7 @@ class HashSetTest {
   case class PackageEntryImpl(name: String)
 
   @Test
-  def addConflicting: Unit = {
+  def addConflicting(): Unit = {
     val hs = HashSet[PackageEntryImpl](PackageEntryImpl("javax"), PackageEntryImpl("java"))
     assertFalse(hs.add(PackageEntryImpl("java")))
   }
@@ -77,7 +77,7 @@ class HashSetTest {
   import scala.jdk.CollectionConverters._
 
   @Test
-  def addAll: Unit = {
+  def addAll(): Unit = {
     val jhs: java.util.HashSet[Type1] = new java.util.HashSet[Type1]
     jhs.add(new Type1("A"))
     jhs.add(new Type1("B"))
@@ -106,7 +106,7 @@ class HashSetTest {
   }
 
   @Test
-  def addAllTest2: Unit = {
+  def addAllTest2(): Unit = {
     val hs = HashSet.empty[Int]
     hs.addAll(new OnceOnly)
   }

--- a/test/junit/scala/collection/mutable/LinkedHashMapTest.scala
+++ b/test/junit/scala/collection/mutable/LinkedHashMapTest.scala
@@ -15,7 +15,7 @@ class LinkedHashMapTest {
   }
   
   @Test
-  def testClear: Unit = {
+  def testClear(): Unit = {
     val lhm = new TestClass
     Seq("a" -> 8, "b" -> 9).foreach(kv => lhm.put(kv._1, kv._2))
     

--- a/test/junit/scala/collection/mutable/LinkedHashSetTest.scala
+++ b/test/junit/scala/collection/mutable/LinkedHashSetTest.scala
@@ -14,7 +14,7 @@ class LinkedHashSetTest {
   }
   
   @Test
-  def testClear: Unit = {
+  def testClear(): Unit = {
     val lhs = new TestClass
     Seq("a", "b").foreach(k => lhs.add(k))
     

--- a/test/junit/scala/collection/mutable/ListBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ListBufferTest.scala
@@ -28,7 +28,7 @@ class ListBufferTest {
   }
 
   @Test
-  def testFlatMapInPlace: Unit = {
+  def testFlatMapInPlace(): Unit = {
     val xs = ListBuffer(3, 4, 5)
     val ys = List(-1, -2, -3, -4, -5, -6)
 
@@ -38,7 +38,7 @@ class ListBufferTest {
   }
 
   @Test
-  def testFilterInPlace: Unit = {
+  def testFilterInPlace(): Unit = {
     assertEquals(ListBuffer(), ListBuffer.range(0, 100).filterInPlace(_ => false))
     assertEquals(ListBuffer.range(0, 100), ListBuffer.range(0, 100).filterInPlace(_ => true))
     assertEquals(ListBuffer.range(start = 0, end = 100, step = 2), ListBuffer.range(0, 100).filterInPlace(_ % 2 == 0))
@@ -46,7 +46,7 @@ class ListBufferTest {
   }
 
   @Test
-  def testTakeInPlace: Unit = {
+  def testTakeInPlace(): Unit = {
     assertEquals(ListBuffer(), ListBuffer().takeInPlace(10))
     assertEquals(ListBuffer(), ListBuffer.range(0, 10).takeInPlace(-1))
     assertEquals(ListBuffer.range(0, 10), ListBuffer.range(0, 10).takeInPlace(10))
@@ -54,7 +54,7 @@ class ListBufferTest {
   }
 
   @Test
-  def testTakeRightInPlace: Unit = {
+  def testTakeRightInPlace(): Unit = {
     assertEquals(ListBuffer(), ListBuffer().takeRightInPlace(10))
     assertEquals(ListBuffer(), ListBuffer.range(0, 10).takeRightInPlace(-1))
     assertEquals(ListBuffer.range(0, 10), ListBuffer.range(0, 10).takeRightInPlace(10))
@@ -62,14 +62,14 @@ class ListBufferTest {
   }
 
   @Test
-  def testTakeWhileInPlace: Unit = {
+  def testTakeWhileInPlace(): Unit = {
     assertEquals(ListBuffer(), ListBuffer[Int]().takeWhileInPlace(_ < 50))
     assertEquals(ListBuffer.range(0, 10), ListBuffer.range(0, 10).takeWhileInPlace(_ < 50))
     assertEquals(ListBuffer.range(0, 50), ListBuffer.range(0, 100).takeWhileInPlace(_ < 50))
   }
 
   @Test
-  def testDropInPlace: Unit = {
+  def testDropInPlace(): Unit = {
     assertEquals(ListBuffer(), ListBuffer().dropInPlace(10))
     assertEquals(ListBuffer.range(0, 10), ListBuffer.range(0, 10).dropInPlace(-1))
     assertEquals(ListBuffer(), ListBuffer.range(0, 10).dropInPlace(10))
@@ -77,7 +77,7 @@ class ListBufferTest {
   }
 
   @Test
-  def testDropRightInPlace: Unit = {
+  def testDropRightInPlace(): Unit = {
     assertEquals(ListBuffer(), ListBuffer().dropRightInPlace(10))
     assertEquals(ListBuffer.range(0, 10), ListBuffer.range(0, 10).dropRightInPlace(-1))
     assertEquals(ListBuffer(), ListBuffer.range(0, 10).dropRightInPlace(10))
@@ -85,14 +85,14 @@ class ListBufferTest {
   }
 
   @Test
-  def testDropWhileInPlace: Unit = {
+  def testDropWhileInPlace(): Unit = {
     assertEquals(ListBuffer(), ListBuffer[Int]().dropWhileInPlace(_ < 50))
     assertEquals(ListBuffer(), ListBuffer.range(0, 10).dropWhileInPlace(_ < 50))
     assertEquals(ListBuffer.range(50, 100), ListBuffer.range(0, 100).dropWhileInPlace(_ < 50))
   }
 
   @Test
-  def testRemove: Unit = {
+  def testRemove(): Unit = {
     val b1 = ListBuffer(0, 1, 2)
     assertEquals(0, b1.remove(0))
     assertEquals(ListBuffer(1, 2), b1)
@@ -107,17 +107,17 @@ class ListBufferTest {
   }
 
   @Test(expected = classOf[IndexOutOfBoundsException])
-  def removeWithNegativeIndex: Unit = {
+  def removeWithNegativeIndex(): Unit = {
     ListBuffer(0, 1, 2).remove(-1)
   }
 
   @Test(expected = classOf[IndexOutOfBoundsException])
-  def removeWithTooLargeIndex: Unit = {
+  def removeWithTooLargeIndex(): Unit = {
     ListBuffer(0).remove(1)
   }
 
   @Test
-  def testRemoveMany: Unit = {
+  def testRemoveMany(): Unit = {
     def testRemoveMany(idx: Int, count: Int, expectation: ListBuffer[Int]): Unit = {
       val buffer = ListBuffer(0, 1, 2)
       buffer.remove(idx, count)
@@ -134,28 +134,28 @@ class ListBufferTest {
   }
 
   @Test(expected = classOf[IndexOutOfBoundsException])
-  def removeManyWithNegativeIndex: Unit = {
+  def removeManyWithNegativeIndex(): Unit = {
     ListBuffer(0, 1, 2).remove(idx = -1, count = 1)
   }
 
   @Test(expected = classOf[IndexOutOfBoundsException])
-  def removeManyWithTooLargeIndex: Unit = {
+  def removeManyWithTooLargeIndex(): Unit = {
     ListBuffer(0).remove(idx = 1, count = 1)
   }
 
   @Test(expected = classOf[IllegalArgumentException])
-  def removeManyWithNegativeCount: Unit = {
+  def removeManyWithNegativeCount(): Unit = {
     ListBuffer(0).remove(idx = 0, count = -1)
   }
 
   @Test(expected = classOf[IndexOutOfBoundsException])
-  def removeManyWithTooLargeCount: Unit = {
+  def removeManyWithTooLargeCount(): Unit = {
     ListBuffer(0).remove(idx = 0, count = 100)
   }
 
   @nowarn("cat=deprecation")
   @Test
-  def testTrimStart: Unit = {
+  def testTrimStart(): Unit = {
     val b1 = ListBuffer()
     b1.trimStart(10)
     assertEquals(ListBuffer(), b1)
@@ -175,7 +175,7 @@ class ListBufferTest {
 
   @nowarn("cat=deprecation")
   @Test
-  def testTrimEnd: Unit = {
+  def testTrimEnd(): Unit = {
     val b1 = ListBuffer()
     b1.trimEnd(10)
     assertEquals(ListBuffer(), b1)
@@ -194,7 +194,7 @@ class ListBufferTest {
   }
 
   @Test
-  def testPatch: Unit = {
+  def testPatch(): Unit = {
     val buffer = ListBuffer(0, 1, 2, 3)
     val patch = List(-3, -2, -1)
     assertEquals(ListBuffer(-3, -2, -1, 0, 1, 2, 3), buffer.patch(from = -1, patch, replaced = -1))
@@ -207,7 +207,7 @@ class ListBufferTest {
   }
 
   @Test
-  def testPatchInPlace: Unit = {
+  def testPatchInPlace(): Unit = {
     def testPatchInPlace(from: Int, replaced: Int, expectation: ListBuffer[Int]) =
       assertEquals(expectation, ListBuffer(0, 1, 2).patchInPlace(from, patch = List(-3, -2, -1), replaced))
 

--- a/test/junit/scala/collection/mutable/QueueTest.scala
+++ b/test/junit/scala/collection/mutable/QueueTest.scala
@@ -31,18 +31,18 @@ class QueueTest {
   }
 
   @Test
-  def copyToArrayOutOfBounds: Unit = {
+  def copyToArrayOutOfBounds(): Unit = {
     val target = Array[Int]()
     assertEquals(0, mutable.Queue(1, 2).copyToArray(target, 1, 0))
   }
 
   @Test
-  def insertsWhenResizeIsNeeded: Unit = {
+  def insertsWhenResizeIsNeeded(): Unit = {
     val q = Queue.from(Array.range(0, 15))
     q.insert(1, -1)
     assertEquals(Queue(0, -1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14), q)
   }
 
   @Test
-  def sliding: Unit = ArrayDequeTest.genericSlidingTest(Queue, "Queue")
+  def sliding(): Unit = ArrayDequeTest.genericSlidingTest(Queue, "Queue")
 }

--- a/test/junit/scala/collection/mutable/StackTest.scala
+++ b/test/junit/scala/collection/mutable/StackTest.scala
@@ -16,12 +16,12 @@ class StackTest {
   }
 
   @Test
-  def insertsWhenResizeIsNeeded: Unit = {
+  def insertsWhenResizeIsNeeded(): Unit = {
     val stack = Stack.from(Array.range(0, 15))
     stack.insert(1, -1)
     assertEquals(Stack(0, -1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14), stack)
   }
 
   @Test
-  def sliding: Unit = ArrayDequeTest.genericSlidingTest(Stack, "Stack")
+  def sliding(): Unit = ArrayDequeTest.genericSlidingTest(Stack, "Stack")
 }

--- a/test/junit/scala/concurrent/duration/SerializationTest.scala
+++ b/test/junit/scala/concurrent/duration/SerializationTest.scala
@@ -8,7 +8,7 @@ import org.junit.Test
 @RunWith(classOf[JUnit4])
 class SerializationTest {
   @Test
-  def test_SI9197: Unit = {
+  def test_SI9197(): Unit = {
     def ser(a: AnyRef): Array[Byte] = {
       val bais = new java.io.ByteArrayOutputStream
       (new java.io.ObjectOutputStream(bais)).writeObject(a)

--- a/test/junit/scala/concurrent/duration/SpecialDurationsTest.scala
+++ b/test/junit/scala/concurrent/duration/SpecialDurationsTest.scala
@@ -7,7 +7,7 @@ import org.junit.Test
 @RunWith(classOf[JUnit4])
 class SpecialDurationsTest {
   @Test
-  def test_11178: Unit = {
+  def test_11178(): Unit = {
     assert(Duration(Duration.Inf.toString) eq Duration.Inf)
     assert(Duration(Duration.MinusInf.toString) eq Duration.MinusInf)
     assert(Duration(Duration.Undefined.toString) eq Duration.Undefined)

--- a/test/junit/scala/jdk/DurationConvertersTest.scala
+++ b/test/junit/scala/jdk/DurationConvertersTest.scala
@@ -17,6 +17,7 @@ import java.time.{Duration => JavaDuration}
 import org.junit.Assert.{assertEquals, assertTrue}
 import org.junit.Test
 
+import scala.AdaptedArrowAssocWorkaround.Tx
 import scala.concurrent.duration._
 import scala.jdk.DurationConverters._
 import scala.jdk.javaapi.{DurationConverters => conv}
@@ -26,13 +27,13 @@ class DurationConvertersTest {
   @Test
   def scalaNanosToJavaDuration(): Unit = {
     Seq[(Long, (Long, Int))](
-      (Long.MinValue + 1) -> (-9223372037L, 145224193), // because java duration nanos are offset from the "wrong" direction
-      -1000000001L        -> (-2, 999999999),
-      -1L                 -> (-1, 999999999),
-      0L                  -> (0, 0),
-      1L                  -> (0, 1),
-      1000000001L         -> (1,1),
-      Long.MaxValue       -> (9223372036L, 854775807)
+      (Long.MinValue + 1) -> Tx(-9223372037L, 145224193), // because java duration nanos are offset from the "wrong" direction
+      -1000000001L        -> Tx(-2, 999999999),
+      -1L                 -> Tx(-1, 999999999),
+      0L                  -> Tx(0, 0),
+      1L                  -> Tx(0, 1),
+      1000000001L         -> Tx(1,1),
+      Long.MaxValue       -> Tx(9223372036L, 854775807)
     ).foreach { case (n, (expSecs, expNanos)) =>
       val result = n.nanos.toJava
       assertEquals(s"toJava($n nanos) -> $expSecs s)", expSecs, result.getSeconds)
@@ -43,11 +44,11 @@ class DurationConvertersTest {
   @Test
   def scalaMilliSecondsToJavaDuration(): Unit = {
     Seq[(Long, (Long, Int))](
-      -9223372036854L -> (-9223372037L, 146000000),
-      -1L             -> (-1L, 999000000),
-      0L              -> (0L,  0),
-      1L              -> (0L,  1000000),
-      9223372036854L  -> (9223372036L, 854000000)
+      -9223372036854L -> Tx(-9223372037L, 146000000),
+      -1L             -> Tx(-1L, 999000000),
+      0L              -> Tx(0L,  0),
+      1L              -> Tx(0L,  1000000),
+      9223372036854L  -> Tx(9223372036L, 854000000)
     ).foreach { case (n, (expSecs, expNanos)) =>
       val result = n.millis.toJava
       assertEquals(s"toJava($n millis) -> $expSecs s)", expSecs, result.getSeconds)
@@ -58,11 +59,11 @@ class DurationConvertersTest {
   @Test
   def scalaMicroSecondsToJavaDuration(): Unit = {
     Seq[(Long, (Long, Int))](
-      -9223372036854775L -> (-9223372037L, 145225000),
-      -1L                -> (-1L, 999999000),
-      0L                 -> (0L,  0),
-      1L                 -> (0L,  1000),
-      9223372036854775L  -> (9223372036L, 854775000)
+      -9223372036854775L -> Tx(-9223372037L, 145225000),
+      -1L                -> Tx(-1L, 999999000),
+      0L                 -> Tx(0L,  0),
+      1L                 -> Tx(0L,  1000),
+      9223372036854775L  -> Tx(9223372036L, 854775000)
     ).foreach { case (n, (expSecs, expNanos)) =>
       val result = n.micros.toJava
       assertEquals(s"toJava($n micros) -> $expSecs s)", expSecs, result.getSeconds)
@@ -73,11 +74,11 @@ class DurationConvertersTest {
   @Test
   def scalaSecondsToJavaDuration(): Unit = {
     Seq[(Long, (Long, Int))](
-      -9223372036L -> (-9223372036L, 0),
-      -1L          -> (-1L, 0),
-      0L           -> (0L,  0),
-      1L           -> (1L,  0),
-      9223372036L  -> (9223372036L, 0)
+      -9223372036L -> Tx(-9223372036L, 0),
+      -1L          -> Tx(-1L, 0),
+      0L           -> Tx(0L,  0),
+      1L           -> Tx(1L,  0),
+      9223372036L  -> Tx(9223372036L, 0)
     ).foreach { case (n, (expSecs, expNanos)) =>
       val result = n.seconds.toJava
       assertEquals(expSecs, result.getSeconds)

--- a/test/junit/scala/math/NumericTest.scala
+++ b/test/junit/scala/math/NumericTest.scala
@@ -10,14 +10,14 @@ class NumericTest {
 
   /* Test for scala/bug#8102 */
   @Test
-  def testAbs: Unit = {
+  def testAbs(): Unit = {
     assertTrue(-0.0.abs equals 0.0)
     assertTrue(-0.0f.abs equals 0.0f)
   }
 
   /* Test for scala/bug#9348 */
   @Test
-  def testBigDecimalAsIfIntegral: Unit = {
+  def testBigDecimalAsIfIntegral(): Unit = {
     val num = scala.math.Numeric.BigDecimalAsIfIntegral
     assertTrue(num.quot(BigDecimal(2.5), BigDecimal(0.5)) equals BigDecimal(5.0))
     assertTrue(num.quot(BigDecimal(5.0), BigDecimal(2.0)) equals BigDecimal(2.0))

--- a/test/junit/scala/reflect/ClassTagTest.scala
+++ b/test/junit/scala/reflect/ClassTagTest.scala
@@ -13,20 +13,20 @@ class ClassTagTest {
   def checkNotInt[A: ClassTag](a: Any)  = a match { case x: Int  => false case x: A => true case _ => false }
   def checkNotLong[A: ClassTag](a: Any) = a match { case x: Long => false case x: A => true case _ => false }
 
-  @Test def checkMisc    = assertTrue(checkNotString[Misc](new Misc))
-  @Test def checkString  = assertTrue(checkNotInt[String] ("woele"))
-  @Test def checkByte    = assertTrue(checkNotInt[Byte]   (0.toByte))
-  @Test def checkShort   = assertTrue(checkNotInt[Short]  (0.toShort))
-  @Test def checkChar    = assertTrue(checkNotInt[Char]   (0.toChar))
-  @Test def checkInt     = assertTrue(checkNotLong[Int]   (0.toInt))
-  @Test def checkLong    = assertTrue(checkNotInt[Long]   (0.toLong))
-  @Test def checkFloat   = assertTrue(checkNotInt[Float]  (0.toFloat))
-  @Test def checkDouble  = assertTrue(checkNotInt[Double] (0.toDouble))
-  @Test def checkBoolean = assertTrue(checkNotInt[Boolean](false))
-  @Test def checkUnit    = assertTrue(checkNotInt[Unit]   ({}))
+  @Test def checkMisc(): Unit    = assertTrue(checkNotString[Misc](new Misc))
+  @Test def checkString(): Unit  = assertTrue(checkNotInt[String] ("woele"))
+  @Test def checkByte(): Unit    = assertTrue(checkNotInt[Byte]   (0.toByte))
+  @Test def checkShort(): Unit   = assertTrue(checkNotInt[Short]  (0.toShort))
+  @Test def checkChar(): Unit    = assertTrue(checkNotInt[Char]   (0.toChar))
+  @Test def checkInt(): Unit     = assertTrue(checkNotLong[Int]   (0.toInt))
+  @Test def checkLong(): Unit    = assertTrue(checkNotInt[Long]   (0.toLong))
+  @Test def checkFloat(): Unit   = assertTrue(checkNotInt[Float]  (0.toFloat))
+  @Test def checkDouble(): Unit  = assertTrue(checkNotInt[Double] (0.toDouble))
+  @Test def checkBoolean(): Unit = assertTrue(checkNotInt[Boolean](false))
+  @Test def checkUnit(): Unit    = assertTrue(checkNotInt[Unit]   ({}))
 
   @deprecated("Tests deprecated API", since="2.13")
-  @Test def t9534: Unit = {
+  @Test def t9534(): Unit = {
     val ct = implicitly[scala.reflect.ClassTag[Unit]]
     val a1 = ct.newArray(1)
     a1(0) = ()

--- a/test/junit/scala/reflect/internal/PrintersTest.scala
+++ b/test/junit/scala/reflect/internal/PrintersTest.scala
@@ -67,81 +67,81 @@ import PrinterHelper._
 
 @RunWith(classOf[JUnit4])
 class BasePrintTest {
-  @Test def testIdent = assertTreeCode(Ident(TermName("*")))("*")
+  @Test def testIdent(): Unit = assertTreeCode(Ident(TermName("*")))("*")
 
-  @Test def testConstant1 = assertTreeCode(Literal(Constant("*")))("\"*\"")
+  @Test def testConstant1(): Unit = assertTreeCode(Literal(Constant("*")))("\"*\"")
 
-  @Test def testConstant2 = assertTreeCode(Literal(Constant(42)))("42")
+  @Test def testConstant2(): Unit = assertTreeCode(Literal(Constant(42)))("42")
 
-  @Test def testConstantFloat = assertTreeCode(Literal(Constant(42f)))("42.0F")
+  @Test def testConstantFloat(): Unit = assertTreeCode(Literal(Constant(42f)))("42.0F")
 
-  @Test def testConstantDouble = assertTreeCode(Literal(Constant(42d)))("42.0")
+  @Test def testConstantDouble(): Unit = assertTreeCode(Literal(Constant(42d)))("42.0")
 
-  @Test def testConstantLong = assertTreeCode(Literal(Constant(42L)))("42L")
+  @Test def testConstantLong(): Unit = assertTreeCode(Literal(Constant(42L)))("42L")
 
   val sq  = "\""
   val tq  = "\"" * 3
   val teq = "\"\"\\\""
 
-  @Test def testConstantMultiline = assertTreeCode(Literal(Constant("hello\nworld")))(s"${tq}hello\nworld${tq}")
+  @Test def testConstantMultiline(): Unit = assertTreeCode(Literal(Constant("hello\nworld")))(s"${tq}hello\nworld${tq}")
 
-  @Test def testConstantFormfeed = assertTreeCode(Literal(Constant("hello\fworld")))(s"${sq}hello\\fworld${sq}")
+  @Test def testConstantFormfeed(): Unit = assertTreeCode(Literal(Constant("hello\fworld")))(s"${sq}hello\\fworld${sq}")
 
-  @Test def testConstantControl = assertTreeCode(Literal(Constant("hello\u0003world")))(s"${sq}hello\\u0003world${sq}")
+  @Test def testConstantControl(): Unit = assertTreeCode(Literal(Constant("hello\u0003world")))(s"${sq}hello\\u0003world${sq}")
 
-  @Test def testConstantFormfeedChar = assertTreeCode(Literal(Constant('\f')))("'\\f'")
+  @Test def testConstantFormfeedChar(): Unit = assertTreeCode(Literal(Constant('\f')))("'\\f'")
 
-  @Test def testConstantControlChar = assertTreeCode(Literal(Constant(3.toChar)))("'\\u0003'")
+  @Test def testConstantControlChar(): Unit = assertTreeCode(Literal(Constant(3.toChar)))("'\\u0003'")
 
-  @Test def testConstantEmbeddedTriple = assertTreeCode(Literal(Constant(s"${tq}hello${tq}\nworld")))(s"${tq}${teq}hello${teq}\nworld${tq}")
+  @Test def testConstantEmbeddedTriple(): Unit = assertTreeCode(Literal(Constant(s"${tq}hello${tq}\nworld")))(s"${tq}${teq}hello${teq}\nworld${tq}")
 
-  @Test def testOpExpr = assertPrintedCode("(5).+(4)", checkTypedTree = false)
+  @Test def testOpExpr(): Unit = assertPrintedCode("(5).+(4)", checkTypedTree = false)
 
-  @Test def testName1 = assertPrintedCode("class test")
+  @Test def testName1(): Unit = assertPrintedCode("class test")
 
-  @Test def testName2 = assertPrintedCode("class *")
+  @Test def testName2(): Unit = assertPrintedCode("class *")
 
-  @Test def testName4 = assertPrintedCode("class `a*`")
+  @Test def testName4(): Unit = assertPrintedCode("class `a*`")
 
-  @Test def testName5 = assertPrintedCode("val :::: = 1")
+  @Test def testName5(): Unit = assertPrintedCode("val :::: = 1")
 
-  @Test def testName6 = assertPrintedCode("val `::::t` = 1")
+  @Test def testName6(): Unit = assertPrintedCode("val `::::t` = 1")
 
-  @Test def testName7 = assertPrintedCode("""class \/""")
+  @Test def testName7(): Unit = assertPrintedCode("""class \/""")
 
-  @Test def testName8 = assertPrintedCode("""class \\\\""")
+  @Test def testName8(): Unit = assertPrintedCode("""class \\\\""")
 
-  @Test def testName9 = assertPrintedCode("""class test_\/""")
+  @Test def testName9(): Unit = assertPrintedCode("""class test_\/""")
 
-  @Test def testName10 = assertPrintedCode("""class `*_*`""")
+  @Test def testName10(): Unit = assertPrintedCode("""class `*_*`""")
 
-  @Test def testName11 = assertPrintedCode("""class `a_*`""")
+  @Test def testName11(): Unit = assertPrintedCode("""class `a_*`""")
 
-  @Test def testName12 = assertPrintedCode("""class `*_a`""")
+  @Test def testName12(): Unit = assertPrintedCode("""class `*_a`""")
 
-  @Test def testName13 = assertPrintedCode("""class a_a""")
+  @Test def testName13(): Unit = assertPrintedCode("""class a_a""")
 
-  @Test def testName14 = assertPrintedCode("val x$11 = 5")
+  @Test def testName14(): Unit = assertPrintedCode("val x$11 = 5")
 
-  @Test def testName15 = assertPrintedCode("class `[]`")
+  @Test def testName15(): Unit = assertPrintedCode("class `[]`")
 
-  @Test def testName16 = assertPrintedCode("class `()`")
+  @Test def testName16(): Unit = assertPrintedCode("class `()`")
 
-  @Test def testName17 = assertPrintedCode("class `{}`")
+  @Test def testName17(): Unit = assertPrintedCode("class `{}`")
 
-  @Test def testName18 = assertPrintedCode("class <>")
+  @Test def testName18(): Unit = assertPrintedCode("class <>")
 
-  @Test def testName19 = assertPrintedCode("""class `class`""")
+  @Test def testName19(): Unit = assertPrintedCode("""class `class`""")
 
-  @Test def testName20 = assertPrintedCode("""class `test name`""")
+  @Test def testName20(): Unit = assertPrintedCode("""class `test name`""")
 
-  @Test def testName21 = assertPrintedCode("""class `test.name`""")
+  @Test def testName21(): Unit = assertPrintedCode("""class `test.name`""")
 
-  @Test def testName22 = assertEquals("val `some-val`: Int = 1", showCode(q"""val ${TermName("some-val")}: Int = 1"""))
+  @Test def testName22(): Unit = assertEquals("val `some-val`: Int = 1", showCode(q"""val ${TermName("some-val")}: Int = 1"""))
 
-  @Test def testName23 = assertEquals("val `some+`: String = \"foo\"", showCode(q"""val ${TermName("some+")}: String = "foo""""))
+  @Test def testName23(): Unit = assertEquals("val `some+`: String = \"foo\"", showCode(q"""val ${TermName("some+")}: String = "foo""""))
 
-  @Test def testIfExpr1 = assertResultCode(code = sm"""
+  @Test def testIfExpr1(): Unit = assertResultCode(code = sm"""
     |val a = 1
     |if (a > 1)
     |  a: Int
@@ -162,7 +162,7 @@ class BasePrintTest {
     |  ((PrintersContext.this.a.toString()): scala.Predef.String)
     """, wrap = true)
 
-  @Test def testIfExpr2 = assertPrintedCode(sm"""
+  @Test def testIfExpr2(): Unit = assertPrintedCode(sm"""
     |class A {
     |  (if (true)
     |  {
@@ -176,7 +176,7 @@ class BasePrintTest {
     |  }).toString()
     |}""")
 
-  @Test def testIfExpr3 = assertPrintedCode(sm"""
+  @Test def testIfExpr3(): Unit = assertPrintedCode(sm"""
     |class A {
     |  (if (true)
     |  {
@@ -191,12 +191,12 @@ class BasePrintTest {
     |}""")
 
   //val x = true && true && false.!
-  @Test def testBooleanExpr1 = assertPrintedCode("val x = true.&&(true).&&(false.`unary_!`)", checkTypedTree = false)
+  @Test def testBooleanExpr1(): Unit = assertPrintedCode("val x = true.&&(true).&&(false.`unary_!`)", checkTypedTree = false)
 
   //val x = true && !(true && false)
-  @Test def testBooleanExpr2 = assertPrintedCode("val x = true.&&(true.&&(false).`unary_!`)", checkTypedTree = false)
+  @Test def testBooleanExpr2(): Unit = assertPrintedCode("val x = true.&&(true.&&(false).`unary_!`)", checkTypedTree = false)
 
-  @Test def testNewExpr1 = assertResultCode(
+  @Test def testNewExpr1(): Unit = assertResultCode(
     code = sm"""
     |class foo
     |new foo()
@@ -210,7 +210,7 @@ class BasePrintTest {
     |""",
     wrap = true)
 
-  @Test def testNewExpr2 = assertResultCode(
+  @Test def testNewExpr2(): Unit = assertResultCode(
     code = sm"""
     |class foo
     |new foo { "test" }
@@ -233,20 +233,20 @@ class BasePrintTest {
     |}""",
     wrap = true)
 
-  @Test def testNewExpr3 = assertPrintedCode(sm"""
+  @Test def testNewExpr3(): Unit = assertPrintedCode(sm"""
     |{
     |  class foo[t];
     |  new foo[scala.Int]()
     |}""")
 
-  @Test def testNewExpr4 = assertPrintedCode(sm"""
+  @Test def testNewExpr4(): Unit = assertPrintedCode(sm"""
     |{
     |  class foo(x: scala.Int);
     |  val x = 5;
     |  new foo(x)
     |}""")
 
-  @Test def testNewExpr5 = assertPrintedCode(sm"""
+  @Test def testNewExpr5(): Unit = assertPrintedCode(sm"""
     |{
     |  class foo[t](x: scala.Int);
     |  val x = 5;
@@ -254,7 +254,7 @@ class BasePrintTest {
     |}""")
 
   //new foo[t](x) { () }
-  @Test def testNewExpr6 = assertResultCode(
+  @Test def testNewExpr6(): Unit = assertResultCode(
     code = sm"""
     |class foo[t](x: Int)
     |new foo[String](3) { () }
@@ -281,7 +281,7 @@ class BasePrintTest {
     |}""")
 
   //new foo with bar
-  @Test def testNewExpr7 = assertPrintedCode(sm"""
+  @Test def testNewExpr7(): Unit = assertPrintedCode(sm"""
     |{
     |  trait foo;
     |  trait bar;
@@ -292,7 +292,7 @@ class BasePrintTest {
     |}""")
 
   //new { anonymous }
-  @Test def testNewExpr8 = assertPrintedCode(sm"""
+  @Test def testNewExpr8(): Unit = assertPrintedCode(sm"""
     |{
     |  final class $$anon {
     |    5
@@ -301,7 +301,7 @@ class BasePrintTest {
     |}""")
 
   //new { val early = 1 } with Parent[Int] { body }
-  @Test def testNewExpr9 = assertPrintedCode(sm"""
+  @Test def testNewExpr9(): Unit = assertPrintedCode(sm"""
     |{
     |  class Parent[t];
     |  {
@@ -315,7 +315,7 @@ class BasePrintTest {
     |}""")
 
   //new Foo { self => }
-  @Test def testNewExpr10 = assertPrintedCode(sm"""
+  @Test def testNewExpr10(): Unit = assertPrintedCode(sm"""
     |{
     |  class Foo;
     |  {
@@ -326,68 +326,68 @@ class BasePrintTest {
     |  }
     |}""")
 
-  @Test def testReturn = assertPrintedCode("def test: scala.Int = return 42")
+  @Test def testReturn(): Unit = assertPrintedCode("def test: scala.Int = return 42")
 
-  @Test def testFunc1 = assertResultCode(
+  @Test def testFunc1(): Unit = assertResultCode(
     code = "List(1, 2, 3).map((i: Int) => i - 1)")(
     parsedCode = "List(1, 2, 3).map(((i: Int) => i.-(1)))",
     typedCode = sm"scala.`package`.List.apply[Int](1, 2, 3).map[Int](((i: scala.Int) => i.-(1)))")
 
-  @Test def testFunc2 = assertResultCode(
+  @Test def testFunc2(): Unit = assertResultCode(
     code = "val sum: Seq[Int] => Int = _ reduceLeft (_+_)")(
     parsedCode = "val sum: _root_.scala.Function1[Seq[Int], Int] = ((x$1) => x$1.reduceLeft(((x$2, x$3) => x$2.+(x$3))))",
     typedCode = "val sum: scala.Function1[scala.`package`.Seq[scala.Int], scala.Int] = ((x$1: Seq[Int]) => x$1.reduceLeft[Int](((x$2: Int, x$3: Int) => x$2.+(x$3))))")
 
-  @Test def testFunc3 = assertResultCode(
+  @Test def testFunc3(): Unit = assertResultCode(
     code = "List(1, 2, 3) map (_ - 1)")(
     parsedCode = "List(1, 2, 3).map(((x$1) => x$1.-(1))) ",
     typedCode = "scala.`package`.List.apply[Int](1, 2, 3).map[Int](((x$1: Int) => x$1.-(1)))")
 
-  @Test def testFunc4 = assertResultCode(
+  @Test def testFunc4(): Unit = assertResultCode(
     code = "val x: String => Int = ((str: String) => 1)")(
     parsedCode = "val x: _root_.scala.Function1[String, Int] = ((str: String) => 1)",
     typedCode = " val x: _root_.scala.Function1[_root_.scala.Predef.String, _root_.scala.Int] = ((str: _root_.scala.Predef.String) => 1)", printRoot = true)
 
-  @Test def testAssign1 = assertPrintedCode("(f.v = 5).toString", checkTypedTree = false)
+  @Test def testAssign1(): Unit = assertPrintedCode("(f.v = 5).toString", checkTypedTree = false)
 
-  @Test def testAssign2 = assertPrintedCode("(f.v = 5)(2)", checkTypedTree = false)
+  @Test def testAssign2(): Unit = assertPrintedCode("(f.v = 5)(2)", checkTypedTree = false)
 
-  @Test def testImport1 = assertPrintedCode("import scala.collection.mutable")
+  @Test def testImport1(): Unit = assertPrintedCode("import scala.collection.mutable")
 
-  @Test def testImport2 = assertPrintedCode("import java.lang.{String=>Str}")
+  @Test def testImport2(): Unit = assertPrintedCode("import java.lang.{String=>Str}")
 
-  @Test def testImport3 = assertPrintedCode("import java.lang.{String=>Str, Object=>_, _}")
+  @Test def testImport3(): Unit = assertPrintedCode("import java.lang.{String=>Str, Object=>_, _}")
 
-  @Test def testImport4 = assertPrintedCode("import scala.collection._")
+  @Test def testImport4(): Unit = assertPrintedCode("import scala.collection._")
 }
 
 @RunWith(classOf[JUnit4])
 class ClassPrintTest {
-  @Test def testClass = assertPrintedCode("class *")
+  @Test def testClass(): Unit = assertPrintedCode("class *")
 
-  @Test def testClassWithBody = assertPrintedCode(sm"""
+  @Test def testClassWithBody(): Unit = assertPrintedCode(sm"""
     |class X {
     |  def y = "test"
     |}""")
 
-  @Test def testClassConstructorModifiers = assertPrintedCode("class X private (x: scala.Int)")
+  @Test def testClassConstructorModifiers(): Unit = assertPrintedCode("class X private (x: scala.Int)")
 
-  @Test def testClassConstructorModifierVisibility = assertPrintedCode(sm"""
+  @Test def testClassConstructorModifierVisibility(): Unit = assertPrintedCode(sm"""
     |object A {
     |  class X protected[A] (x: scala.Int)
     |}""")
 
-  @Test def testClassWithPublicParams = assertPrintedCode("class X(val x: scala.Int, val s: scala.Predef.String)")
+  @Test def testClassWithPublicParams(): Unit = assertPrintedCode("class X(val x: scala.Int, val s: scala.Predef.String)")
 
-  @Test def testClassWithParams1 = assertPrintedCode("class X(x: scala.Int, s: scala.Predef.String)")
+  @Test def testClassWithParams1(): Unit = assertPrintedCode("class X(x: scala.Int, s: scala.Predef.String)")
 
-  @Test def testClassWithParams2 = assertPrintedCode("class X(@test x: Int, s: String)", checkTypedTree = false)
+  @Test def testClassWithParams2(): Unit = assertPrintedCode("class X(@test x: Int, s: String)", checkTypedTree = false)
 
-  @Test def testClassWithParams3 = assertPrintedCode("class X(implicit x: Int, s: String)", checkTypedTree = false)
+  @Test def testClassWithParams3(): Unit = assertPrintedCode("class X(implicit x: Int, s: String)", checkTypedTree = false)
 
-  @Test def testClassWithParams4 = assertPrintedCode("class X(implicit @unchecked x: Int, s: String)", checkTypedTree = false)
+  @Test def testClassWithParams4(): Unit = assertPrintedCode("class X(implicit @unchecked x: Int, s: String)", checkTypedTree = false)
 
-  @Test def testClassWithParams5 = assertPrintedCode(sm"""
+  @Test def testClassWithParams5(): Unit = assertPrintedCode(sm"""
     |{
     |  class Y {
     |    val x = 5
@@ -396,25 +396,25 @@ class ClassPrintTest {
     |  ()
     |}""")
 
-  @Test def testClassWithParams6 = assertPrintedCode("class X(@test1 override private[this] val x: Int, @test2(param1 = 7) s: String) extends Y", checkTypedTree = false)
+  @Test def testClassWithParams6(): Unit = assertPrintedCode("class X(@test1 override private[this] val x: Int, @test2(param1 = 7) s: String) extends Y", checkTypedTree = false)
 
-  @Test def testClassWithParams7 = assertPrintedCode("class X protected (val x: scala.Int, val s: scala.Predef.String)")
+  @Test def testClassWithParams7(): Unit = assertPrintedCode("class X protected (val x: scala.Int, val s: scala.Predef.String)")
 
-  @Test def testClassWithParams8 = assertPrintedCode("class X(var x: scala.Int)")
+  @Test def testClassWithParams8(): Unit = assertPrintedCode("class X(var x: scala.Int)")
 
-  @Test def testClassWithParams9 = assertPrintedCode("def test(x: scala.Int*) = 5")
+  @Test def testClassWithParams9(): Unit = assertPrintedCode("def test(x: scala.Int*) = 5")
 
-  @Test def testClassWithByNameParam = assertPrintedCode("class X(x: => scala.Int)")
+  @Test def testClassWithByNameParam(): Unit = assertPrintedCode("class X(x: => scala.Int)")
 
-  @Test def testClassWithDefault = assertPrintedCode(sm"""
+  @Test def testClassWithDefault(): Unit = assertPrintedCode(sm"""
     |{
     |  class X(var x: scala.Int = 5);
     |  ()
     |}""")
 
-  @Test def testClassWithParams10 = assertPrintedCode("class X(protected[zzz] var x: Int)", checkTypedTree = false)
+  @Test def testClassWithParams10(): Unit = assertPrintedCode("class X(protected[zzz] var x: Int)", checkTypedTree = false)
 
-  @Test def testClassWithParams11 = assertPrintedCode(sm"""
+  @Test def testClassWithParams11(): Unit = assertPrintedCode(sm"""
     |{
     |  class F(x: scala.Int);
     |  trait E {
@@ -424,30 +424,30 @@ class ClassPrintTest {
     |  ()
     |}""")
 
-  @Test def testClassWithParams12 = assertPrintedCode("class X(val y: scala.Int)()(var z: scala.Double)")
+  @Test def testClassWithParams12(): Unit = assertPrintedCode("class X(val y: scala.Int)()(var z: scala.Double)")
 
-  @Test def testClassWithImplicitParams = assertPrintedCode("class X(var i: scala.Int)(implicit val d: scala.Double, var f: scala.Float)")
+  @Test def testClassWithImplicitParams(): Unit = assertPrintedCode("class X(var i: scala.Int)(implicit val d: scala.Double, var f: scala.Float)")
 
-  @Test def testClassWithEarly =
+  @Test def testClassWithEarly(): Unit =
     assertPrintedCode(sm"""
     |class X(var i: scala.Int) extends {
     |  val a = i;
     |  type B
     |} with scala.`package`.Serializable""")
 
-  @Test def testClassWithThrow1 = assertPrintedCode(sm"""
+  @Test def testClassWithThrow1(): Unit = assertPrintedCode(sm"""
     |class Throw1 {
     |  throw new scala.`package`.Exception("exception!")
     |}""")
 
-  @Test def testClassWithThrow2 = assertPrintedCode(sm"""
+  @Test def testClassWithThrow2(): Unit = assertPrintedCode(sm"""
     |class Throw2 {
     |  var msg = "   ";
     |  val e = new scala.`package`.Exception(Throw2.this.msg);
     |  throw Throw2.this.e
     |}""")
 
-  @Test def testClassWithAssignmentWithTuple1 = assertResultCode(sm"""
+  @Test def testClassWithAssignmentWithTuple1(): Unit = assertResultCode(sm"""
     |class Test {
     |  val (a, b) = (1, 2)
     |}""")(
@@ -468,7 +468,7 @@ class ClassPrintTest {
     |  val b = Test.this.x$$1._2
     |}""")
 
-  @Test def testClassWithAssignmentWithTuple2 = assertResultCode(
+  @Test def testClassWithAssignmentWithTuple2(): Unit = assertResultCode(
     code = sm"""
     |class Test {
     |  val (a, b) = (1).->(2)
@@ -495,7 +495,7 @@ class ClassPrintTest {
       val List(one, three, five) = List(1,3,5)
     }
   */
-  @Test def testClassWithPatternMatchInAssignment = assertPrintedCode(sm"""
+  @Test def testClassWithPatternMatchInAssignment(): Unit = assertPrintedCode(sm"""
     |class Test {
     |  private[this] val x$$1 = (scala.collection.immutable.List.apply[scala.Int](1, 3, 5): @scala.unchecked) match {
     |    case scala.collection.immutable.List((one @ _), (three @ _), (five @ _)) => scala.Tuple3.apply[scala.Int, scala.Int, scala.Int](one, three, five)
@@ -506,17 +506,17 @@ class ClassPrintTest {
     |}""")
 
   //class A(l: List[_])
-  @Test def testClassWithExistentialParameter1 = assertPrintedCode(sm"""
+  @Test def testClassWithExistentialParameter1(): Unit = assertPrintedCode(sm"""
     |class Test(l: (scala.`package`.List[_$$1] forSome { 
     |  type _$$1
     |}))""")
 
-  @Test def testClassWithExistentialParameter2 = assertPrintedCode(sm"""
+  @Test def testClassWithExistentialParameter2(): Unit = assertPrintedCode(sm"""
     |class B(l: (scala.`package`.List[T] forSome { 
     |  type T
     |}))""")
 
-  @Test def testClassWithCompoundTypeTree = assertPrintedCode(sm"""
+  @Test def testClassWithCompoundTypeTree(): Unit = assertPrintedCode(sm"""
     |{
     |  trait A;
     |  trait B;
@@ -528,7 +528,7 @@ class ClassPrintTest {
     |  ()
     |}""")
 
-  @Test def testClassWithSelectFromTypeTree = assertPrintedCode(sm"""
+  @Test def testClassWithSelectFromTypeTree(): Unit = assertPrintedCode(sm"""
     |{
     |  trait A {
     |    type T
@@ -537,34 +537,34 @@ class ClassPrintTest {
     |  ()
     |}""")
 
-  @Test def testImplicitClass = assertPrintedCode(sm"""
+  @Test def testImplicitClass(): Unit = assertPrintedCode(sm"""
     |{
     |  implicit class X(protected[this] var x: scala.Int);
     |  ()
     |}""",
     checkTypedTree = true)
 
-  @Test def testAbstractClass = assertPrintedCode("abstract class X(protected[this] var x: scala.Int)")
+  @Test def testAbstractClass(): Unit = assertPrintedCode("abstract class X(protected[this] var x: scala.Int)")
 
-  @Test def testCaseClassWithParams1 = assertPrintedCode(sm"""
+  @Test def testCaseClassWithParams1(): Unit = assertPrintedCode(sm"""
     |{
     |  case class X(x: scala.Int, s: scala.Predef.String);
     |  ()
     |}""")
 
-  @Test def testCaseClassWithParams2 = assertPrintedCode(sm"""
+  @Test def testCaseClassWithParams2(): Unit = assertPrintedCode(sm"""
     |{
     |  case class X(protected val x: scala.Int, s: scala.Predef.String);
     |  ()
     |}""")
 
-  @Test def testCaseClassWithParams3 = assertPrintedCode(sm"""
+  @Test def testCaseClassWithParams3(): Unit = assertPrintedCode(sm"""
     |{
     |  case class X()(implicit x: scala.Int, s: scala.Predef.String);
     |  ()
     |}""")
 
-  @Test def testCaseClassWithParams4 = assertPrintedCode(sm"""
+  @Test def testCaseClassWithParams4(): Unit = assertPrintedCode(sm"""
     |{
     |  trait V {
     |    val x: scala.Int
@@ -573,7 +573,7 @@ class ClassPrintTest {
     |  ()
     |}""")
 
-  @Test def testCaseClassWithBody = assertPrintedCode(sm"""
+  @Test def testCaseClassWithBody(): Unit = assertPrintedCode(sm"""
     |{
     |  case class X() {
     |    def y = "test"
@@ -581,7 +581,7 @@ class ClassPrintTest {
     |  ()
     |}""")
 
-  @Test def testLocalClass = assertPrintedCode(sm"""
+  @Test def testLocalClass(): Unit = assertPrintedCode(sm"""
     |def test = {
     |  class X(var a: scala.Int) {
     |    def y = "test"
@@ -589,7 +589,7 @@ class ClassPrintTest {
     |  new X(5)
     |}""")
 
-  @Test def testLocalCaseClass = assertPrintedCode(sm"""
+  @Test def testLocalCaseClass(): Unit = assertPrintedCode(sm"""
     |def test = {
     |  case class X(var a: scala.Int) {
     |    def y = "test"
@@ -597,7 +597,7 @@ class ClassPrintTest {
     |  new X(5)
     |}""")
 
-  @Test def testSuperInClass = assertPrintedCode(sm"""
+  @Test def testSuperInClass(): Unit = assertPrintedCode(sm"""
     |{
     |  trait Root {
     |    def r = "Root"
@@ -615,7 +615,7 @@ class ClassPrintTest {
     |  ()
     |}""")
 
-  @Test def testThisInClass = assertPrintedCode(sm"""
+  @Test def testThisInClass(): Unit = assertPrintedCode(sm"""
     |class Outer {
     |  class Inner {
     |    val outer = Outer.this
@@ -623,7 +623,7 @@ class ClassPrintTest {
     |  val self = this
     |}""")
 
-  @Test def testCaseClassWithParamsAndBody = assertPrintedCode(sm"""
+  @Test def testCaseClassWithParamsAndBody(): Unit = assertPrintedCode(sm"""
     |{
     |  case class X(var x: scala.Int, var s: scala.Predef.String) {
     |    def y = "test"
@@ -631,42 +631,42 @@ class ClassPrintTest {
     |  ()
     |}""")
 
-  @Test def testObject = assertPrintedCode("object *")
+  @Test def testObject(): Unit = assertPrintedCode("object *")
 
-  @Test def testObjectWithBody = assertPrintedCode(sm"""
+  @Test def testObjectWithBody(): Unit = assertPrintedCode(sm"""
     |object X {
     |  def y = "test"
     |}""")
 
-  @Test def testObjectWithEarly1 = assertPrintedCode(sm"""
+  @Test def testObjectWithEarly1(): Unit = assertPrintedCode(sm"""
     |object X extends {
     |  val early: scala.Int = 42
     |} with scala.`package`.Serializable""")
 
-  @Test def testObjectWithEarly2 = assertPrintedCode(sm"""
+  @Test def testObjectWithEarly2(): Unit = assertPrintedCode(sm"""
     |object X extends {
     |  val early: scala.Int = 42;
     |  type EarlyT = scala.Predef.String
     |} with scala.`package`.Serializable""")
 
-  @Test def testObjectWithSelf = assertPrintedCode(sm"""
+  @Test def testObjectWithSelf(): Unit = assertPrintedCode(sm"""
     |object Foo extends scala.`package`.Serializable { self =>
     |  42
     |}""")
 
-  @Test def testObjectInh = assertPrintedCode(sm"""
+  @Test def testObjectInh(): Unit = assertPrintedCode(sm"""
     |trait Y {
     |  private[Y] object X extends scala.`package`.Serializable with scala.`package`.Cloneable
     |}""")
 
-  @Test def testObjectWithPatternMatch1 = assertPrintedCode(sm"""
+  @Test def testObjectWithPatternMatch1(): Unit = assertPrintedCode(sm"""
     |object PM1 {
     |  scala.collection.immutable.List.apply[scala.Int](1, 2) match {
     |    case (i @ _) => i
     |  }
     |}""")
 
-  @Test def testObjectWithPatternMatch2 = assertResultCode(
+  @Test def testObjectWithPatternMatch2(): Unit = assertResultCode(
     code = sm"""
     |object PM2 {
     |  List(1, 2).map {
@@ -689,7 +689,7 @@ class ClassPrintTest {
     *
     */
 
-  @Test def testObjectWithPatternMatch3 = assertResultCode(
+  @Test def testObjectWithPatternMatch3(): Unit = assertResultCode(
     code = sm"""
     |object PM3 {
     |  List(1, 2).map {
@@ -712,7 +712,7 @@ class ClassPrintTest {
     *
     */
 
-  @Test def testObjectWithPatternMatch4 = assertResultCode(
+  @Test def testObjectWithPatternMatch4(): Unit = assertResultCode(
     code = sm"""
     |object PM4 {
     |  List(1, 2).map {
@@ -735,7 +735,7 @@ class ClassPrintTest {
     *
     */
 
-  @Test def testObjectWithPatternMatch5 = assertResultCode(
+  @Test def testObjectWithPatternMatch5(): Unit = assertResultCode(
     code = sm"""
     |object PM5 {
     |  List(1, 2) match {
@@ -755,7 +755,7 @@ class ClassPrintTest {
     |  }
     |}""")
 
-  @Test def testObjectWithPatternMatch6 = assertResultCode(
+  @Test def testObjectWithPatternMatch6(): Unit = assertResultCode(
     code = sm"""
     |object PM6 {
     |  List(1, 2).map {
@@ -781,14 +781,14 @@ class ClassPrintTest {
     *
     */
 
-  @Test def testObjectWithPatternMatch7 = assertPrintedCode(sm"""
+  @Test def testObjectWithPatternMatch7(): Unit = assertPrintedCode(sm"""
     |object PM7 {
     |  scala.Predef.wrapString("abcde").toList match {
     |    case scala.collection.Seq((car @ _), _*) => car
     |  }
     |}""")
 
-  @Test def testObjectWithPatternMatch8 = assertPrintedCode(sm"""
+  @Test def testObjectWithPatternMatch8(): Unit = assertPrintedCode(sm"""
     |{
     |  object Extractor {
     |    def unapply(i: scala.Int) = scala.Some.apply[scala.Int](i)
@@ -801,14 +801,14 @@ class ClassPrintTest {
     |  ()
     |}""")
 
-  @Test def testObjectWithPartialFunc = assertPrintedCode(sm"""
+  @Test def testObjectWithPartialFunc(): Unit = assertPrintedCode(sm"""
     |object Test {
     |  def partFuncTest[A, B](e: scala.`package`.Either[A, B]): scala.Unit = e match {
     |    case scala.`package`.Right(_) => ()
     |  }
     |}""")
 
-  @Test def testObjectWithTry = assertResultCode(
+  @Test def testObjectWithTry(): Unit = assertResultCode(
     code = sm"""
     |object Test {
     |  import java.io._;
@@ -849,50 +849,50 @@ class ClassPrintTest {
 
 @RunWith(classOf[JUnit4])
 class TraitPrintTest {
-  @Test def testTrait = assertPrintedCode("trait *")
+  @Test def testTrait(): Unit = assertPrintedCode("trait *")
 
-  @Test def testTraitWithBody = assertPrintedCode(sm"""
+  @Test def testTraitWithBody(): Unit = assertPrintedCode(sm"""
     |trait X {
     |  def y = "test"
     |}""")
 
-  @Test def testTraitWithSelfTypeAndBody = assertPrintedCode(sm"""
+  @Test def testTraitWithSelfTypeAndBody(): Unit = assertPrintedCode(sm"""
     |trait X { self: scala.`package`.Cloneable =>
     |  def y = "test"
     |}""")
 
-  @Test def testTraitWithSelf1 = assertPrintedCode(sm"""
+  @Test def testTraitWithSelf1(): Unit = assertPrintedCode(sm"""
     |trait X { self =>
     |  def y = "test"
     |}""")
 
-  @Test def testTraitWithSelf2 = assertPrintedCode(sm"""
+  @Test def testTraitWithSelf2(): Unit = assertPrintedCode(sm"""
     |trait X { self: scala.`package`.Cloneable with scala.`package`.Serializable =>
     |  val x: scala.Int = 1
     |}""")
 
-  @Test def testTraitTypeParams = assertPrintedCode("trait X[A, B]")
+  @Test def testTraitTypeParams(): Unit = assertPrintedCode("trait X[A, B]")
 
-  @Test def testTraitWithBody2 = assertPrintedCode(sm"""
+  @Test def testTraitWithBody2(): Unit = assertPrintedCode(sm"""
     |trait X {
     |  def foo: scala.Unit;
     |  val bar: scala.Predef.String
     |}""")
 
-  @Test def testTraitWithInh = assertPrintedCode("trait X extends scala.`package`.Cloneable with scala.`package`.Serializable")
+  @Test def testTraitWithInh(): Unit = assertPrintedCode("trait X extends scala.`package`.Cloneable with scala.`package`.Serializable")
 
-  @Test def testTraitWithEarly1 = assertPrintedCode(sm"""
+  @Test def testTraitWithEarly1(): Unit = assertPrintedCode(sm"""
     |trait X extends {
     |  val x: Int = 1
     |} with AnyRef""", checkTypedTree = false)
 
-  @Test def testTraitWithEarly2 = assertPrintedCode(sm"""
+  @Test def testTraitWithEarly2(): Unit = assertPrintedCode(sm"""
     |trait X extends {
     |  val x: scala.Int = 0;
     |  type Foo = scala.Unit
     |} with scala.`package`.Cloneable""")
 
-  @Test def testTraitWithEarly3 = assertPrintedCode(sm"""
+  @Test def testTraitWithEarly3(): Unit = assertPrintedCode(sm"""
     |trait X extends {
     |  val x: scala.Int = 5;
     |  val y: scala.Double = 4.0;
@@ -900,7 +900,7 @@ class TraitPrintTest {
     |  type XString = scala.Predef.String
     |} with scala.`package`.Serializable""")
 
-  @Test def testTraitWithEarly4 = assertPrintedCode(sm"""
+  @Test def testTraitWithEarly4(): Unit = assertPrintedCode(sm"""
     |trait X extends {
     |  val x: scala.Int = 5;
     |  val y: scala.Double = 4.0;
@@ -910,24 +910,24 @@ class TraitPrintTest {
     |  val z: scala.Int = 7
     |}""")
 
-  @Test def testTraitWithSingletonTypeTree = assertPrintedCode(sm"""
+  @Test def testTraitWithSingletonTypeTree(): Unit = assertPrintedCode(sm"""
     |trait Test {
     |  def testReturnSingleton(): Test.this.type
     |}""")
 
-  @Test def testTraitWithThis = assertTreeCode(q"trait Test { this: X with Y => }")(sm"""
+  @Test def testTraitWithThis(): Unit = assertTreeCode(q"trait Test { this: X with Y => }")(sm"""
     |trait Test { _ : X with Y =>
     |  
     |}""")
 
-  @Test def testTraitWithWhile1 = assertPrintedCode(sm"""
+  @Test def testTraitWithWhile1(): Unit = assertPrintedCode(sm"""
     |trait Test {
     |  while (false) 
     |    scala.Predef.println("testing...")
     |  
     |}""")
 
-  @Test def testTraitWithWhile2 = assertPrintedCode(sm"""
+  @Test def testTraitWithWhile2(): Unit = assertPrintedCode(sm"""
     |trait Test {
     |  while (true) 
     |    {
@@ -937,14 +937,14 @@ class TraitPrintTest {
     |  
     |}""")
 
-  @Test def testTraitWithDoWhile1 = assertPrintedCode(sm"""
+  @Test def testTraitWithDoWhile1(): Unit = assertPrintedCode(sm"""
     |trait Test {
     |  do 
     |    scala.Predef.println("testing...")
     |   while (true) 
     |}""")  
 
-  @Test def testTraitWithTypes = assertResultCode(
+  @Test def testTraitWithTypes(): Unit = assertResultCode(
     code = sm"""
     |trait Test {
     |  type A = Int;
@@ -970,26 +970,26 @@ class TraitPrintTest {
 
 @RunWith(classOf[JUnit4])
 class ValAndDefPrintTest {
-  @Test def testVal1 = assertPrintedCode("val a: scala.Unit = ()")
+  @Test def testVal1(): Unit = assertPrintedCode("val a: scala.Unit = ()")
 
-  @Test def testVal2 = assertPrintedCode("val * : scala.Unit = ()")
+  @Test def testVal2(): Unit = assertPrintedCode("val * : scala.Unit = ()")
 
-  @Test def testVal3 = assertPrintedCode("val a_ : scala.Unit = ()")
+  @Test def testVal3(): Unit = assertPrintedCode("val a_ : scala.Unit = ()")
 
-  @Test def testDef1 = assertPrintedCode("def a = ()")
+  @Test def testDef1(): Unit = assertPrintedCode("def a = ()")
 
-  @Test def testDef2 = assertPrintedCode("def * : scala.Unit = ()")
+  @Test def testDef2(): Unit = assertPrintedCode("def * : scala.Unit = ()")
 
-  @Test def testDef3 = assertPrintedCode("def a_(x: scala.Int): scala.Unit = ()")
+  @Test def testDef3(): Unit = assertPrintedCode("def a_(x: scala.Int): scala.Unit = ()")
 
-  @Test def testDef4 = assertPrintedCode("def a_ : scala.Unit = ()")
+  @Test def testDef4(): Unit = assertPrintedCode("def a_ : scala.Unit = ()")
 
-  @Test def testDef5 = assertPrintedCode("def a_(* : scala.Int): scala.Unit = ()")
+  @Test def testDef5(): Unit = assertPrintedCode("def a_(* : scala.Int): scala.Unit = ()")
 
-  @Test def testDef6 = assertPrintedCode("def a_(b_ : scala.Int) = ()")
+  @Test def testDef6(): Unit = assertPrintedCode("def a_(b_ : scala.Int) = ()")
 
   @deprecated("Tests deprecated API", since="2.13")
-  @Test def testDef7 = assertTreeCode{
+  @Test def testDef7(): Unit = assertTreeCode{
     Block(
       DefDef(NoMods, TermName("test1"), Nil, Nil, EmptyTree, Literal(Constant(()))),
       DefDef(NoMods, TermName("test2"), Nil, Nil :: Nil, EmptyTree, Literal(Constant(())))
@@ -1000,7 +1000,7 @@ class ValAndDefPrintTest {
     |  def test2() = ()
     |}""")
 
-  @Test def testDef8 = {
+  @Test def testDef8(): Unit = {
     val arg = ValDef(Modifiers(Flag.IMPLICIT) , TermName("a"),
       AppliedTypeTree(Ident(TypeName("R")), List(Ident(TypeName("X")))), EmptyTree)
 
@@ -1011,16 +1011,16 @@ class ValAndDefPrintTest {
     assertTreeCode(tree)("def test[X](implicit a: R[X]) = ()")
   }
 
-  @Test def testDef9 = assertPrintedCode("def a(x: scala.Int)(implicit z: scala.Double, y: scala.Float): scala.Unit = ()")
+  @Test def testDef9(): Unit = assertPrintedCode("def a(x: scala.Int)(implicit z: scala.Double, y: scala.Float): scala.Unit = ()")
 
-  @Test def testDefWithLazyVal1 = assertPrintedCode(sm"""
+  @Test def testDefWithLazyVal1(): Unit = assertPrintedCode(sm"""
     |def a = {
     |  lazy val test: scala.Int = 42;
     |  ()
     |}
     """)
 
-  @Test def testDefWithLazyVal2 = assertPrintedCode(sm"""
+  @Test def testDefWithLazyVal2(): Unit = assertPrintedCode(sm"""
     |def a = {
     |  lazy val test: scala.Unit = {
     |    scala.Predef.println();
@@ -1029,63 +1029,63 @@ class ValAndDefPrintTest {
     |  ()
     |}""")
 
-  @Test def testDefWithParams1 = assertPrintedCode("def foo(x: scala.Int*) = ()")
+  @Test def testDefWithParams1(): Unit = assertPrintedCode("def foo(x: scala.Int*) = ()")
 
-  @Test def testDefWithParams2 = assertPrintedCode(sm"""
+  @Test def testDefWithParams2(): Unit = assertPrintedCode(sm"""
     |{
     |  def foo(x: scala.Int)(y: scala.Int = 1) = ();
     |  ()
     |}""")
 
-  @Test def testDefWithTypeParams1 = assertPrintedCode(sm"""
+  @Test def testDefWithTypeParams1(): Unit = assertPrintedCode(sm"""
     |{
     |  def foo[A, B, C](x: A)(y: scala.Int = 1): C = ().asInstanceOf[C];
     |  ()
     |}""")
 
-  @Test def testDefWithTypeParams2 = assertPrintedCode("def foo[A, B <: scala.AnyVal] = ()")
+  @Test def testDefWithTypeParams2(): Unit = assertPrintedCode("def foo[A, B <: scala.AnyVal] = ()")
 
-  @Test def testDefWithAnn1 = assertPrintedCode("@annot def foo = null", checkTypedTree = false)
+  @Test def testDefWithAnn1(): Unit = assertPrintedCode("@annot def foo = null", checkTypedTree = false)
 
-  @Test def testDefWithAnn2 = assertPrintedCode("@a(x) def foo = null", checkTypedTree = false)
+  @Test def testDefWithAnn2(): Unit = assertPrintedCode("@a(x) def foo = null", checkTypedTree = false)
 
-  @Test def testDefWithAnn3 = assertPrintedCode("@Foo[A, B] def foo = null", checkTypedTree = false)
+  @Test def testDefWithAnn3(): Unit = assertPrintedCode("@Foo[A, B] def foo = null", checkTypedTree = false)
 
-  @Test def testDefWithAnn4 = assertPrintedCode("@Foo(a)(b)(x, y) def foo = null", checkTypedTree = false)
+  @Test def testDefWithAnn4(): Unit = assertPrintedCode("@Foo(a)(b)(x, y) def foo = null", checkTypedTree = false)
 
-  @Test def testDefWithAnn5 = assertPrintedCode("@Foo[A, B](a)(b) @Bar def foo(x: Int) = null", checkTypedTree = false)
+  @Test def testDefWithAnn5(): Unit = assertPrintedCode("@Foo[A, B](a)(b) @Bar def foo(x: Int) = null", checkTypedTree = false)
 
-  @Test def testDefWithAnn6 = assertPrintedCode("@test1(new test2()) def foo = 42", checkTypedTree = false)
+  @Test def testDefWithAnn6(): Unit = assertPrintedCode("@test1(new test2()) def foo = 42", checkTypedTree = false)
 
-  @Test def testDefWithAnn7 = assertPrintedCode("@`t*` def foo = 42", checkTypedTree = false)
+  @Test def testDefWithAnn7(): Unit = assertPrintedCode("@`t*` def foo = 42", checkTypedTree = false)
 
-  @Test def testDefWithAnn8 = assertPrintedCode("@throws(classOf[Exception]) def foo = throw new Exception()", checkTypedTree = false)
+  @Test def testDefWithAnn8(): Unit = assertPrintedCode("@throws(classOf[Exception]) def foo = throw new Exception()", checkTypedTree = false)
 
-  @Test def testAnnotated1 = assertResultCode(
+  @Test def testAnnotated1(): Unit = assertResultCode(
     code = "def foo = 42: @baz")(
     parsedCode = "def foo = 42: @baz",
     typedCode = "def foo = (42: @baz)",
     wrap = true)
 
-  @Test def testAnnotated2 = assertResultCode(
+  @Test def testAnnotated2(): Unit = assertResultCode(
     code = "def foo = 42: @foo2[A1, B1](4)(2)")(
     parsedCode = "def foo = 42: @foo2[A1, B1](4)(2)",
     typedCode = "def foo = (42: @foo2[A1, B1](4)(2))",
     wrap = true)
 
-  @Test def testAnnotated3 = assertResultCode(
+  @Test def testAnnotated3(): Unit = assertResultCode(
     code = "def foo = (42: @foo1[A1, B1]): @foo2[A1, B1](4)(2)")(
     parsedCode = "def foo = (42: @foo1[A1, B1]): @foo2[A1, B1](4)(2)",
     typedCode = "def foo = ((42: @foo1[A1, B1]): @foo2[A1, B1](4)(2))",
     wrap = true)
 
-  @Test def testAnnotated4 = assertResultCode(
+  @Test def testAnnotated4(): Unit = assertResultCode(
     code = "def foo = 42: @foo3[A1, B1](4)(2.0F, new foo1[A1, B1]())")(
     parsedCode = "def foo = 42: @foo3[A1, B1](4)(2.0F, new foo1[A1, B1]())",
     typedCode = "def foo = (42: @foo3[A1, B1](4)(2.0F, new foo1[A1, B1]()))",
     wrap = true)
 
-  @Test def testAnnotated5 = assertPrintedCode(sm"""
+  @Test def testAnnotated5(): Unit = assertPrintedCode(sm"""
     |{
     |  val x = 5;
     |  (x: @unchecked) match {
@@ -1094,7 +1094,7 @@ class ValAndDefPrintTest {
     |  }
     |}""")
 
-  @Test def testAnnotated8 = assertPrintedCode(sm"""
+  @Test def testAnnotated8(): Unit = assertPrintedCode(sm"""
     |{
     |  val x = 5;
     |  ((x: @unchecked): @foo3(4)(2.0F, new foo1[A1, B1]())) match {
@@ -1105,12 +1105,12 @@ class ValAndDefPrintTest {
 
 @RunWith(classOf[JUnit4])
 class PackagePrintTest {
-  @Test def testPackage1 = assertPrintedCode(sm"""
+  @Test def testPackage1(): Unit = assertPrintedCode(sm"""
     |package foo.bar {
     |  
     |}""", checkTypedTree = false)
 
-  @Test def testPackage2 = assertPrintedCode(sm"""
+  @Test def testPackage2(): Unit = assertPrintedCode(sm"""
     |package foo {
     |  class C
     |
@@ -1118,13 +1118,13 @@ class PackagePrintTest {
     |}""", checkTypedTree = false)
 
   //package object foo extends a with b
-  @Test def testPackage3 = assertPrintedCode(sm"""
+  @Test def testPackage3(): Unit = assertPrintedCode(sm"""
     |package foo {
     |  object `package` extends a with b
     |}""", checkTypedTree = false)
 
   //package object foo { def foo; val x = 1 }
-  @Test def testPackage4 = assertPrintedCode(sm"""
+  @Test def testPackage4(): Unit = assertPrintedCode(sm"""
     |package foo {
     |  object `package` {
     |    def foo: scala.Unit = ();
@@ -1133,7 +1133,7 @@ class PackagePrintTest {
     |}""", checkTypedTree = false)
 
   //package object foo extends { val x = 1; type I = Int } with Any
-  @Test def testPackage5 = assertPrintedCode(sm"""
+  @Test def testPackage5(): Unit = assertPrintedCode(sm"""
     |package foo {
     |  object `package` extends {
     |    val x = 1;
@@ -1144,63 +1144,63 @@ class PackagePrintTest {
 
 @RunWith(classOf[JUnit4])
 class QuasiTreesPrintTest {
-  @Test def testQuasiIdent = assertTreeCode(q"*")("*")
+  @Test def testQuasiIdent(): Unit = assertTreeCode(q"*")("*")
 
-  @Test def testQuasiVal = assertTreeCode(q"val * : Unit = null")("val * : Unit = null")
+  @Test def testQuasiVal(): Unit = assertTreeCode(q"val * : Unit = null")("val * : Unit = null")
 
-  @Test def testQuasiDef = assertTreeCode(q"def * : Unit = null")("def * : Unit = null")
+  @Test def testQuasiDef(): Unit = assertTreeCode(q"def * : Unit = null")("def * : Unit = null")
 
-  @Test def testQuasiTrait = assertTreeCode(q"trait *")("trait *")
+  @Test def testQuasiTrait(): Unit = assertTreeCode(q"trait *")("trait *")
 
-  @Test def testQuasiClass = assertTreeCode(q"class *")("class *")
+  @Test def testQuasiClass(): Unit = assertTreeCode(q"class *")("class *")
 
-  @Test def testQuasiClassWithPublicParams = assertTreeCode(q"class X(val x: Int, val s:String)")("class X(val x: Int, val s: String)")
+  @Test def testQuasiClassWithPublicParams(): Unit = assertTreeCode(q"class X(val x: Int, val s:String)")("class X(val x: Int, val s: String)")
 
-  @Test def testQuasiClassWithParams = assertTreeCode(q"class X(x: Int, s:String)")("class X(x: Int, s: String)")
+  @Test def testQuasiClassWithParams(): Unit = assertTreeCode(q"class X(x: Int, s:String)")("class X(x: Int, s: String)")
 
-  @Test def testQuasiObject = assertTreeCode(q"object *")("object *")
+  @Test def testQuasiObject(): Unit = assertTreeCode(q"object *")("object *")
 
-  @Test def testQuasiObjectWithBody = assertTreeCode(q"""object X{ def y = "test" }""")(sm"""
+  @Test def testQuasiObjectWithBody(): Unit = assertTreeCode(q"""object X{ def y = "test" }""")(sm"""
     |object X {
     |  def y = "test"
     |}""")
 
-  @Test def testQuasiClassWithBody = assertTreeCode(q"""class X{ def y = "test" }""")(sm"""
+  @Test def testQuasiClassWithBody(): Unit = assertTreeCode(q"""class X{ def y = "test" }""")(sm"""
     |class X {
     |  def y = "test"
     |}""")
 
-  @Test def testQuasiTraitWithBody = assertTreeCode(q"""trait X{ def y = "test" }""")(sm"""
+  @Test def testQuasiTraitWithBody(): Unit = assertTreeCode(q"""trait X{ def y = "test" }""")(sm"""
     |trait X {
     |  def y = "test"
     |}""")
 
-  @Test def testQuasiTraitWithSelfTypeAndBody = assertTreeCode(q"""trait X{ self: Order => def y = "test" }""")(sm"""
+  @Test def testQuasiTraitWithSelfTypeAndBody(): Unit = assertTreeCode(q"""trait X{ self: Order => def y = "test" }""")(sm"""
     |trait X { self: Order =>
     |  def y = "test"
     |}""")
 
-  @Test def testQuasiTraitWithSelf = assertTreeCode(q"""trait X{ self => def y = "test" }""")(sm"""
+  @Test def testQuasiTraitWithSelf(): Unit = assertTreeCode(q"""trait X{ self => def y = "test" }""")(sm"""
     |trait X { self =>
     |  def y = "test"
     |}""")
 
-  @Test def testQuasiCaseClassWithBody = assertTreeCode(q"""case class X() { def y = "test" }""")(sm"""
+  @Test def testQuasiCaseClassWithBody(): Unit = assertTreeCode(q"""case class X() { def y = "test" }""")(sm"""
     |case class X() {
     |  def y = "test"
     |}""")
 
-  @Test def testQuasiCaseClassWithParamsAndBody = assertTreeCode(q"""case class X(x: Int, s: String){ def y = "test" }""")(sm"""
+  @Test def testQuasiCaseClassWithParamsAndBody(): Unit = assertTreeCode(q"""case class X(x: Int, s: String){ def y = "test" }""")(sm"""
     |case class X(x: Int, s: String) {
     |  def y = "test"
     |}""")
 
-  @Test def testQuasiCaseClassWithTypes1 = assertTreeCode(q"""case class X(x: ${typeOf[Int]}, s: ${typeOf[String]}){ def y = "test" }""")(sm"""
+  @Test def testQuasiCaseClassWithTypes1(): Unit = assertTreeCode(q"""case class X(x: ${typeOf[Int]}, s: ${typeOf[String]}){ def y = "test" }""")(sm"""
     |case class X(x: Int, s: String) {
     |  def y = "test"
     |}""")
 
-  @Test def testQuasiCaseClassWithTypes2 = assertTreeCode(q"""case class X(x: ${typeOf[Int]}, s: ${typeOf[String]}){ def y = "test" }""", typecheck = true)(sm"""
+  @Test def testQuasiCaseClassWithTypes2(): Unit = assertTreeCode(q"""case class X(x: ${typeOf[Int]}, s: ${typeOf[String]}){ def y = "test" }""", typecheck = true)(sm"""
     |{
     |  case class X(x: Int, s: String) {
     |    def y = "test"

--- a/test/junit/scala/reflect/internal/util/FileUtilsTest.scala
+++ b/test/junit/scala/reflect/internal/util/FileUtilsTest.scala
@@ -50,7 +50,7 @@ class FileUtilsTest {
     fileExpected.delete()
   }
 
-  @Test def showPerformance: Unit = {
+  @Test def showPerformance(): Unit = {
     //warmup
     for (i <- 1 to 1000) {
       writeIsSame()

--- a/test/junit/scala/reflect/internal/util/WeakHashSetTest.scala
+++ b/test/junit/scala/reflect/internal/util/WeakHashSetTest.scala
@@ -16,7 +16,7 @@ class WeakHashSetTest {
 
   // basic emptiness check
   @Test
-  def checkEmpty: Unit = {
+  def checkEmpty(): Unit = {
     val hs = new WeakHashSet[String]()
     assertEquals(0, hs.size)
     hs.diagnostics.fullyValidate()
@@ -24,7 +24,7 @@ class WeakHashSetTest {
 
   // make sure += works
   @Test
-  def checkPlusEquals: Unit = {
+  def checkPlusEquals(): Unit = {
     val hs = new WeakHashSet[String]()
     val elements = List("hello", "goodbye")
     elements foreach (hs += _)
@@ -36,7 +36,7 @@ class WeakHashSetTest {
 
   // make sure += works when there are collisions
   @Test
-  def checkPlusEqualsCollisions: Unit = {
+  def checkPlusEqualsCollisions(): Unit = {
     val hs = new WeakHashSet[Collider]()
     val elements = List("hello", "goodbye") map Collider
     elements foreach (hs += _)
@@ -48,7 +48,7 @@ class WeakHashSetTest {
 
   // add a large number of elements to force rehashing and then validate
   @Test
-  def checkRehashing: Unit = {
+  def checkRehashing(): Unit = {
     val size = 200
     val hs = new WeakHashSet[String]()
     val elements = (0 until size).toList map ("a" + _)
@@ -59,7 +59,7 @@ class WeakHashSetTest {
 
   // make sure rehashing works properly when the set is rehashed
   @Test
-  def checkRehashCollisions: Unit = {
+  def checkRehashCollisions(): Unit = {
     val size = 200
     val hs = new WeakHashSet[Collider]()
     val elements = (0 until size).toList map {x => Collider("a" + x)}
@@ -71,7 +71,7 @@ class WeakHashSetTest {
   // test that unreferenced objects are removed
   // not run in an automated environment because gc behavior can't be relied on
   //@Test
-  def checkRemoveUnreferencedObjects: Unit = {
+  def checkRemoveUnreferencedObjects(): Unit = {
     val size = 200
     val hs = new WeakHashSet[Collider]()
     val elements = (0 until size).toList map {x => Collider("a" + x)}
@@ -93,7 +93,7 @@ class WeakHashSetTest {
 
   // make sure findOrUpdate returns the originally entered element
   @Test
-  def checkFindOrUpdate: Unit = {
+  def checkFindOrUpdate(): Unit = {
     val size = 200
     val hs = new WeakHashSet[Collider]()
     val elements = (0 until size).toList map {x => Collider("a" + x)}
@@ -108,7 +108,7 @@ class WeakHashSetTest {
 
   // check -= functionality
   @Test
-  def checkMinusEquals: Unit = {
+  def checkMinusEquals(): Unit = {
     val hs = new WeakHashSet[String]()
     val elements = List("hello", "goodbye")
     elements foreach (hs += _)
@@ -121,7 +121,7 @@ class WeakHashSetTest {
 
   // check -= when there are collisions
   @Test
-  def checkMinusEqualsCollisions: Unit = {
+  def checkMinusEqualsCollisions(): Unit = {
     val hs = new WeakHashSet[Collider]
     val elements = List(Collider("hello"), Collider("goodbye"))
     elements foreach (hs += _)
@@ -137,7 +137,7 @@ class WeakHashSetTest {
 
   // check that the clear method actually cleans everything
   @Test
-  def checkClear: Unit = {
+  def checkClear(): Unit = {
     val size = 200
     val hs = new WeakHashSet[String]()
     val elements = (0 until size).toList map ("a" + _)
@@ -150,7 +150,7 @@ class WeakHashSetTest {
 
   // check that the iterator covers all the contents
   @Test
-  def checkIterator: Unit = {
+  def checkIterator(): Unit = {
     val hs = new WeakHashSet[String]()
     val elements = (0 until 20).toList map ("a" + _)
     elements foreach (hs += _)
@@ -160,7 +160,7 @@ class WeakHashSetTest {
 
   // check that the iterator covers all the contents even when there is a collision
   @Test
-  def checkIteratorCollisions: Unit = {
+  def checkIteratorCollisions(): Unit = {
     val hs = new WeakHashSet[Collider]
     val elements = (0 until 20).toList map {x => Collider("a" + x)}
     elements foreach (hs += _)

--- a/test/junit/scala/reflect/macros/AttachmentsTest.scala
+++ b/test/junit/scala/reflect/macros/AttachmentsTest.scala
@@ -10,7 +10,7 @@ import scala.reflect.internal.util._
 class AttachmentsTest {
   def emptyAtt: Attachments = NoPosition
 
-  @Test def testAttachments = {
+  @Test def testAttachments(): Unit = {
     var atts = emptyAtt
 
     assert(atts.isEmpty)

--- a/test/junit/scala/sys/process/ProcessBuilderTest.scala
+++ b/test/junit/scala/sys/process/ProcessBuilderTest.scala
@@ -10,7 +10,7 @@ import scala.tools.testkit.AssertUtil._
 class ProcessBuilderTest {
 
   @Test
-  def t8406: Unit = {
+  def t8406(): Unit = {
     import java.io.ByteArrayInputStream
     import java.nio.charset.StandardCharsets.UTF_8
     import scala.util.Try

--- a/test/junit/scala/tools/nsc/ScriptRunnerTest.scala
+++ b/test/junit/scala/tools/nsc/ScriptRunnerTest.scala
@@ -7,7 +7,7 @@ import org.junit.runners.JUnit4
 @RunWith(classOf[JUnit4])
 class ScriptRunnerTest {
   @Test
-  def testEmptyScriptSucceeds: Unit = {
+  def testEmptyScriptSucceeds(): Unit = {
     val s = new GenericRunnerSettings(s => ())
     s.usejavacp.value = true
 

--- a/test/junit/scala/tools/nsc/backend/jvm/IndySammyTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/IndySammyTest.scala
@@ -76,7 +76,7 @@ class IndySammyTest extends BytecodeTesting {
 
   // x => x : VC => VC applied to VC(1)
   @Test
-  def testVC_VC_VC =
+  def testVC_VC_VC(): Unit =
     test("VC", "VC", "new VC(1)")("(I)I",
       List(VarOp(ILOAD, 0), Op(IRETURN)),
       List(Op(ICONST_1)),
@@ -84,7 +84,7 @@ class IndySammyTest extends BytecodeTesting {
 
   // x => new VC(x) : Int => VC applied to 1
   @Test
-  def testInt_VC_1 =
+  def testInt_VC_1(): Unit =
     test("Int", "VC", "1", x => s"new VC($x)")("(I)I",
       List(VarOp(ILOAD, 0), Op(IRETURN)),
       List(Op(ICONST_1)),
@@ -92,7 +92,7 @@ class IndySammyTest extends BytecodeTesting {
 
   // x => x : VC => Int applied to VC(1)
   @Test
-  def testVC_Int_VC =
+  def testVC_Int_VC(): Unit =
     test("VC", "Int", "new VC(1)", x => "1")("(I)I",
       List(Op(ICONST_1), Op(IRETURN)),
       List(Op(ICONST_1)),
@@ -100,7 +100,7 @@ class IndySammyTest extends BytecodeTesting {
 
   // x => new VC(1) : VC => Any applied to VC(1)
   @Test
-  def testVC_Any_VC =
+  def testVC_Any_VC(): Unit =
     test("VC", "Any", "new VC(1)", x => s"new VC(1)")("(I)Ljava/lang/Object;",
       List(TypeOp(NEW, "VC"), Op(DUP), Op(ICONST_1), Invoke(INVOKESPECIAL, "VC", "<init>", "(I)V", false), Op(ARETURN)),
       List(Op(ICONST_1)),
@@ -109,7 +109,7 @@ class IndySammyTest extends BytecodeTesting {
 
   // x => x : VC => Unit applied to VC(1)
   @Test
-  def testVC_Unit_VC =
+  def testVC_Unit_VC(): Unit =
     test("VC", "Unit", "new VC(1)")("(I)V",
       List(VarOp(ILOAD, 0), Op(POP), Op(RETURN)),
       List(Op(ICONST_1)),
@@ -124,7 +124,7 @@ class IndySammyTest extends BytecodeTesting {
   //   FunAny_VC  lam() { return x -> BoxesRunTime.unboxToInt((Object)x); }
   //   int    app()    { lam().apply(BoxesRunTime.boxToInteger((int)1));
   @Test
-  def testAny_VC_1 =
+  def testAny_VC_1(): Unit =
     test("Any", "VC", "1", x => s"new VC($x.asInstanceOf[Int])")("(Ljava/lang/Object;)I",
       List(VarOp(ALOAD, 0), Invoke(INVOKESTATIC, "scala/runtime/BoxesRunTime", "unboxToInt", "(Ljava/lang/Object;)I", false), Op(IRETURN)),
       List(Op(ICONST_1), Invoke(INVOKESTATIC, "scala/runtime/BoxesRunTime", "boxToInteger", "(I)Ljava/lang/Integer;", false)),
@@ -139,7 +139,7 @@ class IndySammyTest extends BytecodeTesting {
 
   // Tests ThisReferringMethodsTraverser
   @Test
-  def testStaticIfNoThisReference: Unit = {
+  def testStaticIfNoThisReference(): Unit = {
     val methodNodes = compileAsmMethods("def foo = () => () => () => 42")
     methodNodes.forall(m => !m.name.contains("anonfun") || (m.access & ACC_STATIC) == ACC_STATIC)
   }

--- a/test/junit/scala/tools/nsc/backend/jvm/PerRunInitTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/PerRunInitTest.scala
@@ -83,7 +83,7 @@ abstract class PerRunInitTest {
   }
 
   @Test
-  def clearedWhenExpired: Unit = {
+  def clearedWhenExpired(): Unit = {
     val data = newData()
 
     add(1, data)
@@ -97,7 +97,7 @@ abstract class PerRunInitTest {
   }
 
   @Test
-  def clearedWeakOnly: Unit = {
+  def clearedWeakOnly(): Unit = {
     var data = newData()
     val ref = WeakReference(data)
 
@@ -110,7 +110,7 @@ abstract class PerRunInitTest {
   }
 
   @Test
-  def notClearedIfRequested: Unit = {
+  def notClearedIfRequested(): Unit = {
     val data = newData()
     dontClear(data)
 

--- a/test/junit/scala/tools/nsc/classpath/AggregateClassPathTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/AggregateClassPathTest.scala
@@ -107,7 +107,7 @@ class AggregateClassPathTest {
   }
 
   @Test
-  def testGettingPackages: Unit = {
+  def testGettingPackages(): Unit = {
     case class ClassPathWithPackages(packagesInPackage: EntryNamesInPackage*) extends TestClassPathBase {
       override def packages(inPackage: PackageName): Seq[PackageEntry] =
         packagesInPackage.find(_.inPackage == inPackage.dottedString).map(_.names).getOrElse(Nil) map PackageEntryImpl
@@ -129,7 +129,7 @@ class AggregateClassPathTest {
   }
 
   @Test
-  def testGettingClasses: Unit = {
+  def testGettingClasses(): Unit = {
     val cp = createDefaultTestClasspath()
 
     val classesInPkg1 = Seq(classFileEntry(dir2, pkg1, "C"),
@@ -151,7 +151,7 @@ class AggregateClassPathTest {
   }
 
   @Test
-  def testGettingSources: Unit = {
+  def testGettingSources(): Unit = {
     val partialClassPaths = Seq(TestClassPath(dir1, EntryNamesInPackage(pkg1)("F", "A", "G")),
       TestSourcePath(dir2, EntryNamesInPackage(pkg1)("C", "B", "A"), EntryNamesInPackage(pkg2)("D", "A", "E")),
       TestSourcePath(dir3, EntryNamesInPackage(pkg1)("A", "D", "F")),
@@ -179,7 +179,7 @@ class AggregateClassPathTest {
   }
 
   @Test
-  def testList: Unit = {
+  def testList(): Unit = {
     val cp = createDefaultTestClasspath()
 
     val classesAndSourcesInPkg1 = Seq(
@@ -196,7 +196,7 @@ class AggregateClassPathTest {
   }
 
   @Test
-  def testFindClass: Unit = {
+  def testFindClass(): Unit = {
     val cp = createDefaultTestClasspath()
 
     assertEquals(

--- a/test/junit/scala/tools/nsc/classpath/PathResolverBaseTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/PathResolverBaseTest.scala
@@ -37,7 +37,7 @@ class PathResolverBaseTest {
   private val settings = new Settings
 
   @Before
-  def initTempDirAndSourcePath: Unit = {
+  def initTempDirAndSourcePath(): Unit = {
     // In Java TemporaryFolder in JUnit is managed automatically using @Rule.
     // It would work also in Scala after adding and extending a class like
     // TestWithTempFolder.java containing it. But in this case it doesn't work when running tests
@@ -56,13 +56,13 @@ class PathResolverBaseTest {
   }
 
   @After
-  def deleteTempDir: Unit = tempDir.delete()
+  def deleteTempDir(): Unit = tempDir.delete()
 
   private def createFlatClassPath(settings: Settings) =
     new PathResolver(settings, new CloseableRegistry).result
 
   @Test
-  def testEntriesFromListOperationAgainstSeparateMethods: Unit = {
+  def testEntriesFromListOperationAgainstSeparateMethods(): Unit = {
     val classPath = createFlatClassPath(settings)
 
     def compareEntriesInPackage(inPackage: String): Unit = {
@@ -95,7 +95,7 @@ class PathResolverBaseTest {
   }
 
   @Test
-  def testFindClassFile: Unit = {
+  def testFindClassFile(): Unit = {
     val classPath = createFlatClassPath(settings)
     classFilesToFind foreach { className =>
       assertTrue(s"File for $className should be found", classPath.findClassFile(className).isDefined)
@@ -103,7 +103,7 @@ class PathResolverBaseTest {
   }
 
   @Test
-  def testFindClass: Unit = {
+  def testFindClass(): Unit = {
     val classPath = createFlatClassPath(settings)
     classesToFind foreach { className =>
       assertTrue(s"File for $className should be found", classPath.findClass(className).isDefined)

--- a/test/junit/scala/tools/nsc/symtab/CannotHaveAttrsTest.scala
+++ b/test/junit/scala/tools/nsc/symtab/CannotHaveAttrsTest.scala
@@ -22,13 +22,13 @@ class CannotHaveAttrsTest {
   import symbolTable._
 
   @Test
-  def canHaveAttrsIsFalse =
+  def canHaveAttrsIsFalse(): Unit =
     attrlessTrees.foreach { t =>
       assertFalse(t.canHaveAttrs)
     }
 
   @Test
-  def defaultPosAssignment =
+  def defaultPosAssignment(): Unit =
     attrlessTrees.foreach { t =>
       assertEquals(t.pos, NoPosition)
       t.pos = NoPosition
@@ -38,7 +38,7 @@ class CannotHaveAttrsTest {
     }
 
   @Test
-  def defaultTpeAssignment =
+  def defaultTpeAssignment(): Unit =
     attrlessTrees.foreach { t =>
       assertEquals(t.tpe, NoType)
       t.tpe = NoType
@@ -48,7 +48,7 @@ class CannotHaveAttrsTest {
     }
 
   @Test @org.junit.Ignore("scala/bug#8816")
-  def nonDefaultPosAssignmentFails = {
+  def nonDefaultPosAssignmentFails(): Unit = {
     val pos = new OffsetPosition(null, 0)
     attrlessTrees.foreach { t =>
       assertThrows[IllegalArgumentException] { t.pos = pos }
@@ -57,7 +57,7 @@ class CannotHaveAttrsTest {
   }
 
   @Test @org.junit.Ignore("scala/bug#8816")
-  def nonDefaultTpeAssignmentFails = {
+  def nonDefaultTpeAssignmentFails(): Unit = {
     val tpe = typeOf[Int]
     attrlessTrees.foreach { t =>
       assertThrows[IllegalArgumentException] { t.tpe = tpe }
@@ -67,7 +67,7 @@ class CannotHaveAttrsTest {
 
   class Attach
   @Test
-  def attachmentsAreIgnored = {
+  def attachmentsAreIgnored(): Unit = {
     attrlessTrees.foreach { t =>
       t.setAttachments(NoPosition.update(new Attach))
       assertEquals(NoPosition, t.attachments)

--- a/test/junit/scala/tools/nsc/symtab/FreshNameExtractorTest.scala
+++ b/test/junit/scala/tools/nsc/symtab/FreshNameExtractorTest.scala
@@ -17,7 +17,7 @@ class FreshNameExtractorTest {
   val prefixes = List("foo$", "x$", "bar", "bippy$baz$")
 
   @Test
-  def extractionPreservesPrefix =
+  def extractionPreservesPrefix(): Unit =
     ("" :: prefixes).foreach { creatorPrefix =>
       prefixes.foreach { newPrefix =>
         val Creator = new FreshNameCreator(creatorPrefix)
@@ -28,7 +28,7 @@ class FreshNameExtractorTest {
     }
 
   @Test
-  def extractionFailsOnCreatorPrefixMismatch = {
+  def extractionFailsOnCreatorPrefixMismatch(): Unit = {
     val Creator = new FreshNameCreator(prefixes.head)
     val Extractor = new FreshNameExtractor(prefixes.tail.head)
     assertThrows[MatchError] {
@@ -37,7 +37,7 @@ class FreshNameExtractorTest {
   }
 
   @Test
-  def `no numeric suffix? no problem!` = {
+  def `no numeric suffix? no problem!`(): Unit = {
     val Creator   = new FreshNameCreator(prefixes.head)
     val Extractor = new FreshNameExtractor(prefixes.head)
     TermName(Creator.newName("foo") + "bar") match {

--- a/test/junit/scala/tools/nsc/symtab/SymbolTableTest.scala
+++ b/test/junit/scala/tools/nsc/symtab/SymbolTableTest.scala
@@ -12,12 +12,12 @@ class SymbolTableTest {
   object symbolTable extends SymbolTableForUnitTesting
 
   @Test
-  def initDefinitions = {
+  def initDefinitions(): Unit = {
     symbolTable.definitions.init()
   }
 
   @Test
-  def basicSubTypeCheck = {
+  def basicSubTypeCheck(): Unit = {
     symbolTable.definitions.init()
     val listClassTpe = symbolTable.definitions.ListClass.tpe
     val seqClassTpe = symbolTable.definitions.SeqClass.tpe
@@ -29,7 +29,7 @@ class SymbolTableTest {
    * from scratch and perform sub type check.
    */
   @Test
-  def customClassesSubTypeCheck: Unit = {
+  def customClassesSubTypeCheck(): Unit = {
     import symbolTable._
     symbolTable.definitions.init()
     val rootClass = symbolTable.rootMirror.RootClass
@@ -45,7 +45,7 @@ class SymbolTableTest {
   }
 
   @Test
-  def noSymbolOuterClass_t9133: Unit = {
+  def noSymbolOuterClass_t9133(): Unit = {
     import symbolTable._
     assertEquals(NoSymbol, NoSymbol.outerClass)
   }

--- a/test/junit/scala/tools/nsc/typechecker/InferencerTest.scala
+++ b/test/junit/scala/tools/nsc/typechecker/InferencerTest.scala
@@ -28,11 +28,11 @@ class InferencerTests extends BytecodeTesting {
 
   var storedXsource: ScalaVersion = null
   @Before
-  def storeXsource: Unit = {
+  def storeXsource(): Unit = {
     storedXsource = settings.source.value
   }
   @After
-  def restoreXsource: Unit = {
+  def restoreXsource(): Unit = {
     settings.source.value = storedXsource
   }
 

--- a/test/junit/scala/tools/testkit/AssertThrowsTest.scala
+++ b/test/junit/scala/tools/testkit/AssertThrowsTest.scala
@@ -25,13 +25,13 @@ class AssertThrowsTest {
   class Bar extends Exception
 
   @Test
-  def catchFoo = assertThrows[Foo] { throw new Foo }
+  def catchFoo(): Unit = assertThrows[Foo] { throw new Foo }
 
   @Test
-  def catchSubclass = assertThrows[Foo] { throw new SubFoo }
+  def catchSubclass(): Unit = assertThrows[Foo] { throw new SubFoo }
 
   @Test
-  def wrongThrow =
+  def wrongThrow(): Unit =
     assertTrue("Wrong exception thrown", {
       try {
         assertThrows[Foo] { throw new Bar }
@@ -44,7 +44,7 @@ class AssertThrowsTest {
     })
 
   @Test
-  def errorIfNoThrow: Unit = {
+  def errorIfNoThrow(): Unit = {
     try {
       assertThrows[Foo] { () }
     } catch {

--- a/test/junit/scala/util/EitherTest.scala
+++ b/test/junit/scala/util/EitherTest.scala
@@ -5,7 +5,7 @@ import org.junit.Test
 
 class EitherTest {
 
-  @Test def testFlatten: Unit = {
+  @Test def testFlatten(): Unit = {
     val  l: Either[String, Either[String, Int]] = Left("pancake")
     val rl: Either[String, Either[String, Int]] = Right(Left("flounder"))
     val rr: Either[String, Either[String, Int]] = Right(Right(7))
@@ -20,7 +20,7 @@ class EitherTest {
   }
 
   @Test
-  def testWithRight: Unit = {
+  def testWithRight(): Unit = {
 
     def rightSumOrLeftEmpty(l: List[Int]) =
       l.foldLeft(Left("empty").withRight[Int]) {
@@ -33,7 +33,7 @@ class EitherTest {
   }
 
   @Test
-  def testWithLeft: Unit = {
+  def testWithLeft(): Unit = {
 
     def leftSumOrRightEmpty(l: List[Int]) =
       l.foldLeft(Right("empty").withLeft[Int]) {

--- a/test/junit/scala/util/RandomUtilTest.scala
+++ b/test/junit/scala/util/RandomUtilTest.scala
@@ -4,7 +4,7 @@ import org.junit.{Assert, Test}
 import scala.tools.testkit.AssertUtil.assertThrows
 
 class RandomUtilTest {
-  @Test def testBetween: Unit = {
+  @Test def testBetween(): Unit = {
     val rand = new Random()
     Assert.assertTrue("Random between Int must be inclusive-exclusive", rand.between(0, 1).equals(0))
     Assert.assertTrue("Random between Long must be inclusive-exclusive", rand.between(0L, 1L).equals(0L))
@@ -15,22 +15,22 @@ class RandomUtilTest {
     Assert.assertTrue("Random between Double should be inclusive-exclusive", 0.0f.toDouble <= double && double < 1.0f.toDouble)
   }
 
-  @Test def testBetweenIntException: Unit = assertThrows[IllegalArgumentException] {
+  @Test def testBetweenIntException(): Unit = assertThrows[IllegalArgumentException] {
     val rand = new Random()
     rand.between(1, 0)
   }
 
-  @Test def testBetweenLongException: Unit = assertThrows[IllegalArgumentException] {
+  @Test def testBetweenLongException(): Unit = assertThrows[IllegalArgumentException] {
     val rand = new Random()
     rand.between(1L, 0L)
   }
 
-  @Test def testBetweenFloatException: Unit = assertThrows[IllegalArgumentException] {
+  @Test def testBetweenFloatException(): Unit = assertThrows[IllegalArgumentException] {
     val rand = new Random()
     rand.between(1.0f, 0.0f)
   }
 
-  @Test def testBetweenDoubleException: Unit = assertThrows[IllegalArgumentException] {
+  @Test def testBetweenDoubleException(): Unit = assertThrows[IllegalArgumentException] {
     val rand = new Random()
     rand.between(1.0f.toDouble, 0.0f.toDouble)
   }

--- a/test/junit/scala/util/hashing/MurmurHash3Test.scala
+++ b/test/junit/scala/util/hashing/MurmurHash3Test.scala
@@ -20,7 +20,7 @@ class MurmurHash3Test {
   }
 
   @Test
-  def testRangeConsistency: Unit = for(size <- Seq(0, 1, 2, 3, 4, 10, 100)) {
+  def testRangeConsistency(): Unit = for(size <- Seq(0, 1, 2, 3, 4, 10, 100)) {
     val range = (1 to size)
     val ordered = Array.iterate(1, size)(_ + 1)
     assertEquals(range, ArraySeq.unsafeWrapArray(ordered))
@@ -28,7 +28,7 @@ class MurmurHash3Test {
   }
 
   @Test
-  def testNonRangeConsistency: Unit = for(size <- Seq(2, 3, 4, 10, 100)) {
+  def testNonRangeConsistency(): Unit = for(size <- Seq(2, 3, 4, 10, 100)) {
     val ordered = Array.iterate(1, size)(_ + 1)
     val mixed1 = Array.copyOf(ordered, ordered.length)
     val mixed2 = Array.copyOf(ordered, ordered.length)
@@ -39,7 +39,7 @@ class MurmurHash3Test {
   }
 
   @Test
-  def testRangeAlignment: Unit = {
+  def testRangeAlignment(): Unit = {
     // 2 elements: end is normalized
     val r1 = 1 to 3 by 2
     val r2 = 1 to 4 by 2

--- a/test/junit/scala/util/matching/CharRegexTest.scala
+++ b/test/junit/scala/util/matching/CharRegexTest.scala
@@ -11,36 +11,36 @@ import PartialFunction._
  */
 class CharRegexTest {
   implicit class Averrable(val b: Boolean) /*extends AnyVal*/ {
-    def yes = assert(b)
-    def no = assert(!b)
+    def yes(): Unit = assert(b)
+    def no(): Unit = assert(!b)
   }
   val c: Char = 'c'  // "cat"(0)
   val d: Char = 'D'  // "Dog"(0)
 
   @Test def comparesGroupCorrectly(): Unit = {
     val r = """(\p{Lower})""".r
-    cond(c) { case r(x) => true } .yes
-    cond(c) { case r(_) => true } .yes
-    cond(c) { case r(_*) => true } .yes
-    cond(c) { case r() => true } .no
+    cond(c) { case r(x) => true } .yes()
+    cond(c) { case r(_) => true } .yes()
+    cond(c) { case r(_*) => true } .yes()
+    cond(c) { case r() => true } .no()
 
-    cond(d) { case r(x) => true } .no
-    cond(d) { case r(_) => true } .no
-    cond(d) { case r(_*) => true } .no
-    cond(d) { case r() => true } .no
+    cond(d) { case r(x) => true } .no()
+    cond(d) { case r(_) => true } .no()
+    cond(d) { case r(_*) => true } .no()
+    cond(d) { case r() => true } .no()
   }
 
   @Test def comparesNoGroupCorrectly(): Unit = {
     val rnc = """\p{Lower}""".r
-    cond(c) { case rnc(x) => true } .no
-    cond(c) { case rnc(_) => true } .no
-    cond(c) { case rnc(_*) => true } .yes
-    cond(c) { case rnc() => true } .yes
+    cond(c) { case rnc(x) => true } .no()
+    cond(c) { case rnc(_) => true } .no()
+    cond(c) { case rnc(_*) => true } .yes()
+    cond(c) { case rnc() => true } .yes()
 
-    cond(d) { case rnc(x) => true } .no
-    cond(d) { case rnc(_) => true } .no
-    cond(d) { case rnc(_*) => true } .no
-    cond(d) { case rnc() => true } .no
+    cond(d) { case rnc(x) => true } .no()
+    cond(d) { case rnc(_) => true } .no()
+    cond(d) { case rnc(_*) => true } .no()
+    cond(d) { case rnc() => true } .no()
   }
 
   @Test(expected = classOf[MatchError])


### PR DESCRIPTION
Partially addresses scala/scala-dev#737

The junit module had hundreds—perhaps even thousands—of warnings (sbt cuts off its output at 100 warnings, so I'm estimating based on the number of times I had to rebuild to get a fresh set of 100). I'd like to get this merged ASAP to prevent/reduce backsliding. Most of the changes are trivial; there are just a lot of them.