### PR TITLE
Allow renaming imports from _root_

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -1346,9 +1346,6 @@ trait ContextErrors {
       def ParentSealedInheritanceError(parent: Tree, psym: Symbol) =
         NormalTypeError(parent, "illegal inheritance from sealed " + psym )
 
-      def RootImportError(tree: Tree) =
-        issueNormalTypeError(tree, "_root_ cannot be imported")
-
       def SymbolValidationError(sym: Symbol, errKind: SymValidateErrors.Value): Unit = {
         val msg = errKind match {
           case ImplicitConstr               => "`implicit` modifier not allowed for constructors"

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1825,9 +1825,6 @@ trait Namers extends MethodSynthesis {
       val Import(expr, selectors) = imp
       val expr1 = typer.typedQualifier(expr)
 
-      if (expr1.symbol != null && expr1.symbol.isRootPackage)
-        RootImportError(imp)
-
       if (expr1.isErrorTyped)
         ErrorType
       else {

--- a/test/files/neg/t9125.check
+++ b/test/files/neg/t9125.check
@@ -1,0 +1,6 @@
+t9125.scala:10: error: reference to p is ambiguous;
+it is both defined in package q and imported subsequently by
+import _root_.p
+      def f() = new p.C
+                    ^
+1 error

--- a/test/files/neg/t9125.scala
+++ b/test/files/neg/t9125.scala
@@ -1,0 +1,13 @@
+
+package p {
+  class C
+}
+
+package q {
+  object p {
+    class K {
+      import _root_.p
+      def f() = new p.C
+    }
+  }
+}

--- a/test/files/pos/t283.scala
+++ b/test/files/pos/t283.scala
@@ -1,0 +1,5 @@
+
+import _root_._ // _root_.java._ is OK
+object Test extends App {
+  println(java.util.Locale.getDefault().toString) // static call
+}

--- a/test/files/pos/t9125.scala
+++ b/test/files/pos/t9125.scala
@@ -1,0 +1,14 @@
+
+package p {
+  class C
+}
+
+package q {
+  package p {
+    class K {
+      import _root_.{p => pp}
+      def f() = new pp.C
+      def g() = new _root_.p.C
+    }
+  }
+}


### PR DESCRIPTION
Allow `import _root_.{x => y}`

Fixes scala/bug#9125