### PR TITLE
[REJECTED BINCOMPAT] Prefer Ordering.Ops to wrapping OrderingOps

### DIFF
--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -184,6 +184,7 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
   }
 
   /** This inner class defines comparison operators available for `T`. */
+  @deprecated("Use Ordering.Ops", since="2.13.5")
   class OrderingOps(lhs: T) {
     def <(rhs: T): Boolean = lt(lhs, rhs)
     def <=(rhs: T): Boolean = lteq(lhs, rhs)
@@ -195,9 +196,9 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
   }
 
   /** This implicit method augments `T` with the comparison operators defined
-   *  in `OrderingOps`, with semantics determined by this `Ordering`.
+   *  in `Ordering.Ops`.
    */
-  final implicit def mkOrderingOps(lhs: T): OrderingOps = new OrderingOps(lhs)
+  final implicit def mkOrderingOps(lhs: T): Ordering.Ops[T] = new Ordering.Ops[T](lhs)
 }
 
 trait LowPriorityOrderingImplicits {
@@ -299,7 +300,7 @@ object Ordering extends LowPriorityOrderingImplicits {
       * def lessThan[T: Ordering](x: T, y: T) = x < y
       * }}}
       */
-    implicit def infixOrderingOps[T](x: T)(implicit ord: Ordering[T]): Ordering[T]#OrderingOps = new ord.OrderingOps(x)
+    final implicit def infixOrderingOps[T: Ordering](x: T): Ordering.Ops[T] = new Ordering.Ops[T](x)
   }
 
   /** An object containing implicits which are not in the default scope. */

--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -195,9 +195,9 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
   }
 
   /** This implicit method augments `T` with the comparison operators defined
-    * in `scala.math.Ordering.Ops`.
-    */
-  implicit def mkOrderingOps(lhs: T): OrderingOps = new OrderingOps(lhs)
+   *  in `OrderingOps`, with semantics determined by this `Ordering`.
+   */
+  final implicit def mkOrderingOps(lhs: T): OrderingOps = new OrderingOps(lhs)
 }
 
 trait LowPriorityOrderingImplicits {
@@ -889,5 +889,19 @@ object Ordering extends LowPriorityOrderingImplicits {
       case _ => false
     }
     override def hashCode(): Int = (ord1, ord2, ord3, ord4, ord5, ord6, ord7, ord8, ord9).hashCode()
+  }
+
+  /** Infix ordering operations that delegate to an implicit Ordering.
+   *
+   *  These extension methods avoid allocating a wrapper class when inlined.
+   */
+  implicit class Ops[A](val lhs: A) extends AnyVal {
+    def <(rhs: A)(implicit ord: Ordering[A]): Boolean     = ord.lt(lhs, rhs)
+    def <=(rhs: A)(implicit ord: Ordering[A]): Boolean    = ord.lteq(lhs, rhs)
+    def >(rhs: A)(implicit ord: Ordering[A]): Boolean     = ord.gt(lhs, rhs)
+    def >=(rhs: A)(implicit ord: Ordering[A]): Boolean    = ord.gteq(lhs, rhs)
+    def equiv(rhs: A)(implicit ord: Ordering[A]): Boolean = ord.equiv(lhs, rhs)
+    def max(rhs: A)(implicit ord: Ordering[A]): A         = ord.max(lhs, rhs)
+    def min(rhs: A)(implicit ord: Ordering[A]): A         = ord.min(lhs, rhs)
   }
 }

--- a/test/files/pos/t4273.scala
+++ b/test/files/pos/t4273.scala
@@ -1,8 +1,15 @@
 class A {
-  implicit def compareComparables[T](x: T)(implicit ord: Ordering[T]) = new ord.OrderingOps(x)
-
   class Bippy
-  implicit val bippyOrdering = new Ordering[Bippy] { def compare(x: Bippy, y: Bippy) = util.Random.nextInt }
+  implicit val bippyOrdering: Ordering[Bippy] =
+    new Ordering[Bippy] {
+      def compare(x: Bippy, y: Bippy) = util.Random.nextInt
+    }
 
-  (new Bippy) < (new Bippy)
+  @deprecated("OrderingOps is deprecated", since="2.13.5")
+  def test() = {
+    // tests that (local) type inference of implicit type doesn't break it
+    implicit def compareComparables[T](x: T)(implicit ord: Ordering[T]) = new ord.OrderingOps(x)
+
+    new Bippy < new Bippy
+  }
 }

--- a/test/junit/scala/math/OrderingTest.scala
+++ b/test/junit/scala/math/OrderingTest.scala
@@ -60,21 +60,13 @@ class OrderingTest {
 
       assertEquals(O.tryCompare(t1, t2), R.tryCompare(t2, t1))
 
-      assertEquals(O.mkOrderingOps(t1).<(t2), R.mkOrderingOps(t2).<(t1))
-      assertEquals(O.mkOrderingOps(t1).<=(t2), R.mkOrderingOps(t2).<=(t1))
-      assertEquals(O.mkOrderingOps(t1).>(t2), R.mkOrderingOps(t2).>(t1))
-      assertEquals(O.mkOrderingOps(t1).>=(t2), R.mkOrderingOps(t2).>=(t1))
-
-      assertEquals(O.mkOrderingOps(t1).min(t2), R.mkOrderingOps(t1).max(t2))
-      assertEquals(O.mkOrderingOps(t1).max(t2), R.mkOrderingOps(t1).min(t2))
-
-      // repeat infix tests with Ordering.Ops
+      // infix operations take an implicit ordering
       locally {
         import Ordering.Ops
-        assertEquals(t1 < t2, { implicit val ord: Ordering[T] = R ; t2 < t1 })
-        assertEquals(t1 <= t2, { implicit val ord: Ordering[T] = R ; t2 <= t1 })
-        assertEquals(t1 > t2, { implicit val ord: Ordering[T] = R ; t2 > t1 })
-        assertEquals(t1 >= t2, { implicit val ord: Ordering[T] = R ; t2 >= t1 })
+        assertEquals(t1 < t2,   { implicit val ord: Ordering[T] = R ; t2 < t1 })
+        assertEquals(t1 <= t2,  { implicit val ord: Ordering[T] = R ; t2 <= t1 })
+        assertEquals(t1 > t2,   { implicit val ord: Ordering[T] = R ; t2 > t1 })
+        assertEquals(t1 >= t2,  { implicit val ord: Ordering[T] = R ; t2 >= t1 })
         assertEquals(t1 min t2, { implicit val ord: Ordering[T] = R ; t2 max t1 })
         assertEquals(t1 max t2, { implicit val ord: Ordering[T] = R ; t2 min t1 })
       }

--- a/test/junit/scala/math/OrderingTest.scala
+++ b/test/junit/scala/math/OrderingTest.scala
@@ -42,7 +42,7 @@ class OrderingTest {
   @deprecated("Tests deprecated Ordering for Iterable", since="2.13")
   @Test
   def reverseOrdering(): Unit = {
-    def check[T: Ordering](t1: T, t2: T): Unit = {
+    def check[T](t1: T, t2: T)(implicit ord: Ordering[T]): Unit = {
       val O = Ordering[T]
       val R = O.reverse
       assertEquals(O.min(t1, t2), R.max(t1, t2))
@@ -67,6 +67,17 @@ class OrderingTest {
 
       assertEquals(O.mkOrderingOps(t1).min(t2), R.mkOrderingOps(t1).max(t2))
       assertEquals(O.mkOrderingOps(t1).max(t2), R.mkOrderingOps(t1).min(t2))
+
+      // repeat infix tests with Ordering.Ops
+      locally {
+        import Ordering.Ops
+        assertEquals(t1 < t2, { implicit val ord: Ordering[T] = R ; t2 < t1 })
+        assertEquals(t1 <= t2, { implicit val ord: Ordering[T] = R ; t2 <= t1 })
+        assertEquals(t1 > t2, { implicit val ord: Ordering[T] = R ; t2 > t1 })
+        assertEquals(t1 >= t2, { implicit val ord: Ordering[T] = R ; t2 >= t1 })
+        assertEquals(t1 min t2, { implicit val ord: Ordering[T] = R ; t2 max t1 })
+        assertEquals(t1 max t2, { implicit val ord: Ordering[T] = R ; t2 min t1 })
+      }
     }
     def checkAll[T: Ordering](ts: T*): Unit = {
       for (t1 <- ts; t2 <- ts) check(t1, t2)


### PR DESCRIPTION
Instead of allocating a wrapper to implement extension method, prefer extension method that takes an implicit Ordering.
