### PR TITLE
Make `-target` support JVM 13, 14, 15, and 16

### DIFF
--- a/project/ScalaOptionParser.scala
+++ b/project/ScalaOptionParser.scala
@@ -140,5 +140,5 @@ object ScalaOptionParser {
   private def scaladocPathSettingNames = List("-doc-root-content", "-diagrams-dot-path")
   private def scaladocMultiStringSettingNames = List("-doc-external-doc")
 
-  private val targetSettingNames = (8 to 12).map(_.toString).flatMap(v => v :: s"jvm-1.$v" :: s"jvm-$v" :: s"1.$v" :: Nil).toList
+  private val targetSettingNames = (8 to 16).map(_.toString).flatMap(v => v :: s"jvm-1.$v" :: s"jvm-$v" :: s"1.$v" :: Nil).toList
 }

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
@@ -76,6 +76,10 @@ abstract class BackendUtils extends PerRunInit {
     case "10" => asm.Opcodes.V10
     case "11" => asm.Opcodes.V11
     case "12" => asm.Opcodes.V12
+    case "13" => asm.Opcodes.V13
+    case "14" => asm.Opcodes.V14
+    case "15" => asm.Opcodes.V15
+    case "16" => asm.Opcodes.V16
     // to be continued...
   })
 

--- a/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
@@ -73,7 +73,7 @@ trait StandardScalaSettings { _: MutableSettings =>
 object StandardScalaSettings {
   // not final in case some separately compiled client code wanted to depend on updated values
   val MinTargetVersion = 8
-  val MaxTargetVersion = 12 // this one goes to twelve
+  val MaxTargetVersion = 16
 
   private val AllTargetVersions = (MinTargetVersion to MaxTargetVersion).map(_.toString).to(List)
 }

--- a/test/junit/scala/tools/nsc/settings/TargetTest.scala
+++ b/test/junit/scala/tools/nsc/settings/TargetTest.scala
@@ -57,8 +57,13 @@ class TargetTest {
     check("-target:jvm-12", "12")
     check("-target:12", "12")
 
+    // (scene missing)
+
+    check("-target:jvm-16", "16")
+    check("-target:16", "16")
+
     checkFail("-target:jvm-6")    // no longer
-    checkFail("-target:jvm-13")   // not yet...
+    checkFail("-target:jvm-17")   // not yet...
     checkFail("-target:jvm-3000") // not in our lifetime
     checkFail("-target:msil")     // really?
 


### PR DESCRIPTION
~includes #9480. so we should get that one merged first, then I'll rebase this one~ rebased