### PR TITLE
Fix box-unbox around branches

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/BoxUnbox.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/BoxUnbox.scala
@@ -264,6 +264,9 @@ abstract class BoxUnbox {
             case c: EscapingConsumer =>
               assert(keepBox, s"found escaping consumer, but box is eliminated: $c")
 
+            case Drop(insn) =>
+              if (keepBox) toReplace(insn) = List(getPop(1))
+
             case extraction =>
               val (slot, tp) = localSlots(boxKind.extractedValueIndex(extraction))
               val loadOps = new VarInsnNode(tp.getOpcode(ILOAD), slot) :: extraction.postExtractionAdaptationOps(tp)
@@ -326,31 +329,38 @@ abstract class BoxUnbox {
           if (boxKind.boxedTypes.lengthCompare(1) == 0) {
             // fast path for single-value boxes
             allConsumers.foreach(extraction => extraction.postExtractionAdaptationOps(boxKind.boxedTypes.head) match {
-              case Nil =>
-                toDelete ++= extraction.allInsns
+              case Nil => extraction match {
+                case Drop(_) => toReplace(extraction.consumer) = boxKind.boxedTypes.map(t => getPop(t.getSize))
+                case _ => toDelete ++= extraction.allInsns
+              }
               case ops =>
                 toReplace(extraction.consumer) = ops
                 toDelete ++= extraction.allInsns - extraction.consumer
             })
           } else {
             for (extraction <- allConsumers) {
-              val valueIndex = boxKind.extractedValueIndex(extraction)
-              val replacementOps = if (valueIndex == 0) {
-                val pops = boxKind.boxedTypes.tail.map(t => getPop(t.getSize))
-                pops ::: extraction.postExtractionAdaptationOps(boxKind.boxedTypes.head)
-              } else {
-                var loadOps: List[AbstractInsnNode] = null
-                val consumeStack = boxKind.boxedTypes.zipWithIndex reverseMap {
-                  case (tp, i) =>
-                    if (i == valueIndex) {
-                      val resultSlot = getLocal(tp.getSize)
-                      loadOps = new VarInsnNode(tp.getOpcode(ILOAD), resultSlot) :: extraction.postExtractionAdaptationOps(tp)
-                      new VarInsnNode(tp.getOpcode(ISTORE), resultSlot)
-                    } else {
-                      getPop(tp.getSize)
+              val replacementOps = extraction match {
+                case Drop(_) =>
+                  boxKind.boxedTypes.map(t => getPop(t.getSize))
+                case _ =>
+                  val valueIndex = boxKind.extractedValueIndex(extraction)
+                  if (valueIndex == 0) {
+                    val pops = boxKind.boxedTypes.tail.map(t => getPop(t.getSize))
+                    pops ::: extraction.postExtractionAdaptationOps(boxKind.boxedTypes.head)
+                  } else {
+                    var loadOps: List[AbstractInsnNode] = null
+                    val consumeStack = boxKind.boxedTypes.zipWithIndex reverseMap {
+                      case (tp, i) =>
+                        if (i == valueIndex) {
+                          val resultSlot = getLocal(tp.getSize)
+                          loadOps = new VarInsnNode(tp.getOpcode(ILOAD), resultSlot) :: extraction.postExtractionAdaptationOps(tp)
+                          new VarInsnNode(tp.getOpcode(ISTORE), resultSlot)
+                        } else {
+                          getPop(tp.getSize)
+                        }
                     }
-                }
-                consumeStack ::: loadOps
+                    consumeStack ::: loadOps
+                  }
               }
               toReplace(extraction.consumer) = replacementOps
               toDelete ++= extraction.allInsns - extraction.consumer
@@ -617,7 +627,7 @@ abstract class BoxUnbox {
               val afterInit = initCall.getNext
               val stackTopAfterInit = prodCons.frameAt(afterInit).stackTop
               val initializedInstanceCons = prodCons.consumersOfValueAt(afterInit, stackTopAfterInit)
-              if (initializedInstanceCons == dupConsWithoutInit && prodCons.producersForValueAt(afterInit, stackTopAfterInit) == Set(dupOp)) {
+              if (initializedInstanceCons == dupConsWithoutInit) {
                 return Some((dupOp, initCall))
               }
             }
@@ -704,6 +714,9 @@ abstract class BoxUnbox {
           val success = primBoxSupertypes(kind.boxClass).contains(ti.desc)
           Some(BoxedPrimitiveTypeCheck(ti, success))
 
+        case i: InsnNode if i.getOpcode == POP =>
+          Some(Drop(i))
+
         case _ => None
       }
     }
@@ -756,6 +769,9 @@ abstract class BoxUnbox {
 
       case ti: TypeInsnNode if ti.getOpcode == INSTANCEOF =>
         Some(BoxedPrimitiveTypeCheck(ti, ti.desc == kind.refClass || refSupertypes.contains(ti.desc)))
+
+      case i: InsnNode if i.getOpcode == POP =>
+        Some(Drop(i))
 
       case _ => None
     }
@@ -820,6 +836,7 @@ abstract class BoxUnbox {
           }
 
         case _ =>
+          if (insn.getOpcode == POP) return Some(Drop(insn))
       }
       None
     }
@@ -939,6 +956,8 @@ abstract class BoxUnbox {
   case class StaticSetterOrInstanceWrite(consumer: AbstractInsnNode) extends BoxConsumer
   /** `.\$isInstanceOf[T]` (can be statically proven true or false) */
   case class BoxedPrimitiveTypeCheck(consumer: AbstractInsnNode, success: Boolean) extends BoxConsumer
+  /** POP */
+  case class Drop(consumer: AbstractInsnNode) extends BoxConsumer
   /** An unknown box consumer */
   case class EscapingConsumer(consumer: AbstractInsnNode) extends BoxConsumer
 }

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/BoxUnboxTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/BoxUnboxTest.scala
@@ -146,6 +146,13 @@ class BoxUnboxTest extends BytecodeTesting {
         |    bi + li
         |  }
         |
+        |  def t17(x: Int) = { // this one's pretty contrived but tests that primitives can be unboxed through a branch
+        |    val wat: Any = if (x > 0) x else -x
+        |    wat match {
+        |      case i: Int => String valueOf i
+        |      case _      => "?"
+        |    }
+        |  }
         |}
       """.stripMargin
 
@@ -199,10 +206,11 @@ class BoxUnboxTest extends BytecodeTesting {
     assertDoesNotInvoke(getInstructions(c, "t16"), "boxToLong")
     assertDoesNotInvoke(getInstructions(c, "t16"), "unboxToInt")
     assertDoesNotInvoke(getInstructions(c, "t16"), "unboxToLong")
+    assertDoesNotInvoke(getMethod(c, "t17"), "boxToInteger")
   }
 
   @Test
-  def refEliminiation(): Unit = {
+  def refElimination(): Unit = {
     val code =
       """class C {
         |  import runtime._
@@ -245,6 +253,12 @@ class BoxUnboxTest extends BytecodeTesting {
         |    val res: IntRef = if (b) r1 else r2
         |    res.elem // boxes remain: can't rewrite this read, don't know which local
         |  }
+        |
+        |  // this case is contemplated by BoxUnbox despite my inability to provide a motivating example
+        |  def t7(b: Boolean) = {
+        |    val r1 = if (b) IntRef.zero() else IntRef.create(1)
+        |    r1.elem
+        |  }
         |}
       """.stripMargin
     val c = compileClass(code)
@@ -256,6 +270,7 @@ class BoxUnboxTest extends BytecodeTesting {
       List("scala/runtime/IntRef.elem"))
     assertEquals(getInstructions(c, "t6") collect { case Field(op, owner, name, _) => s"$op $owner.$name" },
       List(s"$PUTFIELD scala/runtime/IntRef.elem", s"$GETFIELD scala/runtime/IntRef.elem"))
+    assertNoInvoke(getMethod(c, "t7"))
   }
 
   @Test
@@ -309,6 +324,21 @@ class BoxUnboxTest extends BytecodeTesting {
         |    case (x, y) if x == y => 0
         |    case (x, y) => x + y
         |  }
+        |
+        |  def t10(a: Int, b: Int) = { // tuple is optimized away
+        |    val (greater, lesser) = if (a > b) (a, b) else (b, a)
+        |    greater - lesser
+        |  }
+        |
+        |  def t11(n: Int)(j: Int) = { // tuple is optimized away
+        |    val (a, b, c, _) = n match {
+        |      case 0 => (j, 0, 1, 1)
+        |      case 1 => (0, j, 0, 1)
+        |      case 2 => (1, 0, j, 0)
+        |      case 3 => (1, 1, 0, j)
+        |    }
+        |    a + b + c
+        |  }
         |}
       """.stripMargin
     val c = compileClass(code, allowMessage = (info: StoreReporter.Info) => info.msg.contains("there was one deprecation warning"))
@@ -328,6 +358,11 @@ class BoxUnboxTest extends BytecodeTesting {
       ILOAD, ILOAD, IADD, ILOAD, IADD, IRETURN))
     assertNoInvoke(getMethod(c, "t8"))
     assertNoInvoke(getMethod(c, "t9"))
+    assertNoInvoke(getMethod(c, "t10"))
+    assertInvokedMethods(getMethod(c, "t11"), List(
+      "scala/runtime/BoxesRunTime.boxToInteger", // only once, for the MatchError
+      "scala/MatchError.<init>",
+    ))
   }
 
 }


### PR DESCRIPTION
(edit: reverted in https://github.com/scala/scala/pull/9403 due to release timing, re-applied in https://github.com/scala/scala/pull/9433)

  -  Support `pop` as BoxConsumer
  - consumer of box creation may be the consumer for multiple values

Inspired by the tuple cases; extended to the ref/primitive cases.

Co-Authored-By: @hrhino 

Re-submission of https://github.com/scala/scala/pull/8516

Fixes https://github.com/scala/bug/issues/11779