### PR TITLE
allow parallel class loading for the scala launcher

### DIFF
--- a/src/reflect/scala/reflect/internal/util/ScalaClassLoader.scala
+++ b/src/reflect/scala/reflect/internal/util/ScalaClassLoader.scala
@@ -138,7 +138,7 @@ object ScalaClassLoader {
          with HasClassPath {
     // Note - this is calling a caller sensitive method so must be called from the class that is being registered
     // and we are behaving like a java static method
-    if (URLClassLoader.registered.compareAndSet(false, true))
+    if (!URLClassLoader.registered.getAndSet(true))
       ClassLoader.registerAsParallelCapable()
 
     private var classloaderURLs: Seq[URL] = urls


### PR DESCRIPTION
Noted that the current Scala launcher is not registered as parallel capable. This means that there is a contention on class loading in multiple threads

Not sure which of the other scala defined classloaders should also be registered

If adopted, this would probably need a community build and mentioning in the release notes