### PR TITLE
Fix cyclic error in runtime reflection (protobuf)

### DIFF
--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -1133,8 +1133,10 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
         }
       case japplied: ParameterizedType =>
         // http://stackoverflow.com/questions/5767122/parameterizedtype-getrawtype-returns-j-l-r-type-not-class
-        val sym = classToScala(japplied.getRawType.asInstanceOf[jClass[_]])
-        val pre = if (japplied.getOwnerType ne null) typeToScala(japplied.getOwnerType) else sym.owner.thisType
+        val jcls = japplied.getRawType.asInstanceOf[jClass[_]]
+        val sym = classToScala(jcls)
+        val isStatic = java.lang.reflect.Modifier.isStatic(jcls.getModifiers)
+        val pre = if (!isStatic && (japplied.getOwnerType ne null)) typeToScala(japplied.getOwnerType) else sym.owner.thisType
         val args0 = japplied.getActualTypeArguments
         val (args, bounds) = targsToScala(pre.typeSymbol, args0.toList)
         newExistentialType(bounds, typeRef(pre, sym, args))

--- a/test/files/run/t12038a.check
+++ b/test/files/run/t12038a.check
@@ -1,0 +1,3 @@
+[BuilderType <: p1.J_1.AbstractMessageLite.Builder[BuilderType]]Object {
+  def <init>(): p1.J_1.AbstractMessageLite[BuilderType]
+}

--- a/test/files/run/t12038a/J_1.java
+++ b/test/files/run/t12038a/J_1.java
@@ -1,0 +1,11 @@
+package p1;
+
+public class J_1 {
+    public abstract static class AbstractMessageLite<
+            BuilderType extends AbstractMessageLite.Builder<BuilderType>> {
+
+        public abstract static class Builder<BuilderType extends Builder<BuilderType>>{
+
+        }
+    }
+}

--- a/test/files/run/t12038a/Test.scala
+++ b/test/files/run/t12038a/Test.scala
@@ -1,0 +1,7 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    import reflect.runtime.universe._
+    val m = scala.reflect.runtime.currentMirror
+    println(m.staticClass("p1.J_1.AbstractMessageLite").info.toString) // was cyclic error
+  }
+}

--- a/test/files/run/t12038b.check
+++ b/test/files/run/t12038b.check
@@ -1,0 +1,1 @@
+(x$1: p1.J_1.O[Object]#$I[String])Unit

--- a/test/files/run/t12038b/J_1.java
+++ b/test/files/run/t12038b/J_1.java
@@ -1,0 +1,21 @@
+package p1;
+
+public class J_1 {
+    public static abstract class O<A> {
+        // non static, runtime reflection should use the generic owner type
+        // in the type signature below.
+        //
+        // also doing for static inner classes runs into cyclic errors (see t12038a.scala)
+        // in the current implementation of runtime reflection.
+        //
+        // This is fine as Java rejects the type selections in `notValidJava` below with:
+        //
+        //   "cannot select a static class from a parameterized type"
+        public abstract class I<B extends A> {}
+
+        public abstract static class J<B> {}
+    }
+    static void test(O<Object>.I<String> oi) {}
+
+    // static void notValidJava(O<Object>.J<String> oj) {}
+}

--- a/test/files/run/t12038b/Test.scala
+++ b/test/files/run/t12038b/Test.scala
@@ -1,0 +1,7 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    import reflect.runtime.universe._
+    val m = scala.reflect.runtime.currentMirror
+    println(m.staticClass("p1.J_1").companion.info.decl(TermName("test")).asMethod.info.toString)
+  }
+}


### PR DESCRIPTION
The use of f-bounded generic in protobuf that refer to static inner classes
started causing cyclic errors in runtime reflecion since #8460.

We can avoid the problem by limiting the use of the
`ParameterizedType#getOwnerType` to cases when the selected inner class is
non-static.

Fixes scala/bug#12038