### PR TITLE
Use a stock URLClassLoader in the scala runner for parallel capability

### DIFF
--- a/src/compiler/scala/tools/nsc/ObjectRunner.scala
+++ b/src/compiler/scala/tools/nsc/ObjectRunner.scala
@@ -25,7 +25,8 @@ trait CommonRunner {
    *  @throws InvocationTargetException
    */
   def run(urls: Seq[URL], objectName: String, arguments: Seq[String]) {
-    (ScalaClassLoader fromURLs urls).run(objectName, arguments)
+    import scala.reflect.internal.util.RichClassLoader._
+    ScalaClassLoader.fromURLsParallelCapable(urls).run(objectName, arguments)
   }
 
   /** Catches exceptions enumerated by run (in the case of InvocationTargetException,

--- a/src/reflect/scala/reflect/internal/util/ScalaClassLoader.scala
+++ b/src/reflect/scala/reflect/internal/util/ScalaClassLoader.scala
@@ -29,17 +29,12 @@ trait HasClassPath {
   def classPathURLs: Seq[URL]
 }
 
-/** A wrapper around java.lang.ClassLoader to lower the annoyance
- *  of java reflection.
- */
-trait ScalaClassLoader extends JClassLoader {
+final class RichClassLoader(private val self: JClassLoader) extends AnyVal {
   /** Executing an action with this classloader as context classloader */
   def asContext[T](action: => T): T = {
-    import ScalaClassLoader.setContext
-
     val saved = Thread.currentThread.getContextClassLoader
-    try { setContext(this) ; action }
-    finally setContext(saved)
+    try { ScalaClassLoader.setContext(self) ; action }
+    finally ScalaClassLoader.setContext(saved)
   }
 
   /** Load and link a class with this classloader */
@@ -49,7 +44,7 @@ trait ScalaClassLoader extends JClassLoader {
 
   private def tryClass[T <: AnyRef](path: String, initialize: Boolean): Option[Class[T]] =
     catching(classOf[ClassNotFoundException], classOf[SecurityException]) opt
-      Class.forName(path, initialize, this).asInstanceOf[Class[T]]
+      Class.forName(path, initialize, self).asInstanceOf[Class[T]]
 
   /** Create an instance of a class with this classloader */
   def create(path: String): AnyRef =
@@ -60,7 +55,7 @@ trait ScalaClassLoader extends JClassLoader {
     def fail(msg: String) = error(msg, new IllegalArgumentException(msg))
     def error(msg: String, e: Throwable) = { errorFn(msg) ; throw e }
     try {
-      val clazz = Class.forName(path, /*initialize =*/ true, /*loader =*/ this)
+      val clazz = Class.forName(path, /*initialize =*/ true, /*loader =*/ self)
       if (classTag[T].runtimeClass isAssignableFrom clazz) {
         val ctor = {
           val maybes = clazz.getConstructors filter (c => c.getParameterCount == args.size &&
@@ -71,7 +66,7 @@ trait ScalaClassLoader extends JClassLoader {
         (ctor.newInstance(args: _*)).asInstanceOf[T]
       } else {
         errorFn(s"""Loader for ${classTag[T]}:   [${show(classTag[T].runtimeClass.getClassLoader)}]
-                   |Loader for ${clazz.getName}: [${show(clazz.getClassLoader)}]""".stripMargin)
+                    |Loader for ${clazz.getName}: [${show(clazz.getClassLoader)}]""".stripMargin)
         fail(s"Not a ${classTag[T]}: ${path}")
       }
     } catch {
@@ -89,7 +84,7 @@ trait ScalaClassLoader extends JClassLoader {
   }
 
   /** An InputStream representing the given class name, or null if not found. */
-  def classAsStream(className: String) = getResourceAsStream {
+  def classAsStream(className: String) = self.getResourceAsStream {
     if (className endsWith ".class") className
     else s"${className.replace('.', '/')}.class"  // classNameToPath
   }
@@ -107,6 +102,41 @@ trait ScalaClassLoader extends JClassLoader {
     catch unwrapHandler({ case ex => throw ex })
   }
 }
+
+object RichClassLoader {
+  implicit def wrapClassLoader(loader: ClassLoader): RichClassLoader = new RichClassLoader(loader)
+}
+
+/** A wrapper around java.lang.ClassLoader to lower the annoyance
+ *  of java reflection.
+ */
+trait ScalaClassLoader extends JClassLoader {
+  private def wrap = new RichClassLoader(this)
+  /** Executing an action with this classloader as context classloader */
+  def asContext[T](action: => T): T = wrap.asContext(action)
+
+  /** Load and link a class with this classloader */
+  def tryToLoadClass[T <: AnyRef](path: String): Option[Class[T]] = wrap.tryToLoadClass[T](path)
+  /** Load, link and initialize a class with this classloader */
+  def tryToInitializeClass[T <: AnyRef](path: String): Option[Class[T]] = wrap.tryToInitializeClass(path)
+
+  /** Create an instance of a class with this classloader */
+  def create(path: String): AnyRef = wrap.create(path)
+
+  /** Create an instance with ctor args, or invoke errorFn before throwing. */
+  def create[T <: AnyRef : ClassTag](path: String, errorFn: String => Unit)(args: AnyRef*): T =
+    wrap.create[T](path, errorFn)(args: _*)
+
+  /** The actual bytes for a class file, or an empty array if it can't be found. */
+  def classBytes(className: String): Array[Byte] = wrap.classBytes(className)
+
+  /** An InputStream representing the given class name, or null if not found. */
+  def classAsStream(className: String) = wrap.classAsStream(className)
+
+  /** Run the main method of a class to be loaded by this classloader */
+  def run(objectName: String, arguments: Seq[String]): Unit = wrap.run(objectName, arguments)
+}
+
 
 /** Methods for obtaining various classloaders.
  *      appLoader: the application classloader.  (Also called the java system classloader.)
@@ -150,6 +180,10 @@ object ScalaClassLoader {
 
   def fromURLs(urls: Seq[URL], parent: ClassLoader = null): URLClassLoader = {
     new URLClassLoader(urls, if (parent == null) bootClassLoader else parent)
+  }
+
+  def fromURLsParallelCapable(urls: Seq[URL], parent: ClassLoader = null): JURLClassLoader = {
+    new JURLClassLoader(urls.toArray, if (parent == null) bootClassLoader else parent)
   }
 
   /** True if supplied class exists in supplied path */


### PR DESCRIPTION
(Resubmission of #9469)

Background: Java 7 introduced a way for classloaders to use
fine grained locking to avoid some deadlocks possibilities.
The same fine grained locks could conceivably improve performance
of multi-threaded code that has non-trivial logic in static
initializers.

This tech note describes the change:
  https://docs.oracle.com/javase/7/docs/technotes/guides/lang/cl-mt.html

For backwards compatibility, custom subclasses of ClassLoader need to
opt into this scheme by calling `ClassLoader.registerParalleCapable`.
This needs to be done from the class itself during it static
initializer (well, at least before the first super constructor call to
`ClassLoader(...)`)

The Scala runners use a custom classloader subclass. This has never
opted into the parallel classloading.

It is extremely difficult to make ScalaClassLoader.URLClassLoader
correctly register itself to ClassLoader.parallelCapable due to
the absence of Scala language support for declaring Java static
initializer blocks. Implementing tbis class in Java is possible
but in turn requires our SBT build to no longer use the
"JavaThenScala" compilation mode.

However, closer inspection reveals that this custom classloader type is
only used for convenience methods.

This PR refactors these into extension methods and uses a plain
`java.net.URLClassLoader` directly.

The changes is observable with:

```scala
object Test extends App {
  val cl = Test.getClass.getClassLoader
  val fld = classOf[java.lang.ClassLoader].getDeclaredField("parallelLockMap")
  fld.setAccessible(true)
  val isParallel = fld.get(cl) != null
  println((cl, "isParallel = " + isParallel))
}
```

```
% (export V=2.12.12; scalac --scala-version $V  -d /tmp sandbox/test.scala && scala --scala-version $V -cp /tmp Test )
(scala.reflect.internal.util.ScalaClassLoader$URLClassLoader@58c1c010,isParallel = false)
% qscalac -d /tmp sandbox/test.scala && qscala -cp /tmp Test
(java.net.URLClassLoader@cac736f,isParallel = true)
```