### PR TITLE
Ensure SingletonTypeTree#ref has symbol after typing

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5627,9 +5627,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
         if (refTyped.isErrorTyped) setError(tree)
         else {
-          tree setType refTyped.tpe.resultType.deconst
           if (!treeInfo.admitsTypeSelection(refTyped)) UnstableTreeError(tree)
-          else tree
+          else SingletonTypeTree(refTyped).setType(refTyped.tpe.resultType.deconst)
         }
       }
 

--- a/test/files/run/reify-each-node-type.check
+++ b/test/files/run/reify-each-node-type.check
@@ -23,7 +23,7 @@
 23                                             new r.List[Int]()  New
 24                                                 0: @unchecked  Annotated
 25                                         (null: r.Outer#Inner)  SelectFromTypeTree
-26                                              (null: Nil.type)  SingletonTypeTree
+26                                            (null: r.Nil.type)  SingletonTypeTree
 27                                  (null: T forSome { type T })  ExistentialTypeTree
 28                                    { import r.{A, B=>C}; () }  Import
 29                                 { def f: Int = return 0; () }  Return


### PR DESCRIPTION
Fixes scala/bug#12296

After this change, the code example attached https://github.com/scala/bug/issues/12296 could retrieve `Symbol`s of the `SingletonTypeTree`'s underlying `RefTree`s