### PR TITLE
Add tests for separate compilation accessibility

### DIFF
--- a/src/partest/scala/tools/partest/SeparateCompileTest.scala
+++ b/src/partest/scala/tools/partest/SeparateCompileTest.scala
@@ -1,0 +1,57 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.tools.partest
+
+import java.io.File
+import scala.tools.nsc._
+
+abstract class SeparateCompileTest extends DirectTest {
+  def classesDir(i: Int): File =
+    new File(new File(sys.props("partest.output")), s"classes$i")
+
+  // Override this
+  def sourcess: List[List[String]]
+
+  def check(global: Global)(source: String, result: Either[Unit, global.CompilationUnit]): Unit =
+    result match {
+      case Left(_) => sys.error("compilation error")
+      case _       => ()
+    }
+
+  def show() = 
+    sourcess.zipWithIndex foreach { case (sources, idx) =>
+      classesDir(idx).mkdirs
+      val testOutput = Directory(classesDir(idx))
+      val settings = newSettings(
+        (if (idx > 0) List("-cp", (0 to idx - 1).toList.map(classesDir).mkString(File.pathSeparator))
+        else Nil) :::
+        List("-usejavacp", "-d", testOutput.path))
+      val global: Global = newCompiler(settings)
+      val result = compilationUnitsEither(global)(sources: _*)
+      result match {
+        case Left(_)      => sources.foreach(check(global)(_, Left(())))
+        case Right(units) => sources.lazyZip(units).foreach((s, u) => check(global)(s, Right(u)))
+      }
+    }
+
+  def compilationUnitsEither(global: Global)(sourceCodes: String*): Either[Unit, List[global.CompilationUnit]] = {
+    val units = sourceFilesToCompiledUnits(global)(newSources(sourceCodes: _*))
+    if (global.reporter.hasErrors) {
+      global.reporter.flush()
+      Left(())
+    }
+    else Right(units)
+  }
+
+  override def code: String = ""
+}

--- a/test/files/run/separate-package-private.check
+++ b/test/files/run/separate-package-private.check
@@ -1,0 +1,3 @@
+newSource1.scala:3: error: class A in package a cannot be accessed as a member of package a from object Test in package example
+object Test { val x = new a.A }
+                            ^

--- a/test/files/run/separate-package-private.scala
+++ b/test/files/run/separate-package-private.scala
@@ -1,0 +1,23 @@
+import scala.tools.partest.SeparateCompileTest
+
+import scala.tools.nsc.Global
+
+object Test extends SeparateCompileTest {
+  val source0 =
+    """package a
+      |private[a] class A
+      |""".stripMargin
+  val source1 =
+    """package example
+      |import a.A
+      |object Test { val x = new a.A }
+      |""".stripMargin
+
+  override def sourcess: List[List[String]] =
+    List(List(source0), List(source1))
+
+  // ok to fail compilation
+  override def check(global: Global)(
+      source: String,
+      result: Either[Unit, global.CompilationUnit]): Unit = ()
+}

--- a/test/files/run/separate-package-protected.check
+++ b/test/files/run/separate-package-protected.check
@@ -1,0 +1,6 @@
+newSource1.scala:3: error: class A in package a cannot be accessed as a member of package a from object Test in package example
+ Access to protected class A not permitted because
+ enclosing object Test in package example is not a subclass of
+ package a where target is defined
+object Test { val x = new a.A }
+                            ^

--- a/test/files/run/separate-package-protected.scala
+++ b/test/files/run/separate-package-protected.scala
@@ -1,0 +1,23 @@
+import scala.tools.partest.SeparateCompileTest
+
+import scala.tools.nsc.Global
+
+object Test extends SeparateCompileTest {
+  val source0 =
+    """package a
+      |protected[a] class A
+      |""".stripMargin
+  val source1 =
+    """package example
+      |import a.A
+      |object Test { val x = new a.A }
+      |""".stripMargin
+
+  override def sourcess: List[List[String]] =
+    List(List(source0), List(source1))
+
+  // ok to fail compilation
+  override def check(global: Global)(
+      source: String,
+      result: Either[Unit, global.CompilationUnit]): Unit = ()
+}

--- a/test/files/run/separate-public.scala
+++ b/test/files/run/separate-public.scala
@@ -1,0 +1,18 @@
+import scala.tools.partest.SeparateCompileTest
+
+import scala.tools.nsc.Global
+
+object Test extends SeparateCompileTest {
+  val source0 =
+    """package a
+      |class A
+      |""".stripMargin
+  val source1 =
+    """package example
+      |import a.A
+      |object Test { val x = new a.A }
+      |""".stripMargin
+
+  override def sourcess: List[List[String]] =
+    List(List(source0), List(source1))
+}


### PR DESCRIPTION
This is a post-dated tests for scala/bug#12321

In Scala 2.12.x and 2.13.0 ~ 1 separate compilation violates package-protected accessibility.
In some coincidence(?) the PR meant for import warning actually fixes this (#8753) in Scala 2.13.2.