### PR TITLE
Only look up the system prop controlling class tag caching once

### DIFF
--- a/src/library/scala/reflect/ClassTag.scala
+++ b/src/library/scala/reflect/ClassTag.scala
@@ -137,7 +137,7 @@ object ClassTag {
   val Nothing : ClassTag[scala.Nothing]    = Manifest.Nothing
   val Null    : ClassTag[scala.Null]       = Manifest.Null
 
-  private val cacheDisabledProp = scala.sys.Prop[String]("scala.reflect.classtag.cache.disable")
+  private val cacheDisabled = java.lang.Boolean.getBoolean("scala.reflect.classtag.cache.disable")
   private[this] object cache extends ClassValue[jWeakReference[ClassTag[_]]] {
     override def computeValue(runtimeClass: jClass[_]): jWeakReference[ClassTag[_]] =
       new jWeakReference(computeTag(runtimeClass))
@@ -173,9 +173,9 @@ object ClassTag {
   }
 
   def apply[T](runtimeClass1: jClass[_]): ClassTag[T] = {
-    if (cacheDisabledProp.isSet)
+    if (cacheDisabled) {
       cache.computeTag(runtimeClass1).asInstanceOf[ClassTag[T]]
-    else {
+    } else {
       val ref = cache.get(runtimeClass1).asInstanceOf[jWeakReference[ClassTag[T]]]
       var tag = ref.get
       if (tag == null) {


### PR DESCRIPTION
Fixes a performance regression in the opt-out mechanism I added to #9276 but neglected to benchmark.

Prior to this PR (with the perf regression)

```
[info] ClassTagBenchmark.lookupClassTag  avgt   20  257.807 ± 12.567  ns/op
```

This PR:

```
[info] Benchmark                         Mode  Cnt   Score   Error  Units
[info] ClassTagBenchmark.lookupClassTag  avgt   20  43.603 ± 0.728  ns/op
```

With the `if (cacheDiabled)` removed:

```
[info] Benchmark                         Mode  Cnt    Score    Error  Units
[info] ClassTagBenchmark.lookupClassTag  avgt   20  42.292 ± 0.789  ns/op
```

The extra `if (cacheDisabled)` now seems to have no significant performance cost, as we need.