### PR TITLE
Fix and extend Array.apply varargs optimization

### DIFF
--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1601,6 +1601,7 @@ trait Definitions extends api.StandardDefinitions {
 
       lazy val Predef_implicitly   = getMemberMethod(PredefModule, nme.implicitly)
       lazy val Predef_wrapRefArray = getMemberMethod(PredefModule, nme.wrapRefArray)
+      lazy val Predef_genericWrapRefArray = getMemberMethod(PredefModule, nme.genericWrapArray)
       lazy val Predef_???          = DefinitionsClass.this.Predef_???
 
       lazy val arrayApplyMethod       = getMemberMethod(ScalaRunTimeModule, nme.array_apply)

--- a/test/files/instrumented/t11882a.check
+++ b/test/files/instrumented/t11882a.check
@@ -1,0 +1,8 @@
+Method call statistics:
+    1  OptimusSeq$.apply1(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lscala/reflect/ClassTag;)LOptimusSeq;
+    1  OptimusSeq$.unsafeFromAnyArray1([Ljava/lang/Object;)LOptimusSeq;
+    1  Test$.doIt$1()LOptimusSeq;
+    1  scala/reflect/ClassTag$.AnyRef()Lscala/reflect/ClassTag;
+    1  scala/reflect/ManifestFactory$ObjectManifest.newArray(I)Ljava/lang/Object;
+    1  scala/reflect/ManifestFactory$ObjectManifest.newArray(I)[Ljava/lang/Object;
+    4  scala/runtime/ScalaRunTime$.array_update(Ljava/lang/Object;ILjava/lang/Object;)V

--- a/test/files/instrumented/t11882a.scala
+++ b/test/files/instrumented/t11882a.scala
@@ -1,0 +1,23 @@
+import scala.reflect.ClassTag
+import scala.tools.partest.instrumented._
+import scala.tools.partest.instrumented.Instrumentation._
+
+class OptimusSeq[T]
+
+object OptimusSeq {
+  private def unsafeFromAnyArray1[T <: AnyRef](ts: Array[T]): OptimusSeq[T] = null;
+  def apply1[T <: AnyRef : ClassTag](p1: T, p2: T, p3: T, p4: T): OptimusSeq[T] = {
+    unsafeFromAnyArray1(Array(p1, p2, p3, p4))
+  }
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    def doIt = OptimusSeq.apply1[AnyRef](null, null, null, null)
+    doIt
+    startProfiling()
+    doIt
+    stopProfiling()
+    printStatistics()
+  }
+}

--- a/test/files/instrumented/t11882b.check
+++ b/test/files/instrumented/t11882b.check
@@ -1,0 +1,8 @@
+Method call statistics:
+    1  OptimusSeq$.apply1(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lscala/reflect/ClassTag;)LOptimusSeq;
+    1  OptimusSeq$.unsafeFromAnyArray1(Ljava/lang/Object;)LOptimusSeq;
+    1  Test$.doIt$1()LOptimusSeq;
+    1  scala/reflect/ClassTag$.AnyRef()Lscala/reflect/ClassTag;
+    1  scala/reflect/ManifestFactory$ObjectManifest.newArray(I)Ljava/lang/Object;
+    1  scala/reflect/ManifestFactory$ObjectManifest.newArray(I)[Ljava/lang/Object;
+    4  scala/runtime/ScalaRunTime$.array_update(Ljava/lang/Object;ILjava/lang/Object;)V

--- a/test/files/instrumented/t11882b.scala
+++ b/test/files/instrumented/t11882b.scala
@@ -1,0 +1,23 @@
+import scala.reflect.ClassTag
+import scala.tools.partest.instrumented._
+import scala.tools.partest.instrumented.Instrumentation._
+
+class OptimusSeq[T]
+
+object OptimusSeq {
+  private def unsafeFromAnyArray1[T](ts: Array[T]): OptimusSeq[T] = null;
+  def apply1[T : ClassTag](p1: T, p2: T, p3: T, p4: T): OptimusSeq[T] = {
+    unsafeFromAnyArray1(Array(p1, p2, p3, p4))
+  }
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    def doIt = OptimusSeq.apply1[AnyRef](null, null, null, null)
+    doIt
+    startProfiling()
+    doIt
+    stopProfiling()
+    printStatistics()
+  }
+}

--- a/test/files/instrumented/t11882c.check
+++ b/test/files/instrumented/t11882c.check
@@ -1,0 +1,2 @@
+Method call statistics:
+    1  Test$.doIt$1()[Ljava/lang/String;

--- a/test/files/instrumented/t11882c.scala
+++ b/test/files/instrumented/t11882c.scala
@@ -1,0 +1,14 @@
+import scala.reflect.ClassTag
+import scala.tools.partest.instrumented._
+import scala.tools.partest.instrumented.Instrumentation._
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    def doIt = Array[String](null, null, null, null)
+    doIt
+    startProfiling()
+    doIt
+    stopProfiling()
+    printStatistics()
+  }
+}

--- a/test/files/run/t11882-class-cast.scala
+++ b/test/files/run/t11882-class-cast.scala
@@ -1,0 +1,8 @@
+object Test {
+  def test[T <: AnyRef: reflect.ClassTag](t: T) = Array(t)
+  def main(args: Array[String]): Unit = {
+    // was: java.lang.ClassCastException: [Ljava.lang.Object; cannot be cast to [Ljava.lang.String;
+    val x: Array[String] = test[String]("x")
+    assert(x(0) == "x")
+  }
+}


### PR DESCRIPTION
The existing optimization for `Array.apply[T]` overreaches by assuming that the `ArrayValue` carrying the varargs will have the same element type as the implicit class tag. However, this is not the case when the type argument is a generic type:

```
scala> def foo[T <: AnyRef : reflect.ClassTag](t: T) = Array.apply[T](t); foo[String]("")
java.lang.ClassCastException: [Ljava.lang.Object; cannot be cast to [Ljava.lang.String;
  ... 32 elided
```

This PR limits the existing optimization to cases where:

  - The class tag is an implicit arg
  - The class tag is materialized (not found via normal implicit search)

The second criterion excludes the call above.

A new, fallback optimization is provided that avoids a temporary
array and collection wrapper by emitting:

```
val arr = classTag.newArray(N)
ScalaRunTime.arrayUpdate(arr, N, elemN)
...
arr
```


Fixes scala/bug#11882