### PR TITLE
Omit `@nowarn` annotations from generated code, for forwards compatibility at compile-time

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -124,7 +124,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def isJavaEnum: Boolean = hasJavaEnumFlag
     def isJavaAnnotation: Boolean = hasJavaAnnotationFlag
     def isStaticAnnotation: Boolean =
-      hasJavaAnnotationFlag || isNonBottomSubClass(StaticAnnotationClass)
+      hasJavaAnnotationFlag || isNonBottomSubClass(StaticAnnotationClass) && this != NowarnClass
 
     def newNestedSymbol(name: Name, pos: Position, newFlags: Long, isClass: Boolean): Symbol = name match {
       case n: TermName => newTermSymbol(n, pos, newFlags)


### PR DESCRIPTION
...by special-casing them.

In principle we have `extends Annotation` vs `extends StaticAnnotation`
for that, but sadly `ConstantAnnotation extends StaticAnnotation`, so
we don't get to choose for those :-/

Fixes https://github.com/scala/bug/issues/12336

(Note that the bug only caused problems at compile time, not at runtime)