### PR TITLE
Performance tweaks for Seq#diff and Seq#intersect

### DIFF
--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -614,6 +614,36 @@ sealed abstract class List[+A]
     }
   }
 
+  // Override for performance: traverse only as much as needed
+  // and share tail when nothing needs to be filtered out anymore
+  override def diff[B >: A](that: collection.Seq[B]): List[A] = {
+    if (that.isEmpty || this.isEmpty) this
+    else if (tail.isEmpty) if (that.contains(head)) Nil else this
+    else {
+      val occ = occCounts(that)
+      val b = new ListBuffer[A]()
+      @tailrec
+      def rec(remainder: List[A]): List[A] = {
+        if(occ.isEmpty) b.prependToList(remainder)
+        else remainder match {
+          case Nil => b.result()
+          case head :: next => {
+            occ.updateWith(head){
+              case None => {
+                b.append(head)
+                None
+              }
+              case Some(1) => None
+              case Some(n) => Some(n - 1)
+            }
+            rec(next)
+          }
+        }
+      }
+      rec(this)
+    }
+  }
+
 }
 
 // Internal code that mutates `next` _must_ call `Statics.releaseFence()` if either immediately, or

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/ListBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/ListBenchmark.scala
@@ -24,6 +24,8 @@ class ListBenchmark {
   var mid: Content = _
   var last: Content = _
   var replacement: Content = _
+  var firstHalf: List[Content] = _
+  var lastHalf: List[Content] = _
 
 
   @Setup(Level.Trial) def initKeys(): Unit = {
@@ -31,6 +33,8 @@ class ListBenchmark {
     mid = Content(size / 2)
     last = Content(Math.max(0,size -1))
     replacement = Content(size * 2 + 1)
+    firstHalf = values.take(size / 2)
+    lastHalf = values.drop(size / 2)
   }
 
   @Benchmark def filter_includeAll: Any = {
@@ -85,5 +89,29 @@ class ListBenchmark {
 
   @Benchmark def partition_exc_last: Any = {
     values.partition(v => v.value != last.value)
+  }
+
+  @Benchmark def diff_single_mid: Any = {
+    values.diff(List(mid))
+  }
+
+  @Benchmark def diff_single_last: Any = {
+    values.diff(List(last))
+  }
+
+  @Benchmark def diff_notIncluded: Any = {
+    values.diff(List(Content(-1)))
+  }
+
+  @Benchmark def diff_identical: Any = {
+    values.diff(values)
+  }
+
+  @Benchmark def diff_first_half: Any = {
+    values.diff(firstHalf)
+  }
+
+  @Benchmark def diff_last_half: Any = {
+    values.diff(lastHalf)
   }
 }


### PR DESCRIPTION
~Special case diff on List by structurally sharing when possible~ reverted

<details><summary>Benchmark results</summary>

Baseline

[info] # Run complete. Total time: 00:20:29
[info] Benchmark                       (size)  Mode  Cnt      Score      Error  Units
[info] ListBenchmark.diff_first_half        0  avgt   20     40.875 ±    0.393  ns/op 1
[info] ListBenchmark.diff_first_half        1  avgt   20     65.350 ±    1.487  ns/op 1
[info] ListBenchmark.diff_first_half       10  avgt   20    592.473 ±   59.870  ns/op 1
[info] ListBenchmark.diff_first_half      100  avgt   20   6392.043 ±  136.179  ns/op 1
[info] ListBenchmark.diff_first_half     1000  avgt   20  69990.051 ± 1484.883  ns/op 1
[info] ListBenchmark.diff_identical         0  avgt   20     42.340 ±    2.373  ns/op 1
[info] ListBenchmark.diff_identical         1  avgt   20     89.342 ±    1.600  ns/op 1
[info] ListBenchmark.diff_identical        10  avgt   20    745.050 ±   28.070  ns/op 1
[info] ListBenchmark.diff_identical       100  avgt   20   8239.964 ±  326.827  ns/op 1
[info] ListBenchmark.diff_identical      1000  avgt   20  96104.255 ± 4346.676  ns/op 1
[info] ListBenchmark.diff_last_half         0  avgt   20     44.855 ±    5.776  ns/op 1
[info] ListBenchmark.diff_last_half         1  avgt   20     87.086 ±    2.926  ns/op 1
[info] ListBenchmark.diff_last_half        10  avgt   20    551.048 ±    9.701  ns/op 1
[info] ListBenchmark.diff_last_half       100  avgt   20   6052.273 ±  216.878  ns/op 1
[info] ListBenchmark.diff_last_half      1000  avgt   20  67614.880 ±  710.706  ns/op 1
[info] ListBenchmark.diff_notIncluded       0  avgt   20     71.985 ±    0.874  ns/op 1
[info] ListBenchmark.diff_notIncluded       1  avgt   20     85.513 ±    3.370  ns/op 1
[info] ListBenchmark.diff_notIncluded      10  avgt   20    429.533 ±   20.771  ns/op 1
[info] ListBenchmark.diff_notIncluded     100  avgt   20   1790.248 ±   40.322  ns/op 1
[info] ListBenchmark.diff_notIncluded    1000  avgt   20  18322.706 ±  555.524  ns/op 1
[info] ListBenchmark.diff_single_last       0  avgt   20     74.841 ±    4.999  ns/op 1
[info] ListBenchmark.diff_single_last       1  avgt   20     97.721 ±    5.290  ns/op 1
[info] ListBenchmark.diff_single_last      10  avgt   20    274.728 ±   13.519  ns/op 1
[info] ListBenchmark.diff_single_last     100  avgt   20   2324.095 ±  362.581  ns/op 1
[info] ListBenchmark.diff_single_last    1000  avgt   20  27409.479 ± 1529.480  ns/op 1
[info] ListBenchmark.diff_single_mid        0  avgt   20     69.905 ±    3.296  ns/op 1
[info] ListBenchmark.diff_single_mid        1  avgt   20     96.262 ±    1.628  ns/op 1
[info] ListBenchmark.diff_single_mid       10  avgt   20    288.531 ±   23.111  ns/op 1
[info] ListBenchmark.diff_single_mid      100  avgt   20   2725.829 ±  108.093  ns/op 1
[info] ListBenchmark.diff_single_mid     1000  avgt   20  26140.306 ±  312.435  ns/op 1

List through new Seq

[info] # Run complete. Total time: 00:20:27
[info] Benchmark                       (size)  Mode  Cnt      Score      Error  Units
[info] ListBenchmark.diff_first_half        0  avgt   20      4.105 ±    0.028  ns/op
[info] ListBenchmark.diff_first_half        1  avgt   20      4.093 ±    0.029  ns/op
[info] ListBenchmark.diff_first_half       10  avgt   20    264.260 ±   10.194  ns/op
[info] ListBenchmark.diff_first_half      100  avgt   20   3364.628 ±   70.029  ns/op
[info] ListBenchmark.diff_first_half     1000  avgt   20  39072.612 ± 2671.788  ns/op
[info] ListBenchmark.diff_identical         0  avgt   20      3.887 ±    0.042  ns/op
[info] ListBenchmark.diff_identical         1  avgt   20     63.033 ±    1.916  ns/op
[info] ListBenchmark.diff_identical        10  avgt   20    368.556 ±   10.840  ns/op
[info] ListBenchmark.diff_identical       100  avgt   20   5861.276 ±  146.805  ns/op
[info] ListBenchmark.diff_identical      1000  avgt   20  69268.715 ± 1607.349  ns/op
[info] ListBenchmark.diff_last_half         0  avgt   20      4.266 ±    0.072  ns/op
[info] ListBenchmark.diff_last_half         1  avgt   20     65.870 ±    3.425  ns/op
[info] ListBenchmark.diff_last_half        10  avgt   20    272.576 ±    8.440  ns/op
[info] ListBenchmark.diff_last_half       100  avgt   20   3802.349 ±   81.459  ns/op
[info] ListBenchmark.diff_last_half      1000  avgt   20  52942.003 ± 9855.334  ns/op
[info] ListBenchmark.diff_notIncluded       0  avgt   20      5.940 ±    0.207  ns/op
[info] ListBenchmark.diff_notIncluded       1  avgt   20     65.802 ±    2.616  ns/op
[info] ListBenchmark.diff_notIncluded      10  avgt   20    194.225 ±    2.471  ns/op
[info] ListBenchmark.diff_notIncluded     100  avgt   20   1635.484 ±   43.555  ns/op
[info] ListBenchmark.diff_notIncluded    1000  avgt   20  15961.686 ±  342.366  ns/op
[info] ListBenchmark.diff_single_last       0  avgt   20      4.305 ±    0.036  ns/op
[info] ListBenchmark.diff_single_last       1  avgt   20     66.875 ±    0.930  ns/op
[info] ListBenchmark.diff_single_last      10  avgt   20    224.710 ±   10.345  ns/op
[info] ListBenchmark.diff_single_last     100  avgt   20   1723.869 ±   25.487  ns/op
[info] ListBenchmark.diff_single_last    1000  avgt   20  17669.288 ±  820.160  ns/op
[info] ListBenchmark.diff_single_mid        0  avgt   20      4.184 ±    0.036  ns/op
[info] ListBenchmark.diff_single_mid        1  avgt   20     68.890 ±    2.777  ns/op
[info] ListBenchmark.diff_single_mid       10  avgt   20    228.758 ±    5.395  ns/op
[info] ListBenchmark.diff_single_mid      100  avgt   20   1731.472 ±   22.302  ns/op
[info] ListBenchmark.diff_single_mid     1000  avgt   20  16487.683 ±  389.199  ns/op

New List:

[info] # Run complete. Total time: 00:20:26
[info] Benchmark                       (size)  Mode  Cnt      Score      Error  Units
[info] ListBenchmark.diff_first_half        0  avgt   20      2.706 ±    0.107  ns/op
[info] ListBenchmark.diff_first_half        1  avgt   20      2.671 ±    0.027  ns/op
[info] ListBenchmark.diff_first_half       10  avgt   20    176.566 ±   12.005  ns/op
[info] ListBenchmark.diff_first_half      100  avgt   20   2724.257 ±   69.220  ns/op
[info] ListBenchmark.diff_first_half     1000  avgt   20  30617.560 ± 2649.887  ns/op
[info] ListBenchmark.diff_identical         0  avgt   20      2.489 ±    0.060  ns/op
[info] ListBenchmark.diff_identical         1  avgt   20      2.989 ±    0.084  ns/op
[info] ListBenchmark.diff_identical        10  avgt   20    359.982 ±   17.850  ns/op
[info] ListBenchmark.diff_identical       100  avgt   20   5488.378 ±  121.688  ns/op
[info] ListBenchmark.diff_identical      1000  avgt   20  68650.204 ± 3627.994  ns/op
[info] ListBenchmark.diff_last_half         0  avgt   20      2.762 ±    0.027  ns/op
[info] ListBenchmark.diff_last_half         1  avgt   20      3.540 ±    0.078  ns/op
[info] ListBenchmark.diff_last_half        10  avgt   20    290.114 ±    4.281  ns/op
[info] ListBenchmark.diff_last_half       100  avgt   20   3755.760 ±  108.688  ns/op
[info] ListBenchmark.diff_last_half      1000  avgt   20  45800.311 ±  878.631  ns/op
[info] ListBenchmark.diff_notIncluded       0  avgt   20      4.710 ±    0.171  ns/op
[info] ListBenchmark.diff_notIncluded       1  avgt   20      9.982 ±    0.182  ns/op
[info] ListBenchmark.diff_notIncluded      10  avgt   20    241.703 ±    6.063  ns/op
[info] ListBenchmark.diff_notIncluded     100  avgt   20   1977.344 ±   23.295  ns/op
[info] ListBenchmark.diff_notIncluded    1000  avgt   20  20022.380 ±  375.221  ns/op
[info] ListBenchmark.diff_single_last       0  avgt   20      2.944 ±    0.078  ns/op
[info] ListBenchmark.diff_single_last       1  avgt   20      4.286 ±    0.060  ns/op
[info] ListBenchmark.diff_single_last      10  avgt   20    268.102 ±    4.289  ns/op
[info] ListBenchmark.diff_single_last     100  avgt   20   2273.511 ±   70.090  ns/op
[info] ListBenchmark.diff_single_last    1000  avgt   20  21951.718 ±  226.428  ns/op
[info] ListBenchmark.diff_single_mid        0  avgt   20      2.842 ±    0.046  ns/op
[info] ListBenchmark.diff_single_mid        1  avgt   20      4.417 ±    0.063  ns/op
[info] ListBenchmark.diff_single_mid       10  avgt   20    162.779 ±    1.520  ns/op
[info] ListBenchmark.diff_single_mid      100  avgt   20   1207.562 ±   25.183  ns/op
[info] ListBenchmark.diff_single_mid     1000  avgt   20  11083.343 ±  129.916  ns/op
</details>

Diff becomes much faster (~20 times) for the special cases of length 0 and 1. For cases where the argument "runs out", structural sharing from that point onwards not only means using less memory used, it also means a speedup proportional to the part not traversed -- traversing half the list until the other runs out means a speed up of about 50%.

Two benchmarks show an unexpected slow down, by about 10%, for lists of 100 or 1000 items where the argument contains a single element not in the list (`ListBenchmark.diff_notIncluded`). I don't know what's up with that. I expected those to roughly converge with the one where the argument is a list consisting of the last value only, but those are 15%-20% faster in this PR. I ran them on my laptop, so maybe some weird power setting thing?

Also special case diff and intersect on Seq for empty case on either side
