### PR TITLE
Fix range position for vars with default initializer

### DIFF
--- a/src/compiler/scala/reflect/quasiquotes/Parsers.scala
+++ b/src/compiler/scala/reflect/quasiquotes/Parsers.scala
@@ -98,9 +98,9 @@ trait Parsers { self: Quasiquotes =>
         override def makeFunctionTypeTree(argtpes: List[Tree], restpe: Tree): Tree = FunctionTypePlaceholder(argtpes, restpe)
 
         // make q"val (x: T) = rhs" be equivalent to q"val x: T = rhs" for sake of bug compatibility (scala/bug#8211)
-        override def makePatDef(mods: Modifiers, pat: Tree, rhs: Tree) = pat match {
-          case TuplePlaceholder(inParensPat :: Nil) => super.makePatDef(mods, inParensPat, rhs)
-          case _ => super.makePatDef(mods, pat, rhs)
+        override def makePatDef(mods: Modifiers, pat: Tree, rhs: Tree, rhsPos: Position) = pat match {
+          case TuplePlaceholder(inParensPat :: Nil) => super.makePatDef(mods, inParensPat, rhs, rhsPos)
+          case _ => super.makePatDef(mods, pat, rhs, rhsPos)
         }
       }
       import treeBuilder.{global => _, unit => _}

--- a/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
@@ -143,5 +143,6 @@ abstract class TreeBuilder {
     }
   }
 
-  def makePatDef(mods: Modifiers, pat: Tree, rhs: Tree) = gen.mkPatDef(mods, pat, rhs)
+  final def makePatDef(mods: Modifiers, pat: Tree, rhs: Tree): List[ValDef] = makePatDef(mods, pat, rhs, rhs.pos)
+  def makePatDef(mods: Modifiers, pat: Tree, rhs: Tree, rhsPos: Position) = gen.mkPatDef(mods, pat, rhs, rhsPos)
 }

--- a/test/files/run/position-val-def.check
+++ b/test/files/run/position-val-def.check
@@ -6,14 +6,14 @@ var x = 0
 
 val x, y = 0
 [NoPosition]{
-  [0:5]val x = [11]0;
+  [4]val x = [11]0;
   [7:12]val y = [11:12]0;
   [NoPosition]()
 }
 
 var x, y = 0
 [NoPosition]{
-  [0:5]var x = [11]0;
+  [4]var x = [11]0;
   [7:12]var y = [11:12]0;
   [NoPosition]()
 }

--- a/test/junit/scala/tools/nsc/parser/ParserTest.scala
+++ b/test/junit/scala/tools/nsc/parser/ParserTest.scala
@@ -3,6 +3,7 @@ package scala.tools.nsc.parser
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import org.junit.Assert._
 
 import scala.tools.testing.BytecodeTesting
 
@@ -28,5 +29,20 @@ class ParserTest extends BytecodeTesting{
     run.compileSources(newSourceFile(lfCode) :: Nil)
     assert(!reporter.hasErrors)
     run.compileSources(newSourceFile(crlfCode) :: Nil)
+  }
+
+  @Test
+  def rangePosOfDefaultInitializer_t12213(): Unit = {
+    val code =
+      """object Other { var x: Int = _; var y: Int = 42 }"""
+    import compiler._, global._
+    val run = new Run
+    run.compileSources(newSourceFile(code) :: Nil)
+    assert(!reporter.hasErrors)
+    val unit = run.units.toList.head
+    def codeOf(pos: Position) = new String(pos.source.content.slice(pos.start, pos.end))
+    val List(x, y) = unit.body.collect { case vd : ValDef => vd }.takeRight(2)
+    assertEquals("var y: Int = 42", codeOf(y.pos))
+    assertEquals("var x: Int", codeOf(x.pos)) // TODO fix parser to include `= _`
   }
 }

--- a/test/junit/scala/tools/nsc/parser/ParserTest.scala
+++ b/test/junit/scala/tools/nsc/parser/ParserTest.scala
@@ -43,6 +43,6 @@ class ParserTest extends BytecodeTesting{
     def codeOf(pos: Position) = new String(pos.source.content.slice(pos.start, pos.end))
     val List(x, y) = unit.body.collect { case vd : ValDef => vd }.takeRight(2)
     assertEquals("var y: Int = 42", codeOf(y.pos))
-    assertEquals("var x: Int", codeOf(x.pos)) // TODO fix parser to include `= _`
+    assertEquals("var x: Int = _", codeOf(x.pos))
   }
 }

--- a/test/scalacheck/scala/reflect/quasiquotes/DefinitionConstructionProps.scala
+++ b/test/scalacheck/scala/reflect/quasiquotes/DefinitionConstructionProps.scala
@@ -12,8 +12,10 @@ object DefinitionConstructionProps
     with PatDefConstruction
     with DefConstruction
     with PackageConstruction
-    with ImportConstruction {
+    with ImportConstruction
+    with QuasiquoteSliceTypeTests
 
+trait QuasiquoteSliceTypeTests { self: QuasiquoteProperties =>
   val x: Tree = q"val x: Int"
   property("scala/bug#6842 a1") = test { assertEqAst(q"def f($x) = 0", "def f(x: Int) = 0") }
   property("scala/bug#6842 a2") = test { assertEqAst(q"class C($x)", "class C(val x: Int)") }
@@ -229,7 +231,7 @@ trait ValDefConstruction { self: QuasiquoteProperties =>
     q"var $name: $tpt = $rhs" ≈ ValDef(Modifiers(MUTABLE), name, tpt, rhs)
   }
 
-  // left tree is not a pattern due to Si-8211
+  // left tree is not a pattern due to scala/bug#8211
   property("scala/bug#8202") = test {
     assertEqAst(q"val (x: Int) = 1", "val x: Int = 1")
   }

--- a/test/scalacheck/scala/reflect/quasiquotes/QuasiquoteProperties.scala
+++ b/test/scalacheck/scala/reflect/quasiquotes/QuasiquoteProperties.scala
@@ -75,7 +75,13 @@ trait Helpers {
       assert(false, "exception wasn't thrown")
   }
 
-  def assertEqAst(tree: Tree, code: String) = assert(eqAst(tree, code))
+  def assertEqAst(tree: Tree, code: String) =
+    assert(eqAst(tree, code),
+      s"""quasiquote tree != parse(code) tree
+         |quasiquote: $tree
+         |parse tree: ${parse(code)}
+         |code (str): $code""".stripMargin)
+
   def eqAst(tree: Tree, code: String) = tree ≈ parse(code)
 
   val toolbox = currentMirror.mkToolBox()


### PR DESCRIPTION
Pass the position of the RHS explicitly rather than using `rhs.pos` within
TreeBuilder, as that doesn't carry the position of the `_` represented by
the singleton tree `EmptyTree`.

Fixes scala/bug#12213