### PR TITLE
Revert "Set `-md md5` when decrypting credentials with openssl"

### DIFF
--- a/admin/init.sh
+++ b/admin/init.sh
@@ -10,7 +10,7 @@ sensitive() {
   perl -p -e 's/\$\{([^}]+)\}/defined $ENV{$1} ? $ENV{$1} : $&/eg' < files/credentials-sonatype     > ~/.credentials-sonatype
   perl -p -e 's/\$\{([^}]+)\}/defined $ENV{$1} ? $ENV{$1} : $&/eg' < files/sonatype-curl            > ~/.sonatype-curl
 
-  openssl aes-256-cbc -md md5 -d -pass "pass:$GPG_SUBKEY_SECRET" -in files/gpg_subkey.enc | gpg --import
+  openssl aes-256-cbc -d -pass "pass:$GPG_SUBKEY_SECRET" -in files/gpg_subkey.enc | gpg --import
 }
 
 # don't let anything escape from the sensitive part (e.g. leak environment var by echoing to log on failure)


### PR DESCRIPTION
This reverts commit fb1e516c3d7aedf79b39448ce2d3de247e4df71d.