### PR TITLE
Reject `@throws` annotation except where specifically allowed (methods, constructors)

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4157,9 +4157,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             }
             if (hasError) ErroneousAnnotation
             else if (unmappable) UnmappableAnnotation
-            else AnnotationInfo(info.atp, Nil, assocs.collect({ case (n, Some(arg)) => (n, arg) })).setOriginal(info.original).setPos(info.pos)
+            else AnnotationInfo(info.atp, Nil, assocs.collect { case (n, Some(arg)) => (n, arg) }).setOriginal(info.original).setPos(info.pos)
           } else
-              info
+            info
         }
       }
     }

--- a/test/files/neg/t12324.check
+++ b/test/files/neg/t12324.check
@@ -1,4 +1,16 @@
 t12324.scala:2: error: `@throws` only allowed for methods and constructors
 @throws[Exception] class ScalaClass[T](someList: List[T]) {
                          ^
-1 error
+t12324.scala:8: error: `@throws` only allowed for methods and constructors
+  @throws[Exception] object Y { ??? }
+                            ^
+t12324.scala:12: error: `@throws` only allowed for methods and constructors
+  def f[A <: AnyRef](a: A) = a: AnyRef @throws[Exception]
+      ^
+t12324.scala:12: error: `@throws` only allowed for methods and constructors
+  def f[A <: AnyRef](a: A) = a: AnyRef @throws[Exception]
+                                        ^
+t12324.scala:14: error: `@throws` only allowed for methods and constructors
+  def g(): Unit = (): @throws[Exception]
+                       ^
+5 errors

--- a/test/files/neg/t12324.check
+++ b/test/files/neg/t12324.check
@@ -1,0 +1,4 @@
+t12324.scala:2: error: `@throws` only allowed for methods and constructors
+@throws[Exception] class ScalaClass[T](someList: List[T]) {
+                         ^
+1 error

--- a/test/files/neg/t12324.scala
+++ b/test/files/neg/t12324.scala
@@ -2,3 +2,16 @@
 @throws[Exception] class ScalaClass[T](someList: List[T]) {
   throw new IllegalArgumentException("Boom!")
 }
+
+object X {
+  // might be useful to annotate accessors of lazy vals
+  @throws[Exception] object Y { ??? }
+}
+
+trait T {
+  def f[A <: AnyRef](a: A) = a: AnyRef @throws[Exception]
+
+  def g(): Unit = (): @throws[Exception]
+
+  def n(i: Int) = i match { case 42 => 27: @throws[Exception] }  // not all cruft reaches refchecks
+}

--- a/test/files/neg/t12324.scala
+++ b/test/files/neg/t12324.scala
@@ -1,0 +1,4 @@
+
+@throws[Exception] class ScalaClass[T](someList: List[T]) {
+  throw new IllegalArgumentException("Boom!")
+}


### PR DESCRIPTION
Fixes scala/bug#12324