### PR TITLE
Don't warnUnusedNowarn in scaladoc (scala 2.12)

### DIFF
--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -76,7 +76,7 @@ trait Reporting extends scala.reflect.internal.Reporting { self: ast.Positions w
     def warnUnusedSuppressions(): Unit = {
       // if we stop before typer completes (errors in parser, Ystop), report all suspended messages
       suspendedMessages.foreach(issueWarning)
-      if (settings.warnUnusedNowarn) {
+      if (settings.warnUnusedNowarn && !settings.isScaladoc) { // scaladoc doesn't run all phases, so not all warnings are emitted
         val sources = suppressions.keysIterator.toList
         for (source <- sources; sups <- suppressions.remove(source); sup <- sups.reverse) {
           if (!sup.used)


### PR DESCRIPTION
Backport of #9038 to Scala 2.12. Fixes https://github.com/scala/bug/issues/12007