### PR TITLE
In the REPL show extended explanations only once

### DIFF
--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -199,6 +199,8 @@ trait Reporting extends internal.Reporting { self: ast.Positions with Compilatio
     }
 
     private[this] var reportedFeature = Set[Symbol]()
+    protected def featureReported(featureTrait: Symbol): Unit = reportedFeature += featureTrait
+
     // we don't have access to runDefinitions here, so mapping from strings instead of feature symbols
     private val featureCategory: Map[String, WarningCategory.Feature] = {
       import WarningCategory._

--- a/src/compiler/scala/tools/nsc/reporters/PrintReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/PrintReporter.scala
@@ -54,12 +54,18 @@ trait PrintReporter extends internal.Reporter {
 
   /** Format a message and emit it. */
   protected def display(pos: Position, msg: String, severity: Severity): Unit = {
-    val text = formatMessage(pos, s"${clabel(severity)}${Reporter.explanation(msg)}", shortname)
+    val text = formatMessage(pos, s"${clabel(severity)}${postProcess(msg)}", shortname)
     severity match {
       case internal.Reporter.INFO => echoMessage(text)
       case _                      => printMessage(text)
     }
   }
+
+  /** Postprocess a message string for reporting.
+   *
+   *  The default implementation uses `Reporter.explanation` to include the explanatory addendum.
+   */
+  protected def postProcess(msg: String): String = Reporter.explanation(msg)
 
   def displayPrompt(): Unit = {
     writer.println()

--- a/src/compiler/scala/tools/nsc/reporters/Reporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/Reporter.scala
@@ -66,11 +66,17 @@ object Reporter {
   /** Take the message without its explanation, if it has one. */
   def stripExplanation(msg: String): String = splitting(msg, explaining = false)
 
+  /** Split the message into main message and explanation, as iterators of the text. */
+  def splitExplanation(msg: String): (Iterator[String], Iterator[String]) = {
+    val (err, exp) = msg.linesIterator.span(!_.startsWith("----"))
+    (err, exp.drop(1))
+  }
+
   /** Split a message into a prefix and an optional explanation that follows a line starting with `"----"`. */
   private def splitting(msg: String, explaining: Boolean): String =
     if (msg != null && msg.indexOf("\n----") > 0) {
-      val (err, exp) = msg.linesIterator.span(!_.startsWith("----"))
-      if (explaining) (err ++ exp.drop(1)).mkString("\n") else err.mkString("\n")
+      val (err, exp) = splitExplanation(msg)
+      if (explaining) (err ++ exp).mkString("\n") else err.mkString("\n")
     } else {
       msg
     }

--- a/src/compiler/scala/tools/nsc/reporters/Reporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/Reporter.scala
@@ -60,26 +60,31 @@ object Reporter {
     loader.create[FilteringReporter](settings.reporter.value, settings.errorFn)(settings)
   }
 
-  /** Take the message with its explanation, if it has one. */
-  def explanation(msg: String): String = splitting(msg, explaining = true)
+  /** Take the message with its explanation, if it has one, but stripping the separator line.
+   */
+  def explanation(msg: String): String =
+    if (msg == null) {
+      msg
+    } else {
+      val marker = msg.indexOf("\n----\n")
+      if (marker > 0) msg.substring(0, marker + 1) + msg.substring(marker + 6) else msg
+    }
 
-  /** Take the message without its explanation, if it has one. */
-  def stripExplanation(msg: String): String = splitting(msg, explaining = false)
+  /** Drop any explanation from the message, including the newline between the message and separator line.
+   */
+  def stripExplanation(msg: String): String =
+    if (msg == null) {
+      msg
+    } else {
+      val marker = msg.indexOf("\n----\n")
+      if (marker > 0) msg.substring(0, marker) else msg
+    }
 
   /** Split the message into main message and explanation, as iterators of the text. */
   def splitExplanation(msg: String): (Iterator[String], Iterator[String]) = {
     val (err, exp) = msg.linesIterator.span(!_.startsWith("----"))
     (err, exp.drop(1))
   }
-
-  /** Split a message into a prefix and an optional explanation that follows a line starting with `"----"`. */
-  private def splitting(msg: String, explaining: Boolean): String =
-    if (msg != null && msg.indexOf("\n----") > 0) {
-      val (err, exp) = splitExplanation(msg)
-      if (explaining) (err ++ exp).mkString("\n") else err.mkString("\n")
-    } else {
-      msg
-    }
 }
 
 /** The reporter used in a Global instance.

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/Reporter.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/Reporter.scala
@@ -14,7 +14,6 @@ package scala.tools.nsc.interpreter.shell
 
 import java.io.PrintWriter
 
-import scala.collection.mutable
 import scala.reflect.internal
 import scala.reflect.internal.util.{NoSourceFile, Position, StringOps}
 import scala.tools.nsc.interpreter.{Naming, ReplReporter, ReplRequest}
@@ -159,7 +158,7 @@ class ReplReporterImpl(val config: ShellConfig, val settings: Settings = new Set
     printMessage(pos, prefix + msg)
   }
 
-  private val boringExplanations = mutable.Set.empty[String]
+  private var boringExplanations = Set.empty[String]
 
   // indent errors, error message uses the caret to point at the line already on the screen instead of repeating it
   // TODO: can we splice the error into the code the user typed when multiple lines were entered?
@@ -168,16 +167,17 @@ class ReplReporterImpl(val config: ShellConfig, val settings: Settings = new Set
   // TODO: the console could be empty due to external changes (also, :reset? -- see unfortunate example in jvm/interpreter (plusOne))
   def printMessage(posIn: Position, msg0: String): Unit = {
     val msg = {
-      val (main, explanation) = Reporter.splitExplanation(msg0)
-      val text =
-        if (explanation.hasNext) {
-          val suffix  = explanation.mkString("\n")
-          val explain = boringExplanations.add(suffix)
-          if (explain) (main ++ Iterator(suffix)) else main
-        } else {
-          main
+      val main = Reporter.stripExplanation(msg0)
+      if (main eq msg0) main
+      else {
+        val (_, explanation) = Reporter.splitExplanation(msg0)
+        val suffix = explanation.mkString("\n")
+        if (boringExplanations(suffix)) main
+        else {
+          boringExplanations += suffix
+          s"$main\n$suffix"
         }
-      text.mkString("\n")
+      }
     }
     if ((posIn eq null) || (posIn.source eq NoSourceFile)) printMessage(msg)
     else if (posIn.source.file.name == "<console>" && posIn.line == 1) {

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/Reporter.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/Reporter.scala
@@ -14,6 +14,7 @@ package scala.tools.nsc.interpreter.shell
 
 import java.io.PrintWriter
 
+import scala.collection.mutable
 import scala.reflect.internal
 import scala.reflect.internal.util.{NoSourceFile, Position, StringOps}
 import scala.tools.nsc.interpreter.{Naming, ReplReporter, ReplRequest}
@@ -158,13 +159,26 @@ class ReplReporterImpl(val config: ShellConfig, val settings: Settings = new Set
     printMessage(pos, prefix + msg)
   }
 
+  private val boringExplanations = mutable.Set.empty[String]
+
   // indent errors, error message uses the caret to point at the line already on the screen instead of repeating it
   // TODO: can we splice the error into the code the user typed when multiple lines were entered?
   // (should also comment out the error to keep multi-line copy/pastable)
   // TODO: multiple errors are not very intuitive (should the second error for same line repeat the line?)
   // TODO: the console could be empty due to external changes (also, :reset? -- see unfortunate example in jvm/interpreter (plusOne))
   def printMessage(posIn: Position, msg0: String): Unit = {
-    val msg = Reporter.explanation(msg0)
+    val msg = {
+      val (main, explanation) = Reporter.splitExplanation(msg0)
+      val text =
+        if (explanation.hasNext) {
+          val suffix  = explanation.mkString("\n")
+          val explain = boringExplanations.add(suffix)
+          if (explain) (main ++ Iterator(suffix)) else main
+        } else {
+          main
+        }
+      text.mkString("\n")
+    }
     if ((posIn eq null) || (posIn.source eq NoSourceFile)) printMessage(msg)
     else if (posIn.source.file.name == "<console>" && posIn.line == 1) {
       // If there's only one line of input, and it's already printed on the console (as indicated by the position's source file name),

--- a/src/repl/scala/tools/nsc/interpreter/ReplGlobal.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplGlobal.scala
@@ -34,6 +34,16 @@ trait ReplGlobal extends Global {
     new AbstractFileClassLoader(virtualDirectory, loader) {}
   }
 
+  private var seenFeatureNames = Set.empty[String]
+
+  override def PerRunReporting = new PerRunReporting {
+    override def featureWarning(pos: Position, featureName: String, featureDesc: String, featureTrait: Symbol, construct: => String, required: Boolean, site: Symbol): Unit = {
+      if (seenFeatureNames(featureName)) featureReported(featureTrait)
+      else seenFeatureNames += featureName
+      super.featureWarning(pos, featureName, featureDesc, featureTrait, construct, required, site)
+    }
+  }
+
   override protected def computeInternalPhases(): Unit = {
     super.computeInternalPhases()
     addToPhasesSet(wrapperCleanup, "Remove unused values from import wrappers to avoid unwanted capture of non-serializable objects")

--- a/test/files/run/t10943.check
+++ b/test/files/run/t10943.check
@@ -1,0 +1,21 @@
+
+scala> class C extends Dynamic
+                       ^
+       error: extension of type scala.Dynamic needs to be enabled
+       by making the implicit value scala.language.dynamics visible.
+       This can be achieved by adding the import clause 'import scala.language.dynamics'
+       or by setting the compiler option -language:dynamics.
+       See the Scaladoc for value scala.language.dynamics for a discussion
+       why the feature needs to be explicitly enabled.
+
+scala> class C extends Dynamic
+                       ^
+       error: extension of type scala.Dynamic needs to be enabled
+       by making the implicit value scala.language.dynamics visible.
+
+scala> class C extends Dynamic
+                       ^
+       error: extension of type scala.Dynamic needs to be enabled
+       by making the implicit value scala.language.dynamics visible.
+
+scala> :quit

--- a/test/files/run/t10943.scala
+++ b/test/files/run/t10943.scala
@@ -1,0 +1,10 @@
+
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  def code = """
+    |class C extends Dynamic
+    |class C extends Dynamic
+    |class C extends Dynamic
+  """.stripMargin
+}


### PR DESCRIPTION
Fixes scala/bug#10943

Per-run reporting adds an extended explanation only once per feature warning.

REPL wants to warn once per resident session.

This PR hooks `featureWarning` to avoid multiple explanations, and also avoids repeated "extended explanations" in the reporter.