### PR TITLE
REPL: JLine 3.18.0 (was 3.17.1)

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -9,5 +9,5 @@ starr.version=2.13.4
 scala-asm.version=7.3.1-scala-1
 
 # jna.version must be updated together with jline-terminal-jna
-jline.version=3.17.1
+jline.version=3.18.0
 jna.version=5.3.1


### PR DESCRIPTION
looking at https://github.com/jline/jline3/blob/master/changelog.md , I don't see any must-haves, but it probably constitutes a collective nice-to-have and anyway staying stuck on an old version isn't an option long term

3.18 came out in December and I haven't seen anything in the bug tracker that would require us to hold off any longer