### PR TITLE
Travis-CI: test on JDK 11 (and 16...?)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,8 +59,11 @@ jobs:
         - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ./scripts/travis-publish-spec.sh; fi'
 
 env:
-  global:
+  matrix:
     - ADOPTOPENJDK=8
+    - ADOPTOPENJDK=11
+    - ADOPTOPENJDK=16
+  global:
     - secure: "TuJOUtALynPd+MV1AuMeIpVb8BUBHr7Ul7FS48XhS2PyuTRpEBkSWybYcNg3AXyzmWDAuOjUxbaNMQBvP8vvehTbIYls5H5wTGKvj0D0TNVaPIXjF8bA8KyNat9xGNzhnWm2/2BMaWpKBJWRF7Jb+zHhijMYCJEbkMtoiE5R/mY=" # PRIV_KEY_SECRET, for scripts/travis-publish-spec.sh
     - secure: "T1fxtvLTxioyXJYiC/zVYdNYsBOt+0Piw+xE04rB1pzeKahm9+G2mISdcAyqv6/vze9eIJt6jNHHpKX32/Z3Cs1/Ruha4m3k+jblj3S0SbxV6ht2ieJXLT5WoUPFRrU68KXI8wqUadXpjxeJJV53qF2FC4lhfMUsw1IwwMhdaE8=" # PRIVATE_REPO_PASS
     - secure: "feE5A8mYNpkNQKVwCj3aXrwjVrJWh/4ENpRfFlr2HOD9ORk1GORD5Yq907WZd+dTkYK54Lh1gA+qHOCIDgJHbi9ZLU+kjzEjtYKF6lQy6Wb0LI8smTOnAA6IWVVYifiXw8d66MI2MKZb2jjGeIzy8Q00SZjLhEGjLyTeCIB88Ws=" # SONA_USER


### PR DESCRIPTION
EXPERIMENT.

we really ought to be testing on more than just 8, for two reasons:
* to verify that Scala can be built on 11+. the standard path would remain 8, but developers ought to be able to work in 11+ locally
* to verify that the tests pass on 11+

it's an open question whether the 11+ testing ought to actually be part of PR validation, or whether it should just run nightly or on merge commits. I feel like nightly or “mergely” is probably fine?

I don't understand how build stages interact with specifying multiple JDKs, so I'll just trial-and-error it, I guess