### PR TITLE
Cleanups from fixing a bug in typedConstructorPattern

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -910,7 +910,7 @@ abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
         case tpnme.CodeATTR =>
           if (sym.owner.isInterface) {
             sym setFlag JAVA_DEFAULTMETHOD
-            log(s"$sym in ${sym.owner} is a java8+ default method.")
+            debuglog(s"$sym in ${sym.owner} is a java8+ default method.")
           }
           in.skip(attrLen)
 

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1197,7 +1197,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             case _                                               => applyPossible
           }
         }
-        if (tree.isType)
+        if (tree.isType) // (6)
           adaptType()
         else if (mode.typingExprNotFun &&
                  treeInfo.isMacroApplication(tree) &&
@@ -1205,17 +1205,18 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           macroExpand(this, tree, mode, pt)
         else if (mode.typingConstructorPattern)
           typedConstructorPattern(tree, pt)
-        else if (shouldInsertApply(tree))
+        else if (shouldInsertApply(tree)) // (8)
           insertApply()
-        else if (hasUndetsInMonoMode) { // (9)
+        else if (hasUndetsInMonoMode) // (9)
           // This used to have
           //     assert(!context.inTypeConstructorAllowed, context)
           // but that's not guaranteed to be true in the face of erroneous code; errors in typedApply might mean we
           // never get around to inferring them, and they leak out and wind up here.
           instantiatePossiblyExpectingUnit(tree, mode, pt)
-        }
-        // TODO: we really shouldn't use T* as a first class types (e.g. for repeated case fields), but we can't allow T* to conform to other types (see isCompatible) because that breaks overload resolution
-        else if (isScalaRepeatedParamType(tree.tpe) && !isScalaRepeatedParamType(pt)) adapt(tree.setType(repeatedToSeq(tree.tpe)), mode, pt, original = EmptyTree)
+        else if (isScalaRepeatedParamType(tree.tpe) && !isScalaRepeatedParamType(pt))
+          // TODO: we really shouldn't use T* as a first class types (e.g. for repeated case fields),
+          //  but we can't allow T* to conform to other types (see isCompatible) because that breaks overload resolution
+          adapt(tree.setType(repeatedToSeq(tree.tpe)), mode, pt, original = EmptyTree)
         else if (tree.tpe <:< pt)
           tree
         else if (mode.inPatternMode && { inferModulePattern(tree, pt); isPopulated(tree.tpe, approximateAbstracts(pt)) })

--- a/src/reflect/scala/reflect/api/Types.scala
+++ b/src/reflect/scala/reflect/api/Types.scala
@@ -307,7 +307,7 @@ trait Types {
      *
      *  {{{
      *  scala> class C { def foo[T](x: T)(y: T) = ??? }
-     *  defined class C
+     *  class C
      *
      *  scala> typeOf[C].member(TermName("foo")).asMethod
      *  res0: reflect.runtime.universe.MethodSymbol = method foo
@@ -337,10 +337,10 @@ trait Types {
      *
      *  {{{
      *  scala> class C {
-     *       | def foo[T](x: T)(y: T) = ???
-     *       | def bar: Int = ???
+     *       |   def foo[T](x: T)(y: T) = ???
+     *       |   def bar: Int = ???
      *       | }
-     *  defined class C
+     *  class C
      *
      *  scala> typeOf[C].member(TermName("foo")).asMethod
      *  res0: reflect.runtime.universe.MethodSymbol = method foo
@@ -363,7 +363,7 @@ trait Types {
      *  scala> typeOf[C].member(TermName("bar")).asMethod
      *  res6: reflect.runtime.universe.MethodSymbol = method bar
      *
-     *  scala> res6.info
+     *  scala> res6.info // vanilla NullaryMethodType
      *  res7: reflect.runtime.universe.Type = => scala.Int
      *
      *  scala> res6.info.resultType

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1078,10 +1078,7 @@ trait Definitions extends api.StandardDefinitions {
     //         extractor to limit exposure to regressions like the reported problem with existentials.
     //         TODO fix the existential problem in the general case, see test/pending/pos/t8128.scala
     private def typeArgOfBaseTypeOr(tp: Type, baseClass: Symbol)(or: => Type): Type = (tp baseType baseClass).typeArgs match {
-      case x :: Nil =>
-        val x1 = x
-        val x2 = repackExistential(x1)
-        x2
+      case x :: Nil => repackExistential(x)
       case _        => or
     }
 

--- a/src/reflect/scala/reflect/internal/Mode.scala
+++ b/src/reflect/scala/reflect/internal/Mode.scala
@@ -14,50 +14,45 @@ package scala
 package reflect
 package internal
 
-import scala.language.implicitConversions
-
 object Mode {
-  private implicit def liftIntBitsToMode(bits: Int): Mode = apply(bits)
   def apply(bits: Int): Mode = new Mode(bits)
 
   /** NOmode, EXPRmode and PATTERNmode are mutually exclusive.
    */
-  final val NOmode: Mode        = 0x000
-  final val EXPRmode: Mode      = 0x001
-  final val PATTERNmode: Mode   = 0x002
+  final val NOmode: Mode        = Mode(0x000)
+  final val EXPRmode: Mode      = Mode(0x001)
+  final val PATTERNmode: Mode   = Mode(0x002)
 
-  /** TYPEmode needs a comment. <-- XXX.
-   */
-  final val TYPEmode: Mode      = 0x004
+  final val TYPEmode: Mode      = Mode(0x004)
 
   /** SCCmode is orthogonal to above. When set we are
    *  in the this or super constructor call of a constructor.
    */
-  final val SCCmode: Mode       = 0x008
+  final val SCCmode: Mode       = Mode(0x008)
 
   /** FUNmode is orthogonal to above.
    *  When set we are looking for a method or constructor.
    */
-  final val FUNmode: Mode       = 0x010
+  final val FUNmode: Mode       = Mode(0x010)
 
   /** POLYmode is orthogonal to above.
    *  When set expression types can be polymorphic.
    */
-  final val POLYmode: Mode      = 0x020
+  final val POLYmode: Mode      = Mode(0x020)
 
   /** QUALmode is orthogonal to above. When set
    *  expressions may be packages and Java statics modules.
    */
-  final val QUALmode: Mode      = 0x040
+  final val QUALmode: Mode      = Mode(0x040)
 
   /** TAPPmode is set for the function/type constructor
    *  part of a type application. When set we do not decompose PolyTypes.
    */
-  final val TAPPmode: Mode      = 0x080
+  final val TAPPmode: Mode      = Mode(0x080)
 
   /** LHSmode is set for the left-hand side of an assignment.
    */
-  final val LHSmode: Mode       = 0x400
+  final val LHSmode: Mode       = Mode(0x400)
 
   /** BYVALmode is set when we are typing an expression
    *  that occurs in a by-value position. An expression e1 is in by-value
@@ -66,11 +61,11 @@ object Mode {
    *  arguments or the conditional of an if-then-else clause.
    *  This mode has been added to support continuations.
    */
-  final val BYVALmode: Mode     = 0x8000
+  final val BYVALmode: Mode     = Mode(0x8000)
 
   /** TYPEPATmode is set when we are typing a type in a pattern.
    */
-  final val TYPEPATmode: Mode   = 0x10000
+  final val TYPEPATmode: Mode   = Mode(0x10000)
 
   /** This mode is set when starting to type check a `Select`, `Apply` or `TypeApply`, e.g., `x.y`
     * or `a.b.foo[T](x, y).bar(z)`. Stabilizers (a feature added in PR scala/scala#5999) created
@@ -92,7 +87,7 @@ object Mode {
     *     })
     *   }
     */
-  final val APPSELmode: Mode   = 0x20000
+  final val APPSELmode: Mode    = Mode(0x20000)
 
   private val StickyModes: Mode       = EXPRmode | PATTERNmode | TYPEmode
   private val StickyModesForFun: Mode = StickyModes | SCCmode
@@ -100,28 +95,26 @@ object Mode {
   final val PolyQualifierModes: Mode  = MonoQualifierModes | POLYmode
   final val OperatorModes: Mode       = EXPRmode | POLYmode | TAPPmode | FUNmode
 
-  /** Translates a mask of mode flags into something readable.
-   */
-  private val modeNameMap = Map[Int, String]( // TODO why duplicate the bitmasks here, rather than just referring to this.EXPRmode etc?
-    (1 << 0)  -> "EXPRmode",
-    (1 << 1)  -> "PATTERNmode",
-    (1 << 2)  -> "TYPEmode",
-    (1 << 3)  -> "SCCmode",
-    (1 << 4)  -> "FUNmode",
-    (1 << 5)  -> "POLYmode",
-    (1 << 6)  -> "QUALmode",
-    (1 << 7)  -> "TAPPmode",
-    (1 << 8)  -> "<>",      // formerly SUPERCONSTRmode
-    (1 << 9)  -> "<>",      // formerly SNDTRYmode
-    (1 << 10) -> "LHSmode",
-    (1 << 11) -> "<>",
-    (1 << 12) -> "<>",      // formerly STARmode
-    (1 << 13) -> "<>",      // formerly ALTmode
-    (1 << 14) -> "<>",      // formerly HKmode
-    (1 << 15) -> "BYVALmode",
-    (1 << 16) -> "TYPEPATmode",
-    (1 << 17) -> "APPSELmode"
-  ).map({ case (k, v) => Mode(k) -> v })
+  /** Translates a mask of mode flags into something readable. */
+  private val modeNameMap = Map[Mode, String](
+    EXPRmode     -> "EXPRmode",
+    PATTERNmode  -> "PATTERNmode",
+    TYPEmode     -> "TYPEmode",
+    SCCmode      -> "SCCmode",
+    FUNmode      -> "FUNmode",
+    POLYmode     -> "POLYmode",
+    QUALmode     -> "QUALmode",
+    TAPPmode     -> "TAPPmode",
+    LHSmode      -> "LHSmode",
+    BYVALmode    -> "BYVALmode",
+    TYPEPATmode  -> "TYPEPATmode",
+    APPSELmode   -> "APPSELmode"
+  )
+
+  // Former modes and their values:
+  // SUPERCONSTRmode (0x100), SNDTRYmode (0x200), CONSTmode (0x800)
+  // STARmode (0x1000), ALTmode (0x2000), HKmode (0x4000)
+  // RETmode (0x20000) - now APPSELmode
 }
 import Mode._
 

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -3061,7 +3061,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       // any more because of t8011.scala, which demonstrates a problem with the extension methods
       // phase. As it moves a method body to an extension method in the companion, it substitutes
       // the new type parameter symbols into the method body, which mutates the base type sequence of
-      // a local class symbol. We can no longer assume that`mtpePre eq pre` is a sufficient condition
+      // a local class symbol. We can no longer assume that `mtpePre eq pre` is a sufficient condition
       // to use the cached result here.
       //
       // Elaborating: If we allow for the possibility of mutation of symbol infos, `sym.tpeHK.asSeenFrom(pre, sym.owner)`


### PR DESCRIPTION
"sym in ${sym.owner} is a java8+ default method." comes up a few times,
making it a noisy log message.  I considered dropping it but I just
lowered it for now.

Removed a reference to "parameterized extractors" which I think I
understand but we never got/implemented.  Perhaps there are
simplifications that can be made based on them not existing and no plans
for them to exist, but I don't know enough to know where to look.