### PR TITLE
Invoke javac from REPL paste [ci: last-only]

### DIFF
--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
@@ -16,7 +16,7 @@ package scala.tools.nsc.interpreter
 package shell
 
 import java.io.{BufferedReader, PrintWriter}
-import java.nio.file.Files
+import java.nio.file.{Files, Path => JPath}
 import java.util.concurrent.TimeUnit
 
 import scala.PartialFunction.cond
@@ -27,6 +27,7 @@ import scala.language.implicitConversions
 import scala.reflect.classTag
 import scala.reflect.internal.util.{BatchSourceFile, NoPosition}
 import scala.reflect.io.{AbstractFile, Directory, File, Path}
+import scala.sys.process.Parser.tokenize
 import scala.tools.asm.ClassReader
 import scala.tools.nsc.Settings
 import scala.tools.nsc.util.{stackTraceString, stringFromStream}
@@ -54,6 +55,7 @@ class ILoop(config: ShellConfig, inOverride: BufferedReader = null,
   def Repl(config: ShellConfig, interpreterSettings: Settings, out: PrintWriter) =
     new IMain(interpreterSettings, None, interpreterSettings, new ReplReporterImpl(config, interpreterSettings, out))
 
+  def global = intp.asInstanceOf[IMain].global
 
   // Set by run and interpretAllFrom (to read input from file).
   private var in: InteractiveReader = _
@@ -70,6 +72,8 @@ class ILoop(config: ShellConfig, inOverride: BufferedReader = null,
     else SimpleReader()
 
   private val interpreterInitialized = new java.util.concurrent.CountDownLatch(1)
+
+  def createTempDirectory(): JPath = Files.createTempDirectory("scala-repl").tap(_.toFile().deleteOnExit())
 
   // TODO: move echo and friends to ReplReporterImpl
   // When you know you are most likely breaking into the middle
@@ -655,14 +659,13 @@ class ILoop(config: ShellConfig, inOverride: BufferedReader = null,
   }
 
   def loadCommand(arg: String): Result = {
-    import scala.sys.process.{Parser => CommandLineParser}
     def run(file: String, args: List[String], verbose: Boolean) = withFile(file) { f =>
       intp.interpret(s"val args: Array[String] = ${ args.map("\"" + _ + "\"").mkString("Array(", ",", ")") }")
       interpretAllFrom(f, verbose)
       Result recording s":load $arg"
     } getOrElse Result.default
 
-    CommandLineParser.tokenize(arg) match {
+    tokenize(arg) match {
       case "-v" :: file :: rest => run(file, rest, verbose = true)
       case file :: rest         => run(file, rest, verbose = false)
       case _                    => echo("usage: :load -v file") ; Result.default
@@ -771,63 +774,73 @@ class ILoop(config: ShellConfig, inOverride: BufferedReader = null,
    * :paste <~ EOF
    *   ~your code
    * EOF
+   * and optionally
+   * :paste -java
    */
   def pasteCommand(arg: String): Result = {
     var shouldReplay: Option[String] = None
     var label = "<pastie>"
     def result = Result(keepRunning = true, shouldReplay)
-    val (raw, file, margin) =
-      if (arg.isEmpty) (false, None, None)
-      else {
-        def maybeRaw(ss: List[String]) = if (ss.nonEmpty && ss.head == "-raw") (true, ss.tail) else (false, ss)
-        def maybeHere(ss: List[String]) =
-          if (ss.nonEmpty && ss.head.startsWith("<")) (ss.head.dropWhile(_ == '<'), ss.tail)
-          else (null, ss)
-
-        val (raw0, ss0) = maybeRaw(words(arg))
-        val (margin0, ss1) = maybeHere(ss0)
-        val file0 = ss1 match {
-          case Nil      => null
-          case x :: Nil => x
-          case _        => echo("usage: :paste [-raw] file | < EOF") ; return result
-        }
-        (raw0, Option(file0), Option(margin0))
+    val (flags, args) = tokenize(arg).span(_.startsWith("-"))
+    def raw  = flags.contains("-raw")
+    def java = flags.contains("-java")
+    def usage() = echo("usage: :paste [-raw | -java] file | < EOF")
+    def pasteFile(name: String): String = {
+      label = name
+      withFile(name) { f =>
+        shouldReplay = Some(s":paste $arg")
+        f.slurp().trim().tap(s => echo(if (s.isEmpty) s"File contains no code: $f" else s"Pasting file $f..."))
+      }.getOrElse("")
+    }
+    def pasteWith(margin: String, eof: Option[String]): String = {
+      echo(s"// Entering paste mode (${ eof getOrElse "ctrl-D" } to finish)\n")
+      in.withSecondaryPrompt("") {
+        val delimiter = eof.orElse(config.pasteDelimiter.option)
+        def atEOF(s: String) = delimiter.map(_ == s).getOrElse(false)
+        val input = readWhile(s => !atEOF(s)).mkString("\n")
+        val text =
+          margin match {
+            case ""  => input.trim
+            case "-" => input.linesIterator.map(_.trim).mkString("\n")
+            case _   => input.stripMargin(margin.head).trim
+          }
+        echo(if (text.isEmpty) "\n// Nothing pasted, nothing gained.\n" else "\n// Exiting paste mode, now interpreting.\n")
+        text
       }
-    val code = (file, margin) match {
-      case (Some(name), None) =>
-        label = name
-        withFile(name) { f =>
-          shouldReplay = Some(s":paste $arg")
-          val s = f.slurp().trim()
-          if (s.isEmpty) echo(s"File contains no code: $f")
-          else echo(s"Pasting file $f...")
-          s
-        } getOrElse ""
-      case (eof, _) =>
-        echo(s"// Entering paste mode (${ eof getOrElse "ctrl-D" } to finish)\n")
-        in.withSecondaryPrompt("") {
-          val delimiter = eof orElse config.pasteDelimiter.option
-          val input = readWhile(s => delimiter.isEmpty || delimiter.get != s) mkString "\n"
-          val text = (
-            margin filter (_.nonEmpty) map {
-              case "-" => input.linesIterator map (_.trim) mkString "\n"
-              case m => input stripMargin m.head // ignore excess chars in "<<||"
-            } getOrElse input
-            ).trim
-          if (text.isEmpty) echo("\n// Nothing pasted, nothing gained.\n")
-          else echo("\n// Exiting paste mode, now interpreting.\n")
-          text
-        }
     }
-    def interpretCode() = {
-      if (intp.withLabel(label)(intp interpret code) == Incomplete)
+    val code: String = args match {
+      case name :: Nil if !name.startsWith("<")       => pasteFile(name)
+      case Nil                                        => pasteWith("", None)
+      case here :: Nil                                => pasteWith(here.slice(1, 2), None)
+      case here :: eof :: Nil if here.startsWith("<") => pasteWith(here.slice(1, 2), Some(eof))
+      case _ => usage() ; ???
+    }
+    def interpretCode() =
+      if (intp.withLabel(label)(intp.interpret(code)) == Incomplete)
         paste.incomplete("The pasted code is incomplete!\n", label, code)
-    }
     def compileCode() = paste.compilePaste(label = label, code = code)
+    def compileJava(): Unit = {
+      def pickLabel(): Unit = {
+        val gstable = global
+        val jparser = gstable.newJavaUnitParser(gstable.newCompilationUnit(code = code))
+        val result  = jparser.parse().collect {
+          case gstable.ClassDef(mods, className, _, _) if mods.isPublic => className
+        }
+        result.headOption.foreach(n => label = s"${n.decoded}")
+      }
+      pickLabel()
+      val out = createTempDirectory()
+      JavacTool(out, intp.classLoader).compile(label, code) match {
+        case Some(errormsg) => echo(s"Compilation failed! $errormsg")
+        case None => intp.addUrlsToClassPath(out.toUri().toURL())
+      }
+    }
 
     if (code.nonEmpty)
       intp.reporter.indenting(0) {
-        if (raw || paste.isPackaged(code)) compileCode() else interpretCode()
+        if (java) compileJava()
+        else if (raw || paste.isPackaged(code)) compileCode()
+        else interpretCode()
       }
     result
   }

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/JavacTool.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/JavacTool.scala
@@ -1,0 +1,116 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.tools.nsc.interpreter
+package shell
+
+import java.io.CharArrayWriter
+import java.net.URI
+import java.nio.charset.Charset
+import java.nio.file.Path
+import java.util.Locale
+import java.util.concurrent.ConcurrentLinkedQueue
+import javax.tools._, JavaFileManager.Location, StandardLocation._, JavaFileObject.Kind, Kind._
+import scala.collection.mutable.Clearable
+import scala.jdk.CollectionConverters._
+import scala.reflect.io.AbstractFile
+import scala.util.chaining._
+
+import System.lineSeparator
+
+class JavacTool private (tool: JavaCompiler, dir: AbstractFile, loader: ClassLoader) {
+  private val out = new CharArrayWriter
+  def written = {
+    out.flush()
+    val w = out.toString
+    out.reset()
+    w
+  }
+  val listener = new JavaReporter
+  val locale = Locale.getDefault
+  val charset = Charset.forName("UTF-8")
+  val fileManager = new JavaToolFileManager(dir, loader)(tool.getStandardFileManager(listener, locale, charset))
+
+  def compile(label: String, code: String): Option[String] = {
+    val options = (
+      "-encoding" ::
+      "UTF-8" ::
+      Nil
+    ).asJava
+    val classes: java.lang.Iterable[String] = null
+    val units = List(StringFileObject(label, code)).asJava
+    val task = tool.getTask(out, fileManager, listener, options, classes, units)
+    val success = task.call()
+    if (success) None else Some(listener.reported(locale))
+  }
+}
+object JavacTool {
+  def apply(dir: AbstractFile, loader: ClassLoader): JavacTool = new JavacTool(ToolProvider.getSystemJavaCompiler, dir, loader)
+  def apply(dir: Path, loader: ClassLoader)        : JavacTool = apply(AbstractFile.getURL(dir.toUri().toURL()), loader)
+}
+
+// use `dir` for output, `loader` for inputs
+class JavaToolFileManager(dir: AbstractFile, loader: ClassLoader)(delegate: JavaFileManager) extends ForwardingJavaFileManager[JavaFileManager](delegate) {
+  override def getJavaFileForOutput(location: Location, className: String, kind: Kind, sibling: FileObject): JavaFileObject = {
+    require(location == CLASS_OUTPUT, s"$location is not CLASS_OUTPUT")
+    require(kind == CLASS, s"$kind is not CLASS")
+    AbstractFileObject(dir, className, kind)
+  }
+}
+
+class AbstractFileObject(file: AbstractFile, uri0: URI, kind0: Kind) extends SimpleJavaFileObject(uri0, kind0) {
+  override def delete()           = { file.delete() ; true }
+  override def openInputStream()  = file.input
+  override def openOutputStream() = file.output
+}
+object AbstractFileObject {
+  def apply(dir: AbstractFile, path: String, kind: Kind) = {
+    val segments = path.replace(".", "/").split("/")
+    val parts    = segments.init
+    val name     = segments.last
+    val subdir   = parts.foldLeft(dir)((vd, n) => vd.subdirectoryNamed(n))
+    val file     = subdir.fileNamed(s"${name}${kind.extension}")
+    val uri      = file.file.toURI
+    new AbstractFileObject(file, uri, kind)
+  }
+}
+
+// name is the URI path
+//
+class StringFileObject(uri0: URI, code: String) extends SimpleJavaFileObject(uri0, SOURCE) {
+  override def getCharContent(ignoreEncodingErrors: Boolean) = code
+}
+object StringFileObject {
+  def apply(label: String, code: String): StringFileObject =
+    new StringFileObject(URI.create(s"string:///${label.replace('.','/')}${SOURCE.extension}"), code)
+}
+
+// A clearable diagnostic collector.
+//
+class JavaReporter extends DiagnosticListener[JavaFileObject] with Clearable {
+  type D = Diagnostic[_ <: JavaFileObject]
+  val diagnostics = new ConcurrentLinkedQueue[D]
+  private def messagesIterator(implicit locale: Locale) = diagnostics.iterator.asScala.map(_.getMessage(locale))
+  override def report(d: Diagnostic[_ <: JavaFileObject]) = diagnostics.add(d)
+  override def clear() = diagnostics.clear()
+  /** All diagnostic messages.
+   *  @param locale Locale for diagnostic messages, null by default.
+   */
+  def messages(implicit locale: Locale = null) = messagesIterator.toList
+
+  def reported(implicit locale: Locale = null): String = 
+    if (diagnostics.isEmpty) ""
+    else
+      messages
+        .mkString("", lineSeparator, lineSeparator)
+        .tap(_ => clear())
+}

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/JavacTool.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/JavacTool.scala
@@ -15,7 +15,7 @@ package shell
 
 import java.io.CharArrayWriter
 import java.net.URI
-import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Path
 import java.util.Locale
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -37,13 +37,12 @@ class JavacTool private (tool: JavaCompiler, dir: AbstractFile, loader: ClassLoa
   }
   val listener = new JavaReporter
   val locale = Locale.getDefault
-  val charset = Charset.forName("UTF-8")
-  val fileManager = new JavaToolFileManager(dir, loader)(tool.getStandardFileManager(listener, locale, charset))
+  val fileManager = new JavaToolFileManager(dir, loader)(tool.getStandardFileManager(listener, locale, UTF_8))
 
   def compile(label: String, code: String): Option[String] = {
     val options = (
       "-encoding" ::
-      "UTF-8" ::
+      UTF_8.name() ::
       Nil
     ).asJava
     val classes: java.lang.Iterable[String] = null

--- a/test/files/run/t10655.check
+++ b/test/files/run/t10655.check
@@ -1,0 +1,28 @@
+
+scala> :paste -java <| EOF
+// Entering paste mode (EOF to finish)
+
+    |package p;
+    |public class C {
+    |    public int c() {
+    |        return 42;
+    |    }
+    |    public String toString() {
+    |        return "hi, C";
+    |    }
+    |}
+EOF
+
+// Exiting paste mode, now interpreting.
+
+
+scala> new p.C
+val res0: p.C = hi, C
+
+scala> class D extends p.C
+class D
+
+scala> new D().c()
+val res1: Int = 42
+
+scala> :quit

--- a/test/files/run/t10655.scala
+++ b/test/files/run/t10655.scala
@@ -1,0 +1,18 @@
+
+object Test extends scala.tools.partest.ReplTest {
+  def code = """:paste -java <| EOF
+    |package p;
+    |public class C {
+    |    public int c() {
+    |        return 42;
+    |    }
+    |    public String toString() {
+    |        return "hi, C";
+    |    }
+    |}
+EOF
+new p.C
+class D extends p.C
+new D().c()
+  """
+}


### PR DESCRIPTION
Requires `nobootcp`.

No wrapping, `-raw` mode is implied.

A package statement is required for class path scanning.

Works just by augmenting the class path, like `:require`.

Good enough for simple experiments.

(Ultimate would be to wrap snippets, compile to in-memory, and manage imported symbols, as with Scala code.)

(Also java tooling should be pushed to "backend".)

Fixes scala/bug#10655