### PR TITLE
[backport] Tweaks to the build definition after backporting the in-sourcing of partest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1074,6 +1074,7 @@ lazy val partest = configureAsSubproject(project)
     name := "scala-partest",
     description := "Scala Compiler Testing Tool",
     libraryDependencies ++= List(testInterfaceDep, diffUtilsDep, junitDep),
+    pomDependencyExclusions ++= List((organization.value, "scala-repl-jline-embedded"), (organization.value, "scala-compiler-doc")),
     fixPom(
       "/project/name" -> <name>Scala Partest</name>,
       "/project/description" -> <description>Scala Compiler Testing Tool</description>,

--- a/build.sbt
+++ b/build.sbt
@@ -1068,7 +1068,6 @@ lazy val scalap = configureAsSubproject(project)
 
 lazy val partest = configureAsSubproject(project)
   .dependsOn(library, reflect, compiler, scalap, replJlineEmbedded, scaladoc)
-  .settings(disableDocs)
   .settings(Osgi.settings)
   .settings(AutomaticModuleName.settings("scala.partest"))
   .settings(


### PR DESCRIPTION
These commits followed the in-sourcing of partest in 2.13.x and also need to be backported to 2.12.x

The [`pom.xml`](https://gist.github.com/0493fded49907986f5b24031288795a3) for partest generated by this PR looks okay, it doesn't have the internal dependencies reported in https://github.com/scala/scala-dev/issues/512