### PR TITLE
Disallow `new MyObj.type`

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -369,10 +369,14 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     private def errorNotClass(tpt: Tree, found: Type)  = { ClassTypeRequiredError(tpt, found); false }
     private def errorNotStable(tpt: Tree, found: Type) = { TypeNotAStablePrefixError(tpt, found); false }
 
-    /** Check that `tpt` refers to a non-refinement class type */
+    /** Check that `tpt` refers to a non-refinement class or module type */
     def checkClassOrModuleType(tpt: Tree): Boolean = {
       val tpe = unwrapToClass(tpt.tpe)
-      isNonRefinementClassType(tpe, allowModules = true) || errorNotClass(tpt, tpe)
+      def isModule = tpe match {
+        case SingleType(_, sym) => sym.isModule
+        case _ => false
+      }
+      isNonRefinementClassType(tpe) || isModule || errorNotClass(tpt, tpe)
     }
 
     /** Check that `tpt` refers to a class type with a stable prefix. */

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -370,9 +370,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     private def errorNotStable(tpt: Tree, found: Type) = { TypeNotAStablePrefixError(tpt, found); false }
 
     /** Check that `tpt` refers to a non-refinement class type */
-    def checkClassType(tpt: Tree): Boolean = {
+    def checkClassOrModuleType(tpt: Tree): Boolean = {
       val tpe = unwrapToClass(tpt.tpe)
-      isNonRefinementClassType(tpe) || errorNotClass(tpt, tpe)
+      isNonRefinementClassType(tpe, allowModules = true) || errorNotClass(tpt, tpe)
     }
 
     /** Check that `tpt` refers to a class type with a stable prefix. */
@@ -4300,7 +4300,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     }
 
     def typedClassOf(tree: Tree, tpt: Tree, noGen: Boolean = false) =
-      if (!checkClassType(tpt) && noGen) tpt
+      if (!checkClassOrModuleType(tpt) && noGen) tpt
       else atPos(tree.pos)(gen.mkClassOf(tpt.tpe))
 
     protected def typedExistentialTypeTree(tree: ExistentialTypeTree, mode: Mode): Tree = {

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4762,8 +4762,8 @@ trait Types
    */
   /** def isNonValueType(tp: Type) = !isValueElseNonValue(tp) */
 
-  def isNonRefinementClassType(tpe: Type) = tpe match {
-    case SingleType(_, sym) => sym.isModuleOrModuleClass
+  def isNonRefinementClassType(tpe: Type, allowModules: Boolean = false) = tpe match {
+    case SingleType(_, sym) => if (allowModules) sym.isModuleOrModuleClass else sym.isModuleClass
     case TypeRef(_, sym, _) => sym.isClass && !sym.isRefinementClass
     case ErrorType          => true
     case _                  => false

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4762,8 +4762,8 @@ trait Types
    */
   /** def isNonValueType(tp: Type) = !isValueElseNonValue(tp) */
 
-  def isNonRefinementClassType(tpe: Type, allowModules: Boolean = false) = tpe match {
-    case SingleType(_, sym) => if (allowModules) sym.isModuleOrModuleClass else sym.isModuleClass
+  def isNonRefinementClassType(tpe: Type) = tpe match {
+    case SingleType(_, sym) => sym.isModuleClass
     case TypeRef(_, sym, _) => sym.isClass && !sym.isRefinementClass
     case ErrorType          => true
     case _                  => false

--- a/test/files/neg/t12322a.check
+++ b/test/files/neg/t12322a.check
@@ -1,0 +1,7 @@
+t12322a.scala:3: error: class type required but Wrapper.this.MyObj.type found
+  val obj = new MyObj.type
+                     ^
+t12322a.scala:6: error: class type required but Wrapper.this.MyObj.type found
+  val oops = new Oops
+                 ^
+2 errors

--- a/test/files/neg/t12322a.scala
+++ b/test/files/neg/t12322a.scala
@@ -1,0 +1,7 @@
+class Wrapper {
+  object MyObj
+  val obj = new MyObj.type
+
+  type Oops = MyObj.type
+  val oops = new Oops
+}

--- a/test/files/neg/t12322b.check
+++ b/test/files/neg/t12322b.check
@@ -1,4 +1,7 @@
+t12322b.scala:7: error: class type required but MyObj.type found
+object ObjectNew extends MyObj.type {
+                              ^
 t12322b.scala:9: error: class type required but MyObj.type found
     val mo: MyObj.type = new MyObj.type() // here
                                   ^
-1 error
+2 errors

--- a/test/files/neg/t12322b.check
+++ b/test/files/neg/t12322b.check
@@ -1,0 +1,4 @@
+t12322b.scala:9: error: class type required but MyObj.type found
+    val mo: MyObj.type = new MyObj.type() // here
+                                  ^
+1 error

--- a/test/files/neg/t12322b.scala
+++ b/test/files/neg/t12322b.scala
@@ -4,7 +4,7 @@ object MyObj {
   val c: String = "ABC"
 }
 
-object ObjectNew {
+object ObjectNew extends MyObj.type {
   def main(args: Array[String]): Unit = {
     val mo: MyObj.type = new MyObj.type() // here
   }

--- a/test/files/neg/t12322b.scala
+++ b/test/files/neg/t12322b.scala
@@ -1,0 +1,11 @@
+object MyObj {
+  val a: Int = 123
+  val b: Double = 456.789
+  val c: String = "ABC"
+}
+
+object ObjectNew {
+  def main(args: Array[String]): Unit = {
+    val mo: MyObj.type = new MyObj.type() // here
+  }
+}


### PR DESCRIPTION
... while still allowing `classOf[MyObj.type]`.

Fixes scala/bug#12322