### PR TITLE
Emit exhaustivity warning despite uninhabited types

### DIFF
--- a/test/files/neg/t8511.check
+++ b/test/files/neg/t8511.check
@@ -1,0 +1,11 @@
+t8511.scala:28: warning: unreachable code
+      ???
+      ^
+t8511.scala:23: warning: match may not be exhaustive.
+It would fail on the following inputs: Bar(_), Baz(), EatsExhaustiveWarning(_)
+  private def logic(head: Expr): String = head match {
+                                          ^
+warning: 1 deprecation (since 2.13.0); re-run with -deprecation for details
+error: No warnings can be incurred under -Werror.
+3 warnings
+1 error

--- a/test/files/neg/t8511.scala
+++ b/test/files/neg/t8511.scala
@@ -1,0 +1,30 @@
+// scalac: -Werror
+sealed trait Expr
+final case class Foo(other: Option[String]) extends Expr
+final case class Bar(someConstant: String) extends Expr
+final case class Baz() extends Expr
+final case class EatsExhaustiveWarning(other: Reference) extends Expr
+
+sealed trait Reference {
+  val value: String
+}
+
+object Reference {
+  def unapply(reference: Reference): Option[(String)] = {
+    Some(reference.value)
+  }
+}
+
+object EntryPoint {
+  def main(args: Array[String]) {
+    println("Successfully ran")
+  }
+
+  private def logic(head: Expr): String = head match {
+    case Foo(_) =>
+      ???
+    // Commenting this line only causes the exhaustive search warning to be emitted
+    case EatsExhaustiveWarning(Reference(text)) =>
+      ???
+  }
+}


### PR DESCRIPTION
An abstract sealed class with no subtypes is uninhabited (ignoring null
for 1 second).  Previously the pattern matcher added an eq axiom of
"False" in this case, which wipes out the whole formula as the axioms
are AND-ed together and with the rest of the pure prop formula.

Keeping the definitions of enumerateSubtypes and domain/domainSyms as
they are, I believe it's correct to fix this locally to removeVarEq.
The branch is dead (indeed it gets a reachability warning) but that
shouldn't preclude the emission of exhaustivity warnings.

However, we should continue to wipe out the formula when the domain is
that of the scrutinee variable.  While I was at it I made the variable
ordering insertion order, which makes it deterministic.

One additional consideration is modelNull/NullConst.  When that is
present then the domain symbols won't be empty as it will contain the
symbol reflecting the proposition that the variable may be null.  In a
such case it's right to continue to add it as an axiom, because even
"uninhabited" types may be inhabited by "null" (sadly).

Fixes scala/bug#8511