### PR TITLE
Tasty: add regression test for selecting extension method

### DIFF
--- a/src/compiler/scala/tools/nsc/tasty/bridge/SymbolOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/SymbolOps.scala
@@ -174,7 +174,7 @@ trait SymbolOps { self: TastyUniverse =>
       val (tyParamCount, argTpeRefs) = {
         val (tyParamCounts, params) = sig.params.partitionMap(identity)
         if (tyParamCounts.length > 1) {
-          unsupportedError(s"multiple type parameter lists on erased method signature ${showSig(sig)}")
+          unsupportedError(s"method with unmergeable type parameters: $qual")
         }
         (tyParamCounts.headOption.getOrElse(0), params)
       }

--- a/test/tasty/neg/src-2/TestDefAnnots.check
+++ b/test/tasty/neg/src-2/TestDefAnnots.check
@@ -10,4 +10,7 @@ TestDefAnnots_fail.scala:7: error: Unsupported Scala 3 assignment expression in 
 TestDefAnnots_fail.scala:8: error: Unsupported Scala 3 block expression in an annotation of parameter arg; note that complex trees are not yet supported for Annotations; found in method withArgAnnotLambda in object tastytest.DefAnnots.
   def test4 = DefAnnots.withArgAnnotLambda(1) == 1 // error
                         ^
-4 errors
+TestDefAnnots_fail.scala:10: error: Unsupported Scala 3 method with unmergeable type parameters: replaceWith; found in method withArgAnnotSelectExtension in object tastytest.DefAnnots.
+  def test6 = DefAnnots.withArgAnnotSelectExtension(1) == 1 // error
+                        ^
+5 errors

--- a/test/tasty/neg/src-2/TestDefAnnots_fail.scala
+++ b/test/tasty/neg/src-2/TestDefAnnots_fail.scala
@@ -7,5 +7,6 @@ object TestDefAnnots {
   def test3 = DefAnnots.withArgAnnotAssign(1) == 1 // error
   def test4 = DefAnnots.withArgAnnotLambda(1) == 1 // error
   def test5 = DefAnnots.withArgAnnotInlined(1) == 1 // ok - arguments to annotations are not forced
+  def test6 = DefAnnots.withArgAnnotSelectExtension(1) == 1 // error
 
 }

--- a/test/tasty/neg/src-3/DefAnnots.scala
+++ b/test/tasty/neg/src-3/DefAnnots.scala
@@ -2,7 +2,12 @@ package tastytest
 
 import scala.annotation.StaticAnnotation
 
+object DefAnnotsAux {
+  extension [A](a: A) inline def replaceWith[B]: B = compiletime.constValue[B]
+}
+
 object DefAnnots {
+  import DefAnnotsAux._
 
   class argAnnot(arg: Any) extends StaticAnnotation
 
@@ -15,5 +20,6 @@ object DefAnnots {
   def withArgAnnotAssign(arg: Any @argAnnot(DefAnnots.global = 0)): Any = arg
   def withArgAnnotLambda(arg: Any @argAnnot((x: Int) => x + DefAnnots.global)): Any = arg // lambdas desugar to blocks
   def withArgAnnotInlined(arg: Any @argAnnot(DefAnnots.foo)): Any = arg
+  def withArgAnnotSelectExtension(arg: Any @argAnnot(23.replaceWith[57])): Any = arg
 
 }


### PR DESCRIPTION
this changes the text of one error message and tests that path.