### PR TITLE
Use a new prefixDirect in checkKindBounds0

### DIFF
--- a/src/reflect/scala/reflect/internal/Kinds.scala
+++ b/src/reflect/scala/reflect/internal/Kinds.scala
@@ -219,14 +219,15 @@ trait Kinds {
       // Prevent WildcardType from causing kind errors, as typevars may be higher-order
       if (targ == WildcardType) Nil else {
         // NOTE: *not* targ.typeSymbol, which normalizes
-        val targSym = targ.typeSymbolDirect
-        // force symbol load for #4205
-        targSym.info
+        // force initialize symbol for scala/bug#4205
+        val targSym = targ.typeSymbolDirect.initialize
+        // NOTE: *not* targ.prefix, which normalizes
+        val targPre = targ.prefixDirect
         // @M must use the typeParams of the *type* targ, not of the *symbol* of targ!!
         val tparamsHO = targ.typeParams
         if (targ.isHigherKinded || tparam.typeParams.nonEmpty) {
           val kindErrors = checkKindBoundsHK(
-            tparamsHO, targSym, targ.prefix, targSym.owner,
+            tparamsHO, targSym, targPre, targSym.owner,
             tparam, tparam.owner, tparam.typeParams, tparamsHO
           )
           if (kindErrors.isEmpty) Nil else {

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -163,6 +163,7 @@ trait Types
     override def upperBound = underlying.upperBound
     override def parents = underlying.parents
     override def prefix = underlying.prefix
+    override def prefixDirect = underlying.prefixDirect
     override def decls = underlying.decls
     override def baseType(clazz: Symbol) = underlying.baseType(clazz)
     override def baseTypeSeq = underlying.baseTypeSeq
@@ -424,6 +425,12 @@ trait Types
     /** For a typeref or single-type, the prefix of the normalized type (@see normalize).
      *  NoType for all other types. */
     def prefix: Type = NoType
+
+    /** The prefix ''directly'' associated with the type.
+     *  In other words, no normalization is performed: if this is an alias type,
+     *  the prefix returned is that of the alias, not the underlying type.
+     */
+    def prefixDirect: Type = prefix
 
     /** A chain of all typeref or singletype prefixes of this type, longest first.
      *  (Only used from safeToString.)
@@ -2580,6 +2587,7 @@ trait Types
 
     override def baseTypeSeqDepth = baseTypeSeq.maxDepth
     override def prefix           = pre
+    override def prefixDirect     = pre
     override def termSymbol       = super.termSymbol
     override def termSymbolDirect = super.termSymbol
     override def typeArgs         = args

--- a/test/files/pos/hk-paths.scala
+++ b/test/files/pos/hk-paths.scala
@@ -1,4 +1,5 @@
 object Test {
+  // scala/bug#12142
   trait Bounds {
     type Upper <: Bounds
   }
@@ -34,5 +35,27 @@ object Test {
   def test[F, A <: U, U, X](fun :Functor[F, A, U], x :Implicit[X, A] { type S >: A <: U }) = {
     x.expr.applyTo[({ type E[B >: A <: U] = fun.Super[B] })#E]
     x.expr.applyTo[fun.Super]
+  }
+
+  // scala/bug#10186
+  trait Foo {
+    type A
+    type F[_ <: A]
+  }
+
+  def noop[A, F[_ <: A]]: Unit = ()
+  def f(foo: Foo): Unit = noop[foo.A, foo.F]
+
+  // scala/bug#9625
+  trait `* -> *`[F[_]]
+
+  trait Bar {
+    type Qux[A]
+    implicit val `* -> *`: `* -> *`[Qux]
+  }
+
+  def foo(bar: Bar): `* -> *`[bar.Qux] = {
+    import bar._
+    implicitly[`* -> *`[bar.Qux]]
   }
 }

--- a/test/files/pos/t9337.scala
+++ b/test/files/pos/t9337.scala
@@ -1,0 +1,13 @@
+object Test {
+  trait TypePreservingFn[T[X <: T[X]]]
+  trait Validator[T, This <: Validator[T,This]]
+
+  trait Foo[T] {
+    type V[This <: Validator[T, This]] = Validator[T, This]
+    val f: TypePreservingFn[V] = ???
+  }
+
+  class Bar[T] extends Foo[T] {
+    val g: TypePreservingFn[V] = ???
+  }
+}


### PR DESCRIPTION
Analogous to `typeSymbolDirect`, we add `prefixDirect`, because `prefix` normalizes type aliases. But kind-checking should not normalize type aliases. This was the intention as noted by comments and `typeSymbolDirect`.

Fixes scala/bug#9337
Closes scala/bug#10186, closes scala/bug#9625 with regression tests (fixed by #9193)