### PR TITLE
Simpler SubstSymMap to leverage reusable instance

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
@@ -312,7 +312,7 @@ abstract class SymbolLoaders {
       }
     }
   }
-  private lazy val classFileDataReader: ReusableInstance[ReusableDataReader] = ReusableInstance[ReusableDataReader](new ReusableDataReader(), enabled = isCompilerUniverse)
+  private lazy val classFileDataReader: ReusableInstance[ReusableDataReader] = ReusableInstance[ReusableDataReader](new ReusableDataReader(), initialSize = 1, enabled = isCompilerUniverse)
   class ClassfileLoader(val classfile: AbstractFile, clazz: ClassSymbol, module: ModuleSymbol) extends SymbolLoader with FlagAssigningCompleter {
     private object classfileParser extends {
       val symbolTable: SymbolLoaders.this.symbolTable.type = SymbolLoaders.this.symbolTable

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -1439,11 +1439,10 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
                               to: List[Symbol],
                               targetClass: Symbol,
                               addressFields: Boolean) extends TreeSymSubstituter(from, to) {
-    override val symSubst = new SubstSymMap(from, to) {
-      override def matches(sym1: Symbol, sym2: Symbol) =
-        if (sym2.isTypeSkolem) sym2.deSkolemize eq sym1
-        else sym1 eq sym2
-    }
+    private def matcher(sym1: Symbol, sym2: Symbol) =
+      if (sym2.isTypeSkolem) sym2.deSkolemize eq sym1
+      else sym1 eq sym2
+    override val symSubst = SubstSymMap(from, to, matcher)
 
     private def isAccessible(sym: Symbol): Boolean =
       if (currentOwner.isAnonymousFunction) {

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -632,7 +632,7 @@ trait Namers extends MethodSynthesis {
       def assignParamTypes(copyDef: DefDef, sym: Symbol): Unit = {
         val clazz = sym.owner
         val constructorType = clazz.primaryConstructor.tpe
-        val subst = new SubstSymMap(clazz.typeParams, copyDef.tparams map (_.symbol))
+        val subst = SubstSymMap(clazz.typeParams, copyDef.tparams.map(_.symbol))
         val classParamss = constructorType.paramss
 
         foreach2(copyDef.vparamss, classParamss)((copyParams, classParams) =>

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -53,8 +53,8 @@ abstract class RefChecks extends Transform {
   def newTransformer(unit: CompilationUnit): RefCheckTransformer =
     new RefCheckTransformer(unit)
 
-  val toJavaRepeatedParam  = new SubstSymMap(RepeatedParamClass -> JavaRepeatedParamClass)
-  val toScalaRepeatedParam = new SubstSymMap(JavaRepeatedParamClass -> RepeatedParamClass)
+  val toJavaRepeatedParam  = SubstSymMap(RepeatedParamClass -> JavaRepeatedParamClass)
+  val toScalaRepeatedParam = SubstSymMap(JavaRepeatedParamClass -> RepeatedParamClass)
 
   def accessFlagsToString(sym: Symbol) = flagsToString(
     sym getFlag (PRIVATE | PROTECTED),

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -3771,7 +3771,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     }
 
   private[this] val cloneSymbolsSubstSymMap: ReusableInstance[SubstSymMap] =
-    ReusableInstance[SubstSymMap](SubstSymMap())
+    ReusableInstance[SubstSymMap](SubstSymMap(), enabled = isCompilerUniverse)
 
   def cloneSymbolsAtOwner(syms: List[Symbol], owner: Symbol): List[Symbol] =
     deriveSymbols(syms, _ cloneSymbol owner)

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -3696,7 +3696,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     if (syms.isEmpty) Nil
     else {
       val syms1 = mapList(syms)(symFn)
-      val map = new SubstSymMap(syms, syms1)
+      val map = SubstSymMap(syms, syms1)
       syms1.foreach(_.modifyInfo(map))
       syms1
     }
@@ -3763,15 +3763,15 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     if (syms.isEmpty) Nil
     else {
       val syms1 = mapList(syms)(_.cloneSymbol)
-      cloneSymbolsSubstSymMap.using { (msm: MutableSubstSymMap) =>
-        msm.reset(syms, syms1)
+      cloneSymbolsSubstSymMap.using { (msm: SubstSymMap) =>
+        msm.reload(syms, syms1)
         syms1.foreach(_.modifyInfo(msm))
       }
       syms1
     }
 
-  private[this] val cloneSymbolsSubstSymMap: ReusableInstance[MutableSubstSymMap] =
-    ReusableInstance[MutableSubstSymMap]( new MutableSubstSymMap())
+  private[this] val cloneSymbolsSubstSymMap: ReusableInstance[SubstSymMap] =
+    ReusableInstance[SubstSymMap](SubstSymMap())
 
   def cloneSymbolsAtOwner(syms: List[Symbol], owner: Symbol): List[Symbol] =
     deriveSymbols(syms, _ cloneSymbol owner)

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -1745,7 +1745,7 @@ trait Trees extends api.Trees {
 
   lazy val EmptyTreeTypeSubstituter = new TreeTypeSubstituter(List(), List())
 
-  class TreeSymSubstTraverser(val from: List[Symbol], val to: List[Symbol]) extends TypeMapTreeSubstituter(new SubstSymMap(from, to)) {
+  class TreeSymSubstTraverser(val from: List[Symbol], val to: List[Symbol]) extends TypeMapTreeSubstituter(SubstSymMap(from, to)) {
     override def toString() = "TreeSymSubstTraverser/" + substituterString("Symbol", "Symbol", from, to)
   }
 
@@ -1759,7 +1759,7 @@ trait Trees extends api.Trees {
    *  a symbol in `from` will have a new type assigned.
    */
   class TreeSymSubstituter(from: List[Symbol], to: List[Symbol]) extends InternalTransformer {
-    val symSubst = new SubstSymMap(from, to)
+    val symSubst = SubstSymMap(from, to)
     private[this] var mutatedSymbols: List[Symbol] = Nil
     override def transform(tree: Tree): Tree = {
       @tailrec

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4042,7 +4042,7 @@ trait Types
     refinedType(parents, owner, newScope, owner.pos)
 
   private[this] val copyRefinedTypeSSM: ReusableInstance[SubstSymMap] =
-    ReusableInstance[SubstSymMap](SubstSymMap())
+    ReusableInstance[SubstSymMap](SubstSymMap(), enabled = isCompilerUniverse)
 
   def copyRefinedType(original: RefinedType, parents: List[Type], decls: Scope) =
     if ((parents eq original.parents) && (decls eq original.decls)) original

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -754,7 +754,7 @@ trait Types
      */
     def substSym(from: List[Symbol], to: List[Symbol]): Type =
       if ((from eq to) || from.isEmpty) this
-      else new SubstSymMap(from, to) apply this
+      else SubstSymMap(from, to).apply(this)
 
     /** Substitute all occurrences of `ThisType(from)` in this type by `to`.
      *
@@ -4041,8 +4041,8 @@ trait Types
   def refinedType(parents: List[Type], owner: Symbol): Type =
     refinedType(parents, owner, newScope, owner.pos)
 
-  private[this] val copyRefinedTypeSSM: ReusableInstance[MutableSubstSymMap] =
-    ReusableInstance[MutableSubstSymMap](new MutableSubstSymMap())
+  private[this] val copyRefinedTypeSSM: ReusableInstance[SubstSymMap] =
+    ReusableInstance[SubstSymMap](SubstSymMap())
 
   def copyRefinedType(original: RefinedType, parents: List[Type], decls: Scope) =
     if ((parents eq original.parents) && (decls eq original.decls)) original
@@ -4058,8 +4058,8 @@ trait Types
         val syms2 = result.decls.toList
         val resultThis = result.typeSymbol.thisType
         val substThisMap = new SubstThisMap(original.typeSymbol, resultThis)
-        copyRefinedTypeSSM.using { (msm: MutableSubstSymMap) =>
-          msm.reset(syms1, syms2)
+        copyRefinedTypeSSM.using { (msm: SubstSymMap) =>
+          msm.reload(syms1, syms2)
           syms2.foreach(_.modifyInfo(info => msm.apply(substThisMap.apply(info))))
         }
       }

--- a/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
@@ -178,7 +178,7 @@ trait TypeComparers {
     sameLength(tparams1, tparams2) && {
     // corresponds does not check length of two sequences before checking the predicate,
     // but SubstMap assumes it has been checked (scala/bug#2956)
-      val substMap = new SubstSymMap(tparams2, tparams1)
+      val substMap = SubstSymMap(tparams2, tparams1)
       (
         (tparams1 corresponds tparams2)((p1, p2) => methodHigherOrderTypeParamsSameVariance(p1, p2) && p1.info =:= substMap(p2.info))
           && (res1 =:= substMap(res2))
@@ -357,8 +357,8 @@ trait TypeComparers {
       //@M for an example of why we need to generate fresh symbols otherwise, see neg/tcpoly_ticket2101.scala
       val substitutes = if (isMethod) tparams1 else cloneSymbols(tparams1)
 
-      val sub1: Type => Type = if (isMethod) (tp => tp) else new SubstSymMap(tparams1, substitutes)
-      val sub2: Type => Type = new SubstSymMap(tparams2, substitutes)
+      val sub1: Type => Type = if (isMethod) (tp => tp) else SubstSymMap(tparams1, substitutes)
+      val sub2: Type => Type = SubstSymMap(tparams2, substitutes)
 
       def cmp(p1: Symbol, p2: Symbol) = sub2(p2.info) <:< sub1(p1.info)
       (tparams1 corresponds tparams2)(cmp) && (sub1(res1) <:< sub2(res2))

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -204,6 +204,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.abstractTypesToBounds
     this.dropIllegalStarTypes
     this.wildcardExtrapolation
+    this.SubstSymMap
     this.IsDependentCollector
     this.ApproximateDependentMap
     this.identityTypeMap


### PR DESCRIPTION
Follow-up to (includes and supersedes) https://github.com/scala/scala/pull/9039

with an opinionated commit that simplifies the classes and just commits to mutable (instead of a forked hierarchy; there were vars anyway).