### PR TITLE
Add some passing GADT exhaustivity tests

### DIFF
--- a/test/files/pos/exhaustive-gadts-1.scala
+++ b/test/files/pos/exhaustive-gadts-1.scala
@@ -1,0 +1,10 @@
+sealed trait Expr[+T]
+case class IntExpr(x: Int) extends Expr[Int]
+case class BooleanExpr(b: Boolean) extends Expr[Boolean]
+
+object Test {
+  def foo[T](x: Expr[T], y: Expr[T]) = (x, y) match {
+    case (IntExpr(_), IntExpr(_)) =>
+    case (BooleanExpr(_), BooleanExpr(_)) =>
+  }
+}

--- a/test/files/pos/exhaustive-gadts-2.scala
+++ b/test/files/pos/exhaustive-gadts-2.scala
@@ -1,0 +1,14 @@
+sealed trait Nat[+T]
+case class Zero() extends Nat[Nothing]
+case class Succ[T]() extends Nat[T]
+
+sealed trait Vect[+N <: Nat[_], +T]
+case class VN[T]() extends Vect[Zero, T]
+case class VC[T, N <: Nat[_]](x: T, xs: Vect[N, T]) extends Vect[Succ[N], T]
+
+object Test {
+  def foo[N <: Nat[_], A, B](v1: Vect[N, A], v2: Vect[N, B]) = (v1, v2) match {
+    case (VN(), VN()) => 1
+    case (VC(x, xs), VC(y, ys)) => 2
+  }
+}


### PR DESCRIPTION
These are from lampepfl/dotty#1364 and they do indeed work correctly for
Scala 2 but not for Scala 3.  #fixed-in-nsc