### PR TITLE
Remove dead code testing for Array[Unit] after Array[AnyRef].

### DIFF
--- a/src/library/scala/runtime/ScalaRunTime.scala
+++ b/src/library/scala/runtime/ScalaRunTime.scala
@@ -64,7 +64,6 @@ object ScalaRunTime {
       case x: Array[Byte]    => x(idx).asInstanceOf[Any]
       case x: Array[Short]   => x(idx).asInstanceOf[Any]
       case x: Array[Boolean] => x(idx).asInstanceOf[Any]
-      case x: Array[Unit]    => x(idx).asInstanceOf[Any]
       case null => throw new NullPointerException
     }
   }
@@ -81,7 +80,6 @@ object ScalaRunTime {
       case x: Array[Byte]    => x(idx) = value.asInstanceOf[Byte]
       case x: Array[Short]   => x(idx) = value.asInstanceOf[Short]
       case x: Array[Boolean] => x(idx) = value.asInstanceOf[Boolean]
-      case x: Array[Unit]    => x(idx) = value.asInstanceOf[Unit]
       case null => throw new NullPointerException
     }
   }
@@ -97,7 +95,6 @@ object ScalaRunTime {
     case x: Array[Byte]    => x.length
     case x: Array[Short]   => x.length
     case x: Array[Boolean] => x.length
-    case x: Array[Unit]    => x.length
     case null => throw new NullPointerException
   }
 
@@ -111,7 +108,6 @@ object ScalaRunTime {
     case x: Array[Byte]    => x.clone()
     case x: Array[Short]   => x.clone()
     case x: Array[Boolean] => x.clone()
-    case x: Array[Unit]    => x
     case null => throw new NullPointerException
   }
 
@@ -143,7 +139,6 @@ object ScalaRunTime {
       case x: Array[Byte]    => copy(x)
       case x: Array[Short]   => copy(x)
       case x: Array[Boolean] => copy(x)
-      case x: Array[Unit]    => copy(x)
       case null => throw new NullPointerException
     }
   }

--- a/test/instrumented/srt.patch
+++ b/test/instrumented/srt.patch
@@ -9,14 +9,14 @@
    def array_apply(xs: AnyRef, idx: Int): Any = {
 +    arrayApplyCount += 1
      xs match {
-@@ -70,2 +73,3 @@
+@@ -69,2 +72,3 @@
    }
 +  var arrayApplyCount = 0
 
-@@ -73,2 +77,3 @@
+@@ -72,2 +76,3 @@
    def array_update(xs: AnyRef, idx: Int, value: Any): Unit = {
 +    arrayUpdateCount += 1
      xs match {
-@@ -87,2 +92,3 @@
+@@ -85,2 +90,3 @@
    }
 +  var arrayUpdateCount = 0


### PR DESCRIPTION
Since `Array[Unit]` is implemented as `Array[BoxedUnit]`, any
`Array[Unit]` already qualifies as an `Array[AnyRef]`. Therefore,
all the removed cases were dead code.