### PR TITLE
Fix checkKindBoundsHK for higher kinds

### DIFF
--- a/test/files/neg/subkinding.check
+++ b/test/files/neg/subkinding.check
@@ -1,0 +1,16 @@
+subkinding.scala:5: error: kinds of the type arguments (Test1.C) do not conform to the expected kinds of the type parameters (type B) in trait A.
+Test1.C's type parameters do not match type B's expected parameters:
+type Y's bounds <: X are stricter than type S's declared bounds >: Nothing <: Any
+  type T = A[C]
+           ^
+subkinding.scala:12: error: kinds of the type arguments (Test2.C) do not conform to the expected kinds of the type parameters (type T) in trait A.
+Test2.C's type parameters do not match type T's expected parameters:
+type _ is invariant, but type _ is declared covariant
+  type T = A[C]
+           ^
+subkinding.scala:20: error: kinds of the type arguments (Test3.Adapter,T) do not conform to the expected kinds of the type parameters (type A,type S) in trait Mixin.
+Test3.Adapter's type parameters do not match type A's expected parameters:
+type B (in trait Adapter)'s bounds <: Test3.Box[T] are stricter than type B's declared bounds <: Test3.Box[S]
+  trait Super[T] extends Mixin[Adapter, T]
+                         ^
+3 errors

--- a/test/files/neg/subkinding.scala
+++ b/test/files/neg/subkinding.scala
@@ -1,0 +1,21 @@
+// scala/bug#2067
+object Test1 {
+  trait A[B[D[X, Y <: X]]]
+  trait C[E[T, S]]
+  type T = A[C]
+}
+
+// scala/bug#2067
+object Test2 {
+  trait A[T[_[_]]]
+  trait C[X[+_]]
+  type T = A[C]
+}
+
+// scala/bug#12242
+object Test3 {
+  trait Box[T]
+  trait Adapter[B <: Box[T], T]
+  trait Mixin[+A[B <: Box[S], X], S]
+  trait Super[T] extends Mixin[Adapter, T]
+}


### PR DESCRIPTION
We need to flip the direction of the checks on every other level.
This is similar to contravariance of higher-order function types.

Another option would be to heed the comment:
```
          // Their arguments use different symbols, but are
          // conceptually the same. Could also replace the types by
          // polytypes, but can't just strip the symbols, as ordering
          // is lost then.
```
although I don't understand the last sentence - what ordering?
If we switch to PolyTypes we would lose the detailed error messages,
but I think this is what Scala 3 does.

fixes scala/bug#2067, fixes scala/bug#12242
This would probably need a community build