### PR TITLE
Do a kind-check in inferPolyAlternatives

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -1558,9 +1558,13 @@ trait Infer extends Checkable {
           finish(sym setInfo tpe, tpe)
       }
       matchingLength.alternatives match {
-        case Nil        => fail()
+        case Nil => fail()
         case alt :: Nil => finish(alt, pre memberType alt)
-        case _          => checkWithinBounds(matchingLength filter (alt => isWithinBounds(pre, alt.owner, alt.typeParams, argtypes)))
+        case _ =>
+          checkWithinBounds(matchingLength.filter { alt =>
+            isWithinBounds(pre, alt.owner, alt.typeParams, argtypes) &&
+              kindsConform(alt.typeParams, argtypes, pre, alt.owner)
+          })
       }
     }
   }

--- a/test/files/pos/t12212.scala
+++ b/test/files/pos/t12212.scala
@@ -1,0 +1,13 @@
+object Test {
+  trait Low[X]
+  trait Lower[V, X] extends Low[X]
+  trait Res[V]
+  trait High[L[X] <: Low[X]]
+  trait HighRes[L[X] <: Lower[V, X], V] extends Res[V]
+  trait Mid[X, Y]
+
+  def m[L[X] <: Lower[V, X], V](high: High[L]): HighRes[L, V] = ???
+  def m[X, Y](mid: Mid[X, Y]): Res[Y] = ???
+  def ok[L[X] <: Lower[V, X], V](high :High[L]): HighRes[L, V] = m(high)
+  def wtf[L[X] <: Lower[V, X], V](high :High[L]): HighRes[L, V] = m[L, V](high)
+}


### PR DESCRIPTION
Filter matching alternatives by kind, not only by bounds. Fixes scala/bug#12212