### PR TITLE
potential improvement on definition of inits?

### DIFF
--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -815,9 +815,20 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
     */
   def tails: Iterator[C] = iterateUntilEmpty(_.tail)
 
-  /** Iterates over the inits of this $coll. The first value will be this
-    *  $coll and the final one will be an empty $coll, with the intervening
-    *  values the results of successive applications of `init`.
+  /** Iterates over the initial segments of this $coll, longest first.
+    *
+    *  The initial segments of a collection, e.g. a list, can be defined recursively as follows:
+    *  1) The empty list Nil has just one initial segment: Nil itself.
+    *  2) The initial segments of list x::xs consist of Nil plus the initial segments of xs, but with x consed onto each of them.
+    *  Note that the order of segments in the above definition is shortest first rather than longest first.
+    *  Purely for illustration purposes, here is an implementation of the above definition for a List:
+    *
+    *  {{{
+    *  def inits[A](xs: List[A]): List[List[A]] = xs match {
+    *    case Nil => List(Nil)
+    *    case x::xs => Nil::inits(xs).map(x::_)
+    *  }
+    *  }}}
     *
     *  $willForceEvaluation
     *


### PR DESCRIPTION
Hello,

I am just speculating (wildly and gratuitously, no doubt) as to whether it could be desirable at all to change the documentation of inits by taking into account both the Haskell definition, and the fact that inits can be defined recursively.

Haskell definition of inits: https://hackage.haskell.org/package/base-4.14.1.0/docs/Data-List.html#v:inits

Recursive definition of inits (in Haskell): https://www2.slideshare.net/pjschwarz/the-functional-programming-triad-of-folding-scanning-and-iteration-a-first-example-in-scala-and-haskell-polyglot-fp-for-fun-and-profit#18

I think in a way the current Scala documentation for inits is quite good because it depends on the definition of init, and so it is very simple and brief. So in a way there is probably no need to change it.

I realise I may be opening a small can of works, e.g. if the documentation for inits were to change, what about that for tails?

The text that I have replaced the original with is just a very first attempt. e.g. the new definition and the sample code could use Seq instead of List. Also, should this whole idea end up being judged to be of any merit, I can imagine the text having to undergo a lot of changes and tweaks to get it to conform to maintainers' notions of what is acceptable in Scala docs, and what is customary, what is superfluous, etc. It could also be that the existing definition can stay in place but in an extended form that incorporates either part(s) of mine, or some new section based on some of the ideas expressed in mine.

I would completely understand if nothing comes of this. I just thought I ought to ask.

Thanks in advance for taking the time to read this.

P.S. https://scastie.scala-lang.org/pmIfdCKrQP2FrNoxlX3xJw