### PR TITLE
Support ConstantAnnotation when extracting literal annotation arguments

### DIFF
--- a/test/files/run/constAnnArgs.check
+++ b/test/files/run/constAnnArgs.check
@@ -1,0 +1,23 @@
+
+scala> @deprecated(message = "x", since = "y") def f = 1; f
+                                                          ^
+       warning: method f is deprecated (since y): x
+def f: Int
+val res0: Int = 1
+
+scala> :pa -raw << JUMP!
+// Entering paste mode (JUMP! to finish)
+
+package scala { class deprecated(message: String = "", since: String = "") extends scala.annotation.ConstantAnnotation }
+JUMP!
+
+// Exiting paste mode, now interpreting.
+
+
+scala> @deprecated(message = "x", since = "y") def g = 1; g
+                                                          ^
+       warning: method g is deprecated (since y): x
+def g: Int
+val res1: Int = 1
+
+scala> :quit

--- a/test/files/run/constAnnArgs.scala
+++ b/test/files/run/constAnnArgs.scala
@@ -1,0 +1,12 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  override def extraSettings = "-deprecation"
+  def code =
+    """@deprecated(message = "x", since = "y") def f = 1; f
+      |:pa -raw << JUMP!
+      |package scala { class deprecated(message: String = "", since: String = "") extends scala.annotation.ConstantAnnotation }
+      |JUMP!
+      |@deprecated(message = "x", since = "y") def g = 1; g
+      |""".stripMargin
+}


### PR DESCRIPTION
This allows changing annotations like `deprecated` to extend `ConstantAnnotation` after a restarr.

See #9336 for context.