### PR TITLE
Improve inferred-`Any` lint (fixing false positives and false negatives)

### DIFF
--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -1105,9 +1105,6 @@ private[internal] trait TypeMaps {
     }
     override protected def pred(sym1: Symbol): Boolean = sym1 == sym
   }
-  class ContainsAnyCollector(syms: List[Symbol]) extends ExistsTypeRefCollector {
-    override protected def pred(sym1: Symbol): Boolean = syms.contains(sym1)
-  }
   class ContainsAnyKeyCollector(symMap: mutable.HashMap[Symbol, _]) extends ExistsTypeRefCollector {
     override protected def pred(sym1: Symbol): Boolean = symMap.contains(sym1)
   }

--- a/test/files/neg/t12320.check
+++ b/test/files/neg/t12320.check
@@ -1,0 +1,21 @@
+t12320.scala:4: warning: a type was inferred to be `Any`; this may indicate a programming error.
+  def f = Option.empty[Int].contains("") || false
+                            ^
+t12320.scala:5: warning: a type was inferred to be `Any`; this may indicate a programming error.
+  def g(other: Option[Int]) = other.contains("") || false
+                                    ^
+t12320.scala:6: warning: a type was inferred to be `Any`; this may indicate a programming error.
+  def any = Option.empty[Int].contains("")
+                              ^
+t12320.scala:11: warning: a type was inferred to be `Any`; this may indicate a programming error.
+  def f = List(1 -> "a", 2 -> "b", 3) map { p => val (a,b) = p; a + " -> " + b }
+          ^
+t12320.scala:17: warning: a type was inferred to be `Any`; this may indicate a programming error.
+  def test = review.f(42)
+                    ^
+t12320.scala:11: warning: method any2stringadd in object Predef is deprecated (since 2.13.0): Implicit injection of + is deprecated. Convert to String to call +
+  def f = List(1 -> "a", 2 -> "b", 3) map { p => val (a,b) = p; a + " -> " + b }
+                                                                ^
+error: No warnings can be incurred under -Werror.
+6 warnings
+1 error

--- a/test/files/neg/t12320.scala
+++ b/test/files/neg/t12320.scala
@@ -1,0 +1,18 @@
+//> using options -Werror -Xlint:infer-any,deprecation
+//
+trait T {
+  def f = Option.empty[Int].contains("") || false
+  def g(other: Option[Int]) = other.contains("") || false
+  def any = Option.empty[Int].contains("")
+}
+
+trait `t9211 via 5898` {
+
+  def f = List(1 -> "a", 2 -> "b", 3) map { p => val (a,b) = p; a + " -> " + b }
+}
+
+object review { def f(x: String) = 0; def f[T >: String](x: T) = 1 }
+
+trait review {
+  def test = review.f(42)
+}

--- a/test/files/neg/t12441.check
+++ b/test/files/neg/t12441.check
@@ -1,3 +1,6 @@
+t12441.scala:6: warning: a type was inferred to be `Any`; this may indicate a programming error.
+  def f: Any = Option.empty[String].contains(1234)
+                                    ^
 t12441.scala:7: warning: a type was inferred to be `Any`; this may indicate a programming error.
   def g = Option.empty[String].contains(1234)
                                ^
@@ -17,5 +20,5 @@ t12441.scala:14: warning: a type was inferred to be `Any`; this may indicate a p
   def peskier = p == (42, List(17, ""))
                           ^
 error: No warnings can be incurred under -Werror.
-5 warnings
+6 warnings
 1 error

--- a/test/files/neg/t12441.scala
+++ b/test/files/neg/t12441.scala
@@ -1,5 +1,5 @@
 
-// scalac: -Xlint -Werror
+//> using options -Werror -Xlint
 
 trait T {
   def k(u: => Unit): Unit = u

--- a/test/files/pos/t9211.scala
+++ b/test/files/pos/t9211.scala
@@ -1,0 +1,9 @@
+//> using options -Werror -Xlint
+
+trait T[A]
+class C extends T[Any]
+
+class Test {
+  def f[A](t: T[A]) = ()
+  def g() = f(new C)
+}

--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -416,9 +416,9 @@ class IteratorTest {
   // scala/bug#8552
   @Test def indexOfShouldWorkForTwoParams(): Unit = {
     assertEquals(1, List(1, 2, 3).iterator.indexOf(2, 0))
-    assertEquals(-1, List(5 -> 0).iterator.indexOf(5, 0))
+    assertEquals(-1, List(5 -> 0).iterator.indexOf[Any](5, 0))
     assertEquals(0, List(5 -> 0).iterator.indexOf((5, 0)))
-    assertEquals(-1, List(5 -> 0, 9 -> 2, 0 -> 3).iterator.indexOf(9, 2))
+    assertEquals(-1, List(5 -> 0, 9 -> 2, 0 -> 3).iterator.indexOf[Any](9, 2))
     assertEquals(1, List(5 -> 0, 9 -> 2, 0 -> 3).iterator.indexOf(9 -> 2))
   }
   // scala/bug#9332

--- a/test/junit/scala/collection/MapTest.scala
+++ b/test/junit/scala/collection/MapTest.scala
@@ -53,7 +53,7 @@ class MapTest {
     val m1 = m ++: m
     assertEquals(m.toList.sorted, (m1: Map[Int, Int]).toList.sorted)
     val s1: Iterable[Any] = List(1) ++: m
-    assertEquals(1 :: m.toList.sorted, s1.toList.sortBy { case (x: Int, _) => x ; case x: Int => x })
+    assertEquals(::[Any](1, m.toList.sorted), s1.toList.sortBy { case (x: Int, _) => x ; case x: Int => x })
   }
 
   @Test

--- a/test/junit/scala/collection/immutable/ArraySeqTest.scala
+++ b/test/junit/scala/collection/immutable/ArraySeqTest.scala
@@ -143,15 +143,15 @@ class ArraySeqTest {
   @Test
   def foldAny(): Unit = {
     val a = ArraySeq[Any](1, "3")
-    assertEquals(a.foldLeft("")(_ + _), "13")
-    assertEquals(a.foldRight(List.empty[Any])(_ :: _), List(1, "3"))
+    assertEquals("13", a.foldLeft("")(_ + _))
+    assertEquals(List[Any](1, "3"), a.foldRight(List.empty[Any])(_ :: _))
   }
 
   @Test
   def from(): Unit = {
     val as = ArraySeq("foo", "bar", "baz")
-    assert(ArraySeq.from(as) eq as)
-    assert(ArraySeq(as: _*) eq as)
+    assertSame(as, ArraySeq.from(as))
+    assertSame(as, ArraySeq(as: _*))
   }
 
   private def assertConcat[A](lhs: ArraySeq[A], rhs: ArraySeq[A], expect: ArraySeq[A]): Array[_] = {

--- a/test/junit/scala/collection/immutable/NumericRangeTest.scala
+++ b/test/junit/scala/collection/immutable/NumericRangeTest.scala
@@ -395,8 +395,8 @@ class NumericRangeTest {
     assertEquals(300 / 5, NumericRange(BigInt(0), BigInt(Int.MaxValue), BigInt(5)).lastIndexOf(BigInt(300)))
 
     // indexOf different type returns -1
-    assertEquals(-1, NumericRange(0L, Int.MaxValue.toLong, 5L).indexOf(300))
-    assertEquals(-1, NumericRange(0L, Int.MaxValue.toLong, 5L).lastIndexOf(300))
+    assertEquals(-1, NumericRange(0L, Int.MaxValue.toLong, 5L).indexOf[AnyVal](300))
+    assertEquals(-1, NumericRange(0L, Int.MaxValue.toLong, 5L).lastIndexOf[AnyVal](300))
 
     /* Attempting an indexOf of a Range with more than Int.MaxValue elements always throws an error.
     Not ideal, but this tests whether backwards compatibility is conserved. */

--- a/test/junit/scala/collection/immutable/VectorTest.scala
+++ b/test/junit/scala/collection/immutable/VectorTest.scala
@@ -465,7 +465,7 @@ class VectorTest {
 
       assertEquals(1 to 5, vector)
       assertEquals(vector.updated(0, 20), Vector(20,2,3,4,5))
-      assertEquals(vector.updated(0, ""), Vector("",2,3,4,5))
+      assertEquals(vector.updated[Any](0, ""), Vector[Any]("",2,3,4,5))
       assertEquals(1 to 5, arraySeq) // ensure arraySeq is not mutated
     }
     locally {
@@ -474,7 +474,7 @@ class VectorTest {
       val vector = Vector.from(arr)
       assertEquals(arr.toList, vector)
       assertEquals(List(20), vector.updated(0, 20))
-      assertEquals(List(""), vector.updated(0, ""))
+      assertEquals(List(""), vector.updated[Any](0, ""))
     }
   }
 

--- a/test/junit/scala/collection/immutable/WrappedStringTest.scala
+++ b/test/junit/scala/collection/immutable/WrappedStringTest.scala
@@ -10,6 +10,6 @@ class WrappedStringTest {
 
   @Test // scala/bug#11518
   def indexOf_nonChar(): Unit = {
-    assertEquals(-1, new WrappedString("test").indexOf("not a Char")) // doesn't overflow
+    assertEquals(-1, new WrappedString("test").indexOf[Any]("not a Char")) // doesn't overflow
   }
 }

--- a/test/junit/scala/collection/mutable/HashMapTest.scala
+++ b/test/junit/scala/collection/mutable/HashMapTest.scala
@@ -194,7 +194,7 @@ class HashMapTest {
 
     val hashMapCollide2 = mutable.HashMap(0 -> "a", (null: Any) -> "b", "" -> "c")
     assertEquals(hashMapCollide2.updateWith((null: Any))(noneAnytime), None)
-    assertEquals(hashMapCollide2, mutable.HashMap(0 -> "a", "" -> "c"))
+    assertEquals(hashMapCollide2, mutable.HashMap[Any, String](0 -> "a", "" -> "c"))
 
     val hashMapCollide3 = mutable.HashMap(0 -> "a", (null: Any) -> "b", "" -> "c")
     assertEquals(hashMapCollide3.updateWith("")(noneAnytime), None)

--- a/test/junit/scala/collection/mutable/LinkedHashMapTest.scala
+++ b/test/junit/scala/collection/mutable/LinkedHashMapTest.scala
@@ -108,7 +108,7 @@ class LinkedHashMapTest {
 
     val hashMapCollide2 = mutable.LinkedHashMap(0 -> "a", (null: Any) -> "b", "" -> "c")
     assertEquals(hashMapCollide2.updateWith((null: Any))(noneAnytime), None)
-    assertEquals(hashMapCollide2, mutable.LinkedHashMap(0 -> "a", "" -> "c"))
+    assertEquals(hashMapCollide2, mutable.LinkedHashMap[Any, String](0 -> "a", "" -> "c"))
 
     val hashMapCollide3 = mutable.LinkedHashMap(0 -> "a", (null: Any) -> "b", "" -> "c")
     assertEquals(hashMapCollide3.updateWith("")(noneAnytime), None)

--- a/test/junit/scala/reflect/macros/AttachmentsTest.scala
+++ b/test/junit/scala/reflect/macros/AttachmentsTest.scala
@@ -1,5 +1,6 @@
 package scala.reflect.macros
 
+import org.junit.Assert._
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -30,8 +31,8 @@ class AttachmentsTest {
 
     object theBar extends Bar
     atts = atts.update(theBar)
-    assert(!atts.isEmpty)
-    assert(atts.all == Set(Foo(0), theBar))
+    assertFalse(atts.isEmpty)
+    assertEquals(Set[Any](Foo(0), theBar), atts.all)
     assert(atts.get[Foo] == Some(Foo(0)))
     assert(atts.get[Bar] == Some(theBar))
     assert(atts.get[theBar.type] == Some(theBar))

--- a/test/junit/scala/runtime/ScalaRunTimeTest.scala
+++ b/test/junit/scala/runtime/ScalaRunTimeTest.scala
@@ -25,7 +25,7 @@ class ScalaRunTimeTest {
     assertEquals("""Array(1, 2, 3)""", stringOf(Array(1, 2, 3)))
     assertEquals("""Array(a, "", " c", null)""", stringOf(Array("a", "", " c", null)))
     assertEquals("""Array(Array("", 1, Array(5)), Array(1))""",
-        stringOf(Array(Array("", 1, Array(5)), Array(1))))
+        stringOf(Array[Any](Array[Any]("", 1, Array(5)), Array(1))))
 
     val map = Map(1->"", 2->"a", 3->" a", 4->null)
     assertEquals(s"""Map(1 -> "", 2 -> a, 3 -> " a", 4 -> null)""", stringOf(map))


### PR DESCRIPTION
`-Xlint:infer-any`, which is part of the default `-Xlint` bundle, warns if an inferred type argument is a "top" type: `Any`, `AnyVal`, `AnyRef`, or `Object`.

The heuristic has been improved not to warn if a type parameter in the expression has an upper or lower bound that is a "top" type.

Typically, the warning is "silenced" by supplying an explicit type argument where needed, if the usage was intended.

It no longer considers whether the "expected type" is `Any`. Previously, just passing an expression to `println` would silence the warning.

Examples illustrating the errors to avoid:

```
scala> Option("hello, world").contains(42)
                              ^
       warning: a type was inferred to be `Any`; this may indicate a programming error.
val res0: Boolean = false

scala> List(42 -> 27).indexOf(42, 27) // indexOf is overloaded
                      ^
       warning: a type was inferred to be `Any`; this may indicate a programming error.
val res1: Int = -1

scala> List(42 -> 27).indexOf((42, 27)) // intended
val res2: Int = 0

scala> println(List(42 -> 27).indexOf(42, 27))
                              ^
       warning: a type was inferred to be `Any`; this may indicate a programming error.
-1
```
Supplying a type argument to an infix expression is irregular syntax in Scala 2, so it may be necessary to rewrite it:
```
scala> "hello, world" :: 42 :: Nil
                      ^
       warning: a type was inferred to be `Any`; this may indicate a programming error.
val res4: List[Any] = List(hello, world, 42)

scala> List[Any]("hello, world", 42)
val res5: List[Any] = List(hello, world, 42)

scala> { ::[Any]("hello, world", 42 :: Nil) }
val res6: scala.collection.immutable.::[Any] = List(hello, world, 42)
```

Fixes scala/bug#12320

Closes scala/bug#9211
