### PR TITLE
TASTy reader: add support for Scala 3.0.0-M3

### DIFF
--- a/project/DottySupport.scala
+++ b/project/DottySupport.scala
@@ -12,8 +12,8 @@ import sbt.librarymanagement.{
   * Settings to support validation of TastyUnpickler against the release of dotty with the matching TASTy version
   */
 object TastySupport {
-  val supportedTASTyRelease = "3.0.0-M2" // TASTy version 25.1
-  val scala3Compiler = "org.scala-lang" % "scala3-compiler_3.0.0-M2" % supportedTASTyRelease
+  val supportedTASTyRelease = "3.0.0-M3" // TASTy version 26.1
+  val scala3Compiler = "org.scala-lang" % "scala3-compiler_3.0.0-M3" % supportedTASTyRelease
 }
 
 /** Settings needed to compile with Dotty,

--- a/src/compiler/scala/tools/nsc/tasty/TreeUnpickler.scala
+++ b/src/compiler/scala/tools/nsc/tasty/TreeUnpickler.scala
@@ -639,7 +639,7 @@ class TreeUnpickler[Tasty <: TastyUniverse](
           case tag @ (VALDEF | DEFDEF | TYPEDEF | TYPEPARAM | PARAM) =>
             symbolAtCurrent()
             skipTree()
-          case IMPORT =>
+          case IMPORT | EXPORT =>
             skipTree()
           case PACKAGE =>
             processPackage(end => implicit ctx => indexStats(end))
@@ -886,6 +886,8 @@ class TreeUnpickler[Tasty <: TastyUniverse](
         readIndexedMember()
       case IMPORT =>
         unsupportedTermTreeError("import statement")
+      case EXPORT =>
+        unsupportedTermTreeError("export statement")
       case PACKAGE =>
         unsupportedTermTreeError("package statement")
       case _ =>

--- a/src/compiler/scala/tools/nsc/tasty/bridge/NameOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/NameOps.scala
@@ -52,6 +52,7 @@ trait NameOps { self: TastyUniverse =>
     final val AnyKind: String = "AnyKind"
     final val TupleCons: String = "*:"
     final val Tuple: String = "Tuple"
+    final val Matchable: String = "Matchable"
 
     val ContextFunctionN = raw"ContextFunction(\d+)".r
     val FunctionN        = raw"Function(\d+)".r

--- a/src/compiler/scala/tools/nsc/tasty/bridge/TypeOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/TypeOps.scala
@@ -346,7 +346,7 @@ trait TypeOps { self: TastyUniverse =>
   }
 
   private val SyntheticScala3Type =
-    raw"^(?:&|\||AnyKind|(?:Context)?Function\d+|\*:|Tuple)$$".r
+    raw"^(?:&|\||AnyKind|(?:Context)?Function\d+|\*:|Tuple|Matchable)$$".r
 
   def selectType(name: TastyName.TypeName, prefix: Type)(implicit ctx: Context): Type = selectType(name, prefix, prefix)
   def selectType(name: TastyName.TypeName, prefix: Type, space: Type)(implicit ctx: Context): Type = {
@@ -365,6 +365,7 @@ trait TypeOps { self: TastyUniverse =>
           case tpnme.TupleCons                                        => genTupleIsUnsupported("scala.*:")
           case tpnme.Tuple               if !ctx.mode.is(ReadParents) => genTupleIsUnsupported("scala.Tuple")
           case tpnme.AnyKind                                          => u.definitions.AnyTpe
+          case tpnme.Matchable                                        => u.definitions.AnyTpe
           case _                                                      => lookupType
         }
 

--- a/src/compiler/scala/tools/tasty/TastyFormat.scala
+++ b/src/compiler/scala/tools/tasty/TastyFormat.scala
@@ -15,7 +15,7 @@ package scala.tools.tasty
 object TastyFormat {
 
   final val header: Array[Int] = Array(0x5C, 0xA1, 0xAB, 0x1F)
-  val MajorVersion: Int = 25
+  val MajorVersion: Int = 26
   val MinorVersion: Int = 1
 
   final val ASTsSection = "ASTs"
@@ -205,6 +205,7 @@ object TastyFormat {
   final val TERMREFin = 174
   final val TYPEREFin = 175
   final val SELECTin = 176
+  final val EXPORT = 177
 
   final val METHODtype = 180
 
@@ -404,6 +405,7 @@ object TastyFormat {
     case TERMREFin => "TERMREFin"
     case TYPEREFin => "TYPEREFin"
     case SELECTin => "SELECTin"
+    case EXPORT => "EXPORT"
 
     case REFINEDtype => "REFINEDtype"
     case REFINEDtpt => "REFINEDtpt"

--- a/test/tasty/run/src-2/tastytest/TestIOApp.scala
+++ b/test/tasty/run/src-2/tastytest/TestIOApp.scala
@@ -1,0 +1,22 @@
+package tastytest
+
+/** test calling $init$ on IOApp parent */
+object TestIOApp extends Suite("TestIOApp") {
+
+  def randOver5 = scala.util.Random.nextInt(5) + 5
+
+  object Static extends IOApp.Simple {
+    def run = assert(randOver5 >= 5)
+  }
+
+  test("static IOApp")(Static.run)
+
+  test("local IOApp") {
+    val Local = new IOApp.Simple {
+      def run = assert(randOver5 >= 5)
+    }
+    Local.run
+  }
+
+
+}

--- a/test/tasty/run/src-2/tastytest/TestMatchables.scala
+++ b/test/tasty/run/src-2/tastytest/TestMatchables.scala
@@ -1,0 +1,10 @@
+package tastytest
+
+object TestMatchables extends Suite("TestMatchables") {
+
+  test(assert(Matchables.foo == true))
+  test(assert(Matchables.bar("hello") === "hello"))
+  test(assert(new Matchables.baz(23).a === 23))
+  test(assert(new Matchables.qux(5.0).a === 5.0))
+
+}

--- a/test/tasty/run/src-2/tastytest/TestTraitInitsBase.scala
+++ b/test/tasty/run/src-2/tastytest/TestTraitInitsBase.scala
@@ -1,0 +1,15 @@
+package tastytest
+
+/** test calling $init$ on TraitInitsBase.SubTrait parent */
+object TestTraitInitsBase extends Suite("TestTraitInitsBase") {
+
+  object Static extends TraitInitsBase.SubTrait {}
+
+  test("static SubTrait")(assert(Static.foo === 23))
+
+  test("local SubTrait") {
+    val Local = new TraitInitsBase.SubTrait {}
+    assert(Local.foo === 23)
+  }
+
+}

--- a/test/tasty/run/src-2/tastytest/TestValueOfErasure.scala
+++ b/test/tasty/run/src-2/tastytest/TestValueOfErasure.scala
@@ -1,0 +1,7 @@
+package tastytest
+
+object TestValueOfErasure extends Suite("TestValueOfErasure") {
+
+  test(assert(ValueOfErasure.reify[23] === 23))
+
+}

--- a/test/tasty/run/src-3/tastytest/IOApp.scala
+++ b/test/tasty/run/src-3/tastytest/IOApp.scala
@@ -1,0 +1,23 @@
+package tastytest
+
+trait IOApp {
+  protected val foo = 23
+
+  def run(args: List[String]): Int
+
+  final def main(args: Array[String]): Unit = {
+    sys.exit(run(args.toList))
+  }
+
+}
+
+object IOApp {
+  trait Simple extends IOApp {
+    def run: Unit
+
+    final def run(args: List[String]): Int = {
+      run
+      0
+    }
+  }
+}

--- a/test/tasty/run/src-3/tastytest/Matchables.scala
+++ b/test/tasty/run/src-3/tastytest/Matchables.scala
@@ -1,0 +1,15 @@
+package tastytest
+
+object Matchables {
+
+  def foo: Matchable = true
+
+  def bar[A <: Matchable](a: A) = a match {
+    case a: A => a
+  }
+
+  class baz[A](val a: A) extends Matchable
+
+  class qux[A <: Matchable](val a: A)
+
+}

--- a/test/tasty/run/src-3/tastytest/TraitInitsBase.scala
+++ b/test/tasty/run/src-3/tastytest/TraitInitsBase.scala
@@ -1,0 +1,8 @@
+package tastytest
+
+trait TraitInitsBase {
+  val foo = 23
+}
+object TraitInitsBase {
+  trait SubTrait extends TraitInitsBase
+}

--- a/test/tasty/run/src-3/tastytest/ValueOfErasure.scala
+++ b/test/tasty/run/src-3/tastytest/ValueOfErasure.scala
@@ -1,0 +1,5 @@
+package tastytest
+
+object ValueOfErasure {
+  def reify[I <: Int](implicit I: ValueOf[I]): I = valueOf[I]
+}


### PR DESCRIPTION
This PR does the minimal thing and substitutes references to `scala.Matchable` to `scala.Any`,

there was no need to add an extra test case for Export clauses in tasty - they were already tested.

Also adds test cases for the updates to trait encoding and Value class erasure in Scala 3

fixes https://github.com/scala/bug/issues/12259
fixes https://github.com/scala/bug/issues/12286