### PR TITLE
Tasty Reader: fix bug in reading parents of cats.Show [ci: last-only]

### DIFF
--- a/test/tasty/pos/src-2/tastytest/TestShow.scala
+++ b/test/tasty/pos/src-2/tastytest/TestShow.scala
@@ -1,0 +1,5 @@
+package tastytest
+
+import fplib.allsyntax._
+
+object TestShow extends scala.App

--- a/test/tasty/pos/src-3/fplib/Show.scala
+++ b/test/tasty/pos/src-3/fplib/Show.scala
@@ -1,0 +1,13 @@
+package fplib
+
+object allsyntax extends Show.Api // must be in a separate tasty file to Show
+
+trait Show extends Show.Impl
+
+object Show {
+
+  trait Impl
+
+  trait Api
+
+}


### PR DESCRIPTION
fixes https://github.com/scala/bug/issues/12241

i have verified on my own compiling the following program with a local snapshot of this commit

```scala
// libraryDependencies += "org.typelevel" % "cats-core_3.0.0-M2" % "2.3.0"
package foo

import cats.syntax.all._

object Main extends App {
  println("cats works")
}

```