### PR TITLE
REPL: Indicate deprecated methods when displaying signatures

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/PresentationCompilation.scala
+++ b/src/repl/scala/tools/nsc/interpreter/PresentationCompilation.scala
@@ -168,9 +168,11 @@ trait PresentationCompilation { self: IMain =>
           sym <- if (member.sym.isClass && isNew) member.sym.info.decl(nme.CONSTRUCTOR).alternatives else member.sym.alternatives
           sugared = sym.sugaredSymbolOrSelf
         } yield {
-          val tp = member.prefix memberType sym
+          val tp         = member.prefix memberType sym
+          val desc       = Seq(if (isMemberDeprecated(member)) "(deprecated)" else "", if (isMemberUniversal(member)) "(universal)" else "")
+          val methodOtherDesc = if (!desc.exists(_ != "")) "" else " " + desc.filter(_ != "").mkString(" ")
           CompletionCandidate(
-            defString = sugared.defStringSeenAs(tp),
+            defString = sugared.defStringSeenAs(tp) + methodOtherDesc,
             arity = memberArity(member),
             isDeprecated = isMemberDeprecated(member),
             isUniversal = isMemberUniversal(member))

--- a/test/junit/scala/tools/nsc/interpreter/CompletionTest.scala
+++ b/test/junit/scala/tools/nsc/interpreter/CompletionTest.scala
@@ -218,6 +218,20 @@ class CompletionTest {
   }
 
   @Test
+  def isDeprecatedInMethodDesc(): Unit = {
+    val (completer, _, _) = interpretLines(
+      """object Stale { @deprecated("","") def oldie = ??? }""",
+      """object Stuff { @deprecated("","") def `this` = ??? ; @deprecated("","") def `that` = ??? }"""
+      )
+    val candidates1 = completer.complete("Stale.oldie").candidates
+    assertEquals(2, candidates1.size) // When exactly matched, there is an empty character
+    assertTrue(candidates1.last.defString.contains("deprecated"))
+    val candidates2 = completer.complete("Stuff.that").candidates
+    assertEquals(2, candidates2.size)
+    assertTrue(candidates2.last.defString.contains("deprecated"))
+  }
+
+  @Test
   def isNotDeprecated(): Unit = {
     val (completer, _, _) = interpretLines(
       """object Stuff { def `this` = ??? ; def `that` = ??? }"""


### PR DESCRIPTION
Appending a description to a method signature

Fixes scala/bug#12279