### PR TITLE
JLine 3.19.0 (was 3.18.0; 2.13.4 had 3.17.1)

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -9,5 +9,5 @@ starr.version=2.13.4
 scala-asm.version=7.3.1-scala-1
 
 # jna.version must be updated together with jline-terminal-jna
-jline.version=3.18.0
+jline.version=3.19.0
 jna.version=5.3.1


### PR DESCRIPTION
3.19.0 includes @retronym's jline/jline3#626, which will help him restore support for camel-cased, acronym-style completion in our REPL (scala/bug#12267)

As with the 3.18.0 upgrade, it looks pretty safe, eyeballing the changelog. We still have some time before 2.13.5 to catch issues.