### PR TITLE
Revert "Give Iterator.newBuilder an efficient addAll"

### DIFF
--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -991,8 +991,7 @@ object Iterator extends IterableFactory[Iterator] {
     */
   def newBuilder[A]: Builder[A, Iterator[A]] =
     new ImmutableBuilder[A, Iterator[A]](empty[A]) {
-      override def addOne(elem: A): this.type             = { elems ++= single(elem); this }
-      override def addAll(xs: IterableOnce[A]): this.type = { elems ++= xs.iterator;  this }
+      override def addOne(elem: A): this.type = { elems = elems ++ single(elem); this }
     }
 
   /** Creates iterator that produces the results of some element computation a number of times.


### PR DESCRIPTION
This reverts commit 7b25684f1b9b9f11f398030374d9d6cec790616a (PR was #9466; see discussion there and on #9483)