### PR TITLE
Use HTTPS for links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ By the way, the team at Lightbend is: @adriaanm, @lrytz, @retronym, @SethTisue, 
 
 ## What kind of PR are you submitting?
 
-Regardless of the nature of your Pull Request, we have to ask you to digitally sign the [Scala CLA](http://www.lightbend.com/contribute/cla/scala), to protect the OSS nature of the code base.
+Regardless of the nature of your Pull Request, we have to ask you to digitally sign the [Scala CLA](https://www.lightbend.com/contribute/cla/scala), to protect the OSS nature of the code base.
 
 You don't need to submit separate PRs for 2.12.x and 2.13.x. Any change accepted on 2.12.x will, in time, be merged onto 2.13.x too. (We are no longer accepting PRs for 2.11.x.)
 
@@ -48,7 +48,7 @@ For longer-running development, likely required for this category of code contri
 
 Any language change (including bug fixes) must be accompanied by the relevant updates to the spec, which lives in the same repository for this reason.
 
-A new language feature or other substantial enough language change requires a SIP (Scala Improvement Process) proposal. For more details on submitting SIPs, see [how to submit a SIP](http://docs.scala-lang.org/sips/sip-submission.html).
+A new language feature or other substantial enough language change requires a SIP (Scala Improvement Process) proposal. For more details on submitting SIPs, see [how to submit a SIP](https://docs.scala-lang.org/sips/sip-submission.html).
 
 ## Guidelines
 
@@ -227,7 +227,7 @@ Follow the [Boy Scout Rule](https://martinfowler.com/bliki/OpportunisticRefactor
 * "Always leave the code behind in a better state than you found it"
 * This translates to using any opportunity possible to improve and clean up the code in front of you
 
-Please also have a look at the [Scala Hacker Guide](http://www.scala-lang.org/contribute/hacker-guide.html) by @xeno-by.
+Please also have a look at the [Scala Hacker Guide](https://www.scala-lang.org/contribute/hacker-guide.html) by @xeno-by.
 
 ### Clean commits, clean history
 
@@ -255,7 +255,7 @@ if this commit should not be merged forward into the next release
 branch.
 
 Here is standard advice on good commit messages:
-http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 
 ### Pass Scabot
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To contribute here, please open a [pull request](https://help.github.com/article
 
 Be aware that we can't accept additions to the standard library, only modifications to existing code.  Binary compatibility forbids adding new public classes or public methods. Additions are made to [scala-library-next](https://github.com/scala/scala-library-next) instead.
 
-We require that you sign the [Scala CLA](http://www.lightbend.com/contribute/cla/scala) before we can merge any of your work, to protect Scala's future as open source software.
+We require that you sign the [Scala CLA](https://www.lightbend.com/contribute/cla/scala) before we can merge any of your work, to protect Scala's future as open source software.
 
 The general workflow is as follows.
 1. Find/file an issue in scala/bug (or submit a well-documented PR right away!).
@@ -28,7 +28,7 @@ For more information on building and developing the core of Scala, read the rest
 
 In order to get in touch with other Scala contributors, join
 [scala/contributors](https://gitter.im/scala/contributors) (Gitter) or post on
-[contributors.scala-lang.org](http://contributors.scala-lang.org) (Discourse).
+[contributors.scala-lang.org](https://contributors.scala-lang.org) (Discourse).
 
 If you need some help with your PR at any time, please feel free to @-mention anyone from the list below, and we will do our best to help you out:
 
@@ -233,10 +233,10 @@ It contains useful information on our coding standards, testing, documentation, 
 we use git and GitHub and how to get your code reviewed.
 
 You may also want to check out the following resources:
-  - The ["Scala Hacker Guide"](http://scala-lang.org/contribute/hacker-guide.html)
+  - The ["Scala Hacker Guide"](https://scala-lang.org/contribute/hacker-guide.html)
     covers some of the same ground as this README, but in greater detail and in a more
     tutorial style, using a running example.
-  - [Scala documentation site](http://docs.scala-lang.org)
+  - [Scala documentation site](https://docs.scala-lang.org)
 
 # Scala CI
 
@@ -285,7 +285,7 @@ The Scala CI builds nightly download releases and publishes
 them to https://scala-ci.typesafe.com/artifactory/scala-integration/ .
 
 Using a nightly build in sbt is explained in
-[this Stack Overflow answer](http://stackoverflow.com/questions/40622878)
+[this Stack Overflow answer](https://stackoverflow.com/questions/40622878)
 
 Although we casually refer to these as "nightly" builds, they aren't
 actually built nightly, but "mergely".  That is to say, a build is

--- a/scripts/readproperties.awk
+++ b/scripts/readproperties.awk
@@ -1,4 +1,4 @@
-# Adapted from http://stackoverflow.com/questions/1682442/reading-java-properties-file-from-bash/2318840#2318840
+# Adapted from https://stackoverflow.com/questions/1682442/reading-java-properties-file-from-bash/2318840#2318840
 BEGIN {
     FS="=";
     n="";

--- a/spec/05-classes-and-objects.md
+++ b/spec/05-classes-and-objects.md
@@ -410,7 +410,7 @@ It is a static error if the inheritance closure of a class type
 consists of an infinite number of types. (This restriction is
 necessary to make subtyping decidable[^kennedy]).
 
-[^kennedy]: Kennedy, Pierce. [On Decidability of Nominal Subtyping with Variance.]( http://research.microsoft.com/pubs/64041/fool2007.pdf) in FOOL 2007
+[^kennedy]: Kennedy, Pierce. [On Decidability of Nominal Subtyping with Variance.]( https://research.microsoft.com/pubs/64041/fool2007.pdf) in FOOL 2007
 
 ### Early Definitions
 

--- a/spec/11-annotations.md
+++ b/spec/11-annotations.md
@@ -148,7 +148,7 @@ Java platform, the following annotations have a standard meaning.
 
     Whenever the static type of an expression matches a specialized variant of
     a definition, the compiler will instead use the specialized version.
-    See the [specialization sid](http://docs.scala-lang.org/sips/completed/scala-specialization.html) for more details of the implementation.
+    See the [specialization sid](https://docs.scala-lang.org/sips/completed/scala-specialization.html) for more details of the implementation.
     
 
 ## User-defined Annotations

--- a/spec/14-references.md
+++ b/spec/14-references.md
@@ -94,7 +94,7 @@ for syntactic definitions?",
   organization = {EPFL},
   month =        feb,
   year =         2007,
-  note =         {http://www.scala-lang.org/docu/manuals.html}
+  note =         {https://www.scala-lang.org/docu/manuals.html}
 }
 
 @Book{odersky:scala-reference,
@@ -125,7 +125,7 @@ for syntactic definitions?",
   year		= 2003,
   month		= jan,
   note		= {\hspace*{\fill}\\
-                  \verb@http://www.cis.upenn.edu/~bcpierce/FOOL/FOOL10.html@}
+                  \verb@https://www.cis.upenn.edu/~bcpierce/FOOL/FOOL10.html@}
 }
 
 %% Misc
@@ -135,14 +135,14 @@ for syntactic definitions?",
   author	= {W3C},
   title		= {Document Object Model ({DOM})},
   howpublished	= {\hspace*{\fill}\\
-                  \verb@http://www.w3.org/DOM/@}
+                  \verb@https://www.w3.org/DOM/@}
 }
 
 @Misc{w3c:xml,
   author	= {W3C},
   title		= {Extensible {M}arkup {L}anguage ({XML})},
   howpublished	= {\hspace*{\fill}\\
-                  \verb@http://www.w3.org/TR/REC-xml@}
+                  \verb@https://www.w3.org/TR/REC-xml@}
 }
 
 @TechReport{scala-overview-tech-report,
@@ -185,7 +185,7 @@ for syntactic definitions?",
   booktitle =    {Proc. FOOL 12},
   year =         2005,
   month =        jan,
-  note =         {\verb@http://homepages.inf.ed.ac.uk/wadler/fool@}
+  note =         {\verb@https://homepages.inf.ed.ac.uk/wadler/fool@}
 }
 
 @InProceedings{odersky:scala-experiment,
@@ -201,7 +201,7 @@ for syntactic definitions?",
   year = {2007},
   month = jan,
   note = {FOOL-WOOD '07},
-  short = {http://www.cis.upenn.edu/~bcpierce/papers/variance.pdf}
+  short = {https://www.cis.upenn.edu/~bcpierce/papers/variance.pdf}
 }
 
 -->

--- a/spec/15-changelog.md
+++ b/spec/15-changelog.md
@@ -639,7 +639,7 @@ The following three words are now reserved; they cannot be used as
 
 #### Newlines as Statement Separators
 
-[Newlines](http://www.scala-lang.org/files/archive/spec/2.11/)
+[Newlines](https://www.scala-lang.org/files/archive/spec/2.11/)
 can now be used as statement separators in place of semicolons.
 
 #### Syntax Restrictions

--- a/spec/README.md
+++ b/spec/README.md
@@ -16,7 +16,7 @@ We aim to track the configuration GitHub Pages use but at times differences will
 
 ## Building
 
-Travis CI builds the spec automatically after every merged pull release and publishes to http://www.scala-lang.org/files/archive/spec/2.13/.
+Travis CI builds the spec automatically after every merged pull release and publishes to https://www.scala-lang.org/files/archive/spec/2.13/.
 
 To preview locally, run the following commands in the root of your checkout scala/scala:
 `bundle install` to install Jekyll and `bundle exec jekyll serve -d build/spec/ -s spec/ -w --baseurl=""` to start it,

--- a/src/compiler/scala/reflect/reify/utils/Extractors.scala
+++ b/src/compiler/scala/reflect/reify/utils/Extractors.scala
@@ -105,7 +105,7 @@ trait Extractors {
   }
 
   // if we're reifying a MethodType, we can't use it as a type argument for TypeTag ctor
-  // http://groups.google.com/group/scala-internals/browse_thread/thread/2d7bb85bfcdb2e2
+  // https://groups.google.com/group/scala-internals/browse_thread/thread/2d7bb85bfcdb2e2
   private def mkTarg(tpe: Type): Tree = (
     if ((tpe eq null) || !isUseableAsTypeArg(tpe)) TypeTree(AnyTpe)
     else TypeTree(tpe)

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -25,7 +25,7 @@ import scala.tools.nsc.backend.jvm.GenBCode._
 
 /*
  *
- *  @author  Miguel Garcia, http://lampwww.epfl.ch/~magarcia/ScalaCompilerCornerReloaded/
+ *  @author  Miguel Garcia, https://lampwww.epfl.ch/~magarcia/ScalaCompilerCornerReloaded/
  *
  */
 abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
@@ -667,7 +667,7 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
               //
               // Note that using `Object.clone()` would work as well, but only because the JVM
               // relaxes protected access specifically if the receiver is an array:
-              //   http://hg.openjdk.java.net/jdk8/jdk8/hotspot/file/87ee5ee27509/src/share/vm/interpreter/linkResolver.cpp#l439
+              //   https://hg.openjdk.java.net/jdk8/jdk8/hotspot/file/87ee5ee27509/src/share/vm/interpreter/linkResolver.cpp#l439
               // Example: `class C { override def clone(): Object = "hi" }`
               // Emitting `def f(c: C) = c.clone()` as `Object.clone()` gives a VerifyError.
               val target: String = tpeTK(qual).asRefBType.classOrArrayType
@@ -824,7 +824,7 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
          * Note: The two verifiers (old: type inference, new: type checking) have different
          * requirements. Very briefly:
          *
-         * Old (http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.10.2.1): at
+         * Old (https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.10.2.1): at
          * each program point, no matter what branches were taken to get there
          *   - Stack is same size and has same typed values
          *   - Local and stack values need to have consistent types
@@ -832,7 +832,7 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
          *     instructions after an ATHROW. For example, there can be another ATHROW (without
          *     loading another throwable first).
          *
-         * New (http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.10.1)
+         * New (https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.10.1)
          *   - Requires consistent stack map frames. GenBCode always generates stack frames.
          *   - In practice: the ASM library computes stack map frames for us (ClassWriter). Emitting
          *     correct frames after an ATHROW is probably complex, so ASM uses the following strategy:
@@ -1007,7 +1007,7 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
               // could add some guess based on types of primitive args.
               // or, we could stringify all the args onto the stack, compute the exact size of
               // the StringBuilder.
-              // or, just let http://openjdk.java.net/jeps/280 (or a re-implementation thereof in our 2.13.x stdlib) do all the hard work at link time
+              // or, just let https://openjdk.java.net/jeps/280 (or a re-implementation thereof in our 2.13.x stdlib) do all the hard work at link time
               0
           }.sum
           bc.genStartConcat(tree.pos, approxBuilderSize)

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -26,7 +26,7 @@ import scala.tools.nsc.Reporting.WarningCategory
 /*
  *  Traits encapsulating functionality to convert Scala AST Trees into ASM ClassNodes.
  *
- *  @author  Miguel Garcia, http://lampwww.epfl.ch/~magarcia/ScalaCompilerCornerReloaded/
+ *  @author  Miguel Garcia, https://lampwww.epfl.ch/~magarcia/ScalaCompilerCornerReloaded/
  *
  */
 abstract class BCodeHelpers extends BCodeIdiomatic {
@@ -355,8 +355,8 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
    * Custom attribute (JVMS 4.7.1) "ScalaSig" used as marker only
    * i.e., the pickle is contained in a custom annotation, see:
    *   (1) `addAnnotations()`,
-   *   (2) SID # 10 (draft) - Storage of pickled Scala signatures in class files, http://www.scala-lang.org/sid/10
-   *   (3) SID # 5 - Internals of Scala Annotations, http://www.scala-lang.org/sid/5
+   *   (2) SID # 10 (draft) - Storage of pickled Scala signatures in class files, https://www.scala-lang.org/sid/10
+   *   (3) SID # 5 - Internals of Scala Annotations, https://www.scala-lang.org/sid/5
    * That annotation in turn is not related to the "java-generic-signature" (JVMS 4.7.9)
    * other than both ending up encoded as attributes (JVMS 4.7)
    * (with the caveat that the "ScalaSig" attribute is associated to some classes,
@@ -1010,7 +1010,7 @@ object BCodeHelpers {
 
   /**
    * Valid flags for InnerClass attribute entry.
-   * See http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.6
+   * See https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.6
    */
   val INNER_CLASSES_FLAGS = {
     asm.Opcodes.ACC_PUBLIC   | asm.Opcodes.ACC_PRIVATE   | asm.Opcodes.ACC_PROTECTED  |

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeIdiomatic.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeIdiomatic.scala
@@ -23,7 +23,7 @@ import scala.tools.nsc.backend.jvm.GenBCode._
 /*
  *  A high-level facade to the ASM API for bytecode generation.
  *
- *  @author  Miguel Garcia, http://lampwww.epfl.ch/~magarcia/ScalaCompilerCornerReloaded/
+ *  @author  Miguel Garcia, https://lampwww.epfl.ch/~magarcia/ScalaCompilerCornerReloaded/
  *
  */
 abstract class BCodeIdiomatic {

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -21,7 +21,7 @@ import GenBCode._
 import BackendReporting._
 
 /*
- *  @author  Miguel Garcia, http://lampwww.epfl.ch/~magarcia/ScalaCompilerCornerReloaded/
+ *  @author  Miguel Garcia, https://lampwww.epfl.ch/~magarcia/ScalaCompilerCornerReloaded/
  */
 abstract class BCodeSkelBuilder extends BCodeHelpers {
   import global._

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSyncAndTry.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSyncAndTry.scala
@@ -20,7 +20,7 @@ import scala.tools.asm
 
 /*
  *
- *  @author  Miguel Garcia, http://lampwww.epfl.ch/~magarcia/ScalaCompilerCornerReloaded/
+ *  @author  Miguel Garcia, https://lampwww.epfl.ch/~magarcia/ScalaCompilerCornerReloaded/
  *
  */
 abstract class BCodeSyncAndTry extends BCodeBodyBuilder {

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -335,8 +335,8 @@ abstract class BTypes {
    *
    * In this summary, "class" means "class or interface".
    *
-   * JLS: http://docs.oracle.com/javase/specs/jls/se8/html/index.html
-   * JVMS: http://docs.oracle.com/javase/specs/jvms/se8/html/index.html
+   * JLS: https://docs.oracle.com/javase/specs/jls/se8/html/index.html
+   * JVMS: https://docs.oracle.com/javase/specs/jvms/se8/html/index.html
    *
    * Terminology
    * -----------
@@ -721,7 +721,7 @@ abstract class BTypes {
     /**
      * Finding the least upper bound in agreement with the bytecode verifier
      * Background:
-     *   http://gallium.inria.fr/~xleroy/publi/bytecode-verification-JAR.pdf
+     *   https://xavierleroy.org/publi/bytecode-verification-JAR.pdf
      *   http://comments.gmane.org/gmane.comp.java.vm.languages/2293
      *   https://github.com/scala/bug/issues/3872#issuecomment-292386375
      */

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -701,7 +701,7 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
     // TODO: give nested objects the ACC_FINAL flag again, since we won't let them be overridden
     //
     // For fields, only eager val fields can receive ACC_FINAL. vars or lazy vals can't:
-    // Source: http://docs.oracle.com/javase/specs/jls/se7/html/jls-17.html#jls-17.5.3
+    // Source: https://docs.oracle.com/javase/specs/jls/se7/html/jls-17.html#jls-17.5.3
     // "Another problem is that the specification allows aggressive
     // optimization of final fields. Within a thread, it is permissible to
     // reorder reads of a final field with those modifications of a final

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
@@ -709,7 +709,7 @@ object BackendUtils {
        *
        * However, the JVM spec does not require subroutines to `RET x` to their caller, they could return back to an
        * outer subroutine caller (nested subroutines), or `RETURN`, or use a static jump. Static analysis of subroutines
-       * is therefore complex (http://www21.in.tum.de/~kleing/papers/KleinW-TPHOLS03.pdf).
+       * is therefore complex (https://www21.in.tum.de/~kleing/papers/KleinW-TPHOLS03.pdf).
        *
        * The asm.Analyzer however makes the assumption that subroutines only occur in the shape emitted by early
        * javac, i.e., `RET` always returns to the next enclosing caller. So we do that as well.

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/ByteCodeRepository.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/ByteCodeRepository.scala
@@ -291,7 +291,7 @@ abstract class ByteCodeRepository extends PerRunInit {
       // TODO: we need to remove them also for classes that are not parsed from classfiles, why not simplify and do it once when inlining?
       // OR: instead of skipping line numbers for inlined code, use write a SourceDebugExtension
       // attribute that contains JSR-45 data that encodes debugging info.
-      //   http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.7.11
+      //   https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.7.11
       //   https://jcp.org/aboutJava/communityprocess/final/jsr045/index.html
       removeLineNumbersAndAddLMFImplMethods(classNode)
       classNode

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
@@ -28,7 +28,7 @@ import scala.tools.nsc.backend.jvm.analysis.InstructionStackEffect
 
 object BytecodeUtils {
 
-  // http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.9.1
+  // https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.9.1
   final val maxJVMMethodSize = 65535
 
   // 5% margin, more than enough for the instructions added by the inliner (store / load args, null check for instance methods)

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
@@ -1277,10 +1277,10 @@ abstract class Inliner {
         //    - the receiver is the target of the CallSite
         //    - the other argument values are those that were on the operand stack at the indy instruction (indyLambda: the captured values)
         //
-        // [1] http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.10
-        // [2] http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.23
-        // [3] http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokedynamic
-        // [4] http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-5.html#jvms-5.4.3
+        // [1] https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.10
+        // [2] https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.23
+        // [3] https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokedynamic
+        // [4] https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-5.html#jvms-5.4.3
 
         // We cannot generically check if an `invokedynamic` instruction can be safely inlined into
         // a different class, that depends on the bootstrap method. The Lookup object passed to the

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/InlinerHeuristics.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/InlinerHeuristics.scala
@@ -284,7 +284,7 @@ abstract class InlinerHeuristics extends PerRunInit {
   }
 
   /*
-  // using http://lihaoyi.github.io/Ammonite/
+  // using https://lihaoyi.github.io/Ammonite/
 
   load.ivy("com.google.guava" % "guava" % "18.0")
   val javaUtilFunctionClasses = {

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/LocalOpt.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/LocalOpt.scala
@@ -574,7 +574,7 @@ abstract class LocalOpt {
      *
      * However, the JVM spec does not require subroutines to `RET x` to their caller, they could return back to an
      * outer subroutine caller (nested subroutines), or `RETURN`, or use a static jump. Static analysis of subroutines
-     * is therefore complex (http://www21.in.tum.de/~kleing/papers/KleinW-TPHOLS03.pdf).
+     * is therefore complex (https://www21.in.tum.de/~kleing/papers/KleinW-TPHOLS03.pdf).
      *
      * The asm.Analyzer however makes the assumption that subroutines only occur in the shape emitted by early
      * javac, i.e., `RET` always returns to the next enclosing caller. So we do that as well.
@@ -796,7 +796,7 @@ object LocalOptImpls {
    *
    * There are no executable instructions that we can assume don't throw (eg ILOAD). The JVM spec
    * basically says that a VirtualMachineError may be thrown at any time:
-   *   http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.3
+   *   https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.3
    *
    * Note that no instructions are eliminated.
    *
@@ -1131,7 +1131,7 @@ object LocalOptImpls {
      * inlining is only done if the GOTO instruction is not part of a try block, otherwise the
      * rewrite might change the behavior. For xRETURN, the reason is that return instructions may throw
      * an IllegalMonitorStateException, as described here:
-     *   http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.return
+     *   https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.return
      */
     def simplifyGotoReturn(instruction: AbstractInsnNode, inTryBlock: Boolean): Boolean = !inTryBlock && (instruction match {
       case Goto(jump) =>

--- a/src/compiler/scala/tools/nsc/classpath/DirectoryClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/DirectoryClassPath.scala
@@ -139,7 +139,7 @@ object JrtClassPath {
       // even if we're running on a JRE or a non OpenJDK JDK where ct.sym is unavailable.
       //
       // Longer term we'd like an official API for this in the JDK
-      // Discussion: http://mail.openjdk.java.net/pipermail/compiler-dev/2018-March/thread.html#11738
+      // Discussion: https://mail.openjdk.java.net/pipermail/compiler-dev/2018-March/thread.html#11738
 
       val currentMajorVersion: Int = JDK9Reflectors.runtimeVersionMajor(JDK9Reflectors.runtimeVersion()).intValue()
       release match {
@@ -225,7 +225,7 @@ final class JrtClassPath(fs: java.nio.file.FileSystem) extends ClassPath with No
 }
 
 /**
-  * Implementation `ClassPath` based on the \$JAVA_HOME/lib/ct.sym backing http://openjdk.java.net/jeps/247
+  * Implementation `ClassPath` based on the \$JAVA_HOME/lib/ct.sym backing https://openjdk.java.net/jeps/247
   */
 final class CtSymClassPath(ctSym: java.nio.file.Path, release: Int) extends ClassPath with NoSourcePaths with Closeable {
   import java.nio.file.Path, java.nio.file._
@@ -234,7 +234,7 @@ final class CtSymClassPath(ctSym: java.nio.file.Path, release: Int) extends Clas
   private val root: Path = fileSystem.getRootDirectories.iterator.next
   private val roots = Files.newDirectoryStream(root).iterator.asScala.toList
 
-  // http://mail.openjdk.java.net/pipermail/compiler-dev/2018-March/011737.html
+  // https://mail.openjdk.java.net/pipermail/compiler-dev/2018-March/011737.html
   private def codeFor(major: Int): String = if (major < 10) major.toString else ('A' + (major - 10)).toChar.toString
 
   private val releaseCode: String = codeFor(release)

--- a/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
@@ -176,7 +176,7 @@ trait Logic extends Debugging  {
      *
      * Complexity: DFS over formula tree
      *
-     * See http://www.decision-procedures.org/slides/propositional_logic-2x3.pdf
+     * See https://www.decision-procedures.org/slides/propositional_logic-2x3.pdf
      */
     def simplify(f: Prop): Prop = {
 

--- a/src/compiler/scala/tools/nsc/transform/patmat/Solving.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Solving.scala
@@ -399,7 +399,7 @@ trait Solving extends Logic {
       aligned
     }
 
-    // adapted from http://lara.epfl.ch/w/sav10:simple_sat_solver (original by Hossein Hojjat)
+    // adapted from https://lara.epfl.ch/w/sav10:simple_sat_solver (original by Hossein Hojjat)
 
     // empty set of clauses is trivially satisfied
     val EmptyModel = Map.empty[Sym, Boolean]

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -566,7 +566,7 @@ trait Implicits {
       // e.g. we have `class Foo(val bar: Bar)` and `class Bar(val x: Int)`
       // then it's quite reasonable for the macro writer to synthesize Complex[Foo] by calling `inferImplicitValue(typeOf[Complex[Bar])`
       // however if we didn't insert the `info.sym.isMacro` check here, then under some circumstances
-      // (e.g. as described here http://groups.google.com/group/scala-internals/browse_thread/thread/545462b377b0ac0a)
+      // (e.g. as described here https://groups.google.com/group/scala-internals/browse_thread/thread/545462b377b0ac0a)
       // `dominates` might decide that `Bar` dominates `Foo` and therefore a recursive implicit search should be prohibited
       // now when we yield control of divergent expansions to the macro writer, what happens next?
       // in the worst case, if the macro writer is careless, we'll get a StackOverflowException from repeated macro calls
@@ -1836,7 +1836,7 @@ trait Implicits {
   object ImplicitAmbiguousMsg extends ImplicitAnnotationMsg(_.implicitAmbiguousMsg, ImplicitAmbiguousClass, "implicitAmbiguous")
 
   class Message(sym: Symbol, msg: String, annotationName: String) {
-    // http://dcsobral.blogspot.com/2010/01/string-interpolation-in-scala-with.html
+    // https://dcsobral.blogspot.com/2010/01/string-interpolation-in-scala-with.html
     private val Intersobralator = """\$\{\s*([^}\s]+)\s*\}""".r
 
     private def interpolate(text: String, vars: Map[String, String]) =

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -578,7 +578,7 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
             }
             expanded match {
               case Success(expanded) =>
-                // also see http://groups.google.com/group/scala-internals/browse_thread/thread/492560d941b315cc
+                // also see https://groups.google.com/group/scala-internals/browse_thread/thread/492560d941b315cc
                 val expanded1 = try onSuccess(duplicateAndKeepPositions(expanded)) finally popMacroContext()
                 if (!hasMacroExpansionAttachment(expanded1)) linkExpandeeAndExpanded(expandee, expanded1)
                 if (settings.Ymacroexpand.value == settings.MacroExpand.Discard && !typer.context.isSearchingForImplicitParam) {

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -823,7 +823,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                 else tpr.typed(withImplicitArgs, mode, pt)
               } orElse { originalErrors =>
                 // Re-try typing (applying to implicit args) without expected type. Add in 53d98e7d42 to
-                // for better error message (scala/bug#2180, http://www.scala-lang.org/old/node/3453.html)
+                // for better error message (scala/bug#2180, https://www.scala-lang.org/old/node/3453.html)
                 val resetTree = resetAttrs(original)
                 resetTree match {
                   case treeInfo.Applied(fun, _, _) =>

--- a/src/compiler/scala/tools/nsc/util/EditDistance.scala
+++ b/src/compiler/scala/tools/nsc/util/EditDistance.scala
@@ -20,7 +20,7 @@ object EditDistance {
   /**
    * @author Paul Phillips
    * Translated from the java version at
-   *    http://www.merriampark.com/ld.htm
+   *    https://www.merriampark.com/ld.htm
    *  which is declared to be public domain.
    */
   def levenshtein(

--- a/src/compiler/templates/tool-windows.tmpl
+++ b/src/compiler/templates/tool-windows.tmpl
@@ -16,7 +16,7 @@ setlocal enableextensions enabledelayedexpansion
 
 set _LINE_TOOLCP=
 
-rem Use "%~1" to handle spaces in paths. See http://ss64.com/nt/syntax-args.html
+rem Use "%~1" to handle spaces in paths. See https://ss64.com/nt/syntax-args.html
 rem scala/bug#7295 The goto here is needed to avoid problems with `scala Script.cmd "arg(with)paren"`,
 rem                we must not evaluate %~2 eagerly, but delayed expansion doesn't seem to allow
 rem                removal of quotation marks.
@@ -157,7 +157,7 @@ rem # subroutines
 goto :eof
 
 rem Variable "%~dps0" works on WinXP SP2 or newer
-rem (see http://support.microsoft.com/?kbid=833431)
+rem (see https://support.microsoft.com/?kbid=833431)
 rem set _SCALA_HOME=%~dps0..
 :set_home
   set _BIN_DIR=
@@ -168,5 +168,5 @@ goto :eof
 :end
 @@endlocal
 
-REM exit code fix, see http://stackoverflow.com/questions/4632891/exiting-batch-with-exit-b-x-where-x-1-acts-as-if-command-completed-successfu
+REM exit code fix, see https://stackoverflow.com/questions/4632891/exiting-batch-with-exit-b-x-where-x-1-acts-as-if-command-completed-successfu
 @@"%COMSPEC%" /C exit %errorlevel% >nul

--- a/src/interactive/scala/tools/nsc/interactive/Pickler.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Pickler.scala
@@ -33,8 +33,8 @@ import java.io.Writer
  *  These Picklers build on the work of Andrew Kennedy. They are most closely inspired by
  *  Iulian Dragos' picklers for Scala to XML. See:
  *
- *  <a href="http://code.google.com/p/gdata-scala-client/wiki/DevelopersGuide">
- *  http://code.google.com/p/gdata-scala-client/wiki/DevelopersGuide
+ *  <a href="https://code.google.com/p/gdata-scala-client/wiki/DevelopersGuide">
+ *  https://code.google.com/p/gdata-scala-client/wiki/DevelopersGuide
  *  </a>
  */
 abstract class Pickler[T] {

--- a/src/library-aux/scala/Any.scala
+++ b/src/library-aux/scala/Any.scala
@@ -31,13 +31,13 @@ package scala
  *     w.print()
  * }}}
  *
- * See the [[http://docs.scala-lang.org/overviews/core/value-classes.html Value Classes and Universal Traits]] for more
+ * See the [[https://docs.scala-lang.org/overviews/core/value-classes.html Value Classes and Universal Traits]] for more
  * details on the interplay of universal traits and value classes.
  */
 abstract class Any {
   /** Compares the receiver object (`this`) with the argument object (`that`) for equivalence.
    *
-   *  Any implementation of this method should be an [[http://en.wikipedia.org/wiki/Equivalence_relation equivalence relation]]:
+   *  Any implementation of this method should be an [[https://en.wikipedia.org/wiki/Equivalence_relation equivalence relation]]:
    *
    *  - It is reflexive: for any instance `x` of type `Any`, `x.equals(x)` should return `true`.
    *  - It is symmetric: for any instances `x` and `y` of type `Any`, `x.equals(y)` should return `true` if and

--- a/src/library-aux/scala/AnyRef.scala
+++ b/src/library-aux/scala/AnyRef.scala
@@ -51,7 +51,7 @@ trait AnyRef extends Any {
 
   /** Tests whether the argument (`that`) is a reference to the receiver object (`this`).
    *
-   *  The `eq` method implements an [[http://en.wikipedia.org/wiki/Equivalence_relation equivalence relation]] on
+   *  The `eq` method implements an [[https://en.wikipedia.org/wiki/Equivalence_relation equivalence relation]] on
    *  non-null instances of `AnyRef`, and has three additional properties:
    *
    *   - It is consistent: for any non-null instances `x` and `y` of type `AnyRef`, multiple invocations of

--- a/src/library/scala/AnyVal.scala
+++ b/src/library/scala/AnyVal.scala
@@ -52,7 +52,7 @@ package scala
  *
  * It's important to note that user-defined value classes are limited, and in some circumstances,
  * still must allocate a value class instance at runtime. These limitations and circumstances are
- * explained in greater detail in the [[http://docs.scala-lang.org/overviews/core/value-classes.html Value Classes and Universal Traits]].
+ * explained in greater detail in the [[https://docs.scala-lang.org/overviews/core/value-classes.html Value Classes and Universal Traits]].
  */
 abstract class AnyVal extends Any {
   def getClass(): Class[_ <: AnyVal] = null

--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -604,9 +604,9 @@ object Array {
  *  by converting to `ArraySeq` first and invoking the variant of `reverse` that returns another
  *  `ArraySeq`.
  *
- *  @see [[http://www.scala-lang.org/files/archive/spec/2.13/ Scala Language Specification]], for in-depth information on the transformations the Scala compiler makes on Arrays (Sections 6.6 and 6.15 respectively.)
- *  @see [[http://docs.scala-lang.org/sips/completed/scala-2-8-arrays.html "Scala 2.8 Arrays"]] the Scala Improvement Document detailing arrays since Scala 2.8.
- *  @see [[http://docs.scala-lang.org/overviews/collections/arrays.html "The Scala 2.8 Collections' API"]] section on `Array` by Martin Odersky for more information.
+ *  @see [[https://www.scala-lang.org/files/archive/spec/2.13/ Scala Language Specification]], for in-depth information on the transformations the Scala compiler makes on Arrays (Sections 6.6 and 6.15 respectively.)
+ *  @see [[https://docs.scala-lang.org/sips/completed/scala-2-8-arrays.html "Scala 2.8 Arrays"]] the Scala Improvement Document detailing arrays since Scala 2.8.
+ *  @see [[https://docs.scala-lang.org/overviews/collections/arrays.html "The Scala 2.8 Collections' API"]] section on `Array` by Martin Odersky for more information.
  *  @hideImplicitConversion scala.Predef.booleanArrayOps
  *  @hideImplicitConversion scala.Predef.byteArrayOps
  *  @hideImplicitConversion scala.Predef.charArrayOps

--- a/src/library/scala/Equals.scala
+++ b/src/library/scala/Equals.scala
@@ -18,7 +18,7 @@ package scala
 trait Equals extends Any {
   /** A method that should be called from every well-designed equals method
    *  that is open to be overridden in a subclass. See
-   *  [[http://www.artima.com/pins1ed/object-equality.html Programming in Scala,
+   *  [[https://www.artima.com/pins1ed/object-equality.html Programming in Scala,
    *  Chapter 28]] for discussion and design.
    *
    *  @param    that    the value being probed for possible equality

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -139,7 +139,7 @@ object Predef extends LowPriorityImplicits {
   /** The `String` type in Scala has all the methods of the underlying
    *  `java.lang.String`, of which it is just an alias.
    *  (See the documentation corresponding to your Java version,
-   *  for example [[http://docs.oracle.com/javase/8/docs/api/java/lang/String.html]].)
+   *  for example [[https://docs.oracle.com/javase/8/docs/api/java/lang/String.html]].)
    *  In addition, extension methods in [[scala.collection.StringOps]]
    *  are added implicitly through the conversion [[augmentString]].
    *  @group aliases

--- a/src/library/scala/SerialVersionUID.scala
+++ b/src/library/scala/SerialVersionUID.scala
@@ -20,7 +20,7 @@ package scala
   * which the JVM's serialization mechanism uses to determine serialization
   * compatibility between different versions of a class.
   *
-  * @see [[http://docs.oracle.com/javase/8/docs/api/java/io/Serializable.html `java.io.Serializable`]]
+  * @see [[https://docs.oracle.com/javase/8/docs/api/java/io/Serializable.html `java.io.Serializable`]]
   * @see [[Serializable]]
   */
 @deprecatedInheritance("Scheduled for being final in the future", "2.13.0")

--- a/src/library/scala/annotation/ClassfileAnnotation.scala
+++ b/src/library/scala/annotation/ClassfileAnnotation.scala
@@ -13,7 +13,7 @@
 package scala.annotation
 
 /** A base class for classfile annotations. These are stored as
- *  [[http://docs.oracle.com/javase/8/docs/technotes/guides/language/annotations.html Java annotations]]]
+ *  [[https://docs.oracle.com/javase/8/docs/technotes/guides/language/annotations.html Java annotations]]]
  *  in classfiles.
  */
 @deprecated("Annotation classes need to be written in Java in order to be stored in classfiles in a Java-compatible manner", "2.13.0")

--- a/src/library/scala/annotation/switch.scala
+++ b/src/library/scala/annotation/switch.scala
@@ -14,7 +14,7 @@ package scala.annotation
 
 /** An annotation to be applied to a match expression.  If present,
  *  the compiler will verify that the match has been compiled to a
- *  [[http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-3.html#jvms-3.10 tableswitch or lookupswitch]]
+ *  [[https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-3.html#jvms-3.10 tableswitch or lookupswitch]]
  *  and issue a warning if it instead compiles into a series of conditional expressions.
  *  Example usage:
 {{{

--- a/src/library/scala/collection/concurrent/Map.scala
+++ b/src/library/scala/collection/concurrent/Map.scala
@@ -20,7 +20,7 @@ import scala.annotation.tailrec
   *
   *  $concurrentmapinfo
   *
-  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#concurrent_maps "Scala's Collection Library overview"]]
+  *  @see [[https://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#concurrent_maps "Scala's Collection Library overview"]]
   *  section on `Concurrent Maps` for more information.
   *
   *  @tparam K  the key type of the map

--- a/src/library/scala/collection/generic/BitOperations.scala
+++ b/src/library/scala/collection/generic/BitOperations.scala
@@ -16,7 +16,7 @@ package generic
 
 /** Some bit operations.
   *
-  *  See [[http://www.drmaciver.com/2008/08/unsigned-comparison-in-javascala/]] for
+  *  See [[https://www.drmaciver.com/2008/08/unsigned-comparison-in-javascala/]] for
   *  an explanation of unsignedCompare.
   */
 private[collection] object BitOperations {

--- a/src/library/scala/collection/immutable/BitSet.scala
+++ b/src/library/scala/collection/immutable/BitSet.scala
@@ -20,7 +20,7 @@ import scala.annotation.{implicitNotFound, nowarn}
 
 /** A class for immutable bitsets.
   *  $bitsetinfo
-  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#immutable-bitsets "Scala's Collection Library overview"]]
+  *  @see [[https://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#immutable-bitsets "Scala's Collection Library overview"]]
   *  section on `Immutable BitSets` for more information.
   *
   *  @define Coll `immutable.BitSet`

--- a/src/library/scala/collection/immutable/IntMap.scala
+++ b/src/library/scala/collection/immutable/IntMap.scala
@@ -164,7 +164,7 @@ private[immutable] class IntMapKeyIterator[V](it: IntMap[V]) extends IntMapItera
 import IntMap._
 
 /** Specialised immutable map structure for integer keys, based on
-  *  [[http://ittc.ku.edu/~andygill/papers/IntMap98.pdf Fast Mergeable Integer Maps]]
+  *  [[https://ittc.ku.edu/~andygill/papers/IntMap98.pdf Fast Mergeable Integer Maps]]
   *  by Okasaki and Gill. Essentially a trie based on binary digits of the integers.
   *
   *  '''Note:''' This class is as of 2.8 largely superseded by HashMap.

--- a/src/library/scala/collection/immutable/LazyList.scala
+++ b/src/library/scala/collection/immutable/LazyList.scala
@@ -220,7 +220,7 @@ import scala.runtime.Statics
   *
   *  @tparam A    the type of the elements contained in this lazy list.
   *
-  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#lazylists "Scala's Collection Library overview"]]
+  *  @see [[https://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#lazylists "Scala's Collection Library overview"]]
   *  section on `LazyLists` for more information.
   *  @define Coll `LazyList`
   *  @define coll lazy list

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -65,7 +65,7 @@ import scala.runtime.Statics.releaseFence
   *        objects that rely on structural sharing), will be serialized and deserialized with multiple lists, one for
   *        each reference to it. I.e. structural sharing is lost after serialization/deserialization.
   *
-  *  @see  [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#lists "Scala's Collection Library overview"]]
+  *  @see  [[https://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#lists "Scala's Collection Library overview"]]
   *  section on `Lists` for more information.
   *
   *  @define coll list

--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -119,7 +119,7 @@ sealed class ListMap[K, +V]
   * n elements will take O(n^2^) time. This makes the builder suitable only for a small number of
   * elements.
   *
-  * @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#list-maps "Scala's Collection Library overview"]]
+  * @see [[https://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#list-maps "Scala's Collection Library overview"]]
   * section on `List Maps` for more information.
   * @define Coll ListMap
   * @define coll list map

--- a/src/library/scala/collection/immutable/LongMap.scala
+++ b/src/library/scala/collection/immutable/LongMap.scala
@@ -160,7 +160,7 @@ private[immutable] class LongMapKeyIterator[V](it: LongMap[V]) extends LongMapIt
 
 /**
   *  Specialised immutable map structure for long keys, based on
-  *  [[http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.37.5452 Fast Mergeable Long Maps]]
+  *  [[https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.37.5452 Fast Mergeable Long Maps]]
   *  by Okasaki and Gill. Essentially a trie based on binary digits of the integers.
   *
   *  Note: This class is as of 2.8 largely superseded by HashMap.

--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -27,7 +27,7 @@ import scala.collection.mutable.{Builder, ListBuffer}
   *  where a pivot is required, in which case, a cost of `O(n)` is incurred, where `n` is the number of elements in the queue. When this happens,
   *  `n` remove operations with `O(1)` cost are guaranteed. Removing an item is on average `O(1)`.
   *
-  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#immutable-queues "Scala's Collection Library overview"]]
+  *  @see [[https://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#immutable-queues "Scala's Collection Library overview"]]
   *  section on `Immutable Queues` for more information.
   *
   *  @define Coll `immutable.Queue`

--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -779,7 +779,7 @@ private[collection] object RedBlackTree {
 
     protected[this] val stackOfNexts = if (root eq null) null else {
       /*
-       * According to "Ralf Hinze. Constructing red-black trees" [http://www.cs.ox.ac.uk/ralf.hinze/publications/#P5]
+       * According to "Ralf Hinze. Constructing red-black trees" [https://www.cs.ox.ac.uk/ralf.hinze/publications/#P5]
        * the maximum height of a red-black tree is 2*log_2(n + 2) - 2.
        *
        * According to {@see Integer#numberOfLeadingZeros} ceil(log_2(n)) = (32 - Integer.numberOfLeadingZeros(n - 1))
@@ -1028,7 +1028,7 @@ private[collection] object RedBlackTree {
 
 
   // Based on Stefan Kahrs' Haskell version of Okasaki's Red&Black Trees
-  // Constructing Red-Black Trees, Ralf Hinze: [[http://www.cs.ox.ac.uk/ralf.hinze/publications/WAAAPL99b.ps.gz]]
+  // Constructing Red-Black Trees, Ralf Hinze: [[https://www.cs.ox.ac.uk/ralf.hinze/publications/WAAAPL99b.ps.gz]]
   // Red-Black Trees in a Functional Setting, Chris Okasaki: [[https://wiki.rice.edu/confluence/download/attachments/2761212/Okasaki-Red-Black.pdf]] */
 
   private[this] def del[A, B](tree: Tree[A, B], k: A)(implicit ordering: Ordering[A]): Tree[A, B] = if (tree eq null) null else {

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -60,7 +60,7 @@ import scala.runtime.AbstractFunction2
   *  @tparam V         the type of the values associated with the keys.
   *  @param ordering   the implicit ordering used to compare objects of type `A`.
   *
-  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#red-black-trees "Scala's Collection Library overview"]]
+  *  @see [[https://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#red-black-trees "Scala's Collection Library overview"]]
   *  section on `Red-Black Trees` for more information.
   *
   *  @define Coll immutable.TreeMap

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -26,7 +26,7 @@ import scala.runtime.AbstractFunction1
   *  @tparam A         the type of the elements contained in this tree set
   *  @param ordering   the implicit ordering used to compare objects of type `A`
   *
-  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#red-black-trees "Scala's Collection Library overview"]]
+  *  @see [[https://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#red-black-trees "Scala's Collection Library overview"]]
   *  section on `Red-Black Trees` for more information.
   *
   *  @define Coll `immutable.TreeSet`

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -26,7 +26,7 @@ import scala.util.chaining._
   *  access take constant time (amortized time). Prepends and removes are
   *  linear in the buffer size.
   *
-  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#array-buffers "Scala's Collection Library overview"]]
+  *  @see [[https://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#array-buffers "Scala's Collection Library overview"]]
   *  section on `Array Buffers` for more information.
 
   *

--- a/src/library/scala/collection/mutable/BitSet.scala
+++ b/src/library/scala/collection/mutable/BitSet.scala
@@ -23,7 +23,7 @@ import scala.annotation.implicitNotFound
   *
   * $bitsetinfo
   *
-  * @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#mutable-bitsets "Scala's Collection Library overview"]]
+  * @see [[https://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#mutable-bitsets "Scala's Collection Library overview"]]
   * section on `Mutable Bitsets` for more information.
   *
   * @define Coll `BitSet`

--- a/src/library/scala/collection/mutable/CollisionProofHashMap.scala
+++ b/src/library/scala/collection/mutable/CollisionProofHashMap.scala
@@ -23,7 +23,7 @@ import scala.runtime.Statics
   * as determined by the `Ordering` has to be consistent with `equals` and `hashCode`. Universal equality
   * of numeric types is not supported (similar to `AnyRefMap`).
   *
-  * @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#hash-tables "Scala's Collection Library overview"]]
+  * @see [[https://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#hash-tables "Scala's Collection Library overview"]]
   * section on `Hash Tables` for more information.
   *
   * @define Coll `mutable.CollisionProofHashMap`

--- a/src/library/scala/collection/mutable/HashMap.scala
+++ b/src/library/scala/collection/mutable/HashMap.scala
@@ -20,7 +20,7 @@ import scala.util.hashing.MurmurHash3
 
 /** This class implements mutable maps using a hashtable.
   *
-  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#hash-tables "Scala's Collection Library overview"]]
+  *  @see [[https://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#hash-tables "Scala's Collection Library overview"]]
   *  section on `Hash Tables` for more information.
   *
   *  @tparam K    the type of the keys contained in this hash map.

--- a/src/library/scala/collection/mutable/HashSet.scala
+++ b/src/library/scala/collection/mutable/HashSet.scala
@@ -20,7 +20,7 @@ import scala.util.hashing.MurmurHash3
 
 /** This class implements mutable sets using a hashtable.
   *
-  * @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#hash-tables "Scala's Collection Library overview"]]
+  * @see [[https://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#hash-tables "Scala's Collection Library overview"]]
   * section on `Hash Tables` for more information.
   *
   * @define Coll `mutable.HashSet`

--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -23,7 +23,7 @@ import scala.runtime.Statics.releaseFence
 /** A `Buffer` implementation backed by a list. It provides constant time
   *  prepend and append. Most other operations are linear.
   *
-  *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#list-buffers "Scala's Collection Library overview"]]
+  *  @see [[https://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#list-buffers "Scala's Collection Library overview"]]
   *  section on `List Buffers` for more information.
   *
   *  @tparam A    the type of this list buffer's elements.

--- a/src/library/scala/collection/mutable/StringBuilder.scala
+++ b/src/library/scala/collection/mutable/StringBuilder.scala
@@ -32,7 +32,7 @@ import scala.Predef.{ // unimport char-related implicit conversions to avoid tri
   *
   * @define Coll `mutable.IndexedSeq`
   * @define coll string builder
-  * @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#stringbuilders "Scala's Collection Library overview"]]
+  * @see [[https://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#stringbuilders "Scala's Collection Library overview"]]
   * section on `StringBuilders` for more information.
   */
 @SerialVersionUID(3L)

--- a/src/library/scala/collection/mutable/WeakHashMap.scala
+++ b/src/library/scala/collection/mutable/WeakHashMap.scala
@@ -24,7 +24,7 @@ import scala.collection.convert.JavaCollectionWrappers.{JMapWrapper, JMapWrapper
  *  @tparam K      type of keys contained in this map
  *  @tparam V      type of values associated with the keys
  *
- *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#weak-hash-maps "Scala's Collection Library overview"]]
+ *  @see [[https://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#weak-hash-maps "Scala's Collection Library overview"]]
  *  section on `Weak Hash Maps` for more information.
  *
  *  @define Coll `WeakHashMap`

--- a/src/library/scala/concurrent/ExecutionContext.scala
+++ b/src/library/scala/concurrent/ExecutionContext.scala
@@ -106,13 +106,13 @@ trait ExecutionContext {
 
 /**
  * An [[ExecutionContext]] that is also a
- * Java [[http://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Executor.html Executor]].
+ * Java [[https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Executor.html Executor]].
  */
 trait ExecutionContextExecutor extends ExecutionContext with Executor
 
 /**
  * An [[ExecutionContext]] that is also a
- * Java [[http://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ExecutorService.html ExecutorService]].
+ * Java [[https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ExecutorService.html ExecutorService]].
  */
 trait ExecutionContextExecutorService extends ExecutionContextExecutor with ExecutorService
 
@@ -287,7 +287,7 @@ object ExecutionContext {
    */
   def fromExecutor(e: Executor): ExecutionContextExecutor = fromExecutor(e, defaultReporter)
 
-  /** The default reporter simply prints the stack trace of the `Throwable` to [[http://docs.oracle.com/javase/8/docs/api/java/lang/System.html#err System.err]].
+  /** The default reporter simply prints the stack trace of the `Throwable` to [[https://docs.oracle.com/javase/8/docs/api/java/lang/System.html#err System.err]].
    *
    *  @return the function for error reporting
    */

--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -41,7 +41,7 @@ import scala.concurrent.ExecutionContext.parasitic
  *  }
  *  }}}
  *
- *  @see [[http://docs.scala-lang.org/overviews/core/futures.html Futures and Promises]]
+ *  @see [[https://docs.scala-lang.org/overviews/core/futures.html Futures and Promises]]
  *
  *  @define multipleCallbacks
  *  Multiple callbacks may be registered; there is no guarantee that they will be

--- a/src/library/scala/concurrent/SyncVar.scala
+++ b/src/library/scala/concurrent/SyncVar.scala
@@ -43,7 +43,7 @@ class SyncVar[A] {
     wait(timeout)
     val elapsed = System.nanoTime() - start
     // nanoTime should be monotonic, but it's not possible to rely on that.
-    // See http://bugs.java.com/view_bug.do?bug_id=6458294
+    // See https://bugs.java.com/view_bug.do?bug_id=6458294
     if (elapsed < 0) 0 else TimeUnit.NANOSECONDS.toMillis(elapsed)
   }
 

--- a/src/library/scala/concurrent/impl/Promise.scala
+++ b/src/library/scala/concurrent/impl/Promise.scala
@@ -28,7 +28,7 @@ import java.io.{IOException, NotSerializableException, ObjectInputStream, Object
   * Inspired by: http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/src/main/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
   * Written by Doug Lea with assistance from members of JCP JSR-166
   * Expert Group and released to the public domain, as explained at
-  * http://creativecommons.org/publicdomain/zero/1.0/
+  * https://creativecommons.org/publicdomain/zero/1.0/
   */
 private[impl] final class CompletionLatch[T] extends AbstractQueuedSynchronizer with (Try[T] => Unit) {
   //@volatie not needed since we use acquire/release

--- a/src/library/scala/concurrent/package.scala
+++ b/src/library/scala/concurrent/package.scala
@@ -21,7 +21,7 @@ import scala.annotation.implicitNotFound
  *
  * A more detailed guide to Futures and Promises, including discussion and examples
  * can be found at
- * [[http://docs.scala-lang.org/overviews/core/futures.html]].
+ * [[https://docs.scala-lang.org/overviews/core/futures.html]].
  *
  * == Common Imports ==
  *

--- a/src/library/scala/deprecated.scala
+++ b/src/library/scala/deprecated.scala
@@ -49,7 +49,7 @@ import scala.annotation.meta._
  *  all 2.13.x releases, but may be removed in the future. (A deprecated element
  *  might be kept longer to ease migration, but developers should not rely on this.)
  *
- *  @see    The official documentation on [[http://www.scala-lang.org/news/2.11.0/#binary-compatibility binary compatibility]].
+ *  @see    The official documentation on [[https://www.scala-lang.org/news/2.11.0/#binary-compatibility binary compatibility]].
  *  @param  message the message to print during compilation if the definition is accessed
  *  @param  since   a string identifying the first version in which the definition was deprecated
  *  @see    [[scala.deprecatedInheritance]]

--- a/src/library/scala/math/Equiv.scala
+++ b/src/library/scala/math/Equiv.scala
@@ -21,7 +21,7 @@ import scala.annotation.migration
  *  equivalence and a representation of equivalence on some type. This
  *  trait is for representing the latter.
  *
- *  An [[http://en.wikipedia.org/wiki/Equivalence_relation equivalence relation]]
+ *  An [[https://en.wikipedia.org/wiki/Equivalence_relation equivalence relation]]
  *  is a binary relation on a type. This relation is exposed as
  *  the `equiv` method of the `Equiv` trait.  The relation must be:
  *

--- a/src/library/scala/math/PartialOrdering.scala
+++ b/src/library/scala/math/PartialOrdering.scala
@@ -18,7 +18,7 @@ package math
  *  of partial ordering on some type.  This trait is for representing the
  *  latter.
  *
- *  A [[http://en.wikipedia.org/wiki/Partially_ordered_set partial ordering]] is a
+ *  A [[https://en.wikipedia.org/wiki/Partially_ordered_set partial ordering]] is a
  *  binary relation on a type `T`, exposed as the `lteq` method of this trait.
  *  This relation must be:
  *
@@ -31,7 +31,7 @@ package math
  *    for any `x`, `y`, and `z` of type `T`.
  *
  *  Additionally, a partial ordering induces an
- *  [[http://en.wikipedia.org/wiki/Equivalence_relation equivalence relation]]
+ *  [[https://en.wikipedia.org/wiki/Equivalence_relation equivalence relation]]
  *  on a type `T`: `x` and `y` of type `T` are equivalent if and only if
  *  `lteq(x, y) && lteq(y, x) == '''true'''`. This equivalence relation is
  *  exposed as the `equiv` method, inherited from the

--- a/src/library/scala/reflect/ClassTag.scala
+++ b/src/library/scala/reflect/ClassTag.scala
@@ -42,7 +42,7 @@ import scala.annotation.{implicitNotFound, nowarn}
  * }}}
  *
  * See [[scala.reflect.api.TypeTags]] for more examples, or the
- * [[http://docs.scala-lang.org/overviews/reflection/typetags-manifests.html Reflection Guide: TypeTags]]
+ * [[https://docs.scala-lang.org/overviews/reflection/typetags-manifests.html Reflection Guide: TypeTags]]
  * for more details.
  *
  */

--- a/src/library/scala/sys/process/Process.scala
+++ b/src/library/scala/sys/process/Process.scala
@@ -205,7 +205,7 @@ trait ProcessImplicits {
     * input to a process. For example:
     * {{{
     * import scala.sys.process._
-    * Seq("xmllint", "--html", "-") #< new java.net.URL("http://www.scala-lang.org") #> new java.io.File("fixed.html") !
+    * Seq("xmllint", "--html", "-") #< new java.net.URL("https://www.scala-lang.org") #> new java.io.File("fixed.html") !
     * }}}
     */
   implicit def urlToProcess(url: URL): URLBuilder                         = apply(url)

--- a/src/library/scala/sys/process/ProcessBuilder.scala
+++ b/src/library/scala/sys/process/ProcessBuilder.scala
@@ -67,7 +67,7 @@ import ProcessBuilder.{Sink, Source}
   * something else such as a `java.io.File` or a `java.io.InputStream`.
   * For example:
   * {{{
-  * new URL("http://databinder.net/dispatch/About") #> "grep JSON" #>> new File("About_JSON") !
+  * new URL("https://databinder.net/dispatch/About") #> "grep JSON" #>> new File("About_JSON") !
   * }}}
   *
   * ==Starting Processes==

--- a/src/library/scala/sys/process/package.scala
+++ b/src/library/scala/sys/process/package.scala
@@ -186,7 +186,7 @@ package scala.sys {
     * import java.io.File
     * import java.net.URL
     * import scala.sys.process._
-    * new URL("http://www.scala-lang.org/") #> new File("scala-lang.html") !
+    * new URL("https://www.scala-lang.org/") #> new File("scala-lang.html") !
     * }}}
     *
     * More information about the other ways of controlling I/O can be found

--- a/src/library/scala/util/Properties.scala
+++ b/src/library/scala/util/Properties.scala
@@ -148,7 +148,7 @@ private[scala] trait PropertiesTrait {
   /* Some derived values. */
   /** Returns `true` iff the underlying operating system is a version of Microsoft Windows. */
   def isWin                 = osName startsWith "Windows"
-  // See http://mail.openjdk.java.net/pipermail/macosx-port-dev/2012-November/005148.html for
+  // See https://mail.openjdk.java.net/pipermail/macosx-port-dev/2012-November/005148.html for
   // the reason why we don't follow developer.apple.com/library/mac/#technotes/tn2002/tn2110.
   /** Returns `true` iff the underlying operating system is a version of Apple Mac OSX.  */
   def isMac                 = osName startsWith "Mac OS X"

--- a/src/library/scala/util/control/Exception.scala
+++ b/src/library/scala/util/control/Exception.scala
@@ -34,16 +34,16 @@ import scala.language.implicitConversions
  *  import scala.util.control.Exception._
  *  import java.net._
  *
- *  val s = "http://www.scala-lang.org/"
+ *  val s = "https://www.scala-lang.org/"
  *
- *  // Some(http://www.scala-lang.org/)
+ *  // Some(https://www.scala-lang.org/)
  *  val x1: Option[URL] = catching(classOf[MalformedURLException]) opt new URL(s)
  *
- *  // Right(http://www.scala-lang.org/)
+ *  // Right(https://www.scala-lang.org/)
  *  val x2: Either[Throwable,URL] =
  *    catching(classOf[MalformedURLException], classOf[NullPointerException]) either new URL(s)
  *
- *  // Success(http://www.scala-lang.org/)
+ *  // Success(https://www.scala-lang.org/)
  *  val x3: Try[URL] = catching(classOf[MalformedURLException], classOf[NullPointerException]) withTry new URL(s)
  *
  *  val defaultUrl = new URL("http://example.com")
@@ -69,7 +69,7 @@ import scala.language.implicitConversions
  *  //     at java.net.URL.<init>(URL.java:586)
  *  withThrowableLogging { printUrl(badUrl) }
  *
- *  val goodUrl = "http://www.scala-lang.org/"
+ *  val goodUrl = "https://www.scala-lang.org/"
  *  // Prints page content,
  *  //   &lt;!DOCTYPE html&gt;
  *  //   &lt;html&gt;

--- a/src/library/scala/util/control/TailCalls.scala
+++ b/src/library/scala/util/control/TailCalls.scala
@@ -19,7 +19,7 @@ package util.control
  *  of evaluating a tailcalling function can be retrieved from a `Tailrec`
  *  value using method `result`.
  *  Implemented as described in "Stackless Scala with Free Monads"
- *  [[http://blog.higher-order.com/assets/trampolines.pdf]]
+ *  [[https://blog.higher-order.com/assets/trampolines.pdf]]
  *
  *  Here's a usage example:
  *  {{{

--- a/src/manual/scala/man1/Command.scala
+++ b/src/manual/scala/man1/Command.scala
@@ -41,7 +41,7 @@ trait Command {
   def authors = Section("AUTHOR",
 
     "Written by Martin Odersky and other members of the " &
-    Link("Scala team", "http://www.scala-lang.org/news/2014/01/22/10-years-of-scala.html") & ".")
+    Link("Scala team", "https://www.scala-lang.org/news/2014/01/22/10-years-of-scala.html") & ".")
 
   def copyright = Section("COPYRIGHT",
 

--- a/src/manual/scala/man1/fsc.scala
+++ b/src/manual/scala/man1/fsc.scala
@@ -16,7 +16,7 @@ object fsc extends Command {
   val name = Section("NAME",
 
     MBold(command) & " " & NDash & " Fast offline compiler for the " &
-    Link("Scala 2", "http://scala-lang.org/") & " language")
+    Link("Scala 2", "https://scala-lang.org/") & " language")
 
   val synopsis = Section("SYNOPSIS",
 

--- a/src/manual/scala/man1/scala.scala
+++ b/src/manual/scala/man1/scala.scala
@@ -16,7 +16,7 @@ object scala extends Command {
   val name = Section("NAME",
 
     MBold(command) & " " & NDash & " Run code in the " &
-    Link("Scala 2", "http://scala-lang.org/") &
+    Link("Scala 2", "https://scala-lang.org/") &
     " language")
 
   val synopsis = Section("SYNOPSIS",

--- a/src/manual/scala/man1/scalac.scala
+++ b/src/manual/scala/man1/scalac.scala
@@ -13,7 +13,7 @@ object scalac extends Command {
   val name = Section("NAME",
 
     MBold(command) & " " & NDash & " Compiler for the " &
-    Link("Scala 2", "http://scala-lang.org/") & " language")
+    Link("Scala 2", "https://scala-lang.org/") & " language")
 
   val synopsis = Section("SYNOPSIS",
 

--- a/src/manual/scala/man1/scaladoc.scala
+++ b/src/manual/scala/man1/scaladoc.scala
@@ -13,7 +13,7 @@ object scaladoc extends Command {
 
   protected def cn = new Error().getStackTrace()(0).getClassName()
 
-  val scalaLink = Link("Scala 2", "http://scala-lang.org/")
+  val scalaLink = Link("Scala 2", "https://scala-lang.org/")
 
   val name = Section("NAME",
 

--- a/src/manual/scala/man1/scalap.scala
+++ b/src/manual/scala/man1/scalap.scala
@@ -16,7 +16,7 @@ object scalap extends Command {
   val name = Section("NAME",
 
     MBold(command) & " " & NDash & " Scala class file decoder for the " &
-    Link("Scala 2", "http://scala-lang.org/") & " language")
+    Link("Scala 2", "https://scala-lang.org/") & " language")
 
   val synopsis = Section("SYNOPSIS",
 

--- a/src/manual/scala/tools/docutil/EmitManPage.scala
+++ b/src/manual/scala/tools/docutil/EmitManPage.scala
@@ -150,7 +150,7 @@ object EmitManPage {
     out println ".\\\" #      ________ ___   / /  ___     Scala 2 On-line Manual Pages          #"
     out println ".\\\" #     / __/ __// _ | / /  / _ |    (c) 2002-2013, LAMP/EPFL              #"
     out println ".\\\" #   __\\ \\/ /__/ __ |/ /__/ __ |                                          #"
-    out println ".\\\" #  /____/\\___/_/ |_/____/_/ | |    http://scala-lang.org/                #"
+    out println ".\\\" #  /____/\\___/_/ |_/____/_/ | |    https://scala-lang.org/                #"
     out println ".\\\" #                           |/                                           #"
     out println ".\\\" ##########################################################################"
     out println ".\\\""

--- a/src/manual/scala/tools/docutil/resources/css/style.css
+++ b/src/manual/scala/tools/docutil/resources/css/style.css
@@ -10,7 +10,7 @@
 	font-size: 90%;
 }
 
-/* see http://www.maxdesign.com.au/presentation/external/ */
+/* see https://www.maxdesign.com.au/presentation/external/ */
 a.external span {
 	position: absolute;
 	left: -5000px;

--- a/src/manual/scala/tools/docutil/resources/index.html
+++ b/src/manual/scala/tools/docutil/resources/index.html
@@ -17,7 +17,7 @@
 
 <body>
 <div style="float:left; width:20%;">
-  <a href="http://scala-lang.org/">
+  <a href="https://scala-lang.org/">
   <img src="images/scala_logo.png" alt="Scala" width="80" height="55"/></a>
 </div>
 <div style="float:right; width:20%;">
@@ -87,9 +87,9 @@
   </td>
   <td>
     [<a class="external"
-    href="http://java.sun.com/j2se/1.5.0/docs/tooldocs/solaris/classpath.html">Solaris and Linux</a>]
+    href="https://java.sun.com/j2se/1.5.0/docs/tooldocs/solaris/classpath.html">Solaris and Linux</a>]
     [<a class="external"
-    href="http://java.sun.com/j2se/1.5.0/docs/tooldocs/windows/classpath.html">Windows</a>]
+    href="https://java.sun.com/j2se/1.5.0/docs/tooldocs/windows/classpath.html">Windows</a>]
   </td>
 </tr>
 
@@ -99,7 +99,7 @@
   </td>
   <td>
     [<a class="external"
-    href="http://java.sun.com/j2se/1.5.0/docs/tooldocs/findingclasses.html">Solaris, Linux and Windows</a>]
+    href="https://java.sun.com/j2se/1.5.0/docs/tooldocs/findingclasses.html">Solaris, Linux and Windows</a>]
   </td>
 </tr>
 </table>
@@ -180,7 +180,7 @@
   <hr/>
 
   <div style="font-size:x-small;">
-    Copyright (c) 2002-2013 <a href="http://www.epfl.ch/">EPFL</a>,
+    Copyright (c) 2002-2013 <a href="https://www.epfl.ch/">EPFL</a>,
     Lausanne, unless specified otherwise.<br/>
     All rights reserved.
   </div>

--- a/src/reflect/scala/reflect/api/Annotations.scala
+++ b/src/reflect/scala/reflect/api/Annotations.scala
@@ -41,7 +41,7 @@ import scala.collection.immutable.ListMap
  *  has to analyze trees representing annotation arguments to manually extract corresponding values. Towards that end,
  *  arguments of an annotation can be obtained via `annotation.tree.children.tail`.
  *
- *  For more information about `Annotation`s, see the [[http://docs.scala-lang.org/overviews/reflection/annotations-names-scopes.html Reflection Guide: Annotations, Names, Scopes, and More]]
+ *  For more information about `Annotation`s, see the [[https://docs.scala-lang.org/overviews/reflection/annotations-names-scopes.html Reflection Guide: Annotations, Names, Scopes, and More]]
  *
  *  @contentDiagram hideNodes "*Api"
  *  @group ReflectionAPI

--- a/src/reflect/scala/reflect/api/FlagSets.scala
+++ b/src/reflect/scala/reflect/api/FlagSets.scala
@@ -61,7 +61,7 @@ import scala.language.implicitConversions
  * quite possible that in future releases of the reflection API, flag sets could be replaced with something else.
  *
  * For more details about `FlagSet`s and other aspects of Scala reflection, see the
- * [[http://docs.scala-lang.org/overviews/reflection/overview.html Reflection Guide]]
+ * [[https://docs.scala-lang.org/overviews/reflection/overview.html Reflection Guide]]
  *
  * @group ReflectionAPI
  *

--- a/src/reflect/scala/reflect/api/JavaUniverse.scala
+++ b/src/reflect/scala/reflect/api/JavaUniverse.scala
@@ -24,7 +24,7 @@ package api
  *  and vice versa. It can also perform reflective invocations (getting/setting field values,
  *  calling methods, etc).
  *
- *  See the [[http://docs.scala-lang.org/overviews/reflection/overview.html Reflection Guide]] for details on how to use runtime reflection.
+ *  See the [[https://docs.scala-lang.org/overviews/reflection/overview.html Reflection Guide]] for details on how to use runtime reflection.
  *
  *  @groupname JavaUniverse Java Mirrors
  *  @group ReflectionAPI
@@ -51,7 +51,7 @@ trait JavaUniverse extends Universe { self =>
    *  become capable of performing reflective invocations (getting/setting field values, calling methods, etc).
    *
    *  For more information about `Mirrors`s, see [[scala.reflect.api.Mirrors]] or the
-   * [[http://docs.scala-lang.org/overviews/reflection/environment-universes-mirrors.html Reflection Guide: Mirrors]]
+   * [[https://docs.scala-lang.org/overviews/reflection/environment-universes-mirrors.html Reflection Guide: Mirrors]]
    *
    *  @group JavaMirrors
    */
@@ -63,7 +63,7 @@ trait JavaUniverse extends Universe { self =>
   /** Creates a runtime reflection mirror from a JVM classloader.
    *
    *  For more information about `Mirrors`s, see [[scala.reflect.api.Mirrors]] or the
-   * [[http://docs.scala-lang.org/overviews/reflection/environment-universes-mirrors.html Reflection Guide: Mirrors]]
+   * [[https://docs.scala-lang.org/overviews/reflection/environment-universes-mirrors.html Reflection Guide: Mirrors]]
    *
    *  @group JavaMirrors
    */

--- a/src/reflect/scala/reflect/api/Liftables.scala
+++ b/src/reflect/scala/reflect/api/Liftables.scala
@@ -18,7 +18,7 @@ trait Liftables { self: Universe =>
 
   /** A type class that defines a representation of `T` as a `Tree`.
    *
-   *  @see [[http://docs.scala-lang.org/overviews/quasiquotes/lifting.html]]
+   *  @see [[https://docs.scala-lang.org/overviews/quasiquotes/lifting.html]]
    */
   trait Liftable[T] {
     def apply(value: T): Tree
@@ -44,7 +44,7 @@ trait Liftables { self: Universe =>
      *  lifted: universe.Tree = O
      *  }}}
      *
-     *  @see [[http://docs.scala-lang.org/overviews/quasiquotes/lifting.html]]
+     *  @see [[https://docs.scala-lang.org/overviews/quasiquotes/lifting.html]]
      */
     def apply[T](f: T => Tree): Liftable[T] =
       new Liftable[T] { def apply(value: T): Tree = f(value) }
@@ -52,7 +52,7 @@ trait Liftables { self: Universe =>
 
   /** A type class that defines a way to extract instance of `T` from a `Tree`.
    *
-   *  @see [[http://docs.scala-lang.org/overviews/quasiquotes/unlifting.html]]
+   *  @see [[https://docs.scala-lang.org/overviews/quasiquotes/unlifting.html]]
    */
   trait Unliftable[T] {
     def unapply(tree: Tree): Option[T]
@@ -78,7 +78,7 @@ trait Liftables { self: Universe =>
      *  scala> val q"\${_: O.type}" = q"\$Oref"
      *  }}}
      *
-     *  @see [[http://docs.scala-lang.org/overviews/quasiquotes/unlifting.html]]
+     *  @see [[https://docs.scala-lang.org/overviews/quasiquotes/unlifting.html]]
      */
     def apply[T](pf: PartialFunction[Tree, T]): Unliftable[T] = new Unliftable[T] {
       def unapply(value: Tree): Option[T] = pf.lift(value)

--- a/src/reflect/scala/reflect/api/Mirrors.scala
+++ b/src/reflect/scala/reflect/api/Mirrors.scala
@@ -213,7 +213,7 @@ package api
  * }}}
  *
  * For more information about `Mirrors`s, see the
- * [[http://docs.scala-lang.org/overviews/reflection/environment-universes-mirrors.html Reflection Guide: Mirrors]]
+ * [[https://docs.scala-lang.org/overviews/reflection/environment-universes-mirrors.html Reflection Guide: Mirrors]]
  *
  *  @contentDiagram hideNodes "*Api"
  *  @group ReflectionAPI

--- a/src/reflect/scala/reflect/api/Names.scala
+++ b/src/reflect/scala/reflect/api/Names.scala
@@ -33,7 +33,7 @@ package api
  *
  *  To search for a type member, one can follow the same procedure, using `TypeName` instead.
  *
- *  For more information about creating and using `Name`s, see the [[http://docs.scala-lang.org/overviews/reflection/annotations-names-scopes.html Reflection Guide: Annotations, Names, Scopes, and More]]
+ *  For more information about creating and using `Name`s, see the [[https://docs.scala-lang.org/overviews/reflection/annotations-names-scopes.html Reflection Guide: Annotations, Names, Scopes, and More]]
  *
  *  @contentDiagram hideNodes "*Api"
  *  @group ReflectionAPI

--- a/src/reflect/scala/reflect/api/Position.scala
+++ b/src/reflect/scala/reflect/api/Position.scala
@@ -58,7 +58,7 @@ import scala.reflect.macros.Attachments
  *  pos.focus           Converts a range position to an offset position focused on the point
  *  pos.makeTransparent Convert an opaque range into a transparent range
  *
- *  For more information about `Position`s, see the [[http://docs.scala-lang.org/overviews/reflection/annotations-names-scopes.html Reflection Guide: Annotations, Names, Scopes, and More]]
+ *  For more information about `Position`s, see the [[https://docs.scala-lang.org/overviews/reflection/annotations-names-scopes.html Reflection Guide: Annotations, Names, Scopes, and More]]
  *
  *  @groupname Common   Commonly used methods
  *  @group ReflectionAPI

--- a/src/reflect/scala/reflect/api/Printers.scala
+++ b/src/reflect/scala/reflect/api/Printers.scala
@@ -143,7 +143,7 @@ import java.io.{ PrintWriter, StringWriter }
  * }}}
  *
  * For more details about `Printer`s and other aspects of Scala reflection, see the
- * [[http://docs.scala-lang.org/overviews/reflection/overview.html Reflection Guide]]
+ * [[https://docs.scala-lang.org/overviews/reflection/overview.html Reflection Guide]]
  *
  *  @group ReflectionAPI
  */

--- a/src/reflect/scala/reflect/api/Quasiquotes.scala
+++ b/src/reflect/scala/reflect/api/Quasiquotes.scala
@@ -19,7 +19,7 @@ trait Quasiquotes { self: Universe =>
    *  that are also known as quasiquotes. With their help you can easily manipulate
    *  Scala reflection ASTs.
    *
-   *  @see [[http://docs.scala-lang.org/overviews/quasiquotes/intro.html]]
+   *  @see [[https://docs.scala-lang.org/overviews/quasiquotes/intro.html]]
    */
   implicit class Quasiquote(ctx: StringContext) {
     protected trait api {

--- a/src/reflect/scala/reflect/api/Symbols.scala
+++ b/src/reflect/scala/reflect/api/Symbols.scala
@@ -55,7 +55,7 @@ package api
  *  to obtain the symbol that represents their declaration. During the typechecking phase, the compiler looks up the
  *  symbol based on the name and scope and sets the [[Trees.SymTreeApi.symbol `symbol` field]] of tree nodes.
  *
- *  For more information about `Symbol` usage and attached intricacies, see the [[http://docs.scala-lang.org/overviews/reflection/symbols-trees-types.html Reflection Guide: Symbols]]
+ *  For more information about `Symbol` usage and attached intricacies, see the [[https://docs.scala-lang.org/overviews/reflection/symbols-trees-types.html Reflection Guide: Symbols]]
  *
  *  @group ReflectionAPI
  *
@@ -458,7 +458,7 @@ trait Symbols { self: Universe =>
     /** Is this symbol static (i.e. with no outer instance)?
      *  Q: When exactly is a sym marked as STATIC?
      *  A: If it's a member of a toplevel object, or of an object contained in a toplevel object, or any number of levels deep.
-     *  http://groups.google.com/group/scala-internals/browse_thread/thread/d385bcd60b08faf6
+     *  https://groups.google.com/group/scala-internals/browse_thread/thread/d385bcd60b08faf6
      *
      *  @group Tests
      */

--- a/src/reflect/scala/reflect/api/Trees.scala
+++ b/src/reflect/scala/reflect/api/Trees.scala
@@ -52,7 +52,7 @@ import scala.annotation.{nowarn, tailrec}
  *    print( showRaw( reify{5}.tree ) )` // prints Literal(Constant(5))
  *  }}}
  *
- *  For more information about `Tree`s, see the [[http://docs.scala-lang.org/overviews/reflection/symbols-trees-types.html Reflection Guide: Symbols, Trees, Types]].
+ *  For more information about `Tree`s, see the [[https://docs.scala-lang.org/overviews/reflection/symbols-trees-types.html Reflection Guide: Symbols, Trees, Types]].
  *
  *  @groupname Traversal Tree Traversal and Transformation
  *  @groupprio Traversal 1

--- a/src/reflect/scala/reflect/api/TypeTags.scala
+++ b/src/reflect/scala/reflect/api/TypeTags.scala
@@ -150,7 +150,7 @@ import java.io.ObjectStreamException
  * APIs to use `Tag`s.
  *
  * For more information about `TypeTag`s, see the
- * [[http://docs.scala-lang.org/overviews/reflection/typetags-manifests.html Reflection Guide: TypeTags]]
+ * [[https://docs.scala-lang.org/overviews/reflection/typetags-manifests.html Reflection Guide: TypeTags]]
  *
  * @see [[scala.reflect.ClassTag]], [[scala.reflect.api.TypeTags#TypeTag]], [[scala.reflect.api.TypeTags#WeakTypeTag]]
  * @group ReflectionAPI
@@ -170,7 +170,7 @@ trait TypeTags { self: Universe =>
    * [[scala.reflect.api.TypeTags#TypeTag]] instead, which statically guarantees this property.
    *
    * For more information about `TypeTag`s, see the
-   * [[http://docs.scala-lang.org/overviews/reflection/typetags-manifests.html Reflection Guide: TypeTags]]
+   * [[https://docs.scala-lang.org/overviews/reflection/typetags-manifests.html Reflection Guide: TypeTags]]
    *
    * @see [[scala.reflect.api.TypeTags]]
    * @group TypeTags

--- a/src/reflect/scala/reflect/api/Types.scala
+++ b/src/reflect/scala/reflect/api/Types.scala
@@ -51,7 +51,7 @@ package api
  *  ''Note:'' Method `typeOf` does not work for types with type parameters, such as `typeOf[List[A]]` where `A` is
  *  a type parameter. In this case, use [[scala.reflect.api.TypeTags#weakTypeOf]] instead.
  *
- *  For other ways to instantiate types, see the [[http://docs.scala-lang.org/overviews/reflection/symbols-trees-types.html corresponding section of the Reflection Guide]].
+ *  For other ways to instantiate types, see the [[https://docs.scala-lang.org/overviews/reflection/symbols-trees-types.html corresponding section of the Reflection Guide]].
  *
  *  === Common Operations on Types ===
  *
@@ -69,7 +69,7 @@ package api
  *     res1: reflect.runtime.universe.Symbol = method map
  *  }}}
  *
- * For more information about `Type`s, see the [[http://docs.scala-lang.org/overviews/reflection/symbols-trees-types.html Reflection Guide: Symbols, Trees, and Types]]
+ * For more information about `Type`s, see the [[https://docs.scala-lang.org/overviews/reflection/symbols-trees-types.html Reflection Guide: Symbols, Trees, and Types]]
  *
  *  @groupname TypeCreators Types - Creation
  *  @groupname TypeOps      Types - Operations

--- a/src/reflect/scala/reflect/api/Universe.scala
+++ b/src/reflect/scala/reflect/api/Universe.scala
@@ -63,7 +63,7 @@ package api
  *  }
  * }}}
  *
- * For more information about `Universe`s, see the [[http://docs.scala-lang.org/overviews/reflection/environment-universes-mirrors.html Reflection Guide: Universes]]
+ * For more information about `Universe`s, see the [[https://docs.scala-lang.org/overviews/reflection/environment-universes-mirrors.html Reflection Guide: Universes]]
  *
  *  @groupprio Universe -1
  *  @group ReflectionAPI

--- a/src/reflect/scala/reflect/api/package.scala
+++ b/src/reflect/scala/reflect/api/package.scala
@@ -33,7 +33,7 @@ import scala.reflect.api.{Universe => ApiUniverse}
  *  - [[scala.reflect.api.Universe]]
  *
  *  For more information about Scala Reflection, see the
- * [[http://docs.scala-lang.org/overviews/reflection/overview.html Reflection Guide]]
+ * [[https://docs.scala-lang.org/overviews/reflection/overview.html Reflection Guide]]
  *
  *  @groupname ReflectionAPI Scala Reflection API
  *  @groupprio API        9

--- a/src/reflect/scala/reflect/internal/ClassfileConstants.scala
+++ b/src/reflect/scala/reflect/internal/ClassfileConstants.scala
@@ -21,7 +21,7 @@ object ClassfileConstants {
   final val JAVA_MAJOR_VERSION = 45
   final val JAVA_MINOR_VERSION = 3
 
-  /** (see http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.1)
+  /** (see https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.1)
    *
    *  If the `ACC_INTERFACE` flag is set, the `ACC_ABSTRACT` flag must also
    *  be set (ch. 2.13.1).

--- a/src/reflect/scala/reflect/internal/Kinds.scala
+++ b/src/reflect/scala/reflect/internal/Kinds.scala
@@ -261,7 +261,7 @@ trait Kinds {
      */
     def scalaNotation: String
 
-    /** Kind notation used in http://adriaanm.github.com/files/higher.pdf.
+    /** Kind notation used in https://adriaanm.github.com/files/higher.pdf.
      * Proper types are expressed as *.
      * Type constructors are expressed * -> *(lo, hi) -(+)-> *.
      */

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -975,7 +975,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
      * Q: When exactly is a sym marked as STATIC?
      * A: If it's a member of a toplevel object, or of an object contained in a toplevel object, or
      * any number of levels deep.
-     * http://groups.google.com/group/scala-internals/browse_thread/thread/d385bcd60b08faf6
+     * https://groups.google.com/group/scala-internals/browse_thread/thread/d385bcd60b08faf6
      *
      * TODO: should this only be invoked on class / module symbols? because there's also `isStaticMember`.
      *

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -239,7 +239,7 @@ trait Types
         }
         // erasure screws up all ThisTypes for modules into PackageTypeRefs
         // we need to unscrew them, or certain typechecks will fail mysteriously
-        // http://groups.google.com/group/scala-internals/browse_thread/thread/6d3277ae21b6d581
+        // https://groups.google.com/group/scala-internals/browse_thread/thread/6d3277ae21b6d581
         result = result.map(tpe => tpe match {
           case tpe: PackageTypeRef => ThisType(tpe.sym)
           case _ => tpe
@@ -1565,7 +1565,7 @@ trait Types
       (if (emptyLowerBound) "" else " >: " + typeString(lo)) +
       (if (emptyUpperBound) "" else " <: " + typeString(hi))
     }
-    /** Bounds notation used in http://adriaanm.github.com/files/higher.pdf.
+    /** Bounds notation used in https://adriaanm.github.com/files/higher.pdf.
       * For example *(scala.collection.generic.Sorted[K,This]).
       */
     private[internal] def starNotation(typeString: Type => String): String = {

--- a/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
+++ b/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
@@ -232,7 +232,7 @@ abstract class UnPickler {
 
           (module map { case (group, art) =>
             s"""\n(NOTE: It looks like the $art module is missing; try adding a dependency on "$group" : "$art".
-               |       See http://docs.scala-lang.org/overviews/ for more information.)""".stripMargin
+               |       See https://docs.scala-lang.org/overviews/ for more information.)""".stripMargin
            } getOrElse "")
         }
 

--- a/src/reflect/scala/reflect/macros/Typers.scala
+++ b/src/reflect/scala/reflect/macros/Typers.scala
@@ -128,7 +128,7 @@ trait Typers {
    *  which makes it sometimes corrupt trees so that they don't make sense anymore. Unfortunately, there's no workaround for that.
    *  We plan to fix this issue soon, but for now please keep it in mind.
    *
-   *  @see [[http://stackoverflow.com/questions/20936509/scala-macros-what-is-the-difference-between-typed-aka-typechecked-an-untyped]]
+   *  @see [[https://stackoverflow.com/questions/20936509/scala-macros-what-is-the-difference-between-typed-aka-typechecked-an-untyped]]
    */
   def untypecheck(tree: Tree): Tree
 }

--- a/src/reflect/scala/reflect/macros/blackbox/Context.scala
+++ b/src/reflect/scala/reflect/macros/blackbox/Context.scala
@@ -41,7 +41,7 @@ package blackbox
  *  which means that its expansion will be upcast to its return type, enforcing faithfulness of that macro to its
  *  type signature. Whitebox macros, i.e. the ones defined with `whitebox.Context`, aren't bound by this restriction,
  *  which enables a number of important use cases, but they are also going to enjoy less support than blackbox macros,
- *  so choose wisely. See the [[http://docs.scala-lang.org/overviews/macros/overview.html Macros Guide]] for more information.
+ *  so choose wisely. See the [[https://docs.scala-lang.org/overviews/macros/overview.html Macros Guide]] for more information.
  *
  *  @see `scala.reflect.macros.whitebox.Context`
  */

--- a/src/reflect/scala/reflect/macros/package.scala
+++ b/src/reflect/scala/reflect/macros/package.scala
@@ -22,14 +22,14 @@ package reflect
  *  Within these functions the programmer has access to compiler APIs.
  *  For example, it is possible to generate, analyze and typecheck code.
  *
- *  See the [[http://docs.scala-lang.org/overviews/macros/overview.html Macros Guide]] on how to get started with Scala macros.
+ *  See the [[https://docs.scala-lang.org/overviews/macros/overview.html Macros Guide]] on how to get started with Scala macros.
  */
 package object macros {
   /** The Scala macros context.
    *
    *  In Scala 2.11, macros that were once the one are split into blackbox and whitebox macros,
    *  with the former being better supported and the latter being more powerful. You can read about
-   *  the details of the split and the associated trade-offs in the [[http://docs.scala-lang.org/overviews/macros/overview.html Macros Guide]].
+   *  the details of the split and the associated trade-offs in the [[https://docs.scala-lang.org/overviews/macros/overview.html Macros Guide]].
    *
    *  `scala.reflect.macros.Context` follows this tendency and turns into `scala.reflect.macros.blackbox.Context`
    *  and `scala.reflect.macros.whitebox.Context`. The original `Context` is left in place for compatibility reasons,

--- a/src/reflect/scala/reflect/macros/whitebox/Context.scala
+++ b/src/reflect/scala/reflect/macros/whitebox/Context.scala
@@ -41,7 +41,7 @@ package whitebox
  *  gaining the ability to refine the type of its expansion beyond its official return type, which enables a number of important use cases.
  *  Blackbox macros, i.e. the ones defined with `blackbox.Context`, can't do that, so they are less powerful.
  *  However blackbox macros are also going to enjoy better support than whitebox macros, so choose wisely.
- *  See the [[http://docs.scala-lang.org/overviews/macros/overview.html Macros Guide]] for more information.
+ *  See the [[https://docs.scala-lang.org/overviews/macros/overview.html Macros Guide]] for more information.
  *
  *  @see `scala.reflect.macros.blackbox.Context`
  */

--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -897,7 +897,7 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
      * The Scala owner of the Scala class corresponding to the Java class `jclazz`
      */
     // @eb: a weird classloader might return a null package for something with a non-empty package name
-    // for example, http://groups.google.com/group/scala-internals/browse_thread/thread/7be09ff8f67a1e5c
+    // for example, https://groups.google.com/group/scala-internals/browse_thread/thread/7be09ff8f67a1e5c
     // in that case we could invoke packageNameToScala(jPackageName) and, probably, be okay
     // however, I think, it's better to blow up, since weirdness of the class loader might bite us elsewhere
     // [martin] I think it's better to be forgiving here. Restoring packageNameToScala.
@@ -1068,7 +1068,7 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
             // otherwise we may mistake mangled symbolic names for mangled nested names
             //
             // in case when a Java binary name can be treated both as a top-level class and as a nested class
-            // (as described in http://groups.google.com/group/scala-internals/browse_thread/thread/10855403bbf04298)
+            // (as described in https://groups.google.com/group/scala-internals/browse_thread/thread/10855403bbf04298)
             // we check for a top-level class first
             // this is totally correct, because a top-level class and a nested class with the same name cannot coexist
             // so it's either one or another, but not both - therefore we always load $-bearing classes correctly
@@ -1152,7 +1152,7 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
           }
         }
       case japplied: ParameterizedType =>
-        // http://stackoverflow.com/questions/5767122/parameterizedtype-getrawtype-returns-j-l-r-type-not-class
+        // https://stackoverflow.com/questions/5767122/parameterizedtype-getrawtype-returns-j-l-r-type-not-class
         val sym = classToScala(japplied.getRawType.asInstanceOf[jClass[_]])
         val pre = if (japplied.getOwnerType ne null) typeToScala(japplied.getOwnerType) else sym.owner.thisType
         val args0 = japplied.getActualTypeArguments

--- a/src/reflect/scala/reflect/runtime/JavaUniverse.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverse.scala
@@ -154,7 +154,7 @@ class JavaUniverse extends InternalSymbolTable with JavaUniverseForce with Refle
   def init(): Unit = {
     definitions.init()
 
-    // workaround for http://groups.google.com/group/scala-internals/browse_thread/thread/97840ba4fd37b52e
+    // workaround for https://groups.google.com/group/scala-internals/browse_thread/thread/97840ba4fd37b52e
     // constructors are by definition single-threaded, so we initialize all lazy vals (and local object) in advance
     // in order to avoid deadlocks later (e.g. one thread holds a global reflection lock and waits for definitions.Something to initialize,
     // whereas another thread holds a definitions.Something initialization lock and needs a global reflection lock to complete the initialization)

--- a/src/reflect/scala/reflect/runtime/ReflectionUtils.scala
+++ b/src/reflect/scala/reflect/runtime/ReflectionUtils.scala
@@ -106,7 +106,7 @@ object ReflectionUtils {
     // I think we can keep the source code though, because it can be useful to the others
     //
     // def inferAssociatedFile(clazz: Class[_]): AbstractFile = {
-    //   // http://stackoverflow.com/questions/227486/find-where-java-class-is-loaded-from
+    //   // https://stackoverflow.com/questions/227486/find-where-java-class-is-loaded-from
     //   try {
     //     var cl = clazz.getClassLoader()
     //     if (cl == null) {

--- a/src/reflect/scala/reflect/runtime/SymbolTable.scala
+++ b/src/reflect/scala/reflect/runtime/SymbolTable.scala
@@ -35,7 +35,7 @@ private[scala] trait SymbolTable extends internal.SymbolTable with JavaMirrors w
    *
    *  On the other hand, this also means that usage scenarios of the universe
    *  will differ from the conventional ones. For example, we have to do additional cleanup
-   *  in order to prevent memory leaks: http://groups.google.com/group/scala-internals/browse_thread/thread/eabcf3d406dab8b2.
+   *  in order to prevent memory leaks: https://groups.google.com/group/scala-internals/browse_thread/thread/eabcf3d406dab8b2.
    */
   override def isCompilerUniverse = false
 }

--- a/src/reflect/scala/reflect/runtime/ThreadLocalStorage.scala
+++ b/src/reflect/scala/reflect/runtime/ThreadLocalStorage.scala
@@ -19,7 +19,7 @@ private[reflect] trait ThreadLocalStorage {
   self: SymbolTable =>
 
   // see a discussion at scala-internals for more information:
-  // http://groups.google.com/group/scala-internals/browse_thread/thread/337ce68aa5e51f79
+  // https://groups.google.com/group/scala-internals/browse_thread/thread/337ce68aa5e51f79
   trait ThreadLocalStorage[T] { def get: T; def set(newValue: T): Unit }
   private class MyThreadLocalStorage[T](initialValue: => T) extends ThreadLocalStorage[T] {
     // TODO: how do we use org.cliffc.high_scale_lib.NonBlockingHashMap here?

--- a/src/reflect/scala/reflect/runtime/package.scala
+++ b/src/reflect/scala/reflect/runtime/package.scala
@@ -23,7 +23,7 @@ package object runtime {
    * To use Scala runtime reflection, simply use or import `scala.reflect.runtime.universe._`
    *
    * See [[scala.reflect.api.Universe]] or the
-   * [[http://docs.scala-lang.org/overviews/reflection/environment-universes-mirrors.html Reflection Guide: Universes]]
+   * [[https://docs.scala-lang.org/overviews/reflection/environment-universes-mirrors.html Reflection Guide: Universes]]
    * for more details.
    */
   lazy val universe: api.JavaUniverse = new runtime.JavaUniverse

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
@@ -341,7 +341,7 @@ trait EntityPage extends HtmlPage {
     val postamble =
       List(Div(id = "tooltip"),
            if (Set("epfl", "EPFL").contains(tpl.universe.settings.docfooter.value))
-             Div(id = "footer", elems = Txt("Scala programming documentation. Copyright (c) 2002-2020 ") :: A(href = "http://www.epfl.ch", target = "_top", elems = Txt("EPFL")) :: Txt(" and ") :: A(href = "http://www.lightbend.com", target = "_top", elems = Txt("Lightbend")) :: Txt("."))
+             Div(id = "footer", elems = Txt("Scala programming documentation. Copyright (c) 2002-2020 ") :: A(href = "https://www.epfl.ch", target = "_top", elems = Txt("EPFL")) :: Txt(" and ") :: A(href = "https://www.lightbend.com", target = "_top", elems = Txt("Lightbend")) :: Txt("."))
            else
              Div(id = "footer", elems = Txt(tpl.universe.settings.docfooter.value)))
 
@@ -528,7 +528,7 @@ trait EntityPage extends HtmlPage {
                 case _      => "" // no parameters
               }
               Br ++ Txt("To access this member you can use a ") ++
-              A(href="http://stackoverflow.com/questions/2087250/what-is-the-purpose-of-type-ascription-in-scala",
+              A(href="https://stackoverflow.com/questions/2087250/what-is-the-purpose-of-type-ascription-in-scala",
                 target="_blank", elems= Txt("type ascription")) ++ Txt(":") ++
               Br ++ Div(`class`="cmt", elems=Pre(Txt(s"(${EntityPage.lowerFirstLetter(tpl.name)}: ${conv.targetType.name}).${mbr.name}$params")))
             }
@@ -1008,7 +1008,7 @@ trait EntityPage extends HtmlPage {
         templateToHtml(ktcc.typeClassEntity) ++ Txt(")")
     case tcc: TypeClassConstraint =>
       Txt(tcc.typeParamName + " is ") ++
-        A(href="http://stackoverflow.com/questions/2982276/what-is-a-context-bound-in-scala", target="_blank", elems=
+        A(href="https://stackoverflow.com/questions/2982276/what-is-a-context-bound-in-scala", target="_blank", elems=
         Txt("context-bounded")) ++ Txt(" by " + tcc.typeClassEntity.qualifiedName + " (" + tcc.typeParamName + ": ") ++
         templateToHtml(tcc.typeClassEntity) ++ Txt(")")
     case impl: ImplicitInScopeConstraint =>

--- a/test/async/jvm/concurrent_fetch.check
+++ b/test/async/jvm/concurrent_fetch.check
@@ -1,3 +1,3 @@
 fetching
 fetching
-63
+65

--- a/test/async/jvm/concurrent_fetch.scala
+++ b/test/async/jvm/concurrent_fetch.scala
@@ -10,8 +10,8 @@ object Test extends App {
 
   val sumLengths: Future[Int] = {
     async {
-      val body1 = fetchURL("http://scala-lang.org")
-      val body2 = fetchURL("http://docs.scala-lang.org")
+      val body1 = fetchURL("https://scala-lang.org")
+      val body2 = fetchURL("https://docs.scala-lang.org")
       await(body1).length + await(body2).length
     }
   }

--- a/test/benchmarks/README.md
+++ b/test/benchmarks/README.md
@@ -1,7 +1,7 @@
 # Scala library benchmarks
 
 This directory is used by the `bench` subproject of the Scala sbt build.
-It makes use of the [sbt plugin](https://github.com/ktoso/sbt-jmh) for [JMH](http://openjdk.java.net/projects/code-tools/jmh/).
+It makes use of the [sbt plugin](https://github.com/ktoso/sbt-jmh) for [JMH](https://openjdk.java.net/projects/code-tools/jmh/).
 
 ## Running a benchmark
 
@@ -44,7 +44,7 @@ derived from the fully-qualified package name of the `Runner` class.
 ## Some useful HotSpot options
 Adding these to the `jmh:run` or `jmh:runMain` command line may help if you're using the HotSpot (Oracle, OpenJDK) compiler.
 They require prefixing with `-jvmArgs`.
-See [the Java documentation](http://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html) for more options. 
+See [the Java documentation](https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html) for more options. 
 
 ### Viewing JIT compilation events
 Adding `-XX:+PrintCompilation` shows when Java methods are being compiled or deoptimized.
@@ -130,7 +130,7 @@ Follow instructions in the output above and start gleaning insights!
 ## Useful reading
 * [OpenJDK advice on microbenchmarks](https://wiki.openjdk.java.net/display/HotSpot/MicroBenchmarks)
 * Brian Goetz's "Java theory and practice" articles:
-  * "[Dynamic compilation and performance measurement](http://www.ibm.com/developerworks/java/library/j-jtp12214/)"
-  * "[Anatomy of a flawed benchmark](http://www.ibm.com/developerworks/java/library/j-jtp02225/)"
+  * "[Dynamic compilation and performance measurement](https://www.ibm.com/developerworks/java/library/j-jtp12214/)"
+  * "[Anatomy of a flawed benchmark](https://www.ibm.com/developerworks/java/library/j-jtp02225/)"
 * [Doug Lea's JSR 166 benchmarks](http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/src/test/loops/)
-* "[Measuring performance](http://docs.scala-lang.org/overviews/parallel-collections/performance.html)" of Scala parallel collections
+* "[Measuring performance](https://docs.scala-lang.org/overviews/parallel-collections/performance.html)" of Scala parallel collections

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/OldVector.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/OldVector.scala
@@ -106,7 +106,7 @@ object OldVector extends StrictOptimizedSeqFactory[OldVector] {
  *  endian bit-mapped vector trie with a branching factor of 32.  Locality is very good, but not
  *  contiguous, which is good for very large sequences.
  *
- *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#vectors "Scala's Collection Library overview"]]
+ *  @see [[https://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#vectors "Scala's Collection Library overview"]]
  *  section on `Vectors` for more information.
  *
  *  @tparam A the element type

--- a/test/files/filters
+++ b/test/files/filters
@@ -5,5 +5,5 @@ OpenJDK .* warning:
 # Hotspot receiving VM options through the $_JAVA_OPTIONS
 # env variable outputs them on stderr
 Picked up _JAVA_OPTIONS:
-# Filter out a message caused by this bug: http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=8021205
+# Filter out a message caused by this bug: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8021205
 objc\[\d+\]: Class JavaLaunchHelper is implemented in both .* and .*\. One of the two will be used\. Which one is undefined\.

--- a/test/files/jvm/annotations.check
+++ b/test/files/jvm/annotations.check
@@ -1,7 +1,7 @@
 #partest java8
 class java.io.IOException
 @java.lang.Deprecated()
-@test.SourceAnnotation_1(mails={scala@lists.epfl.ch,scala-lounge@lists.epfl.ch}, value=http://scala-lang.org)
+@test.SourceAnnotation_1(mails={scala@lists.epfl.ch,scala-lounge@lists.epfl.ch}, value=https://scala-lang.org)
 class Test4$Foo1
 
 @test.SourceAnnotation_1(mails={you@bloodsuckers.com}, value=http://bloodsuckers.com)
@@ -43,7 +43,7 @@ public int Test4$Foo9.getZ2()
 @test.SourceAnnotation_1(mails={bill.gates@bloodsuckers.com}, value=http://eppli.com)
 public int Test4$Foo9.getZ3()
 
-@test.SourceAnnotation_1(mails={bill.gates@bloodsuckers.com}, value=http://apple.com)
+@test.SourceAnnotation_1(mails={bill.gates@bloodsuckers.com}, value=https://apple.com)
 public int Test4$Foo9.x()
 
 @test.SourceAnnotation_1(mails={bill.gates@bloodsuckers.com}, value=http://uppla.com)
@@ -65,7 +65,7 @@ dylan
 #partest !java8
 class java.io.IOException
 @java.lang.Deprecated(forRemoval=false, since="")
-@test.SourceAnnotation_1(mails={scala@lists.epfl.ch,scala-lounge@lists.epfl.ch}, value=http://scala-lang.org)
+@test.SourceAnnotation_1(mails={scala@lists.epfl.ch,scala-lounge@lists.epfl.ch}, value=https://scala-lang.org)
 class Test4$Foo1
 
 @test.SourceAnnotation_1(mails={you@bloodsuckers.com}, value=http://bloodsuckers.com)
@@ -107,7 +107,7 @@ public int Test4$Foo9.getZ2()
 @test.SourceAnnotation_1(mails={bill.gates@bloodsuckers.com}, value=http://eppli.com)
 public int Test4$Foo9.getZ3()
 
-@test.SourceAnnotation_1(mails={bill.gates@bloodsuckers.com}, value=http://apple.com)
+@test.SourceAnnotation_1(mails={bill.gates@bloodsuckers.com}, value=https://apple.com)
 public int Test4$Foo9.x()
 
 @test.SourceAnnotation_1(mails={bill.gates@bloodsuckers.com}, value=http://uppla.com)

--- a/test/files/jvm/annotations/Test_2.scala
+++ b/test/files/jvm/annotations/Test_2.scala
@@ -47,7 +47,7 @@ object Test3 {
    public String url();
    public String mail();
 }
-@Source(url="http://scala.epfl.ch", mail="scala@lists.epfl.ch")
+@Source(url="https://scala.epfl.ch", mail="scala@lists.epfl.ch")
 class Foo {}
 public class Main {
     public static void main(String[] args) throws Exception {
@@ -55,13 +55,13 @@ public class Main {
         Annotation[] annotations = clazz.getAnnotations();
         for (int i = 0; i < annotations.length; i++)
             System.out.println(annotations[i]);
-        // @test.Main$Source(url=http://scala-lang.org, mail=scala@lists.epfl.ch)
+        // @test.Main$Source(url=https://scala-lang.org, mail=scala@lists.epfl.ch)
     }
 }
 */
 object Test4 {
   import test.SourceAnnotation_1
-  @SourceAnnotation_1(value = "http://scala-lang.org",
+  @SourceAnnotation_1(value = "https://scala-lang.org",
                     mails = Array("scala@lists.epfl.ch", "scala-lounge@lists.epfl.ch"))
   class Foo1
   @SourceAnnotation_1(value = "http://bloodsuckers.com",
@@ -90,7 +90,7 @@ object Test4 {
   class Foo9 {
     import scala.annotation.meta._
     import scala.beans.BeanProperty
-    @(SourceAnnotation_1 @getter)("http://apple.com") val x = 0
+    @(SourceAnnotation_1 @getter)("https://apple.com") val x = 0
     @BeanProperty @(SourceAnnotation_1 @beanSetter)("http://uppla.com") var y = 0
 
     type myAnn = SourceAnnotation_1 @beanGetter @field

--- a/test/files/jvm/innerClassEnclMethodJavaReflection.scala
+++ b/test/files/jvm/innerClassEnclMethodJavaReflection.scala
@@ -34,7 +34,7 @@ object Test extends App {
     val classFullNames = flatten(classPath, "").filter(_._1.hasExtension("class")).map(_._2.replace("/", ".").replaceAll(".class$", ""))
 
     // it seems that Class objects can only be GC'd together with their class loader
-    //   (http://stackoverflow.com/questions/2433261/when-and-how-are-classes-garbage-collected-in-java)
+    //   (https://stackoverflow.com/questions/2433261/when-and-how-are-classes-garbage-collected-in-java)
     // if we just use the same class loader for the entire test (Class.forName), we run out of PermGen
     // even with that, we still neeed a PermGen of 90M or so, the default 64 is not enough. I tried
     // using one class loader per 100 classes, but that didn't help, the classes didn't get GC'd.

--- a/test/files/jvm/javaReflection/Test.scala
+++ b/test/files/jvm/javaReflection/Test.scala
@@ -7,7 +7,7 @@ getSimpleName / getCanonicalName / isAnonymousClass / isLocalClass / isSynthetic
     therefore give surprising answers or may even throw an exception.
 
     In particular, the method "getSimpleName" assumes that classes are named after the Java spec
-      http://docs.oracle.com/javase/specs/jls/se8/html/jls-13.html#jls-13.1
+      https://docs.oracle.com/javase/specs/jls/se8/html/jls-13.html#jls-13.1
 
     Consider the following Scala example:
       class A { object B { class C } }

--- a/test/files/neg/byname-implicits-18.scala
+++ b/test/files/neg/byname-implicits-18.scala
@@ -2,7 +2,7 @@
  * Demo of using by name implicits to resolve (hidden) divergence issues when
  * traversing recursive generic structures.
  *
- * See http://stackoverflow.com/questions/25923974
+ * See https://stackoverflow.com/questions/25923974
  */
 sealed trait HList
 object HList {

--- a/test/files/neg/t8146-non-finitary-2.scala
+++ b/test/files/neg/t8146-non-finitary-2.scala
@@ -1,5 +1,5 @@
 // Example 3 from "On Decidability of Nominal Subtyping with Variance" (Pierce, Kennedy)
-// http://research.microsoft.com/pubs/64041/fool2007.pdf
+// https://research.microsoft.com/pubs/64041/fool2007.pdf
 trait N[-Z]
 trait D[Y]
 trait C[X] extends N[N[C[D[X]]]]

--- a/test/files/neg/t8146-non-finitary.scala
+++ b/test/files/neg/t8146-non-finitary.scala
@@ -1,5 +1,5 @@
 // Example 3 from "On Decidability of Nominal Subtyping with Variance" (Pierce, Kennedy)
-// http://research.microsoft.com/pubs/64041/fool2007.pdf
+// https://research.microsoft.com/pubs/64041/fool2007.pdf
 trait N[-A]
 trait C[A] extends N[N[C[C[A]]]]
 object Test {

--- a/test/files/pos/alladin763.scala
+++ b/test/files/pos/alladin763.scala
@@ -1,4 +1,4 @@
-// Test from http://lrytz.github.io/scala-aladdin-bugtracker/displayItem.do%3Fid=763.html
+// Test from https://lrytz.github.io/scala-aladdin-bugtracker/displayItem.do%3Fid=763.html
 // and expanded with package object variants
 
 

--- a/test/files/run/byname-implicits-6.scala
+++ b/test/files/run/byname-implicits-6.scala
@@ -2,7 +2,7 @@
  * Demo of using by name implicits to resolve (hidden) divergence issues when
  * traversing recursive generic structures.
  *
- * See http://stackoverflow.com/questions/25923974
+ * See https://stackoverflow.com/questions/25923974
  */
 sealed trait HList
 object HList {

--- a/test/files/run/literals.scala
+++ b/test/files/run/literals.scala
@@ -72,7 +72,7 @@ object Test {
       0xffffffffffffffffL, -1L)
 
     // see JLS at address:
-    // http://java.sun.com/docs/books/jls/second_edition/html/lexical.doc.html#230798
+    // https://java.sun.com/docs/books/jls/second_edition/html/lexical.doc.html#230798
 
     // float
     check_success("1e1f == 10.0f", 1e1f, 10.0f)

--- a/test/files/run/macro-vampire-false-warning/Macros_1.scala
+++ b/test/files/run/macro-vampire-false-warning/Macros_1.scala
@@ -1,4 +1,4 @@
-// As per http://meta.plasm.us/posts/2013/08/31/feeding-our-vampires/
+// As per https://meta.plasm.us/posts/2013/08/31/feeding-our-vampires/
 // scalac: -Werror
 
 import scala.annotation.StaticAnnotation

--- a/test/files/run/sip23-singleton-isas.scala
+++ b/test/files/run/sip23-singleton-isas.scala
@@ -2,7 +2,7 @@ object Test extends App {
 
   // expr.isInstanceOf[Singleton] is true iff the expression has a singleton type
   // However, expr.asInstanceOf[Singleton] is erased to expr.asInstanceOf[Any] so it never throws
-  // as discussed in http://docs.scala-lang.org/sips/minutes/2017-12-06-sip-minutes.html
+  // as discussed in https://docs.scala-lang.org/sips/minutes/2017-12-06-sip-minutes.html
 
   val foo: String = "foo"
   assert(foo.isInstanceOf[Singleton])

--- a/test/files/run/t7741a/Test.scala
+++ b/test/files/run/t7741a/Test.scala
@@ -27,7 +27,7 @@ object Test extends DirectTest {
     //   // This is the line that causes scalac to choke.
     //   // It results in a GroovyInterface$1 class, which is a non-static inner class but its constructor does not
     //   // include the implicit parameter that is the immediate enclosing instance.
-    //   // See http://jira.codehaus.org/browse/GROOVY-7312
+    //   // See https://issues.apache.org/jira/browse/GROOVY-7312
     //   //
     //   // Scalac error:
     //   //   [scalac] error: error while loading 1, class file '..../scala_groovy_interop/classes/com/example/groovy/GroovyInterface$1.class' is broken

--- a/test/files/run/t8048b/Macros_1.scala
+++ b/test/files/run/t8048b/Macros_1.scala
@@ -1,8 +1,8 @@
 // see the following discussions to understand what's being tested here:
 // * https://github.com/scala/bug/issues/6992
 // * https://github.com/scala/bug/issues/8048
-// * http://stackoverflow.com/questions/14370842/getting-a-structural-type-with-an-anonymous-classs-methods-from-a-macro
-// * http://stackoverflow.com/questions/18480707/method-cannot-be-accessed-in-macro-generated-class/18485004#18485004
+// * https://stackoverflow.com/questions/14370842/getting-a-structural-type-with-an-anonymous-classs-methods-from-a-macro
+// * https://stackoverflow.com/questions/18480707/method-cannot-be-accessed-in-macro-generated-class/18485004#18485004
 // * https://groups.google.com/forum/#!topic/scala-internals/eXQt-BPm4i8
 
 import scala.language.experimental.macros

--- a/test/files/run/tcpoly_monads.scala
+++ b/test/files/run/tcpoly_monads.scala
@@ -9,7 +9,7 @@ trait Monads {
    *
    * MonadTC encodes the above Haskell type class,
    * an instance of MonadTC corresponds to a method dictionary.
-   * (see http://lampwww.epfl.ch/~odersky/talks/wg2.8-boston06.pdf)
+   * (see https://lampwww.epfl.ch/~odersky/talks/wg2.8-boston06.pdf)
    *
    * Note that the identity (`this`) of the method dictionary does not really correspond
    * to the instance of m[x] (`self`) that is `wrapped`: e.g., unit does not use `self` (which

--- a/test/files/run/typetags_without_scala_reflect_manifest_lookup.scala
+++ b/test/files/run/typetags_without_scala_reflect_manifest_lookup.scala
@@ -19,7 +19,7 @@ object Test extends DirectTest {
       // and then force scalac to perform implicit search for a manifest
       // if type tag lookup is not disabled, the compiler will crash
       // if it is disabled, then the compilation will succeed
-      // http://groups.google.com/group/scala-internals/browse_thread/thread/166ce4b71b7c46bb
+      // https://groups.google.com/group/scala-internals/browse_thread/thread/166ce4b71b7c46bb
       def foo[T: Manifest] = ()
       foo[List[Int]]
     }

--- a/test/junit/scala/lang/traits/BytecodeTest.scala
+++ b/test/junit/scala/lang/traits/BytecodeTest.scala
@@ -184,7 +184,7 @@ class BytecodeTest extends BytecodeTesting {
 
   @Test
   def invocationReceiversProtected(): Unit = {
-    // http://lrytz.github.io/scala-aladdin-bugtracker/displayItem.do%3Fid=455.html / 9954eaf
+    // https://lrytz.github.io/scala-aladdin-bugtracker/displayItem.do%3Fid=455.html / 9954eaf
     // also https://github.com/scala/bug/issues/1430 / 0bea2ab (same but with interfaces)
     val aC =
       """package a;

--- a/test/macro-annot/run/repl/repl_1.scala
+++ b/test/macro-annot/run/repl/repl_1.scala
@@ -1,4 +1,4 @@
-// http://stackoverflow.com/questions/22549647/whats-the-right-way-to-generate-a-companion-class-de-novo-using-quasiquotes
+// https://stackoverflow.com/questions/22549647/whats-the-right-way-to-generate-a-companion-class-de-novo-using-quasiquotes
 import scala.annotation.StaticAnnotation
 import scala.language.experimental.macros
 import scala.reflect.macros.whitebox.Context

--- a/test/scalacheck/treemap.scala
+++ b/test/scalacheck/treemap.scala
@@ -25,7 +25,7 @@ object TreeMapTest extends Properties("TreeMap") {
 
   property("worst-case tree height is iterable") = forAll(choose(0, 10), arbitrary[Boolean]) { (n: Int, even: Boolean) =>
     /*
-     * According to "Ralf Hinze. Constructing red-black trees" [http://www.cs.ox.ac.uk/ralf.hinze/publications/#P5]
+     * According to "Ralf Hinze. Constructing red-black trees" [https://www.cs.ox.ac.uk/ralf.hinze/publications/#P5]
      * you can construct a skinny tree of height 2n by inserting the elements [1 .. 2^(n+1) - 2] and a tree of height
      * 2n+1 by inserting the elements [1 .. 3 * 2^n - 2], both in reverse order.
      *

--- a/test/scalacheck/treeset.scala
+++ b/test/scalacheck/treeset.scala
@@ -23,7 +23,7 @@ object TreeSetTest extends Properties("TreeSet") {
 
   property("worst-case tree height is iterable") = forAll(choose(0, 10), arbitrary[Boolean]) { (n: Int, even: Boolean) =>
     /*
-     * According to "Ralf Hinze. Constructing red-black trees" [http://www.cs.ox.ac.uk/ralf.hinze/publications/#P5]
+     * According to "Ralf Hinze. Constructing red-black trees" [https://www.cs.ox.ac.uk/ralf.hinze/publications/#P5]
      * you can construct a skinny tree of height 2n by inserting the elements [1 .. 2^(n+1) - 2] and a tree of height
      * 2n+1 by inserting the elements [1 .. 3 * 2^n - 2], both in reverse order.
      *

--- a/test/scaladoc/filters
+++ b/test/scaladoc/filters
@@ -5,5 +5,5 @@ OpenJDK .* warning:
 # Hotspot receiving VM options through the $_JAVA_OPTIONS
 # env variable outputs them on stderr
 Picked up _JAVA_OPTIONS:
-# Filter out a message caused by this bug: http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=8021205
+# Filter out a message caused by this bug: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8021205
 objc\[\d+\]: Class JavaLaunchHelper is implemented in both .* and .*\. One of the two will be used\. Which one is undefined\.

--- a/test/scaladoc/resources/doc-root/Any.scala
+++ b/test/scaladoc/resources/doc-root/Any.scala
@@ -31,13 +31,13 @@ package scala
  *     w.print()
  * }}}
  *
- * See the [[http://docs.scala-lang.org/overviews/core/value-classes.html Value Classes and Universal Traits]] for more
+ * See the [[https://docs.scala-lang.org/overviews/core/value-classes.html Value Classes and Universal Traits]] for more
  * details on the interplay of universal traits and value classes.
  */
 abstract class Any {
   /** Compares the receiver object (`this`) with the argument object (`that`) for equivalence.
    *
-   *  Any implementation of this method should be an [[http://en.wikipedia.org/wiki/Equivalence_relation equivalence relation]]:
+   *  Any implementation of this method should be an [[https://en.wikipedia.org/wiki/Equivalence_relation equivalence relation]]:
    *
    *  - It is reflexive: for any instance `x` of type `Any`, `x.equals(x)` should return `true`.
    *  - It is symmetric: for any instances `x` and `y` of type `Any`, `x.equals(y)` should return `true` if and

--- a/test/scaladoc/resources/doc-root/AnyRef.scala
+++ b/test/scaladoc/resources/doc-root/AnyRef.scala
@@ -51,7 +51,7 @@ trait AnyRef extends Any {
 
   /** Tests whether the argument (`that`) is a reference to the receiver object (`this`).
    *
-   *  The `eq` method implements an [[http://en.wikipedia.org/wiki/Equivalence_relation equivalence relation]] on
+   *  The `eq` method implements an [[https://en.wikipedia.org/wiki/Equivalence_relation equivalence relation]] on
    *  non-null instances of `AnyRef`, and has three additional properties:
    *
    *   - It is consistent: for any non-null instances `x` and `y` of type `AnyRef`, multiple invocations of

--- a/test/scaladoc/run/t8113.scala
+++ b/test/scaladoc/run/t8113.scala
@@ -7,7 +7,7 @@ object Test extends ScaladocModelTest {
 
   override def code = """
   /**
-   *  Check out [[http://www.scala-lang.org
+   *  Check out [[https://www.scala-lang.org
    *  this great website]]!
    */
   class Test
@@ -30,7 +30,7 @@ object Test extends ScaladocModelTest {
 
     val link = find(test.comment.get.body).collect { case Link(ta, Text(ti)) => (ta, ti) }
     assert(link.isDefined)
-    val expected = ("http://www.scala-lang.org", "this great website")
+    val expected = ("https://www.scala-lang.org", "this great website")
     link.foreach {l => assert(l == expected, s"$l != $expected")}
   }
 }

--- a/test/scaladoc/run/t8557.scala
+++ b/test/scaladoc/run/t8557.scala
@@ -17,7 +17,7 @@ object Test extends ScaladocModelTest {
       class A
     """
 
-  def scalaURL = "http://www.scala-lang.org/api/current/"
+  def scalaURL = "https://www.scala-lang.org/api/current/"
 
   // a non-canonical path to scala-library.jar should still work
   override def scaladocSettings = {


### PR DESCRIPTION
Currently there are multiple links in this project which use HTTP as protocol instead of HTTPS despite the target site supporting it. Even though the browser then upgrades the connection to HTTPS, it first sends an unencrypted request which could be read and whose response could be manipulated by an adversary in the same network.

Note that the creation of these changes was mostly automated, but only for links where a HTTPS connection did not appear to cause any issues.
Dead links (there are a few) and pages which returned a non-200 or 300 HTTP status code have not been changed; however I did not verify that every link still points to the correct page (in case a 200 status code was returned).

I have created a separate commit (e9b4c76) for the `License.rtf` file because I am not familiar with the RTF format and not sure whether simply replacing the link might cause issues (trying to edit the file in LibreOffice would have caused major changes). If these changes are fine I would squash the commit.

Please let me know if you want any changes or if you do not think that these changes are worth it, especially if the license header should not be changed (commit 595f5c2 of this pull request). Any feedback is appreciated!