### PR TITLE
Travis-CI: only compile benchmarks during PR validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,7 @@ jobs:
 
       - stage: test
         name: build benchmarks (bootstrapped)
+        if: type = pull_request OR repo != scala/scala
         workspaces:
           use: bootstrapped
         script:


### PR DESCRIPTION
oops, I missed this during review of #9367

as a consequence, in a non-PR build such as https://travis-ci.org/github/scala/scala/builds/748354835 we were getting:

    $ STARR=$(sed -n 's/^maven\.version\.number=//p' buildcharacter.properties) && echo $STARR
    sed: can't read buildcharacter.properties: No such file or directory