### PR TITLE
Fix mimaReportBinaryIssues, doesn't run aggregate

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1015,7 +1015,8 @@ lazy val partests = List(
 lazy val remainingTests = List(
   (osgiTestFelix   / Test / Keys.test).result.map(_ -> "osgiTestFelix/test"),
   (osgiTestEclipse / Test / Keys.test).result.map(_ -> "osgiTestEclipse/test"),
-  (mimaReportBinaryIssues                ).result.map(_ -> "mimaReportBinaryIssues"),
+  (library / mimaReportBinaryIssues      ).result.map(_ -> "library/mimaReportBinaryIssues"), // doesn't aggregate..
+  (reflect / mimaReportBinaryIssues      ).result.map(_ -> "reflect/mimaReportBinaryIssues"), // ..so specify both
   (testJDeps                             ).result.map(_ -> "testJDeps"),
   (testJarSize                           ).result.map(_ -> "testJarSize"),
   (bench / Compile / compile).map(_ => ()).result.map(_ -> "bench/compile"),

--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -24,6 +24,9 @@ object MimaFilters extends AutoPlugin {
     // with JDK 11 and run MiMa it'll complain IteratorWrapper isn't forwards compatible with 2.13.0 - but we
     // don't publish the artifact built with JDK 11 anyways
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.convert.JavaCollectionWrappers#IteratorWrapper.asIterator"),
+
+    // #9425 Node is private[collection]
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.mutable.HashMap#Node.foreachEntry"),
   )
 
   override val buildSettings = Seq(


### PR DESCRIPTION
When you run a task in the shell, it uses the current project (normally
root) and runs the tasks on the project and the project it aggregates.
That's why "compile" compiles all and "test" tests all.  But "testAll"
is our custom thing, defined only on the root project, which refers to
specific tasks to run.  So while just "mimaReportBinaryIssues" does the
right thing in the shell, it only checks root (which is a noop) when
used in "testAll".  So back to specifying both - but at least I still
fixed unqualified "mimaReportBinaryIssues" from working in the shell.