### PR TITLE
mutable.HashMap should override 'foreachEntry' to avoid tuple allocation

### DIFF
--- a/src/library/scala/collection/mutable/HashMap.scala
+++ b/src/library/scala/collection/mutable/HashMap.scala
@@ -491,6 +491,16 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
     }
   }
 
+  override def foreachEntry[U](f: (K, V) => U): Unit = {
+    val len = table.length
+    var i = 0
+    while(i < len) {
+      val n = table(i)
+      if(n ne null) n.foreachEntry(f)
+      i += 1
+    }
+  }
+
   protected[this] def writeReplace(): AnyRef = new DefaultSerializationProxy(new mutable.HashMap.DeserializationFactory[K, V](table.length, loadFactor), this)
 
   override def filterInPlace(p: (K, V) => Boolean): this.type = {
@@ -616,6 +626,12 @@ object HashMap extends MapFactory[HashMap] {
     def foreach[U](f: ((K, V)) => U): Unit = {
       f((_key, _value))
       if(_next ne null) _next.foreach(f)
+    }
+
+    @tailrec
+    def foreachEntry[U](f: (K, V) => U): Unit = {
+      f(_key, _value)
+      if(_next ne null) _next.foreachEntry(f)
     }
 
     override def toString = s"Node($key, $value, $hash) -> $next"


### PR DESCRIPTION
The method ```foreachEntry``` is a hot method in our project and I noticed that ```mutable.HashMap``` does not override ```foreachEntry``` so default implementation (```Map#foreachEntry```) creates many ```tuple2```. We should do the improvement like b88a55d000d130b0d54bf52fcfff47cc740952f7 for ```mutable.HashMap```