### PR TITLE
provide a legacy ordering for groupBy

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -415,6 +415,8 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.*Manifest.emptyArray"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.*Manifest.emptyWrappedArray"),
 
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.Traversable.legacyGroupBy"),
+
     //
     // scala-reflect
     //

--- a/src/library/scala/collection/Traversable.scala
+++ b/src/library/scala/collection/Traversable.scala
@@ -13,8 +13,10 @@
 package scala
 package collection
 
+import java.security.{AccessController, PrivilegedAction}
 import generic._
 import mutable.Builder
+import scala.util.Try
 import scala.util.control.Breaks
 
 /** A trait for traversable collections.
@@ -102,7 +104,9 @@ object Traversable extends TraversableFactory[Traversable] { self =>
   implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Traversable[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
 
   def newBuilder[A]: Builder[A, Traversable[A]] = immutable.Traversable.newBuilder[A]
-  private[collection] val legacyGroupBy = java.lang.Boolean.getBoolean("scala.groupBy.legacy")
+  private[collection] val legacyGroupBy = java.security.AccessController.doPrivileged(new PrivilegedAction[Boolean]() {
+    override def run = Try(System.getProperty("scala.groupBy.legacy", "false").toBoolean).getOrElse(false)
+  })
 }
 
 /** Explicit instantiation of the `Traversable` trait to reduce class file size in subclasses. */

--- a/src/library/scala/collection/Traversable.scala
+++ b/src/library/scala/collection/Traversable.scala
@@ -102,6 +102,7 @@ object Traversable extends TraversableFactory[Traversable] { self =>
   implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Traversable[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
 
   def newBuilder[A]: Builder[A, Traversable[A]] = immutable.Traversable.newBuilder[A]
+  private[collection] val legacyGroupBy = java.lang.Boolean.getBoolean("scala.groupBy.legacy")
 }
 
 /** Explicit instantiation of the `Traversable` trait to reduce class file size in subclasses. */

--- a/src/library/scala/collection/TraversableLike.scala
+++ b/src/library/scala/collection/TraversableLike.scala
@@ -503,7 +503,25 @@ trait TraversableLike[+A, +Repr] extends Any
             hashMap.getOrElseUpdate(key, apply())
         }
 
-      def result(): immutable.Map[K, Repr] =
+      def result(): immutable.Map[K, Repr] = {
+        if (Traversable.legacyGroupBy && size > 1 && size <= 4) {
+          val legacyOrdering = mutable.Map[K, Builder[A, Repr]]()
+          legacyOrdering.update(k0, v0)
+          legacyOrdering.update(k1, v1)
+          if (size > 2) legacyOrdering.update(k2, v2)
+          if (size > 3) legacyOrdering.update(k3, v3)
+
+          val it = legacyOrdering.iterator
+
+          var kv = it.next(); k0 = kv._1; v0 = kv._2
+          kv = it.next();     k1 = kv._1; v1 = kv._2
+
+          if (size > 2)
+            { kv = it.next(); k2 = kv._1; v2 = kv._2}
+          if (size > 3)
+            { kv = it.next(); k3 = kv._1; v3 = kv._2}
+
+        }
         size match {
           case 0 => immutable.Map.empty
           case 1 => new immutable.Map.Map1(k0, v0.result())
@@ -519,7 +537,7 @@ trait TraversableLike[+A, +Repr] extends Any
             }
             m1.result()
         }
-
+      }
     }
     this.seq.foreach(grouper)
     grouper.result()


### PR DESCRIPTION
Performance optimizations in groupBy mean that the order of the result may change

This PR allows a legacy mode to ease migration of apps that were sensitive to this undefined, but stable order