### PR TITLE
Enable reachability warnings in pattern matching PartialFunctions

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2639,7 +2639,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       val casesTrue = cases map (c => deriveCaseDef(c)(x => atPos(x.pos.focus)(TRUE)).duplicate.asInstanceOf[CaseDef])
 
       // must generate a new tree every time
-      def selector(paramSym: Symbol): Tree = gen.mkUnchecked(
+      def selector(paramSym: Symbol): Tree = (
         if (sel != EmptyTree) sel.duplicate
         else atPos(tree.pos.focusStart)(
           // scala/bug#6925: subsume type of the selector to `argTp`

--- a/test/files/neg/patmat-reachable-partial.check
+++ b/test/files/neg/patmat-reachable-partial.check
@@ -1,0 +1,7 @@
+patmat-reachable-partial.scala:5: warning: match may not be exhaustive.
+It would fail on the following inputs: None, Some(_)
+  def test(c: Seq[Option[Int]]) = c.collect { case _: C => }
+                                            ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/patmat-reachable-partial.scala
+++ b/test/files/neg/patmat-reachable-partial.scala
@@ -1,0 +1,6 @@
+// scalac: -Xfatal-warnings
+
+trait C
+class Test {
+  def test(c: Seq[Option[Int]]) = c.collect { case _: C => }
+}


### PR DESCRIPTION
Remove the `@unchecked` annotation from the scrutinee of the match
in the desugaring of pattern matching anoynmous partial functions.

I believe this was on necessary historically to avoid
false-positive pattern matcher warnings but the pattern matcher
now avoids these more directly (see `TreeInfo.isSyntheticDefaultCase`).
That was added in dfbaaa17 which sought to make these trees
compatible with macros and `resetAttrs`, but that change might have
obviated the use of `@unchecked`.

Draft to see what breaks in the test suite, community build etc.

TODO: 

  - [ ] Opt out flag for backwards compatibility to aide migration?
  - [ ] Community build error/warning analysis