### PR TITLE
TastyReader: enable opaque types and erase correctly

### DIFF
--- a/src/compiler/scala/tools/nsc/tasty/TastyModes.scala
+++ b/src/compiler/scala/tools/nsc/tasty/TastyModes.scala
@@ -32,6 +32,8 @@ object TastyModes {
   final val ReadMacro: TastyMode = TastyMode(1 << 4)
   /** When not at the package scope */
   final val InnerScope: TastyMode = TastyMode(1 << 5)
+  /** When reading the tree of an Opaque type */
+  final val OpaqueTypeDef: TastyMode = TastyMode(1 << 6)
 
   /** The union of `IndexStats` and `InnerScope` */
   final val IndexScopedStats: TastyMode = IndexStats | InnerScope
@@ -55,6 +57,7 @@ object TastyModes {
         if (mode.is(IndexStats))     sb += "IndexStats"
         if (mode.is(ReadMacro))      sb += "ReadMacro"
         if (mode.is(InnerScope))     sb += "InnerScope"
+        if (mode.is(OpaqueTypeDef))  sb += "OpaqueTypeDef"
         sb.mkString(" | ")
       }
     }

--- a/src/compiler/scala/tools/nsc/tasty/TreeUnpickler.scala
+++ b/src/compiler/scala/tools/nsc/tasty/TreeUnpickler.scala
@@ -782,7 +782,7 @@ class TreeUnpickler[Tasty <: TastyUniverse](
               val info =
                 if (repr.originalFlagSet.is(Opaque)) {
                   val (info, alias) = defn.OpaqueTypeToBounds(rhs.tpe)
-                  sym.updateAttachment(new symbolTable.DottyOpaqueTypeAlias(alias))
+                  ctx.markAsOpaqueType(sym, alias)
                   info
                 }
                 else rhs.tpe

--- a/src/compiler/scala/tools/nsc/tasty/TreeUnpickler.scala
+++ b/src/compiler/scala/tools/nsc/tasty/TreeUnpickler.scala
@@ -768,8 +768,9 @@ class TreeUnpickler[Tasty <: TastyUniverse](
               else tpe
             )
           case TYPEDEF | TYPEPARAM =>
-            val allowedTypeFlags = Enum | Open | Exported | Infix
-            val allowedClassFlags = allowedTypeFlags | Opaque | Transparent
+            val allowedShared = Enum | Opaque | Infix
+            val allowedTypeFlags = allowedShared | Exported
+            val allowedClassFlags = allowedShared | Open | Transparent
             if (sym.isClass) {
               checkUnsupportedFlags(repr.tastyOnlyFlags &~ allowedClassFlags)
               sym.owner.ensureCompleted()
@@ -777,8 +778,15 @@ class TreeUnpickler[Tasty <: TastyUniverse](
             }
             else {
               checkUnsupportedFlags(repr.tastyOnlyFlags &~ allowedTypeFlags)
-              val rhs = readTpt()(localCtx)
-              ctx.setInfo(sym, defn.NormalisedBounds(rhs.tpe, sym))
+              val rhs = readTpt()(if (repr.originalFlagSet.is(Opaque)) localCtx.addMode(OpaqueTypeDef) else localCtx)
+              val info =
+                if (repr.originalFlagSet.is(Opaque)) {
+                  val (info, alias) = defn.OpaqueTypeToBounds(rhs.tpe)
+                  sym.updateAttachment(new symbolTable.DottyOpaqueTypeAlias(alias))
+                  info
+                }
+                else rhs.tpe
+              ctx.setInfo(sym, defn.NormalisedBounds(info, sym))
               if (sym.is(Param)) sym.reset(Private | Protected)
               // sym.resetFlag(Provisional)
             }
@@ -1007,9 +1015,19 @@ class TreeUnpickler[Tasty <: TastyUniverse](
             case LAMBDAtpt => tpd.LambdaTypeTree(readParams[NoCycle](TYPEPARAM).map(symFromNoCycle), readTpt())
             case MATCHtpt => matchTypeIsUnsupported
             case TYPEBOUNDStpt =>
-              val lo    = readTpt()
-              val hi    = if (currentAddr == end) lo else readTpt()
-              val alias = if (currentAddr == end) untpd.EmptyTree else readTpt()
+              val lo = readTpt()
+              val hi = if (currentAddr == end) lo else readTpt()
+
+              val alias = {
+                if (currentAddr == end) {
+                  untpd.EmptyTree
+                }
+                else {
+                  assert(ctx.mode.is(OpaqueTypeDef))
+                  readTpt()(ctx.retractMode(OpaqueTypeDef))
+                }
+              }
+
               tpd.TypeBoundsTree(lo, hi, alias)
             case BLOCK =>
               if (inParentCtor | ctx.mode.is(ReadMacro)) {

--- a/src/compiler/scala/tools/nsc/tasty/bridge/ContextOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/ContextOps.scala
@@ -430,6 +430,9 @@ trait ContextOps { self: TastyUniverse =>
     final def markAsEnumSingleton(sym: Symbol): Unit =
       sym.updateAttachment(new u.DottyEnumSingleton(sym.name.toString))
 
+    final def markAsOpaqueType(sym: Symbol, alias: Type): Unit =
+      sym.updateAttachment(new u.DottyOpaqueTypeAlias(alias))
+
     final def onCompletionError[T](sym: Symbol): PartialFunction[Throwable, T] = {
       case err: u.TypeError =>
         sym.info = u.ErrorType

--- a/src/compiler/scala/tools/nsc/tasty/bridge/TreeOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/TreeOps.scala
@@ -181,8 +181,11 @@ trait TreeOps { self: TastyUniverse =>
     }
 
     def TypeBoundsTree(lo: Tree, hi: Tree, alias: Tree): Tree = {
-      val _ = alias // ignore until we enable opaque types
-      u.TypeBoundsTree(lo, hi).setType(u.TypeBounds(lo.tpe, hi.tpe))
+      val tpe = alias match {
+        case untpd.EmptyTree => u.TypeBounds(lo.tpe, hi.tpe)
+        case alias           => new OpaqueTypeBounds(lo.tpe, hi.tpe, alias.tpe)
+      }
+      u.TypeBoundsTree(lo, hi).setType(tpe)
     }
   }
 

--- a/src/compiler/scala/tools/nsc/tasty/bridge/TypeOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/TypeOps.scala
@@ -104,6 +104,14 @@ trait TypeOps { self: TastyUniverse =>
     private[bridge] def CopyInfo(underlying: u.TermSymbol, originalFlagSet: TastyFlagSet): TastyRepr =
       new CopyCompleter(underlying, originalFlagSet)
 
+    def OpaqueTypeToBounds(tpe: Type): (Type, Type) = tpe match {
+      case tpe: OpaqueTypeBounds => (tpe, tpe.alias)
+
+      case _ =>
+        // An alias opaque type is defined as IDENTtpt with a simple type, so has no bounds
+        (u.TypeBounds.empty, tpe)
+
+    }
     def ByNameType(arg: Type): Type = u.definitions.byNameType(arg)
     def TypeBounds(lo: Type, hi: Type): Type = u.TypeBounds.apply(lo, hi)
     def SingleType(pre: Type, sym: Symbol): Type = u.singleType(pre, sym)
@@ -472,6 +480,8 @@ trait TypeOps { self: TastyUniverse =>
       case tpe               => u.TypeBounds.upper(tpe)
     }
   }
+
+  private[bridge] final class OpaqueTypeBounds(lo: Type, hi: Type, val alias: Type) extends u.TypeBounds(lo, hi)
 
   def typeRef(tpe: Type): Type = u.appliedType(tpe, Nil)
 

--- a/src/compiler/scala/tools/nsc/tasty/bridge/TypeOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/TypeOps.scala
@@ -105,6 +105,10 @@ trait TypeOps { self: TastyUniverse =>
       new CopyCompleter(underlying, originalFlagSet)
 
     def OpaqueTypeToBounds(tpe: Type): (Type, Type) = tpe match {
+      case u.PolyType(tparams, tpe) =>
+        val (bounds, alias) = OpaqueTypeToBounds(tpe)
+        (u.PolyType(tparams, bounds), u.PolyType(tparams, alias))
+
       case tpe: OpaqueTypeBounds => (tpe, tpe.alias)
 
       case _ =>

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -120,6 +120,8 @@ trait StdAttachments {
 
   class DottyParameterisedTrait(val params: List[Symbol])
 
+  class DottyOpaqueTypeAlias(val tpe: Type)
+
   class QualTypeSymAttachment(val sym: Symbol)
 
   case object ConstructorNeedsFence extends PlainAttachment

--- a/src/reflect/scala/reflect/internal/transform/Erasure.scala
+++ b/src/reflect/scala/reflect/internal/transform/Erasure.scala
@@ -151,7 +151,10 @@ trait Erasure {
         else if (sym.isDerivedValueClass) eraseDerivedValueClassRef(tref)
         else if (isDottyEnumSingleton(sym)) apply(intersectionType(tp.parents)) // TODO [tasty]: dotty enum singletons are not modules.
         else if (sym.isClass) eraseNormalClassRef(tref)
-        else apply(sym.info.asSeenFrom(pre, sym.owner)) // alias type or abstract type
+        else sym.attachments.get[DottyOpaqueTypeAlias] match {
+          case Some(alias: DottyOpaqueTypeAlias) => apply(alias.tpe) // TODO [tasty]: refactor if we build-in opaque types
+          case _                                 => apply(sym.info.asSeenFrom(pre, sym.owner)) // alias type or abstract type
+        }
       case PolyType(tparams, restpe) =>
         apply(restpe)
       case ExistentialType(tparams, restpe) =>

--- a/test/tasty/neg/src-2/TestLogarithms.check
+++ b/test/tasty/neg/src-2/TestLogarithms.check
@@ -1,7 +1,4 @@
-TestLogarithms_fail.scala:7: error: Unsupported Scala 3 opaque type Logarithm; found in object tastytest.Logarithms.
-  val Some(l1) = Logarithm.of(2)
-          ^
-TestLogarithms_fail.scala:10: error: value - is not a member of Any
-  val l3: Double = l1 - l2 // error
-                      ^
-2 errors
+TestLogarithms_fail.scala:10: error: value - is not a member of tastytest.Logarithms.Logarithm
+  val l3 = l1 - l2 // error
+              ^
+1 error

--- a/test/tasty/neg/src-2/TestLogarithms_fail.scala
+++ b/test/tasty/neg/src-2/TestLogarithms_fail.scala
@@ -7,6 +7,9 @@ object TestLogarithms {
   val Some(l1) = Logarithm.of(2)
   val Some(l2) = Logarithm.of(3)
 
-  val l3: Double = l1 - l2 // error
+  val l3 = l1 - l2 // error
+  val l4 = l1 + l2 // ok (`+` is an extension method on Logarithm)
+  val l5 = l1 * l2 // ok (`*` is an extension method on Logarithm)
+  val d  = l1.toDouble // ok (`toDouble` is an extension method on Logarithm)
 
 }

--- a/test/tasty/neg/src-2/TestNames.check
+++ b/test/tasty/neg/src-2/TestNames.check
@@ -1,0 +1,6 @@
+TestNames_fail.scala:10: error: type mismatch;
+ found   : String("Tom")
+ required: tastytest.Names.Name
+  def initialOfString = initial("Tom") // error, ("Tom": String)
+                                ^
+1 error

--- a/test/tasty/neg/src-2/TestNames_fail.scala
+++ b/test/tasty/neg/src-2/TestNames_fail.scala
@@ -1,0 +1,12 @@
+package tastytest
+
+import Names._
+
+object TestNames {
+
+  val Some(tom) = Name.read("Tom")
+
+  def initialOfName = initial(tom) // ok, (tom: Name)
+  def initialOfString = initial("Tom") // error, ("Tom": String)
+
+}

--- a/test/tasty/neg/src-3/Names.scala
+++ b/test/tasty/neg/src-3/Names.scala
@@ -1,0 +1,15 @@
+package tastytest
+
+// lets test bounds on an opaque type, here Name is just a refinement to String
+object Names {
+
+  opaque type Name >: Null <: String = String
+
+  object Name {
+    def read(str: String): Option[Name] = Option.when(str(0).isUpper)(str)
+  }
+
+  // to test rejection of plain string
+  def initial(name: Name): Char = name(0)
+
+}

--- a/test/tasty/run/src-2/tastytest/TestEntityDb.scala
+++ b/test/tasty/run/src-2/tastytest/TestEntityDb.scala
@@ -1,0 +1,14 @@
+package tastytest
+
+/** contains transitive erasure of opaque types: Entity -> Id -> Long */
+object TestEntityDb extends Suite("TestEntityDb") {
+  import EntityDb._, Ids._, Data._
+
+  test {
+    val p = Data.newPerson(Id.nextId)(name = "Sarah", age = 23)
+
+    assert(p.name === "Sarah", "p.name")
+    assert(p.age === 23, "p.age")
+  }
+
+}

--- a/test/tasty/run/src-2/tastytest/TestLogarithms.scala
+++ b/test/tasty/run/src-2/tastytest/TestLogarithms.scala
@@ -1,0 +1,13 @@
+package tastytest
+
+import Logarithms._
+
+object TestLogarithms extends Suite("TestLogarithms") {
+
+  val Some(l1) = Logarithm.of(2)
+  val Some(l2) = Logarithm.of(3)
+
+  test(assert((l1 + l2).toDouble == 4.999999999999999))
+  test(assert((l1 * l2).toDouble == 6.0))
+
+}

--- a/test/tasty/run/src-2/tastytest/TestNames.scala
+++ b/test/tasty/run/src-2/tastytest/TestNames.scala
@@ -1,0 +1,24 @@
+package tastytest
+
+import Names._
+
+object TestNames extends Suite("TestNames") {
+
+  def acceptString(s: String) = s.length
+
+  test("read names") {
+    val Some(tom) = Name.read("Tom")
+    val _  @ None = Name.read("harry")
+  }
+
+  test("initial") {
+    val Some(tom) = Name.read("Tom")
+    assert(initial(tom) == 'T')
+  }
+
+  test("name is a string") {
+    val Some(tom) = Name.read("Tom")
+    assert(acceptString(tom) === 3)
+  }
+
+}

--- a/test/tasty/run/src-2/tastytest/TestVecs.scala
+++ b/test/tasty/run/src-2/tastytest/TestVecs.scala
@@ -1,0 +1,12 @@
+package tastytest
+
+/** test references to type parameters in an opaque type alias */
+object TestVecs extends Suite("TestVecs") {
+  import Vecs._, Vec._
+
+  test {
+    val v = Vec.single("Hello")
+    assert(v.safeHead === "Hello")
+  }
+
+}

--- a/test/tasty/run/src-3/tastytest/EntityDb.scala
+++ b/test/tasty/run/src-3/tastytest/EntityDb.scala
@@ -1,0 +1,59 @@
+package tastytest
+
+/** contains transitive erasure of opaque types: Entity -> Id -> Long */
+object EntityDb {
+  import Ids._, Entities._
+
+  object Ids {
+    opaque type Id = Long
+
+    object Id {
+
+      private var _nextId = 0L
+
+      def nextId: Id = {
+        val id = _nextId
+        _nextId += 1
+        id
+      }
+
+      final implicit class IdOps(val id: Id) extends AnyVal {
+        def toLong: Long = id
+      }
+    }
+  }
+
+  object Entities {
+    opaque type Entity[+T] = Id
+
+    object Entity {
+      def ofKind[T <: Singleton](id: Id)(kind: T): Entity[kind.type] = id
+
+      final implicit class EntityOps[T](val entity: Entity[T]) extends AnyVal {
+        def id: Id = entity
+      }
+    }
+  }
+
+  object Data {
+
+    opaque type Person = Kind.OfPerson.type
+
+    private enum Kind { case OfPerson }
+
+    def newPerson(id: Id)(name: String, age: Int): Entity[Person] =
+      personName(id.toLong) = name
+      personAge(id.toLong)  = age
+      Entity.ofKind(id)(Kind.OfPerson)
+
+    final implicit class PersonOps(val person: Entity[Person]) extends AnyVal {
+      def name: String = personName(person.id.toLong)
+      def age: Int = personAge(person.id.toLong)
+    }
+
+    private val personName = collection.mutable.LongMap.empty[String]
+    private val personAge = collection.mutable.LongMap.empty[Int]
+
+  }
+
+}

--- a/test/tasty/run/src-3/tastytest/Logarithms.scala
+++ b/test/tasty/run/src-3/tastytest/Logarithms.scala
@@ -1,0 +1,24 @@
+package tastytest
+
+object Logarithms {
+
+  opaque type Logarithm = Double
+
+  object Logarithm {
+
+    // These are the two ways to lift to the Logarithm type
+
+    private[Logarithms] def apply(d: Double): Logarithm = math.log(d)
+
+    def of(d: Double): Option[Logarithm] =
+      if (d > 0.0) Some(math.log(d)) else None
+  }
+
+  // implicit define cross compatible public APIs for opaque types
+  final implicit class LogarithmOps(val logarithm: Logarithm) extends AnyVal {
+    def toDouble: Double = math.exp(logarithm)
+    def + (other: Logarithm): Logarithm = Logarithm(math.exp(logarithm) + math.exp(other))
+    def * (other: Logarithm): Logarithm = logarithm + other
+  }
+
+}

--- a/test/tasty/run/src-3/tastytest/Names.scala
+++ b/test/tasty/run/src-3/tastytest/Names.scala
@@ -1,0 +1,15 @@
+package tastytest
+
+// lets test bounds on an opaque type, here Name is just a refinement to String
+object Names {
+
+  opaque type Name >: Null <: String = String
+
+  object Name {
+    def read(str: String): Option[Name] = Option.when(str(0).isUpper)(str)
+  }
+
+  // to test rejection of plain string
+  def initial(name: Name): Char = name(0)
+
+}

--- a/test/tasty/run/src-3/tastytest/Vecs.scala
+++ b/test/tasty/run/src-3/tastytest/Vecs.scala
@@ -1,0 +1,16 @@
+package tastytest
+
+/** test references to type parameters in an opaque type alias */
+object Vecs {
+
+  opaque type Vec[+A] = List[A]
+
+  object Vec {
+    def single[A](elem: A): Vec[A] = elem :: Nil
+
+    final implicit class VecOps[A](val vec: Vec[A]) extends AnyVal {
+      def safeHead = vec.head
+    }
+  }
+
+}


### PR DESCRIPTION
This PR re-enables opaque types because they can remain opaque but be correctly erased.

The main part to observe here is the addition of another symbol attachment which stored the private alias of the opaque type which is recovered at erasure, perhaps there is a more efficient way to do this.

There may also be required some edge cases to check that the opaque type is always dealiased correctly.