### PR TITLE
delete temp dirs made by tastytest

### DIFF
--- a/src/tastytest/scala/tools/tastytest/package.scala
+++ b/src/tastytest/scala/tools/tastytest/package.scala
@@ -6,12 +6,17 @@ package object tastytest {
 
   import Files.{pathSep, classpathSep}
 
+  private val verbose = false
+
+  def log(s: => String): Unit =
+    if (verbose) println(s)
+
   def printerrln(str: String): Unit = System.err.println(red(str))
   def printwarnln(str: String): Unit = System.err.println(yellow(str))
   def printsuccessln(str: String): Unit = System.err.println(green(str))
 
   implicit final class ZipOps[T](val t: Try[T]) extends AnyVal {
-    @inline final def *>[U](u: Try[U]): Try[(T, U)] = for {
+    @inline final def <*>[U](u: Try[U]): Try[(T, U)] = for {
       x <- t
       y <- u
     } yield (x, y)

--- a/test/tasty/test/scala/tools/tastytest/TastyTestJUnit.scala
+++ b/test/tasty/test/scala/tools/tastytest/TastyTestJUnit.scala
@@ -12,7 +12,7 @@ class TastyTestJUnit {
   @test def run(): Unit = TastyTest.runSuite(
     src                     = "run",
     srcRoot                 = assertPropIsSet(propSrc),
-    pkgName                 = assertPropIsSet(propPkgName),
+    pkg                     = assertPropIsSet(propPkgName),
     outDir                  = None,
     additionalSettings      = Nil,
     additionalDottySettings = Nil
@@ -21,7 +21,7 @@ class TastyTestJUnit {
   @test def pos(): Unit = TastyTest.posSuite(
     src                     = "pos",
     srcRoot                 = assertPropIsSet(propSrc),
-    pkgName                 = assertPropIsSet(propPkgName),
+    pkg                     = assertPropIsSet(propPkgName),
     outDir                  = None,
     additionalSettings      = Nil,
     additionalDottySettings = Nil
@@ -30,7 +30,7 @@ class TastyTestJUnit {
   @test def posFalseNoAnnotations(): Unit = TastyTest.posSuite(
     src                     = "pos-false-noannotations",
     srcRoot                 = assertPropIsSet(propSrc),
-    pkgName                 = assertPropIsSet(propPkgName),
+    pkg                     = assertPropIsSet(propPkgName),
     outDir                  = None,
     additionalSettings      = Seq("-Ytasty-no-annotations"),
     additionalDottySettings = Nil
@@ -39,7 +39,7 @@ class TastyTestJUnit {
   @test def neg(): Unit = TastyTest.negSuite(
     src                     = "neg",
     srcRoot                 = assertPropIsSet(propSrc),
-    pkgName                 = assertPropIsSet(propPkgName),
+    pkg                     = assertPropIsSet(propPkgName),
     outDir                  = None,
     additionalSettings      = Nil,
     additionalDottySettings = Nil
@@ -48,7 +48,7 @@ class TastyTestJUnit {
   @test def negMoveMacros(): Unit = TastyTest.negChangePreSuite(
     src                     = "neg-move-macros",
     srcRoot                 = assertPropIsSet(propSrc),
-    pkgName                 = assertPropIsSet(propPkgName),
+    pkg                     = assertPropIsSet(propPkgName),
     outDirs                 = None,
     additionalSettings      = Nil,
     additionalDottySettings = Nil
@@ -57,14 +57,14 @@ class TastyTestJUnit {
   @test def negIsolated(): Unit = TastyTest.negSuiteIsolated(
     src                     = "neg-isolated",
     srcRoot                 = assertPropIsSet(propSrc),
-    pkgName                 = assertPropIsSet(propPkgName),
+    pkg                     = assertPropIsSet(propPkgName),
     outDirs                 = None,
     additionalSettings      = Nil,
     additionalDottySettings = Nil
   ).eval
 
-  val propSrc          = "tastytest.src"
-  val propPkgName      = "tastytest.packageName"
+  val propSrc     = "tastytest.src"
+  val propPkgName = "tastytest.packageName"
 
   def assertPropIsSet(prop: String): String = {
     Properties.propOrNull(prop).ensuring(_ != null, s"-D$prop is not set")


### PR DESCRIPTION
using `scala.reflect.io.Directory` to delete a directory recursively.

If a temp directory is required by tastytest, add the automatic cleanup of that directory after the test has finished.

I thought it was not critical if there is a problem in cleaning up the temp directory, so if the temp directory is not fully deleted then the test will still pass, perhaps we want to change that?