### PR TITLE
TASTy reader: add support for Scala 3.0.0-M2

### DIFF
--- a/project/DottySupport.scala
+++ b/project/DottySupport.scala
@@ -12,8 +12,8 @@ import sbt.librarymanagement.{
   * Settings to support validation of TastyUnpickler against the release of dotty with the matching TASTy version
   */
 object TastySupport {
-  val supportedTASTyRelease = "3.0.0-M1-bin-20201026-ac4e29d-NIGHTLY" // TASTy version 24
-  val scala3Compiler = "org.scala-lang" % "scala3-compiler_3.0.0-M1" % supportedTASTyRelease
+  val supportedTASTyRelease = "3.0.0-M2" // TASTy version 25.1
+  val scala3Compiler = "org.scala-lang" % "scala3-compiler_3.0.0-M2" % supportedTASTyRelease
 }
 
 /** Settings needed to compile with Dotty,

--- a/src/compiler/scala/tools/nsc/tasty/bridge/AnnotationOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/AnnotationOps.scala
@@ -50,7 +50,7 @@ trait AnnotationOps { self: TastyUniverse =>
         ctx.log(s"annotation on $annotee: $atree")
         val annot = mkAnnotation(atree)
         val annotSym = annot.tpe.typeSymbol
-        if ((annotSym eq defn.AlphaAnnotationClass) || (annotSym eq defn.StaticMethodAnnotationClass)) {
+        if ((annotSym eq defn.TargetNameAnnotationClass) || (annotSym eq defn.StaticMethodAnnotationClass)) {
           annotee.addAnnotation(
             u.definitions.CompileTimeOnlyAttr,
             u.Literal(u.Constant(unsupportedMessage(s"annotation on $annotee: @$annot"))))

--- a/src/compiler/scala/tools/nsc/tasty/bridge/FlagOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/FlagOps.scala
@@ -24,7 +24,7 @@ trait FlagOps { self: TastyUniverse =>
 
   object FlagSets {
     val TastyOnlyFlags: TastyFlagSet = (
-      Erased | Internal | Inline | InlineProxy | Opaque | Extension | Given | Exported | SuperTrait | Enum
+      Erased | Internal | Inline | InlineProxy | Opaque | Extension | Given | Exported | Transparent | Enum | Infix
       | Open | ParamAlias
     )
     val TermParamOrAccessor: TastyFlagSet = Param | ParamSetter
@@ -75,21 +75,22 @@ trait FlagOps { self: TastyUniverse =>
   def showTasty(flags: TastyFlagSet): String = { // keep up to date with with FlagSets.TastyOnlyFlags
     val tflags = flags & FlagSets.TastyOnlyFlags
     if (!tflags) "EmptyTastyFlags"
-    else (tflags).toSingletonSets.map { f =>
-      (f: @unchecked) match {
-        case Erased      => "erased"
-        case Internal    => "<internal>"
-        case Inline      => "inline"
-        case InlineProxy => "<inlineproxy>"
-        case Opaque      => "opaque"
-        case Extension   => "<extension>"
-        case Given       => "given"
-        case Exported    => "<exported>"
-        case SuperTrait  => "<supertrait>"
-        case Enum        => "enum"
-        case Open        => "open"
-        case ParamAlias  => "<paramalias>"
-      }
-    } mkString(" | ")
+    else {
+      val sb = collection.mutable.ArrayBuffer.empty[String]
+      if (flags.is(Erased))      sb += "erased"
+      if (flags.is(Internal))    sb += "<internal>"
+      if (flags.is(Inline))      sb += "inline"
+      if (flags.is(InlineProxy)) sb += "<inlineproxy>"
+      if (flags.is(Opaque))      sb += "opaque"
+      if (flags.is(Extension))   sb += "<extension>"
+      if (flags.is(Given))       sb += "given"
+      if (flags.is(Exported))    sb += "<exported>"
+      if (flags.is(Transparent)) sb += "transparent"
+      if (flags.is(Enum))        sb += "enum"
+      if (flags.is(Open))        sb += "open"
+      if (flags.is(ParamAlias))  sb += "<paramalias>"
+      if (flags.is(Infix))       sb += "infix"
+      sb.mkString(" | ")
+    }
   }
 }

--- a/src/compiler/scala/tools/nsc/tasty/bridge/TypeOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/TypeOps.scala
@@ -77,7 +77,7 @@ trait TypeOps { self: TastyUniverse =>
 
     final val ChildAnnot: Symbol = u.definitions.ChildAnnotationClass
     final val RepeatedAnnot: Symbol = u.definitions.RepeatedAnnotationClass
-    final val AlphaAnnotationClass: Symbol = u.definitions.AlphaAnnotationClass
+    final val TargetNameAnnotationClass: Symbol = u.definitions.TargetNameAnnotationClass
     final val StaticMethodAnnotationClass: Symbol = u.definitions.StaticMethodAnnotationClass
 
     object PolyFunctionType {

--- a/src/compiler/scala/tools/tasty/TastyFlags.scala
+++ b/src/compiler/scala/tools/tasty/TastyFlags.scala
@@ -55,10 +55,11 @@ object TastyFlags {
   final val Given                 = Extension.next
   final val Exported              = Given.next
   final val Macro                 = Exported.next
-  final val SuperTrait            = Macro.next
-  final val Enum                  = SuperTrait.next
+  final val Transparent           = Macro.next
+  final val Enum                  = Transparent.next
   final val Open                  = Enum.next
   final val ParamAlias            = Open.next
+  final val Infix                 = ParamAlias.next
 
   private[TastyFlags] final val maxFlag: Long = ParamAlias.shift
 
@@ -80,7 +81,6 @@ object TastyFlags {
       TastyFlagSet(1L << shift)
     }
 
-    def toSingletonSets: SingletonSets                        = SingletonSets(toLong)
     def |(other: TastyFlagSet): TastyFlagSet                  = TastyFlagSet(toLong | other.toLong)
     def &(mask: TastyFlagSet): TastyFlagSet                   = TastyFlagSet(toLong & mask.toLong)
     def &~(mask: TastyFlagSet): TastyFlagSet                  = TastyFlagSet(toLong & ~mask.toLong)
@@ -96,50 +96,49 @@ object TastyFlags {
         "EmptyTastyFlags"
       }
       else {
-        toSingletonSets.map { f =>
-          (f: @unchecked) match {
-            case Private => "Private"
-            case Protected => "Protected"
-            case AbsOverride => "AbsOverride"
-            case Abstract => "Abstract"
-            case Final => "Final"
-            case Sealed => "Sealed"
-            case Case => "Case"
-            case Implicit => "Implicit"
-            case Lazy => "Lazy"
-            case Override => "Override"
-            case Static => "Static"
-            case Object => "Object"
-            case Trait => "Trait"
-            case Local => "Local"
-            case Synthetic => "Synthetic"
-            case Artifact => "Artifact"
-            case Mutable => "Mutable"
-            case FieldAccessor => "FieldAccessor"
-            case CaseAccessor => "CaseAccessor"
-            case Covariant => "Covariant"
-            case Contravariant => "Contravariant"
-            case HasDefault => "HasDefault"
-            case Stable => "Stable"
-            case ParamSetter => "ParamSetter"
-            case Param => "Param"
-            case Deferred => "Deferred"
-            case Method => "Method"
-            case Erased => "Erased"
-            case Internal => "Internal"
-            case Inline => "Inline"
-            case InlineProxy => "InlineProxy"
-            case Opaque => "Opaque"
-            case Extension => "Extension"
-            case Given => "Given"
-            case Exported => "Exported"
-            case Macro => "Macro"
-            case SuperTrait => "SuperTrait"
-            case Enum => "Enum"
-            case Open => "Open"
-            case ParamAlias => "ParamAlias"
-          }
-        } mkString(" | ")
+        val sb = collection.mutable.ArrayBuffer.empty[String]
+        if (is(Private))       sb += "Private"
+        if (is(Protected))     sb += "Protected"
+        if (is(AbsOverride))   sb += "AbsOverride"
+        if (is(Abstract))      sb += "Abstract"
+        if (is(Final))         sb += "Final"
+        if (is(Sealed))        sb += "Sealed"
+        if (is(Case))          sb += "Case"
+        if (is(Implicit))      sb += "Implicit"
+        if (is(Lazy))          sb += "Lazy"
+        if (is(Override))      sb += "Override"
+        if (is(Static))        sb += "Static"
+        if (is(Object))        sb += "Object"
+        if (is(Trait))         sb += "Trait"
+        if (is(Local))         sb += "Local"
+        if (is(Synthetic))     sb += "Synthetic"
+        if (is(Artifact))      sb += "Artifact"
+        if (is(Mutable))       sb += "Mutable"
+        if (is(FieldAccessor)) sb += "FieldAccessor"
+        if (is(CaseAccessor))  sb += "CaseAccessor"
+        if (is(Covariant))     sb += "Covariant"
+        if (is(Contravariant)) sb += "Contravariant"
+        if (is(HasDefault))    sb += "HasDefault"
+        if (is(Stable))        sb += "Stable"
+        if (is(ParamSetter))   sb += "ParamSetter"
+        if (is(Param))         sb += "Param"
+        if (is(Deferred))      sb += "Deferred"
+        if (is(Method))        sb += "Method"
+        if (is(Erased))        sb += "Erased"
+        if (is(Internal))      sb += "Internal"
+        if (is(Inline))        sb += "Inline"
+        if (is(InlineProxy))   sb += "InlineProxy"
+        if (is(Opaque))        sb += "Opaque"
+        if (is(Extension))     sb += "Extension"
+        if (is(Given))         sb += "Given"
+        if (is(Exported))      sb += "Exported"
+        if (is(Macro))         sb += "Macro"
+        if (is(Transparent))   sb += "Transparent"
+        if (is(Enum))          sb += "Enum"
+        if (is(Open))          sb += "Open"
+        if (is(ParamAlias))    sb += "ParamAlias"
+        if (is(Infix))         sb += "Infix"
+        sb.mkString(" | ")
       }
     }
   }

--- a/src/compiler/scala/tools/tasty/TastyFormat.scala
+++ b/src/compiler/scala/tools/tasty/TastyFormat.scala
@@ -15,8 +15,12 @@ package scala.tools.tasty
 object TastyFormat {
 
   final val header: Array[Int] = Array(0x5C, 0xA1, 0xAB, 0x1F)
-  val MajorVersion: Int = 24
-  val MinorVersion: Int = 0
+  val MajorVersion: Int = 25
+  val MinorVersion: Int = 1
+
+  final val ASTsSection = "ASTs"
+  final val PositionsSection = "Positions"
+  final val CommentsSection = "Comments"
 
   /** Tags used to serialize names */
   class NameTags {
@@ -44,6 +48,9 @@ object TastyFormat {
                                   // body of an inline method
 
     final val OBJECTCLASS = 23    // The name of an object class (or: module class) `<name>$`.
+
+    final val TARGETSIGNED = 62   // A triple of a name, a targetname and a signature, used to identify
+                                  // possibly overloaded methods that carry a @targetName annotation.
 
     final val SIGNED = 63         // A pair of a name and a signature, used to identify
                                   // possibly overloaded methods.
@@ -98,7 +105,8 @@ object TastyFormat {
   final val OPEN = 40
   final val PARAMEND = 41
   final val PARAMalias = 42
-  final val SUPERTRAIT = 43
+  final val TRANSPARENT = 43
+  final val INFIX = 44
 
   // Cat. 2:    tag Nat
 
@@ -202,6 +210,7 @@ object TastyFormat {
 
   final val MATCHtype = 190
   final val MATCHtpt = 191
+  final val MATCHCASEtype = 192
 
   final val HOLE = 255
 
@@ -212,7 +221,7 @@ object TastyFormat {
 
   /** Useful for debugging */
   def isLegalTag(tag: Int): Boolean =
-    firstSimpleTreeTag <= tag && tag <= SUPERTRAIT ||
+    firstSimpleTreeTag <= tag && tag <= INFIX ||
     firstNatTreeTag <= tag && tag <= RENAMED ||
     firstASTTreeTag <= tag && tag <= BOUNDED ||
     firstNatASTTreeTag <= tag && tag <= NAMEDARG ||
@@ -241,7 +250,8 @@ object TastyFormat {
        | STATIC
        | OBJECT
        | TRAIT
-       | SUPERTRAIT
+       | TRANSPARENT
+       | INFIX
        | ENUM
        | LOCAL
        | SYNTHETIC
@@ -303,7 +313,8 @@ object TastyFormat {
     case OBJECT => "OBJECT"
     case TRAIT => "TRAIT"
     case ENUM => "ENUM"
-    case SUPERTRAIT => "SUPERTRAIT"
+    case TRANSPARENT => "TRANSPARENT"
+    case INFIX => "INFIX"
     case LOCAL => "LOCAL"
     case SYNTHETIC => "SYNTHETIC"
     case ARTIFACT => "ARTIFACT"
@@ -409,6 +420,7 @@ object TastyFormat {
     case TYPELAMBDAtype => "TYPELAMBDAtype"
     case LAMBDAtpt => "LAMBDAtpt"
     case MATCHtype => "MATCHtype"
+    case MATCHCASEtype => "MATCHCASEtype"
     case MATCHtpt => "MATCHtpt"
     case PARAMtype => "PARAMtype"
     case ANNOTATION => "ANNOTATION"

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1315,7 +1315,7 @@ trait Definitions extends api.StandardDefinitions {
     // Tasty Unpickling Helpers - only access when Scala 3 library is expected to be available
     lazy val ChildAnnotationClass        = getClassIfDefined("scala.annotation.internal.Child")
     lazy val RepeatedAnnotationClass     = getClassIfDefined("scala.annotation.internal.Repeated")
-    lazy val AlphaAnnotationClass        = getClassIfDefined("scala.annotation.alpha")
+    lazy val TargetNameAnnotationClass   = getClassIfDefined("scala.annotation.targetName")
     lazy val StaticMethodAnnotationClass = getClassIfDefined("scala.annotation.static")
     lazy val PolyFunctionClass           = getClassIfDefined("scala.PolyFunction")
 

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -435,7 +435,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.uncheckedVarianceClass
     definitions.ChildAnnotationClass
     definitions.RepeatedAnnotationClass
-    definitions.AlphaAnnotationClass
+    definitions.TargetNameAnnotationClass
     definitions.StaticMethodAnnotationClass
     definitions.PolyFunctionClass
     definitions.BeanPropertyAttr

--- a/test/tasty/neg-move-macros/src-3/MacroCompat.scala
+++ b/test/tasty/neg-move-macros/src-3/MacroCompat.scala
@@ -13,10 +13,11 @@ object MacroCompat {
   object Macros3 {
     import quoted._
 
-    def posImpl(using qctx: QuoteContext): Expr[Position] = {
-      import qctx.reflect.given
-      val name = qctx.reflect.rootPosition.sourceFile.jpath.getFileName.toString
-      val line = qctx.reflect.rootPosition.startLine + 1
+    def posImpl(using quotes: Quotes): Expr[Position] = {
+      import quotes.reflect.given
+      val pos = quotes.reflect.Position.ofMacroExpansion
+      val name = pos.sourceFile.jpath.getFileName.toString
+      val line = pos.startLine + 1
       '{ Position(${Expr(name)}, ${Expr(line)}) }
     }
   }

--- a/test/tasty/neg/src-2/TestAlphaAnnot.check
+++ b/test/tasty/neg/src-2/TestAlphaAnnot.check
@@ -1,4 +1,0 @@
-TestAlphaAnnot_fail.scala:4: error: Unsupported Scala 3 annotation on method ++: @scala.annotation.alpha("doubleplus"); found in object tastytest.AlphaAnnot.
-  def test1 = AlphaAnnot.++  // error
-                         ^
-1 error

--- a/test/tasty/neg/src-2/TestAlphaAnnot_fail.scala
+++ b/test/tasty/neg/src-2/TestAlphaAnnot_fail.scala
@@ -1,6 +1,0 @@
-package tastytest
-
-object TestAlphaAnnot {
-  def test1 = AlphaAnnot.++  // error
-  def test2 = AlphaAnnot.foo // ok
-}

--- a/test/tasty/neg/src-2/TestCompiletimeQuoteType.check
+++ b/test/tasty/neg/src-2/TestCompiletimeQuoteType.check
@@ -1,4 +1,4 @@
-TestCompiletimeQuoteType_fail.scala:4: error: Unsupported Scala 3 context function type in result: scala.quoted.QuoteContext ?=> scala.quoted.Type[T]; found in method apply in object scala.quoted.Type.
+TestCompiletimeQuoteType_fail.scala:4: error: Unsupported Scala 3 context function type in result: scala.quoted.Quotes ?=> scala.quoted.Type[T]; found in method of in object scala.quoted.Type.
   def test = CompiletimeQuoteType.f[Int]
                                    ^
 1 error

--- a/test/tasty/neg/src-2/TestIntent.check
+++ b/test/tasty/neg/src-2/TestIntent.check
@@ -1,7 +1,7 @@
 TestIntent_fail.scala:6: error: Unsupported Scala 3 inline macro method here; found in object tastytest.intent.Position.
-  extension_apply("3 + 3") {
-                           ^
+  apply("3 + 3") {
+                 ^
 TestIntent_fail.scala:7: error: could not find implicit value for parameter pos: tastytest.intent.Position
-    extension_in("should be 6")(extension_toEqual(expect(3 + 3))(6))
-                               ^
+    in("should be 6")(toEqual(expect(3 + 3))(6))
+                     ^
 2 errors

--- a/test/tasty/neg/src-2/TestIntent_fail.scala
+++ b/test/tasty/neg/src-2/TestIntent_fail.scala
@@ -3,7 +3,7 @@ package tastytest
 import intent._
 
 class TestIntent extends TestSuite with Stateless {
-  extension_apply("3 + 3") {
-    extension_in("should be 6")(extension_toEqual(expect(3 + 3))(6))
+  apply("3 + 3") {
+    in("should be 6")(toEqual(expect(3 + 3))(6))
   }
 }

--- a/test/tasty/neg/src-2/TestSelectWithTarget.check
+++ b/test/tasty/neg/src-2/TestSelectWithTarget.check
@@ -1,0 +1,4 @@
+TestSelectWithTarget_fail.scala:10: error: Unsupported Scala 3 selection of method foo with @targetName("fooString"); found in method selectFooString in object tastytest.SelectWithTarget.
+  def test = SelectWithTarget.selectFooString
+                              ^
+1 error

--- a/test/tasty/neg/src-2/TestSelectWithTarget_fail.scala
+++ b/test/tasty/neg/src-2/TestSelectWithTarget_fail.scala
@@ -1,0 +1,12 @@
+package tastytest
+
+object TestSelectWithTarget {
+
+  // We error when an annotation selects a
+  // method overloaded with a targetAnnot
+  // until we can erase them correctly.
+  // e.g. the annotation arguments may be
+  // reflected by a macro into real trees
+  def test = SelectWithTarget.selectFooString
+
+}

--- a/test/tasty/neg/src-2/TestTargetNameAnnot.check
+++ b/test/tasty/neg/src-2/TestTargetNameAnnot.check
@@ -1,0 +1,4 @@
+TestTargetNameAnnot_fail.scala:4: error: Unsupported Scala 3 annotation on method ++: @scala.annotation.targetName("doubleplus"); found in object tastytest.TargetNameAnnot.
+  def test1 = TargetNameAnnot.++  // error
+                              ^
+1 error

--- a/test/tasty/neg/src-2/TestTargetNameAnnot_fail.scala
+++ b/test/tasty/neg/src-2/TestTargetNameAnnot_fail.scala
@@ -1,0 +1,6 @@
+package tastytest
+
+object TestTargetNameAnnot {
+  def test1 = TargetNameAnnot.++  // error
+  def test2 = TargetNameAnnot.foo // ok
+}

--- a/test/tasty/neg/src-3/AlphaAnnot.scala
+++ b/test/tasty/neg/src-3/AlphaAnnot.scala
@@ -1,9 +1,0 @@
-package tastytest
-
-object AlphaAnnot {
-
-  @annotation.alpha("doubleplus") def ++ : Unit = println("++")
-
-  def foo = 23
-
-}

--- a/test/tasty/neg/src-3/CompiletimeQuoteType.scala
+++ b/test/tasty/neg/src-3/CompiletimeQuoteType.scala
@@ -3,7 +3,7 @@ package tastytest
 import scala.quoted._
 
 object CompiletimeQuoteType {
-  def f[T: Type](using QuoteContext) = {
+  def f[T: Type](using Quotes) = {
     implicitly[Type[List[T]]]
   }
 }

--- a/test/tasty/neg/src-3/SelectWithTarget.scala
+++ b/test/tasty/neg/src-3/SelectWithTarget.scala
@@ -1,0 +1,22 @@
+package tastytest
+
+import scala.annotation.{StaticAnnotation, targetName}
+
+object SelectWithTarget {
+
+  class defAnnot(arg: Any) extends StaticAnnotation
+
+  @defAnnot(Overloads.foo("hi"))
+  def selectFooString: Int = 23
+
+  object Overloads {
+
+    @targetName("fooString")
+    def foo(t: => String): Int = t.length
+
+    @targetName("fooInt")
+    def foo(t: => Int): Int = t
+
+  }
+
+}

--- a/test/tasty/neg/src-3/TargetNameAnnot.scala
+++ b/test/tasty/neg/src-3/TargetNameAnnot.scala
@@ -1,0 +1,9 @@
+package tastytest
+
+object TargetNameAnnot {
+
+  @annotation.targetName("doubleplus") def ++ : Unit = println("++")
+
+  def foo = 23
+
+}

--- a/test/tasty/neg/src-3/intent/Position.scala
+++ b/test/tasty/neg/src-3/intent/Position.scala
@@ -27,5 +27,5 @@ object Position:
 
   implicit inline def here: Position = ${ genPosition }
 
-  private def genPosition(implicit qctx: QuoteContext): Expr[Position] =
+  private def genPosition(implicit q: Quotes): Expr[Position] =
     '{ ??? }

--- a/test/tasty/pos/src-2/tastytest/TestInfix.scala
+++ b/test/tasty/pos/src-2/tastytest/TestInfix.scala
@@ -1,0 +1,12 @@
+package tastytest
+
+import Infix.BoxedInt
+
+object TestInfix {
+
+  val x = BoxedInt(0)
+  val y = BoxedInt(2)
+
+  def test = assert((x min y) == x)
+
+}

--- a/test/tasty/pos/src-3/tastytest/Infix.scala
+++ b/test/tasty/pos/src-3/tastytest/Infix.scala
@@ -1,0 +1,13 @@
+package tastytest
+
+object Infix {
+
+  final case class BoxedInt(toInt: Int) {
+
+    infix def min (that: BoxedInt): BoxedInt =
+      if toInt.min(that.toInt) == toInt then this
+      else that
+
+  }
+
+}

--- a/test/tasty/run/src-2/tastytest/TestFunctor.scala
+++ b/test/tasty/run/src-2/tastytest/TestFunctor.scala
@@ -3,20 +3,20 @@ package tastytest
 object TestFunctor extends Suite("TestFunctor") {
 
   implicit object ListFunctor extends Functor[List] {
-    def extension_map[A, B](fa: List[A])(f: A => B): List[B] = fa.map(f)
+    def map[A, B](fa: List[A])(f: A => B): List[B] = fa.map(f)
   }
 
   implicit object ListFunctorI extends FunctorI[List] {
-    def extension_map[A, B](fa: List[A])(f: A => B): List[B] = fa.map(f)
+    def map[A, B](fa: List[A])(f: A => B): List[B] = fa.map(f)
   }
 
   implicit object ListFunctorL extends FunctorL[List] {
-    def extension_map[A, B](fa: List[A])(f: A => B): List[B] = fa.map(f)
+    def map[A, B](fa: List[A])(f: A => B): List[B] = fa.map(f)
   }
 
-  def toStringOnFunctorL[F[X] <: List[X]: FunctorL, A](fa: F[A]): F[String] = implicitly[FunctorL[F]].extension_map(fa)(_.toString())
-  def toStringOnFunctor[F[_]: Functor, A](fa: F[A]): F[String]   = implicitly[Functor[F]].extension_map(fa)(_.toString())
-  def hashOnFunctorI[F[_]: FunctorI, A <: Int](fa: F[A]): F[Int] = implicitly[FunctorI[F]].extension_map(fa)(_.##)
+  def toStringOnFunctorL[F[X] <: List[X]: FunctorL, A](fa: F[A]): F[String] = implicitly[FunctorL[F]].map(fa)(_.toString())
+  def toStringOnFunctor[F[_]: Functor, A](fa: F[A]): F[String]   = implicitly[Functor[F]].map(fa)(_.toString())
+  def hashOnFunctorI[F[_]: FunctorI, A <: Int](fa: F[A]): F[Int] = implicitly[FunctorI[F]].map(fa)(_.##)
 
   test(assert(toStringOnFunctor(List(true,false)) === List("true","false")))
   test(assert(hashOnFunctorI(List(1,2)) === List(1,2)))

--- a/test/tasty/run/src-2/tastytest/TestMonad.scala
+++ b/test/tasty/run/src-2/tastytest/TestMonad.scala
@@ -4,12 +4,12 @@ object TestMonad extends Suite("TestMonad") {
 
   implicit object ListMonad extends Monad[List] {
     def pure[A](x: A): List[A] = x :: Nil
-    def extension_flatMap[A, B](fa: List[A])(f: A => List[B]): List[B] = fa.flatMap(f)
-    override def extension_map[A, B](fa: List[A])(f: A => B): List[B] = fa.map(f)
+    def flatMap[A, B](fa: List[A])(f: A => List[B]): List[B] = fa.flatMap(f)
+    override def map[A, B](fa: List[A])(f: A => B): List[B] = fa.map(f)
   }
 
   def pureToString[F[_], A](fa: F[A])(implicit F: Monad[F]): F[String] =
-    F.extension_flatMap(fa)(a => F.pure(a.toString))
+    F.flatMap(fa)(a => F.pure(a.toString))
 
   test(assert(pureToString(List(1,2,3)) === List("1","2","3")))
 

--- a/test/tasty/run/src-2/tastytest/TestReader.scala
+++ b/test/tasty/run/src-2/tastytest/TestReader.scala
@@ -5,7 +5,7 @@ object TestReader extends Suite("TestReader") {
   implicit def mkReaderMonad[Ctx]: Reader[Ctx] = new Reader[Ctx]() {}
 
   def pureToString[F[_], A](fa: F[A])(implicit F: Monad[F]): F[String] =
-    F.extension_flatMap(fa)(a => F.pure(a.toString))
+    F.flatMap(fa)(a => F.pure(a.toString))
 
   test {
     val f = pureToString((s: Unit) => 101)

--- a/test/tasty/run/src-2/tastytest/TestRefinements.scala
+++ b/test/tasty/run/src-2/tastytest/TestRefinements.scala
@@ -129,7 +129,7 @@ object TestRefinements extends Suite("TestRefinements") {
 
     def create: EncoderIntSel = {
       new Refinements.MethodSelectable(
-        method("encode", ClassTag.Int) { xs => xs.head.toString }
+        method("encode", classOf[Int]) { xs => xs.head.toString }
       ).asInstanceOf[EncoderIntSel]
     }
   }

--- a/test/tasty/run/src-2/tastytest/TestSymbollicEnums.scala
+++ b/test/tasty/run/src-2/tastytest/TestSymbollicEnums.scala
@@ -9,11 +9,11 @@ object TestSymbollicEnums extends Suite("TestSymbollicEnums") {
     val zero = 0L.lit
     val one  = 1L.lit
 
-    def extension_interpret(e: Expr[Long]): Long = e match {
+    def interpret(e: Expr[Long]): Long = e match {
       case Expr.Literal(x)      => x
       case Expr.Infix(op, l, r) => op match {
-        case Ops.+ => extension_interpret(l) + extension_interpret(r)
-        case Ops.* => extension_interpret(l) * extension_interpret(r)
+        case Ops.+ => interpret(l) + interpret(r)
+        case Ops.* => interpret(l) * interpret(r)
       }
     }
   }

--- a/test/tasty/run/src-3/tastytest/MacroCompat.scala
+++ b/test/tasty/run/src-3/tastytest/MacroCompat.scala
@@ -24,17 +24,18 @@ object MacroCompat {
   object Macros3 {
     import quoted._
 
-    def monoImpl(using QuoteContext) = '{1}
-    def polyImpl[T: Type](using QuoteContext) = Expr(summon[Type[T]].show)
+    def monoImpl(using Quotes) = '{1}
+    def polyImpl[T: Type](using quotes: Quotes) = Expr(quotes.reflect.TypeRepr.of[T].show)
 
-    def posImpl(using qctx: QuoteContext): Expr[Position] = {
-      import qctx.reflect.given
-      val name = qctx.reflect.rootPosition.sourceFile.jpath.getFileName.toString
-      val line = qctx.reflect.rootPosition.startLine + 1
+    def posImpl(using quotes: Quotes): Expr[Position] = {
+      import quotes.reflect.given
+      val pos = quotes.reflect.Position.ofMacroExpansion
+      val name = pos.sourceFile.jpath.getFileName.toString
+      val line = pos.startLine + 1
       '{ Position(${Expr(name)}, ${Expr(line)}) }
     }
 
-    def constIntImpl[T: Type](x: Expr[T])(using QuoteContext): Expr[Int] = '{1}
+    def constIntImpl[T: Type](x: Expr[T])(using Quotes): Expr[Int] = '{1}
 
   }
 

--- a/test/tasty/run/src-3/tastytest/Monad.scala
+++ b/test/tasty/run/src-3/tastytest/Monad.scala
@@ -4,6 +4,6 @@ trait Monad[F[_]] extends Functor[F] {
   def pure[A](x: A): F[A]
   extension [A, B](fa: F[A]) {
     def flatMap(f: A => F[B]): F[B]
-    def map (f: A => B) = extension_flatMap(fa)(f `andThen` pure)
+    def map (f: A => B) = flatMap(f `andThen` pure)
   }
 }

--- a/test/tasty/run/src-3/tastytest/Refinements.scala
+++ b/test/tasty/run/src-3/tastytest/Refinements.scala
@@ -178,15 +178,15 @@ object Refinements {
   extends scala.Selectable {
     private val map = methods.toMap
 
-    def applyDynamic(name: String, paramClasses: ClassTag[_]*)(args: Any*): Any =
+    def applyDynamic(name: String, paramClasses: Class[_]*)(args: Any*): Any =
       map.get(name, paramClasses) match
         case Some(f) => f(args)
         case None    => throw NoSuchMethodException(s"$name(${paramClasses.mkString(",")})")
 
   }
   object MethodSelectable {
-    type Method = ((String, Seq[ClassTag[_]]), Seq[Any] => Any)
-    def method(name: String, paramClasses: ClassTag[_]*)(impl: Seq[Any] => Any): Method =
+    type Method = ((String, Seq[Class[_]]), Seq[Any] => Any)
+    def method(name: String, paramClasses: Class[_]*)(impl: Seq[Any] => Any): Method =
       ((name, paramClasses), impl)
   }
 

--- a/test/tasty/run/src-3/tastytest/SuperOps.scala
+++ b/test/tasty/run/src-3/tastytest/SuperOps.scala
@@ -1,3 +1,3 @@
 package tastytest
 
-super trait SuperOps[Impl <: SuperOps[Impl]]
+transparent trait SuperOps[Impl <: SuperOps[Impl]]


### PR DESCRIPTION
- Drops support for `3.0.0-M1`

If we wanted to support both `3.0.0-M1` and `3.0.0-M2` that could be possible at least in this release, future releases of scala 3 may make more serious changes. If we did, I think in tastytest it would be simple enough to support versioned source directories, but mamaging the different scala 3 versions in classloaders would be more tricky

cc @sjrd 