### PR TITLE
Reduce indent, avoid deprecation

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/ClassfileWriters.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/ClassfileWriters.scala
@@ -171,19 +171,18 @@ abstract class ClassfileWriters {
   }
 
   object FileWriter {
-    def apply(global: Global, file: AbstractFile, jarManifestMainClass: Option[String]): FileWriter = {
-      if (file hasExtension "jar") {
+    def apply(global: Global, file: AbstractFile, jarManifestMainClass: Option[String]): FileWriter =
+      if (file.hasExtension("jar")) {
         val jarCompressionLevel = global.settings.YjarCompressionLevel.value
-        val jarFactory = Class.forName(global.settings.YjarFactory.value).asSubclass(classOf[JarFactory]).newInstance()
+        val jarFactory =
+          Class.forName(global.settings.YjarFactory.value)
+            .asSubclass(classOf[JarFactory])
+            .getDeclaredConstructor().newInstance()
         new JarEntryWriter(file, jarManifestMainClass, jarCompressionLevel, jarFactory, global.plugins)
-      } else if (file.isVirtual) {
-        new VirtualFileWriter(file)
-      } else if (file.isDirectory) {
-        new DirEntryWriter(file.file.toPath)
-      } else {
-        throw new IllegalStateException(s"don't know how to handle an output of $file [${file.getClass}]")
       }
-    }
+      else if (file.isVirtual) new VirtualFileWriter(file)
+      else if (file.isDirectory) new DirEntryWriter(file.file.toPath)
+      else throw new IllegalStateException(s"don't know how to handle an output of $file [${file.getClass}]")
   }
 
   private final class JarEntryWriter(file: AbstractFile, mainClass: Option[String], compressionLevel: Int, jarFactory: JarFactory, plugins: List[Plugin]) extends FileWriter {

--- a/src/compiler/scala/tools/nsc/transform/Mixin.scala
+++ b/src/compiler/scala/tools/nsc/transform/Mixin.scala
@@ -263,78 +263,73 @@ abstract class Mixin extends Transform with ast.TreeDSL with AccessorSynthesis {
 
     /* Mix in members of implementation class mixinClass into class clazz */
     def mixinTraitForwarders(mixinClass: Symbol): Unit = {
-      for (member <- mixinClass.info.decls ; if isImplementedStatically(member)) {
-        member overridingSymbol clazz match {
-          case NoSymbol =>
-            val isMemberOfClazz = clazz.info.findMember(member.name, 0, 0L, stableOnly = false).alternatives.contains(member)
-            if (isMemberOfClazz) {
-              def genForwarder(required: Boolean): Unit = {
-                val owner = member.owner
-                val isJavaInterface = owner.isJavaDefined && owner.isInterface
-                if (isJavaInterface && !clazz.parentSymbolsIterator.contains(owner)) {
-                  if (required) {
-                    val text = s"Unable to implement a mixin forwarder for $member in $clazz unless interface ${owner.name} is directly extended by $clazz."
-                    reporter.error(clazz.pos, text)
-                  }
-                } else {
-                  if (isJavaInterface)
-                    erasure.requiredDirectInterfaces.getOrElseUpdate(clazz, mutable.Set.empty) += owner
-                  cloneAndAddMixinMember(mixinClass, member).asInstanceOf[TermSymbol] setAlias member
-                }
+      def isMemberOfClass(member: Symbol): Boolean =
+        clazz.info.findMember(member.name, 0, 0L, stableOnly = false).alternatives.contains(member)
+      for (member <- mixinClass.info.decls)
+        if (isImplementedStatically(member) && member.overridingSymbol(clazz) == NoSymbol && isMemberOfClass(member)) {
+          def genForwarder(required: Boolean): Unit = {
+            val owner = member.owner
+            val isJavaInterface = owner.isJavaDefined && owner.isInterface
+            if (isJavaInterface && !clazz.parentSymbolsIterator.contains(owner)) {
+              if (required) {
+                val text = s"Unable to implement a mixin forwarder for $member in $clazz unless interface ${owner.name} is directly extended by $clazz."
+                reporter.error(clazz.pos, text)
               }
-
-              // `member` is a concrete method defined in `mixinClass`, which is a base class of
-              // `clazz`, and the method is not overridden in `clazz`. A forwarder is needed if:
-              //
-              //   - A non-trait base class of `clazz` defines a matching method. Example:
-              //       class C {def f: Int}; trait T extends C {def f = 1}; class D extends T
-              //     Even if C.f is abstract, the forwarder in D is needed, otherwise the JVM would
-              //     resolve `D.f` to `C.f`, see jvms-6.5.invokevirtual.
-              //
-              //   - There exists another concrete, matching method in a parent interface `p` of
-              //     `clazz`, and the `mixinClass` does not itself extend `p`. In this case the
-              //     forwarder is needed to disambiguate. Example:
-              //       trait T1 {def f = 1}; trait T2 extends T1 {override def f = 2}; class C extends T2
-              //     In C we don't need a forwarder for f because T2 extends T1, so the JVM resolves
-              //     C.f to T2.f non-ambiguously. See jvms-5.4.3.3, "maximally-specific method".
-              //       trait U1 {def f = 1}; trait U2 {self:U1 => override def f = 2}; class D extends U2
-              //     In D the forwarder is needed, the interfaces U1 and U2 are unrelated at the JVM
-              //     level.
-
-              @tailrec
-              def existsCompetingMethod(baseClasses: List[Symbol]): Boolean = baseClasses match {
-                case baseClass :: rest =>
-                  if (baseClass ne mixinClass) {
-                    val m = member.overriddenSymbol(baseClass)
-                    val isCompeting = m.exists && {
-                      !m.owner.isTraitOrInterface ||
-                        (!m.isDeferred && !mixinClass.isNonBottomSubClass(m.owner))
-                    }
-                    isCompeting || existsCompetingMethod(rest)
-                  } else existsCompetingMethod(rest)
-
-                case _ => false
-              }
-
-              def generateJUnitForwarder: Boolean = {
-                settings.mixinForwarderChoices.isAtLeastJunit &&
-                  member.annotations.nonEmpty &&
-                  JUnitAnnotations.exists(annot => annot.exists && member.hasAnnotation(annot))
-              }
-
-              def generateSerializationForwarder: Boolean = {
-                (member.name == nme.readResolve || member.name == nme.writeReplace) && member.info.paramss == ListOfNil
-              }
-
-              if (existsCompetingMethod(clazz.baseClasses) || generateJUnitForwarder || generateSerializationForwarder)
-                genForwarder(required = true)
-              else if (settings.mixinForwarderChoices.isTruthy)
-                genForwarder(required = false)
+            } else {
+              if (isJavaInterface)
+                erasure.requiredDirectInterfaces.getOrElseUpdate(clazz, mutable.Set.empty) += owner
+              cloneAndAddMixinMember(mixinClass, member).asInstanceOf[TermSymbol] setAlias member
             }
+          }
 
-          case _        =>
+          // `member` is a concrete method defined in `mixinClass`, which is a base class of
+          // `clazz`, and the method is not overridden in `clazz`. A forwarder is needed if:
+          //
+          //   - A non-trait base class of `clazz` defines a matching method. Example:
+          //       class C {def f: Int}; trait T extends C {def f = 1}; class D extends T
+          //     Even if C.f is abstract, the forwarder in D is needed, otherwise the JVM would
+          //     resolve `D.f` to `C.f`, see jvms-6.5.invokevirtual.
+          //
+          //   - There exists another concrete, matching method in a parent interface `p` of
+          //     `clazz`, and the `mixinClass` does not itself extend `p`. In this case the
+          //     forwarder is needed to disambiguate. Example:
+          //       trait T1 {def f = 1}; trait T2 extends T1 {override def f = 2}; class C extends T2
+          //     In C we don't need a forwarder for f because T2 extends T1, so the JVM resolves
+          //     C.f to T2.f non-ambiguously. See jvms-5.4.3.3, "maximally-specific method".
+          //       trait U1 {def f = 1}; trait U2 {self:U1 => override def f = 2}; class D extends U2
+          //     In D the forwarder is needed, the interfaces U1 and U2 are unrelated at the JVM
+          //     level.
+
+          @tailrec
+          def existsCompetingMethod(baseClasses: List[Symbol]): Boolean = baseClasses match {
+            case baseClass :: rest =>
+              if (baseClass ne mixinClass) {
+                val m = member.overriddenSymbol(baseClass)
+                val isCompeting = m.exists && {
+                  !m.owner.isTraitOrInterface ||
+                    (!m.isDeferred && !mixinClass.isNonBottomSubClass(m.owner))
+                }
+                isCompeting || existsCompetingMethod(rest)
+              } else existsCompetingMethod(rest)
+
+            case _ => false
+          }
+
+          def generateJUnitForwarder: Boolean = {
+            settings.mixinForwarderChoices.isAtLeastJunit &&
+              member.annotations.nonEmpty &&
+              JUnitAnnotations.exists(annot => annot.exists && member.hasAnnotation(annot))
+          }
+
+          def generateSerializationForwarder: Boolean = {
+            (member.name == nme.readResolve || member.name == nme.writeReplace) && member.info.paramss == ListOfNil
+          }
+
+          if (existsCompetingMethod(clazz.baseClasses) || generateJUnitForwarder || generateSerializationForwarder)
+            genForwarder(required = true)
+          else if (settings.mixinForwarderChoices.isTruthy)
+            genForwarder(required = false)
         }
-      }
     }
 
     /* Mix in members of trait mixinClass into class clazz.


### PR DESCRIPTION
Avoid deprecated `Class#newInstance` and reduce braces in `FileWriter`.

Reduce indent by consolidating the boolean expression at the top of the for loop in `mixinTraitForwarders`.

via https://github.com/scala/scala/pull/9431 and squashed