### PR TITLE
give sbt more heap (2G instead of 1.5)

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,2 +1,2 @@
--Xmx1536M
+-Xmx2G
 -Xss1M


### PR DESCRIPTION
people have more RAM in their machines these days, and more cores
too which means more parallelism which needs more heap.  I've sometimes
seen sbt give GC warnings, so that's evidence more heap would help,
and 2G is still pretty small by current standards so I don't really
see a downside here

as evidence 2G is actually a modest number, I have lots of Scala OSS
repos on my machine because of my community build work, and:

```
% cat */.jvmopts | grep Xmx
-Xmx2g
-Xmx6G
-Xmx5G
-Xmx3G
-Xmx4096m
-Xmx6G
-Xmx8G
-Xmx6G
-Xmx4G
-Xmx4g
-Xmx4G
-Xmx4G
-Xmx4G
-Xmx2G
-Xmx2048M
-Xmx3G
-Xmx3G
-Xmx2G
-Xmx4G -XX:MaxMetaspaceSize=1G -XX:MaxInlineLevel=20
-Xmx1536M
-Xmx1536M
-Xmx2G
-Xmx2G
-Xmx3G
-Xmx1536M
-Xmx8G
-Xmx4000M
-Xmx4096M
-Xmx4096M
-Xmx3g
-Xmx8G
-Xmx3G
```