### PR TITLE
Enumeration documentation: remove nested class shadowing in "override" position

### DIFF
--- a/src/library/scala/Enumeration.scala
+++ b/src/library/scala/Enumeration.scala
@@ -56,21 +56,21 @@ import scala.util.matching.Regex
  * @example {{{
  * // Example of adding attributes to an enumeration by extending the Enumeration.Val class
  * object Planet extends Enumeration {
- *   protected case class Val(mass: Double, radius: Double) extends super.Val {
+ *   protected case class PlanetVal(mass: Double, radius: Double) extends super.Val {
  *     def surfaceGravity: Double = Planet.G * mass / (radius * radius)
  *     def surfaceWeight(otherMass: Double): Double = otherMass * surfaceGravity
  *   }
- *   implicit def valueToPlanetVal(x: Value): Val = x.asInstanceOf[Val]
+ *   implicit def valueToPlanetVal(x: Value): PlanetVal = x.asInstanceOf[PlanetVal]
  *
  *   val G: Double = 6.67300E-11
- *   val Mercury = Val(3.303e+23, 2.4397e6)
- *   val Venus   = Val(4.869e+24, 6.0518e6)
- *   val Earth   = Val(5.976e+24, 6.37814e6)
- *   val Mars    = Val(6.421e+23, 3.3972e6)
- *   val Jupiter = Val(1.9e+27, 7.1492e7)
- *   val Saturn  = Val(5.688e+26, 6.0268e7)
- *   val Uranus  = Val(8.686e+25, 2.5559e7)
- *   val Neptune = Val(1.024e+26, 2.4746e7)
+ *   val Mercury = PlanetVal(3.303e+23, 2.4397e6)
+ *   val Venus   = PlanetVal(4.869e+24, 6.0518e6)
+ *   val Earth   = PlanetVal(5.976e+24, 6.37814e6)
+ *   val Mars    = PlanetVal(6.421e+23, 3.3972e6)
+ *   val Jupiter = PlanetVal(1.9e+27, 7.1492e7)
+ *   val Saturn  = PlanetVal(5.688e+26, 6.0268e7)
+ *   val Uranus  = PlanetVal(8.686e+25, 2.5559e7)
+ *   val Neptune = PlanetVal(1.024e+26, 2.4746e7)
  * }
  *
  * println(Planet.values.filter(_.radius > 7.0e6))


### PR DESCRIPTION
[Enumeration documentation](https://www.scala-lang.org/api/current/scala/Enumeration.html) has an example that is affected by https://github.com/scala/scala/pull/8705 with the following code:

```scala
protected case class Val(mass: Double, radius: Double) extends super.Val
```

This PR changes the shadowing class name to avoid the ambiguity.