### PR TITLE
Fix `ArrayBufferView`, `ArrayOps.ArrayIterator` and `View.Patched`

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -123,7 +123,7 @@ object ArrayOps {
   private[collection] final class ArrayIterator[@specialized(Specializable.Everything) A](xs: Array[A]) extends AbstractIterator[A] with Serializable {
     private[this] var pos = 0
     private[this] val len = xs.length
-    override def knownSize = len - pos
+    override def knownSize: Int = len - pos
     def hasNext: Boolean = pos < len
     def next(): A = try {
       val r = xs(pos)
@@ -131,7 +131,12 @@ object ArrayOps {
       r
     } catch { case _: ArrayIndexOutOfBoundsException => Iterator.empty.next() }
     override def drop(n: Int): Iterator[A] = {
-      if (n > 0) pos = Math.min(xs.length, pos + n)
+      if (n > 0) {
+        val newPos = pos + n
+        pos =
+          if (newPos < 0 /* overflow */) len
+          else Math.min(len, newPos)
+      }
       this
     }
   }

--- a/test/junit/scala/collection/ArrayOpsTest.scala
+++ b/test/junit/scala/collection/ArrayOpsTest.scala
@@ -142,4 +142,16 @@ class ArrayOpsTest {
     assertEquals(classOf[Double], something.intersect(empty).getClass.getComponentType)
     assertTrue(something.intersect(empty).isEmpty)
   }
+
+  // discovered while working on scala/scala#9388
+  @Test
+  def iterator_drop(): Unit = {
+    val it = Array(1, 2, 3)
+      .iterator
+      .drop(Int.MaxValue)
+      .drop(Int.MaxValue)  // potential index overflow to negative
+    assert(!it.hasNext)    // bug had index as negative and this returning true
+                           // even though the index is both out of bounds and should
+                           // always be between `0` and `Array#length`.
+  }
 }

--- a/test/junit/scala/collection/ViewTest.scala
+++ b/test/junit/scala/collection/ViewTest.scala
@@ -1,10 +1,10 @@
 package scala.collection
 
-import scala.collection.immutable.List
 import org.junit.Assert._
 import org.junit.Test
 
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
+import scala.tools.testkit.AssertUtil.assertSameElements
 
 class ViewTest {
 
@@ -112,5 +112,22 @@ class ViewTest {
   @Test
   def _toString(): Unit = {
     assertEquals("View(<not computed>)", View(1, 2, 3).toString)
+  }
+
+  // see scala/scala#9388
+  @Test
+  def patch(): Unit = {
+    // test re-iterability
+    val v1 = List(2).view.patch(1, List(3, 4, 5).iterator, 0)
+    assertSameElements(Seq(2, 3, 4, 5), v1.toList)
+    assertSameElements(Seq(2, 3, 4, 5), v1.toList) // check that it works twice
+
+    // https://github.com/scala/scala/pull/9388#discussion_r709392221
+    val v2 = List(2).view.patch(1, Nil, 0)
+    assert(!v2.isEmpty)
+
+    // https://github.com/scala/scala/pull/9388#discussion_r709481748
+    val v3 = Nil.view.patch(0, List(1).iterator, 0)
+    assert(v3.knownSize != 0)
   }
 }

--- a/test/junit/scala/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBufferTest.scala
@@ -455,4 +455,21 @@ class ArrayBufferTest {
     buf.insertAll(1, buf)
     assertSameElements(List(1, 1, 2, 3, 2, 3), buf)
   }
+
+  // scala/bug#12284
+  @Test
+  def viewConsistency(): Unit = {
+    def check[U](op: ArrayBuffer[Int] => U): Unit = {
+      val buf = ArrayBuffer.from(1 to 50)
+      val view = buf.view
+      op(buf)
+      assertSameElements(buf, view)
+    }
+
+    check(_.clear())
+    check(_.dropRightInPlace(30))
+    check(_.dropInPlace(30))
+    check(_ ++= (1 to 100))
+    check(_.insertAll(1, 1 to 100))
+  }
 }

--- a/test/scalacheck/scala/collection/IteratorProperties.scala
+++ b/test/scalacheck/scala/collection/IteratorProperties.scala
@@ -29,17 +29,22 @@ object IteratorProperties extends Properties("Iterator") {
     case it: Iterator[Int] => View.dropRightIterator(it, n)
     case x                 => throw new MatchError(x)
   })
+  property("patch") = check((it, n) => it match {
+    case it: Iterable[Int] => it.iterator.patch(1, Iterator.empty, n)
+    case it: Iterator[Int] => it.patch(1, Iterator.empty, n)
+    case x                 => throw new MatchError(x)
+  })
 
   def check(f: (IterableOnceOps[Int, IterableOnce, IterableOnce[Int]], Int) => IterableOnce[Int]): Prop = forAll(Arbitrary.arbitrary[Seq[Int]], smallInteger) { (s: Seq[Int], n: Int) =>
     val indexed = s.toIndexedSeq // IndexedSeqs and their Iterators have a knownSize
     val simple = new SimpleIterable(s) // SimpleIterable and its Iterator don't
-    val stream = LazyList.from(s) // Lazy
+    val lazyList = LazyList.from(s) // Lazy
     val indexed1 = f(indexed, n).iterator.to(Seq)
     val indexed2 = f(indexed.iterator, n).iterator.to(Seq)
     val simple1 = f(simple, n).iterator.to(Seq)
     val simple2 = f(simple.iterator, n).iterator.to(Seq)
-    val stream1 = f(stream, n).iterator.to(Seq)
-    val stream2 = f(stream.iterator, n).iterator.to(Seq)
+    val stream1 = f(lazyList, n).iterator.to(Seq)
+    val stream2 = f(lazyList.iterator, n).iterator.to(Seq)
     (indexed1 == indexed2) :| s"indexed: $indexed1 != $indexed2" &&
       (simple1 == simple2) :| s"simple: $simple1 != $simple2" &&
       (stream1 == stream2) :| s"stream: $stream1 != $stream2" &&

--- a/test/scalacheck/scala/collection/ViewProperties.scala
+++ b/test/scalacheck/scala/collection/ViewProperties.scala
@@ -1,0 +1,57 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection
+
+import org.scalacheck._
+import org.scalacheck.Prop._
+
+import scala.collection.mutable.ListBuffer
+
+object ViewProperties extends Properties("View") {
+
+  type Elem = Int
+  type SomeSeqOps = SeqOps[Elem, Iterable, Iterable[Elem]]
+
+  private def expectedPatch(seq: SomeSeqOps, from: Int, other: Iterable[Elem], replaced: Int): Seq[Elem] = {
+    val (prefix, suffix) = seq.splitAt(from)
+    ListBuffer.empty[Elem] ++= prefix ++= other ++= suffix.drop(replaced)
+  }
+
+  property("`SeqOps#patch(...)` (i.e. `iterableFactory.from(View.Patched(...))`) correctness") = {
+    // we use `mutable.ArraySeq` because it uses the default `patch`
+    // implementation, rather than one from `StrictOptimisedSeqOps`
+    forAll { (seq: mutable.ArraySeq[Elem], from: Int, other: Iterable[Elem], replaced: Int) =>
+      val expected = expectedPatch(seq, from, other, replaced)
+      val patchedWithIterable = seq.patch(from, other, replaced)
+      val patchedWithIterableOnce = seq.patch(from, other.iterator, replaced)
+
+      // we don't need to use `sameElements` like below, because
+      // both `expected` and patched are `Seq` this time
+      ((expected =? patchedWithIterable) :| "`patch(_, Iterable, _)` is performed correctly") &&
+        ((expected =? patchedWithIterableOnce) :| "`patch(_, IterableOnce, _)` is performed correctly")
+    }
+  }
+
+
+  property("`SeqOps#view.patch(...)` (i.e. `View.Patched` used directly) correctness and consistency") =
+    forAll { (seq: Seq[Elem], from: Int, other: Iterable[Elem], replaced: Int) =>
+      val expected = expectedPatch(seq, from, other, replaced)
+      val patchedWithIterable = seq.view.patch(from, other, replaced)
+      val patchedWithIterableOnce = seq.view.patch(from, other.iterator, replaced)
+
+      (expected.sameElements(patchedWithIterable) :| "`patch(_, Iterable, _)` is performed correctly") &&
+        (expected.sameElements(patchedWithIterable) :| "`view.patch(_, Iterable, _)` remains the same after multiple iterations") &&
+        (expected.sameElements(patchedWithIterableOnce) :| "`patch(_, IterableOnce, _)` is performed correctly") &&
+        (expected.sameElements(patchedWithIterableOnce) :| "`view.patch(_, IterableOnce, _)` remains the same after multiple iterations")
+    }
+}

--- a/test/scalacheck/scala/collection/mutable/ArrayBufferProperties.scala
+++ b/test/scalacheck/scala/collection/mutable/ArrayBufferProperties.scala
@@ -1,0 +1,39 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection.mutable
+
+import org.scalacheck._
+import org.scalacheck.Prop._
+
+object ArrayBufferProperties extends Properties("mutable.ArrayBuffer") {
+
+  type Elem = Int
+
+  property("view consistency after modifications") = forAll { (buf: ArrayBuffer[Elem]) =>
+    def check[U](op: ArrayBuffer[Elem] => U): Prop = {
+      val b    = buf.clone()
+      val view = b.view
+      op(b) // modifies the buffer
+      b.sameElements(view)
+    }
+
+    val spaceForMoreElems = buf.sizeIs <= (Int.MaxValue / 2 - 101)
+
+    (check(_.clear()) :| "_.clear()") &&
+      (check(_.dropRightInPlace(1)) :| "_.dropRightInPlace(1)") &&
+      (check(_.dropInPlace(1)) :| "_.dropInPlace(1)") &&
+      (spaceForMoreElems ==> (check(_ ++= (1 to 100)) :| "_ ++= (1 to 100)")) &&
+      (spaceForMoreElems ==> (check(_.prependAll(1 to 100)) :| "_.prependAll(1 to 100)")) &&
+      ((!buf.isEmpty && spaceForMoreElems) ==> (check(_.insertAll(1, 1 to 100)) :| "_.insertAll(1, 1 to 100)"))
+  }
+}


### PR DESCRIPTION
Ensure `ArrayBufferView` is consistent with its buffer.

Simplify `ArrayBuffer#insertAll` code.

Fix unreported bug in `ArrayOps.ArrayIterator` where
index in array can overflow to negative, and in such cases
the iterator reports `hasNext` incorrectly as `true`.

Improve code documentation and readability of
`Iterator.patch` implementation, which was bumped
into while investigating the bug.

Discovered while writing tests for bug in `View.Patched`
(see below).

Fix unreported bug in `View.Patched` where iterator
is incorrect due to the patch only being iterable once,
and already having been exhausted.

Discovered while attempting to optimise `ArrayBuffer` alongside
fixing `ArrayBufferView` (eventually scrapped).

Fixes scala/bug#12284