### PR TITLE
Support for external annotations

### DIFF
--- a/src/compiler/scala/tools/nsc/ExternalAnnotations.scala
+++ b/src/compiler/scala/tools/nsc/ExternalAnnotations.scala
@@ -1,0 +1,248 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.tools.nsc
+
+import java.net.URLClassLoader
+
+import scala.annotation.tailrec
+import scala.collection.mutable
+import scala.io.Codec
+import scala.reflect.io.AbstractFile
+import scala.tools.nsc.Reporting.WarningCategory
+import scala.tools.nsc.settings.DefaultPathFactory
+import scala.tools.nsc.util.ClassPath
+
+/**
+ * TODO
+ *   - checking of external annotations: annotations exist, selected symbols exist
+ *   - respect target meta-annotations
+ *   - overloading resolution
+ *   - support named arguments, reorder according to params
+ *   - multiple selections, like imports (a.b.{c, d})
+ */
+trait ExternalAnnotations { self: Global =>
+
+  case class ExtAnn(ownerNames: List[Name], annot: String, args: List[Any]) {
+    final def matchesOwner(owner: Symbol): Boolean = {
+      @tailrec def checkOwners(owner: Symbol, names: List[Name]): Boolean = names match {
+        case n :: ns if !owner.isRoot =>
+          val on = if (owner.isModuleClass) owner.name.toTermName else owner.name
+          on == n && checkOwners(owner.owner, ns)
+        case ns =>
+          ns.isEmpty && owner.isRoot
+      }
+
+      if (owner.isPackageClass) false // don't add annotations to packages, sub-packages
+      else if (ownerNames.head == termNames.WILDCARD) checkOwners(owner.owner, ownerNames.tail)
+      else checkOwners(owner, ownerNames)
+    }
+
+    def toAnnotationInfo: Option[AnnotationInfo] = {
+      def toTreeArg(a: Any): Tree = Literal(Constant(a))
+
+      def toConstArg(a: Any): ClassfileAnnotArg = a match {
+        case a: Array[_] => ArrayAnnotArg(a.map(toConstArg))
+        case c           => LiteralAnnotArg(Constant(c))
+      }
+
+      val annotCls = rootMirror.getClassIfDefined(annot)
+      if (annotCls == NoSymbol) {
+        runReporting.warning(NoPosition, s"annotation class '$annot' for external annotation not found", WarningCategory.OtherExternalAnnotations, "")
+        None
+      }
+      else {
+        val isConst = annotCls.isNonBottomSubClass(definitions.ConstantAnnotationClass)
+        def annotArgs = args.iterator.map(a => toTreeArg(a)).toList
+        def annotAssocs = args.zip(annotCls.primaryConstructor.info.params).iterator.map({
+          case (arg, paramSym) => (paramSym.name, toConstArg(arg))
+        }).toList
+        Some(AnnotationInfo(annotCls.tpe, if (isConst) Nil else annotArgs, if (isConst) annotAssocs else Nil))
+      }
+    }
+  }
+
+  def parseExternalAnnotations(s: String, filename: String): List[ExtAnn] =
+    parseExternalAnnotations(newCompilationUnit(s, filename))
+
+  def parseExternalAnnotations(unit: CompilationUnit): List[ExtAnn] = {
+    import syntaxAnalyzer._
+
+    // Override error reporting, external annotations only generate warnings
+    object parser extends UnitParser(unit) {
+      val errPos = mutable.Set.empty[Position]
+
+      override def syntaxError(offset: Offset, msg: String): Unit = {
+        val pos = o2p(offset)
+        if (!errPos(pos)) {
+          warning(pos, msg)
+          errPos += pos
+        }
+      }
+
+      // Ignore warning category, always use OtherExternalAnnotations
+      override def warning(offset: Offset, msg: String, category: WarningCategory): Unit = warning(offset, msg)
+
+      def warning(offset: Offset, msg: String): Unit = warning(o2p(offset), msg)
+
+      def warning(pos: Position, msg: String): Unit =
+        if (!errPos(pos.focus))
+          runReporting.warning(pos, msg, WarningCategory.OtherExternalAnnotations, "")
+    }
+
+    import parser._
+
+    import scala.tools.nsc.ast.parser.Tokens._
+
+    def warnUnexpectedToken(): Unit =
+      parser.warning(in.offset, s"invalid syntax in external annotation, unexpected ${token2string(in.token)}")
+
+    def nameByCase(n: Name) = {
+      val first = n.charAt(0)
+      if (first >= 'A' && first <= 'Z') n.toTypeName
+      else n.toTermName
+    }
+
+    def id(): Option[Name] = in.token match {
+      case BACKQUOTED_IDENT =>
+        val n = ident()
+        Some {
+          if (in.token == HASH) { in.nextToken(); n.toTypeName }
+          else if (in.token == IDENTIFIER && in.name.toString == "$") { in.nextToken(); n.toTermName }
+          else nameByCase(n)
+        }
+
+      case IDENTIFIER =>
+        val n = ident()
+        Some {
+          if (in.token == HASH) { in.nextToken(); n.toTypeName }
+          else if (n.endsWith('$')) n.dropRight(1).toTermName
+          else nameByCase(n)
+        }
+
+      case USCORE =>
+        in.nextToken()
+        Some(termNames.WILDCARD)
+
+      case _ =>
+        warnUnexpectedToken()
+        None
+    }
+
+    def ownerNames(): List[Name] = {
+      var res = List.empty[Name]
+      id().foreach(res ::= _)
+      while (in.token == DOT) {
+        in.nextToken()
+        id().foreach(res ::= _)
+      }
+      res
+    }
+
+    def annotAndArgs(ann: Tree): Option[(String, List[Any])] = {
+      def annotPath(t: Tree, names: List[Name] = Nil): Option[String] = t match {
+        case Select(qual, name) => annotPath(qual, name :: names)
+        case Ident(name) => Some((name :: names).mkString("."))
+        case t =>
+          parser.warning(t.pos, s"unexpected tree in annotation selector: $t")
+          None
+      }
+
+      def annotArg(tree: Tree): Option[Any] = tree match {
+        case Literal(Constant(v)) => Some(v)
+        case NamedArg(_, Literal(Constant(v))) =>
+          parser.warning(tree.pos, "named arguments not supported, treating as positional")
+          Some(v)
+        case t =>
+          parser.warning(t.pos, s"annotation arguments need to be constants, found $t")
+          None
+      }
+
+      ann match {
+        case Apply(Select(New(tp), _), args) =>
+          annotPath(tp).flatMap(p => {
+            val aso = args.map(annotArg)
+            if (aso.exists(_.isEmpty)) None else Some((p, aso.map(_.get)))
+          })
+        case t =>
+          parser.warning(t.pos, s"unexpected annotation tree, found $t")
+          None
+      }
+    }
+
+    val res = mutable.ListBuffer.empty[ExtAnn]
+    while (isAnnotation) {
+      val annots = parser.annotations(skipNewLines = true).flatMap(annotAndArgs)
+      if (!isIdent)
+        parser.warning(in.offset, s"stale external annotation, no annotation targets found")
+      while (isIdent) {
+        val owners = ownerNames()
+        if (owners.nonEmpty) for ((ann, args) <- annots)
+          res += ExtAnn(owners, ann, args)
+        newLinesOpt()
+      }
+    }
+    if (in.token != EOF)
+      warnUnexpectedToken()
+    res.toList
+  }
+
+  private var extAnnsByName: Map[String, List[ExtAnn]] = null
+  private var extAnnsByOwnerName: Map[String, List[ExtAnn]] = null
+
+  private def extAnnotFiles: List[AbstractFile] = {
+    val ps = ClassPath.expandPath(settings.YexternalAnnotationFiles.value, expandStar = false)
+    ps.map(DefaultPathFactory.getFile)
+  }
+
+  private def extAnnotsFromClasspath: List[(String, String)] = {
+    if (settings.YexternalAnnotations.value) {
+      import scala.jdk.CollectionConverters._
+      val loader = new URLClassLoader(classPath.asURLs.toArray)
+      val urls = loader.getResources("external-annotations.txt").asScala.toList
+      val contents = urls.map(url => (scala.io.Source.fromInputStream(url.openStream())(Codec.UTF8).mkString, url.getPath))
+      loader.close()
+      contents
+    } else Nil
+
+  }
+
+  private def initExternalAnnotations() = if (extAnnsByName == null) {
+    val parsedExtAnns =
+      extAnnotFiles.flatMap(f => parseExternalAnnotations(new CompilationUnit(getSourceFile(f)))) ++
+        extAnnotsFromClasspath.flatMap({ case (content, filename) => parseExternalAnnotations(content, filename)})
+    val (wild, name) = parsedExtAnns.partition(_.ownerNames.head == termNames.WILDCARD)
+    extAnnsByName = name.groupBy(_.ownerNames.head.toString)
+    extAnnsByOwnerName = wild.groupBy(_.ownerNames.tail.head.toString)
+  }
+
+  // some symbols are completed multiple times (lazy type -> lazy type -> actual type, unpickler); add annots only once
+  private lazy val extAnnsAdded: mutable.Set[Symbol] = {
+    initExternalAnnotations()
+    perRunCaches.newSet()
+  }
+
+  def addExternalAnnotations(sym: Symbol): Unit = if (!extAnnsAdded(sym)) {
+    val matchingName = extAnnsByName.getOrElse(sym.name.toString, Nil) ++ extAnnsByOwnerName.getOrElse(sym.owner.name.toString, Nil)
+    val annInfos = matchingName.filter(_.matchesOwner(sym)).flatMap(_.toAnnotationInfo)
+    if (annInfos.nonEmpty) {
+      val syms =
+        if (sym.isModuleClass) List(sym, sym.module)
+        else if (sym.isModule) List(sym, sym.moduleClass)
+        else List(sym)
+      for (sym <- syms) {
+        extAnnsAdded += sym
+        annInfos.foreach(sym.addAnnotation)
+      }
+    }
+  }
+}

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -53,7 +53,8 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
     with DocComments
     with Positions
     with Reporting
-    with Parsing { self =>
+    with Parsing
+    with ExternalAnnotations { self =>
 
   // the mirror --------------------------------------------------
 
@@ -107,6 +108,8 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
   def picklerPhase: Phase = if (currentRun.isDefined) currentRun.picklerPhase else NoPhase
 
   def erasurePhase: Phase = if (currentRun.isDefined) currentRun.erasurePhase else NoPhase
+
+  override def symbolInfoCompleted(sym: Symbol): Unit = addExternalAnnotations(sym)
 
   /* Override `newStubSymbol` defined in `SymbolTable` to provide us access
    * to the last tree to typer, whose position is the trigger of stub errors. */

--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -351,6 +351,7 @@ object Reporting {
     object OtherDebug extends Other; add(OtherDebug)
     object OtherNullaryOverride extends Other; add(OtherNullaryOverride)
     object OtherNonCooperativeEquals extends Other; add(OtherNonCooperativeEquals)
+    object OtherExternalAnnotations extends Other; add(OtherExternalAnnotations)
 
     sealed trait WFlag extends WarningCategory { override def summaryCategory: WarningCategory = WFlag }
     object WFlag extends WFlag { override def includes(o: WarningCategory): Boolean = o.isInstanceOf[WFlag] }; add(WFlag)

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -270,6 +270,9 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
 
   val Youtline        = BooleanSetting    ("-Youtline", "Don't compile method bodies. Use together with `-Ystop-after:pickler` to generate the pickled signatures for all source files.").internalOnly()
 
+  val YexternalAnnotations = BooleanSetting("-Yexternal-annotations", "Apply external annotations defined in the `external-annotations.txt` resource in classpath entries.")
+  val YexternalAnnotationFiles = PathSetting("-Yexternal-annotation-files", "Files from which to read external annotations", "")
+
   val exposeEmptyPackage = BooleanSetting ("-Yexpose-empty-package", "Internal only: expose the empty package.").internalOnly()
   val Ydelambdafy        = ChoiceSetting  ("-Ydelambdafy", "strategy", "Strategy used for translating lambdas into JVM code.", List("inline", "method"), "method")
 

--- a/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
@@ -264,7 +264,7 @@ abstract class SymbolLoaders {
       }
     }
 
-    override def load(root: Symbol): Unit = { complete(root) }
+    override def load(root: Symbol): Unit = { complete(root); symbolInfoCompleted(root) }
 
     private def markAbsent(sym: Symbol): Unit = {
       val tpe: Type = if (ok) NoType else ErrorType

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -53,6 +53,8 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
   protected def freshExistentialName(suffix: String): TypeName = freshExistentialName(suffix, nextExistentialId())
   protected def freshExistentialName(suffix: String, id: Int): TypeName = newTypeName("_" + id + suffix)
 
+  def symbolInfoCompleted(sym: Symbol): Unit = ()
+
   // Set the fields which point companions at one another.  Returns the module.
   def connectModuleToClass(m: ModuleSymbol, moduleClass: ClassSymbol): ModuleSymbol = {
     moduleClass.sourceModule = m
@@ -1537,6 +1539,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
         def abortNoProgress() = abort(s"no progress in completing $this: ${infos.info}")
         if (cnt == 3) abortNoProgress()
       }
+      if (cnt > 0) symbolInfoCompleted(this)
       rawInfo
     }
 

--- a/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
+++ b/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
@@ -737,7 +737,7 @@ abstract class UnPickler {
         completeInternal(sym)
         if (!isCompilerUniverse) markAllCompleted(sym)
       }
-      override def load(sym: Symbol): Unit = { complete(sym) }
+      override def load(sym: Symbol): Unit = { complete(sym); symbolInfoCompleted(sym) }
     }
 
     /** A lazy type which when completed returns type at index `i` and sets alias

--- a/src/reflect/scala/reflect/runtime/SymbolLoaders.scala
+++ b/src/reflect/scala/reflect/runtime/SymbolLoaders.scala
@@ -39,7 +39,7 @@ private[reflect] trait SymbolLoaders { self: SymbolTable =>
         // if (!isCompilerUniverse) markAllCompleted(clazz, module)
       }
     }
-    override def load(sym: Symbol) = complete(sym)
+    override def load(sym: Symbol) = { complete(sym); symbolInfoCompleted(sym) }
   }
 
   /** Create a class and a companion object, enter in enclosing scope,

--- a/test/files/run/external-annotations.check
+++ b/test/files/run/external-annotations.check
@@ -1,0 +1,33 @@
+newSource1.scala:3: warning: class C in package v is deprecated (since 2.13.0): dis?
+  val c = new C // dis
+              ^
+newSource1.scala:4: warning: method m in class C is deprecated (since 2.13.0): dis?
+  c.m           // dis
+    ^
+newSource1.scala:5: warning: method m in class C is deprecated (since 2.13.0): dis?
+  c.m(1)        // dis
+    ^
+newSource1.scala:6: warning: method :: in class C is deprecated (since 2.13.0): dis?
+  c.::          // dis
+    ^
+newSource1.scala:7: warning: class :: in class C is deprecated (since 2.13.0): dat?
+  (new c.::).m  // dat
+         ^
+newSource1.scala:9: warning: object D in class C is deprecated (since 2.13.0): dis?
+  c.D.m         // dis
+    ^
+newSource1.scala:10: warning: method m in object C is deprecated (since 2.13.0): dat?
+  C.m           // dat
+    ^
+newSource1.scala:11: warning: method #### in object O is deprecated (since 2.13.0): dis?
+  O.####        // dis
+    ^
+newSource1.scala:12: warning: class #### in object O is deprecated (since 2.13.0): dat?
+  new O.####    // dat
+        ^
+newSource1.scala:14: warning: class K in package u is deprecated (since 2.13.0): whu?
+  (new p.u.K).m // whu
+           ^
+newSource1.scala:15: warning: object K in package u is deprecated (since 2.13.0): whu?
+  p.u.K.m       // whu
+      ^

--- a/test/files/run/external-annotations/Test.scala
+++ b/test/files/run/external-annotations/Test.scala
@@ -1,0 +1,69 @@
+import scala.tools.partest.{DirectTest, fileSeparator, pathSeparator}
+
+package p {
+  package u {
+    package v {
+      class C {
+        def m = 1
+        def m(x: Int) = 1
+        def :: = 1
+        class :: {
+          def m = 1
+        }
+        class D {
+          def m = 1
+        }
+        object D {
+          def m = 1
+        }
+      }
+      object C {
+        def m = 1
+      }
+      object O {
+        def #### = 1
+        class ####
+        def ### = 1
+      }
+    }
+    class K {
+      def m = 1
+    }
+    object K {
+      def m = 1
+    }
+    package w {
+      object O {
+        def m = 1
+      }
+    }
+  }
+}
+
+object Test extends DirectTest {
+  override def extraSettings: String = s"-usejavacp -deprecation -cp ${testOutput.path} -Yexternal-annotation-files ${testPath.path}${fileSeparator}annots.txt"
+
+  def code =
+    """class A {
+      |  import p.u.v._
+      |  val c = new C // dis
+      |  c.m           // dis
+      |  c.m(1)        // dis
+      |  c.::          // dis
+      |  (new c.::).m  // dat
+      |  (new c.D).m   // -
+      |  c.D.m         // dis
+      |  C.m           // dat
+      |  O.####        // dis
+      |  new O.####    // dat
+      |  O.###         // -
+      |  (new p.u.K).m // whu
+      |  p.u.K.m       // whu
+      |  p.u.w.O.m     // -
+      |}
+      |""".stripMargin
+
+  def show(): Unit = {
+    compile()
+  }
+}

--- a/test/files/run/external-annotations/annots.txt
+++ b/test/files/run/external-annotations/annots.txt
@@ -1,0 +1,17 @@
+@scala.deprecated("dis?", "2.13.0")
+p.u.v.C          // class C
+p.u.v.C.D$       // object D
+p.u.v.C.::       // method
+p.u.v.C.m        // both overloads in class
+p.u.v.O$.`####`$ // method ####
+
+@scala.deprecated("dat?", "2.13.0")
+p.u.v.C.`::`#    // class
+p.u.v.C$.m       // method in object
+p.u.v.O$.`####`# // class ####
+
+@scala.deprecated("wut?", "2.13.0")
+p.u              // no-op, cannot annotate a package
+
+@scala.deprecated("whu?", "2.13.0")
+p.u._            // members of u, but not sub-packages

--- a/test/junit/scala/tools/nsc/ExternalAnnotationsTest.scala
+++ b/test/junit/scala/tools/nsc/ExternalAnnotationsTest.scala
@@ -1,0 +1,116 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.tools.nsc
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+import scala.language.implicitConversions
+import scala.reflect.internal.Reporter
+import scala.tools.nsc.reporters.StoreReporter
+import scala.tools.testkit.BytecodeTesting
+
+class ExternalAnnotationsTest extends BytecodeTesting {
+  import compiler._
+  import global._
+
+  def parse(extAnns: String, nbMessages: Int = 0, allowMessage: StoreReporter.Info => Boolean = _ => false): List[ExtAnn] = {
+    newRun()
+    val r = global.parseExternalAnnotations(extAnns, "<external-annotations>")
+    runReporting.reportSuspendedMessages()
+    assertEquals(nbMessages, global.reporter.asInstanceOf[StoreReporter].infos.size)
+    compiler.checkReport(allowMessage)
+    r
+  }
+
+  implicit def toNameInt(sc: StringContext) = new NameInt(sc)
+  class NameInt(sc: StringContext) {
+    def tm(args: Any*): TermName = TermName(sc.parts(0))
+    def tp(args: Any*): TypeName = TypeName(sc.parts(0))
+  }
+
+  // Only warnings from external annotations, no errors
+  def checkMessage(s: String) = (i: StoreReporter.Info) => i.severity == Reporter.WARNING && i.msg.contains(s)
+
+  @Test
+  def parsing(): Unit = {
+    val r = parse(
+      """@a1
+        |@a2("arg", 1) @a3(param = 0) // multiple annotations on a line
+        |C
+        |a.b.C.d
+        |
+        |@a4
+        |a$.`b`$.C#.`D`#.`e`         // default term / type
+        |a#.C$.`x#`.`D$`.`k$`#.`U#`$ // change term / type
+        |x.y._
+        |
+        |@a5 p.`::` u.`###` v.`::`#  // annotation and multiple targets on a line
+        |""".stripMargin,
+      1, checkMessage("named arguments not supported"))
+    assertEquals(
+      List(
+        ExtAnn(List(tp"C"), "a1", List()),
+        ExtAnn(List(tp"C"), "a2", List("arg", 1)),
+        ExtAnn(List(tp"C"), "a3", List(0)),
+        ExtAnn(List(tm"d", tp"C", tm"b", tm"a"), "a1" , List()),
+        ExtAnn(List(tm"d", tp"C", tm"b", tm"a"), "a2" , List("arg", 1)),
+        ExtAnn(List(tm"d", tp"C", tm"b", tm"a"), "a3" , List(0)),
+        ExtAnn(List(tm"e", tp"D", tp"C", tm"b", tm"a"), "a4", List()),
+        ExtAnn(List(tm"U$$hash", tp"k$$", tp"D$$", tm"x$$hash", tm"C", tp"a"), "a4", List()),
+        ExtAnn(List(tm"_", tm"y", tm"x"), "a4", List()),
+        ExtAnn(List(tm"$$colon$$colon", tm"p"), "a5", List()),
+        ExtAnn(List(tm"$$hash$$hash$$hash", tm"u"), "a5", List()),
+        ExtAnn(List(tp"$$colon$$colon", tm"v"), "a5", List())),
+      r)
+  }
+
+  @Test
+  def noTarget(): Unit = {
+    parse(
+      """@a1 @a2("hai")
+        |""".stripMargin, 1, checkMessage("no annotation targets found"))
+  }
+
+  @Test
+  def unexpectedToken(): Unit = {
+    val m = "invalid syntax in external annotation, unexpected 'def'"
+    parse(
+      """@a x.P
+        |@b y.C def.D
+        |""".stripMargin,
+      1, checkMessage(m))
+    parse(
+      """@a x.P.def.U
+        |""".stripMargin,
+      1, checkMessage(m))
+  }
+
+  @Test
+  def invlidAnnots(): Unit = {
+    parse(
+      """@a.def.foo x
+        |""".stripMargin,
+      1, checkMessage("identifier expected but 'def' found"))
+
+    parse(
+      """@a(foo) x
+        |""".stripMargin,
+      1, checkMessage("annotation arguments need to be constants"))
+
+    parse(
+      """@a(2 + 3) x
+        |""".stripMargin,
+      1, checkMessage("annotation arguments need to be constants"))
+  }
+}


### PR DESCRIPTION
This change adds support for defining external annotations, i.e., for adding annotations to classes on the classpath.

### Use case

External annotations can be used for low-overhead API-level linting by adding deprecations and potentially making them fatal using `-Wconf`. The propsed [`@apiStatus` annotation](https://github.com/scala/scala/pull/8820) which generalizes deprecations would also be a good match for external annotations.

There is overlap between external annotations and existing Scala linters like [scalafix](https://github.com/scalacenter/scalafix) and [wartremover](https://github.com/wartremover/wartremover). The advantage of external annotations is the low overhead (low compile-time overhead, no new tool in the toolchain) and simplicity (writing wartremover or scalafix rules uses non-trivial APIs).

External annotations could potentially become useful for [explicit null checking in Scala 3](http://dotty.epfl.ch/docs/internals/explicit-nulls.html).

### Details

There are two new compiler flags:

  - `-Yexternal-annotation-files annots.txt:more-annots.txt` enables reading external annotations from specific files
  - `-Yexternal-annotations` enables reading external annotations from jars / directories on the classpath. Each each classpath entry is scanned for the file `/external-annotations.txt`. External annotations can be shared across projects by publishing them to a repository and adding them as `libraryDependencies`.

External annotations are added to symbols at the moment their lazy type is completed. This makes external annotations available already in the type checking phase, but does not cause symbol infos to be forced eagerly.

An alternative implementation strategy is to add external annotations in a separate phase after type checking. This would make external annotations only visible after type checking, which would be OK for deprecations (they are checked in the refchecks phase). This strategy could be implemented as a compiler plugin.

Syntax for external annotations:

```
@path.to.annotation
@another.annot
path.to.Class
some.Class.method
some.Object$

@scala.deprecated("don't use ???", "2.13.0")
scala.Predef$.???

@scala.deprecated("no mutable collections")
scala.collection.mutable._
```

Details:
  - All paths need to be fully qualified
  - Members need to be selected from the class in which they are defined (don't select inherited members)
  - Annotation arguments need to be constants
  - `lwoercase` and symbolic names (`???`) refer to term symbols
  - `Uppercase` names refer to type symbols
  - A trailing `$` changes the name into a term (`Predef$`)
  - A trailing `#` makes a type name (``scala.collection.immutable.`::`#``)
  - Backticks can be used for symbolic names (``scala.sys.process.ProcessBuilder.`###` ``)
  - A wildcard `_` applies to all symbols that share a parent
  - Packages can't be annotated
  - For overloaded methods, annotations are applied to all alternatives (for now)

Issues with external annotation files (e.g. syntax errors, unknown annotations, non-constant annotation arguments) are reported as warnings with category `other-external-annotations` (not as errors).

### Todos

  - [ ] a way for eagerly checking external annotation files (syntax is correct, annotation classes exist, selected symbols exist)
  - [ ] respect [target meta-annotations](https://www.scala-lang.org/api/current/scala/annotation/meta/index.html)
  - [ ] support paths to specific overloaded members
  - [ ] support named annotation arguments
  - [ ] multiple selections like imports: `a.b.{c, d}`