### PR TITLE
[backport] Avoid silence during CI, which Travis finds unacceptable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ jobs:
           - deriveModuleVersions
           - removeExistingBuilds $integrationRepoUrl
           - if [ ! -z "$STARR_REF" ]; then buildStarr; fi
-          - travis_wait 90 buildLocker
-          - travis_wait 90 buildQuick
+          - buildLocker
+          - buildQuick
           - triggerScalaDist
 
       # pull request validation (w/ mini-bootstrap)
@@ -40,9 +40,9 @@ jobs:
         name: "JDK 8 pr validation"
         if: type = pull_request
         script:
-          - travis_wait 90 sbt -warn setupPublishCore generateBuildCharacterPropertiesFile headerCheck publishLocal
+          - sbt -warn setupPublishCore generateBuildCharacterPropertiesFile headerCheck publishLocal
           - STARR=`cat buildcharacter.properties | grep ^maven.version.number | cut -d= -f2` && echo $STARR
-          - travis_wait 90 sbt -Dstarr.version=$STARR -warn setupValidateTest test:compile info testAll
+          - sbt -Dstarr.version=$STARR -warn setupValidateTest test:compile info testAll
 
       # build the spec using jekyll
       - stage: build

--- a/build.sbt
+++ b/build.sbt
@@ -1796,3 +1796,8 @@ def findJar(files: Seq[Attributed[File]], dep: ModuleID): Option[Attributed[File
 whitesourceProduct               := "Lightbend Reactive Platform"
 whitesourceAggregateProjectName  := "scala-2.12-stable"
 whitesourceIgnoredScopes         := Vector("test", "scala-tool")
+
+{
+  scala.build.TravisOutput.installIfOnTravis()
+  Nil
+}

--- a/project/TravisOutput.scala
+++ b/project/TravisOutput.scala
@@ -1,0 +1,69 @@
+package scala.build
+
+import java.util.TimerTask
+import java.io._
+import java.util.concurrent.TimeUnit
+
+// Prints some output to console periodically if the build itself is silent to avoid Travis CI's 10 minute timeout
+// from aborting the build.
+//
+// A hopefully better behaved version of travis_wait and travis_wait_enhanced.
+object TravisOutput {
+  def install(): Unit = {
+    val out = System.out
+    if (out.getClass.getName != classOf[Redirecter].getName) {
+      schedule()
+      System.setOut(new Redirecter(out))
+      savedOut = out
+    }
+  }
+
+  def installIfOnTravis(): Unit =
+    if (sys.env.contains("TRAVIS")) install()
+
+  private var savedOut: PrintStream = _
+  private val delayMS = TimeUnit.MINUTES.toMillis(9)
+  private lazy val timer = new java.util.Timer(true)
+  private var task: TimerTask = _
+
+  private def schedule(): Unit = {
+    task = new PrintNewline
+    val period = delayMS
+    timer.schedule(task, delayMS, period)
+  }
+
+  private def reschedule(): Unit = {
+    task.cancel()
+    schedule()
+  }
+
+  private class PrintNewline extends java.util.TimerTask() {
+    override def run(): Unit = {
+      savedOut.println("")
+    }
+  }
+
+  private class Redirecter(stream: PrintStream) extends PrintStream(new OutputStream {
+    def write(b: Int): Unit = {
+      reschedule()
+      stream.write(b)
+    }
+    override def write(b: Array[Byte]): Unit = {
+      reschedule()
+      stream.write(b)
+    }
+    override def write(b: Array[Byte], off: Int, len: Int): Unit = {
+      reschedule()
+      stream.write(b, off, len)
+    }
+    override def flush(): Unit = {
+      reschedule()
+      stream.flush()
+    }
+    override def close(): Unit = {
+      reschedule()
+      stream.close()
+    }
+  })
+
+}


### PR DESCRIPTION
Trying to release 2.12.13 is failing with

```
/home/travis/.travis/functions: line 607:  4860 Terminated              travis_jigger "${!}" "${timeout}" "${cmd[@]}"
```

https://travis-ci.org/github/scala/scala/jobs/748054633

In 2.13.x this was fixed by https://github.com/scala/scala/pull/8496