### PR TITLE
Retain positions of SingletonTypeTree

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5628,7 +5628,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         if (refTyped.isErrorTyped) setError(tree)
         else {
           if (!treeInfo.admitsTypeSelection(refTyped)) UnstableTreeError(tree)
-          else SingletonTypeTree(refTyped).setType(refTyped.tpe.resultType.deconst)
+          else treeCopy.SingletonTypeTree(tree, refTyped).setType(refTyped.tpe.resultType.deconst)
         }
       }
 

--- a/test/junit/scala/tools/nsc/typechecker/TypedTreeTest.scala
+++ b/test/junit/scala/tools/nsc/typechecker/TypedTreeTest.scala
@@ -1,6 +1,6 @@
 package scala.tools.nsc.typechecker
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.{assertEquals, assertNotEquals}
 import org.junit.Test
 
 import scala.tools.testing.BytecodeTesting
@@ -59,6 +59,7 @@ class TypedTreeTest extends BytecodeTesting {
 
     singletonTypeTrees.foreach { t =>
       assertEquals(t.ref.symbol.fullName, "root.impl")
+      assertNotEquals(NoPosition, t.pos)
     }
   }
 }


### PR DESCRIPTION
Regressed in #9426. I noticed the missing position when merging
that change forward to 2.13.x, in which a new test case
(neg/t12322a.scala) started giving inaccurate positions.