### PR TITLE
Use -s option to decode junit test names

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -710,7 +710,7 @@ lazy val junit = project.in(file("test") / "junit")
     ),
     Compile / javacOptions ++= Seq("-Xlint"),
     libraryDependencies ++= Seq(junitInterfaceDep, jolDep, diffUtilsDep),
-    testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),
+    testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v", "-s"),
     Compile / unmanagedSourceDirectories := Nil,
     Test / unmanagedSourceDirectories := List(baseDirectory.value)
   )


### PR DESCRIPTION
It doesn't put it in backticks, unfortunately. Compare:
```
[info] Test scala.lang.stringinterpol.StringContextTest.f$u0020interpolator$u0020baseline started
[info] Test scala.lang.stringinterpol.StringContextTest.f interpolator baseline started
```