### PR TITLE
Use Any_== to compare case class elements

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
@@ -191,11 +191,10 @@ trait SyntheticMethods extends ast.TreeDSL {
           if (usefulEquals) {
             val thisAcc  = Select(mkThis, acc)
             val otherAcc = Select(Ident(otherSym), acc)
-            val op       = acc.tpe.member(nme.EQ)
             if (isPrimitiveValueType(resultType))
-              prims += fn(thisAcc, op, otherAcc)
+              prims += fn(thisAcc, acc.tpe.member(nme.EQ), otherAcc)
             else
-              refs  += fn(thisAcc, op, gen.mkCast(otherAcc, AnyTpe))
+              refs  += fn(thisAcc, Any_==, otherAcc)
           }
         }
         prims.prependToList(refs.toList)      // (prims ++ refs).toList

--- a/test/files/pos/t12248.scala
+++ b/test/files/pos/t12248.scala
@@ -1,0 +1,9 @@
+trait A
+
+trait B {
+  def ==[T](o: T)(implicit a: A): Boolean = ???
+}
+
+case class C(b: B)
+
+// cf test/files/pos/t10536.scala

--- a/test/files/pos/t12248b.scala
+++ b/test/files/pos/t12248b.scala
@@ -1,0 +1,9 @@
+trait A
+
+trait B extends Any {
+  def ==[T](o: T)(implicit a: A): Boolean = ???
+}
+
+case class C(b: B)
+
+// cf test/files/pos/t10536.scala

--- a/test/files/pos/t12248c.scala
+++ b/test/files/pos/t12248c.scala
@@ -1,0 +1,9 @@
+trait A
+
+class B(private val n: Int) extends AnyVal {
+  def ==[T](o: T)(implicit a: A): Boolean = ???
+}
+
+case class C(b: B)
+
+// cf test/files/pos/t10536.scala


### PR DESCRIPTION
The spec says case class equality considers elements equal
with respect to equals. That means `Any_==` and not
any old `==`.

The previous fix attempt was especially wrong because it
incurs boxing of value classes. Cf this oops
https://github.com/scala/scala/commit/b39a70

Fixes scala/bug#12248