### PR TITLE
Tailcalls overrides enabled

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/TailCalls.scala
+++ b/src/compiler/scala/tools/nsc/transform/TailCalls.scala
@@ -16,7 +16,7 @@ package transform
 
 import symtab.Flags
 import Flags.SYNTHETIC
-import scala.annotation.{nowarn, tailrec}
+import scala.annotation.tailrec
 
 /** Perform tail recursive call elimination.
  *
@@ -29,25 +29,10 @@ abstract class TailCalls extends Transform {
 
   val phaseName: String = "tailcalls"
 
+  override def enabled = settings.debuginfo.value != "notailcalls"
+
   def newTransformer(unit: CompilationUnit): AstTransformer =
     new TailCallElimination(unit)
-
-  /** Create a new phase which applies transformer */
-  override def newPhase(prev: scala.tools.nsc.Phase): StdPhase = new TailCallsPhase(prev)
-
-  @nowarn("""cat=deprecation&origin=scala\.tools\.nsc\.transform\.TailCalls\.Phase""")
-  final type TailCallsPhase = Phase
-
-  /** The phase defined by this transform */
-  @nowarn("msg=shadowing a nested class of a parent is deprecated")
-  @deprecated("use TailCallsPhase instead", since = "2.13.4")
-  class Phase(prev: scala.tools.nsc.Phase) extends StdPhase(prev) {
-    def apply(unit: global.CompilationUnit): Unit = {
-      if (!(settings.debuginfo.value == "notailcalls")) {
-        newTransformer(unit).transformUnit(unit)
-      }
-    }
-  }
 
   import treeInfo.hasSynthCaseSymbol
 


### PR DESCRIPTION
Noticed a commit on an old branch -- perhaps it is fine with the weird Phase class business.

This has the advantage of excluding the phase from construction.
```
➜  scala git:(tweak/tailcalls-enabled) ✗ skalac -Vphases -g:notailcalls
    phase name  id  description
    ----------  --  -----------
        parser   1  parse source into ASTs, perform simple desugaring
         namer   2  resolve names, attach symbols to named trees
packageobjects   3  load package objects
         typer   4  the meat and potatoes: type the trees
superaccessors   5  add super accessors in traits and nested classes
    extmethods   6  add extension methods for inline classes
       pickler   7  serialize symbol tables
     refchecks   8  reference/override checking, translate nested objects
        patmat   9  translate match expressions
       uncurry  10  uncurry, translate function values to anonymous classes
        fields  11  synthesize accessors and fields, add bitmaps for lazy vals
    specialize  12  @specialized-driven class and method specialization
 explicitouter  13  this refs to outer pointers
       erasure  14  erase types, add interfaces for traits
   posterasure  15  clean up erased inline classes
    lambdalift  16  move nested functions to top level
  constructors  17  move field definitions into constructors
       flatten  18  eliminate inner classes
         mixin  19  mixin composition
       cleanup  20  platform-specific cleanups, generate reflective calls
    delambdafy  21  remove lambdas
           jvm  22  generate JVM bytecode
      terminal  23  the last phase during a compilation run
```