### PR TITLE
enable fatal warnings when compiling partest's Java sources

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -596,6 +596,8 @@ lazy val partest = configureAsSubproject(project)
     name := "scala-partest",
     description := "Scala Compiler Testing Tool",
     libraryDependencies ++= List(testInterfaceDep, diffUtilsDep, junitDep),
+    Compile / javacOptions ++= Seq("-XDenableSunApiLintControl", "-Xlint") ++
+      (if (fatalWarnings.value) Seq("-Werror") else Seq()),
     Compile / scalacOptions ++= Seq("-feature", "-Xlint"),
     pomDependencyExclusions ++= List((organization.value, "scala-repl-frontend"), (organization.value, "scala-compiler-doc")),
     fixPom(

--- a/src/partest/scala/tools/partest/nest/UnsafeAccess.java
+++ b/src/partest/scala/tools/partest/nest/UnsafeAccess.java
@@ -14,7 +14,7 @@ package scala.tools.partest.nest;
 
 import java.lang.reflect.Field;
 
-@SuppressWarnings("unsafe")
+@SuppressWarnings("sunapi")  // also requires passing -XDenableSunApiLintControl to javac
 public class UnsafeAccess {
     public final static sun.misc.Unsafe U;
 


### PR DESCRIPTION
warnings in our build logs are now so few that these really stood out:

```
[warn] /home/jenkins/workspace/scala-2.13.x-validate-main@2/src/partest/scala/tools/partest/nest/UnsafeAccess.java:19:1: sun.misc.Unsafe is internal proprietary API and may be removed in a future release
[warn] sun.misc.Unsafe
[warn] /home/jenkins/workspace/scala-2.13.x-validate-main@2/src/partest/scala/tools/partest/nest/UnsafeAccess.java:25:1: sun.misc.Unsafe is internal proprietary API and may be removed in a future release
[warn] sun.misc.Unsafe
[warn] /home/jenkins/workspace/scala-2.13.x-validate-main@2/src/partest/scala/tools/partest/nest/UnsafeAccess.java:27:1: sun.misc.Unsafe is internal proprietary API and may be removed in a future release
[warn] sun.misc.Unsafe
[warn] /home/jenkins/workspace/scala-2.13.x-validate-main@2/src/partest/scala/tools/partest/nest/UnsafeAccess.java:28:1: sun.misc.Unsafe is internal proprietary API and may be removed in a future release
[warn] sun.misc.Unsafe
[warn] /home/jenkins/workspace/scala-2.13.x-validate-main@2/src/partest/scala/tools/partest/nest/UnsafeAccess.java:29:1: sun.misc.Unsafe is internal proprietary API and may be removed in a future release
[warn] sun.misc.Unsafe
[warn] /home/jenkins/workspace/scala-2.13.x-validate-main@2/src/partest/scala/tools/partest/nest/UnsafeAccess.java:31:1: sun.misc.Unsafe is internal proprietary API and may be removed in a future release
[warn] sun.misc.Unsafe
```