### PR TITLE
Allow only protected when overriding Java methods

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -383,7 +383,7 @@ abstract class RefChecks extends Transform {
           def isOverrideAccessOK = member.isPublic || {      // member is public, definitely same or relaxed access
             (!other.isProtected || member.isProtected) &&    // if o is protected, so is m
             ((!isRootOrNone(ob) && ob.hasTransOwner(mb)) ||  // m relaxes o's access boundary
-             other.isJavaDefined)                           // overriding a protected java member, see #3946
+            (other.isJavaDefined && other.isProtected))      // overriding a protected java member, see #3946 #12349
           }
           if (!isOverrideAccessOK) {
             overrideAccessError()

--- a/test/files/neg/t12349.check
+++ b/test/files/neg/t12349.check
@@ -1,0 +1,229 @@
+# scalac ./javapkg/t12349b.scala
+./javapkg/t12349b.scala:7: error: weaker access privileges in overriding
+def a2(): Unit (defined in class t12349a)
+  override should be public
+    protected          override def a2(): Unit = println("Inner12349b#a2()") // weaker access privileges
+                                    ^
+./javapkg/t12349b.scala:8: error: weaker access privileges in overriding
+def a3(): Unit (defined in class t12349a)
+  override should not be private
+      private          override def a3(): Unit = println("Inner12349b#a3()") // weaker access privileges
+                                    ^
+./javapkg/t12349b.scala:9: error: weaker access privileges in overriding
+def a4(): Unit (defined in class t12349a)
+  override should be public
+    protected[t12349b] override def a4(): Unit = println("Inner12349b#a4()") // weaker access privileges
+                                    ^
+./javapkg/t12349b.scala:10: error: weaker access privileges in overriding
+def a5(): Unit (defined in class t12349a)
+  override should be public
+      private[t12349b] override def a5(): Unit = println("Inner12349b#a5()") // weaker access privileges
+                                    ^
+./javapkg/t12349b.scala:11: error: weaker access privileges in overriding
+def a6(): Unit (defined in class t12349a)
+  override should be public
+    protected[javapkg] override def a6(): Unit = println("Inner12349b#a6()") // weaker access privileges
+                                    ^
+./javapkg/t12349b.scala:12: error: weaker access privileges in overriding
+def a7(): Unit (defined in class t12349a)
+  override should be public
+      private[javapkg] override def a7(): Unit = println("Inner12349b#a7()") // weaker access privileges
+                                    ^
+./javapkg/t12349b.scala:13: error: weaker access privileges in overriding
+def a8(): Unit (defined in class t12349a)
+  override should be public
+    protected[this]    override def a8(): Unit = println("Inner12349b#a8()") // weaker access privileges
+                                    ^
+./javapkg/t12349b.scala:18: error: weaker access privileges in overriding
+protected[package javapkg] def b3(): Unit (defined in class t12349a)
+  override should not be private
+      private          override def b3(): Unit = println("Inner12349b#b3()") // weaker access privileges
+                                    ^
+./javapkg/t12349b.scala:20: error: weaker access privileges in overriding
+protected[package javapkg] def b5(): Unit (defined in class t12349a)
+  override should at least be protected[javapkg]
+      private[t12349b] override def b5(): Unit = println("Inner12349b#b5()") // weaker access privileges
+                                    ^
+./javapkg/t12349b.scala:22: error: weaker access privileges in overriding
+protected[package javapkg] def b7(): Unit (defined in class t12349a)
+  override should at least be protected[javapkg]
+      private[javapkg] override def b7(): Unit = println("Inner12349b#b7()") // weaker access privileges
+                                    ^
+./javapkg/t12349b.scala:27: error: weaker access privileges in overriding
+private[package javapkg] def c2(): Unit (defined in class t12349a)
+  override should at least be private[javapkg]
+    protected          override def c2(): Unit = println("Inner12349b#c2()") // weaker access privileges
+                                    ^
+./javapkg/t12349b.scala:28: error: weaker access privileges in overriding
+private[package javapkg] def c3(): Unit (defined in class t12349a)
+  override should not be private
+      private          override def c3(): Unit = println("Inner12349b#c3()") // weaker access privileges
+                                    ^
+./javapkg/t12349b.scala:29: error: weaker access privileges in overriding
+private[package javapkg] def c4(): Unit (defined in class t12349a)
+  override should at least be private[javapkg]
+    protected[t12349b] override def c4(): Unit = println("Inner12349b#c4()") // weaker access privileges
+                                    ^
+./javapkg/t12349b.scala:30: error: weaker access privileges in overriding
+private[package javapkg] def c5(): Unit (defined in class t12349a)
+  override should at least be private[javapkg]
+      private[t12349b] override def c5(): Unit = println("Inner12349b#c5()") // weaker access privileges
+                                    ^
+./javapkg/t12349b.scala:33: error: weaker access privileges in overriding
+private[package javapkg] def c8(): Unit (defined in class t12349a)
+  override should at least be private[javapkg]
+    protected[this]    override def c8(): Unit = println("Inner12349b#c8()") // weaker access privileges
+                                    ^
+./javapkg/t12349b.scala:36: error: method d1 overrides nothing
+                       override def d1(): Unit = println("Inner12349b#d1()") // overrides nothins
+                                    ^
+./javapkg/t12349b.scala:37: error: method d2 overrides nothing
+    protected          override def d2(): Unit = println("Inner12349b#d2()") // overrides nothins
+                                    ^
+./javapkg/t12349b.scala:38: error: method d3 overrides nothing
+      private          override def d3(): Unit = println("Inner12349b#d3()") // overrides nothins
+                                    ^
+./javapkg/t12349b.scala:39: error: method d4 overrides nothing
+    protected[t12349b] override def d4(): Unit = println("Inner12349b#d4()") // overrides nothins
+                                    ^
+./javapkg/t12349b.scala:40: error: method d5 overrides nothing
+      private[t12349b] override def d5(): Unit = println("Inner12349b#d5()") // overrides nothins
+                                    ^
+./javapkg/t12349b.scala:41: error: method d6 overrides nothing
+    protected[javapkg] override def d6(): Unit = println("Inner12349b#d6()") // overrides nothins
+                                    ^
+./javapkg/t12349b.scala:42: error: method d7 overrides nothing
+      private[javapkg] override def d7(): Unit = println("Inner12349b#d7()") // overrides nothins
+                                    ^
+./javapkg/t12349b.scala:43: error: method d8 overrides nothing
+    protected[this]    override def d8(): Unit = println("Inner12349b#d8()") // overrides nothins
+                                    ^
+./javapkg/t12349b.scala:44: error: method d9 overrides nothing
+      private[this]    override def d9(): Unit = println("Inner12349b#d9()") // overrides nothins
+                                    ^
+24 errors
+
+
+
+# scalac ./pkg/t12349c.scala
+./pkg/t12349c.scala:9: error: weaker access privileges in overriding
+def a2(): Unit (defined in class t12349a)
+  override should be public
+    protected          override def a2(): Unit = println("Inner12349c#a2()") // weaker access privileges
+                                    ^
+./pkg/t12349c.scala:10: error: weaker access privileges in overriding
+def a3(): Unit (defined in class t12349a)
+  override should not be private
+      private          override def a3(): Unit = println("Inner12349c#a3()") // weaker access privileges
+                                    ^
+./pkg/t12349c.scala:11: error: weaker access privileges in overriding
+def a4(): Unit (defined in class t12349a)
+  override should be public
+    protected[t12349c] override def a4(): Unit = println("Inner12349c#a4()") // weaker access privileges
+                                    ^
+./pkg/t12349c.scala:12: error: weaker access privileges in overriding
+def a5(): Unit (defined in class t12349a)
+  override should be public
+      private[t12349c] override def a5(): Unit = println("Inner12349c#a5()") // weaker access privileges
+                                    ^
+./pkg/t12349c.scala:13: error: weaker access privileges in overriding
+def a6(): Unit (defined in class t12349a)
+  override should be public
+    protected[pkg]     override def a6(): Unit = println("Inner12349c#a6()") // weaker access privileges
+                                    ^
+./pkg/t12349c.scala:14: error: weaker access privileges in overriding
+def a7(): Unit (defined in class t12349a)
+  override should be public
+      private[pkg]     override def a7(): Unit = println("Inner12349c#a7()") // weaker access privileges
+                                    ^
+./pkg/t12349c.scala:15: error: weaker access privileges in overriding
+def a8(): Unit (defined in class t12349a)
+  override should be public
+    protected[this]    override def a8(): Unit = println("Inner12349c#a8()") // weaker access privileges
+                                    ^
+./pkg/t12349c.scala:20: error: weaker access privileges in overriding
+protected[package javapkg] def b3(): Unit (defined in class t12349a)
+  override should not be private
+      private          override def b3(): Unit = println("Inner12349c#b3()") // weaker access privileges
+                                    ^
+./pkg/t12349c.scala:22: error: weaker access privileges in overriding
+protected[package javapkg] def b5(): Unit (defined in class t12349a)
+  override should at least be protected[javapkg]
+      private[t12349c] override def b5(): Unit = println("Inner12349c#b5()") // weaker access privileges
+                                    ^
+./pkg/t12349c.scala:24: error: weaker access privileges in overriding
+protected[package javapkg] def b7(): Unit (defined in class t12349a)
+  override should at least be protected[javapkg]
+      private[pkg]     override def b7(): Unit = println("Inner12349c#b7()") // weaker access privileges
+                                    ^
+./pkg/t12349c.scala:29: error: weaker access privileges in overriding
+private[package javapkg] def c2(): Unit (defined in class t12349a)
+  override should at least be private[javapkg]
+    protected          override def c2(): Unit = println("Inner12349c#c2()") // weaker access privileges
+                                    ^
+./pkg/t12349c.scala:30: error: weaker access privileges in overriding
+private[package javapkg] def c3(): Unit (defined in class t12349a)
+  override should not be private
+      private          override def c3(): Unit = println("Inner12349c#c3()") // weaker access privileges
+                                    ^
+./pkg/t12349c.scala:31: error: weaker access privileges in overriding
+private[package javapkg] def c4(): Unit (defined in class t12349a)
+  override should at least be private[javapkg]
+    protected[t12349c] override def c4(): Unit = println("Inner12349c#c4()") // weaker access privileges
+                                    ^
+./pkg/t12349c.scala:32: error: weaker access privileges in overriding
+private[package javapkg] def c5(): Unit (defined in class t12349a)
+  override should at least be private[javapkg]
+      private[t12349c] override def c5(): Unit = println("Inner12349c#c5()") // weaker access privileges
+                                    ^
+./pkg/t12349c.scala:33: error: weaker access privileges in overriding
+private[package javapkg] def c6(): Unit (defined in class t12349a)
+  override should at least be private[javapkg]
+    protected[pkg]     override def c6(): Unit = println("Inner12349c#c6()") // weaker access privileges
+                                    ^
+./pkg/t12349c.scala:34: error: weaker access privileges in overriding
+private[package javapkg] def c7(): Unit (defined in class t12349a)
+  override should at least be private[javapkg]
+      private[pkg]     override def c7(): Unit = println("Inner12349c#c7()") // weaker access privileges
+                                    ^
+./pkg/t12349c.scala:35: error: weaker access privileges in overriding
+private[package javapkg] def c8(): Unit (defined in class t12349a)
+  override should at least be private[javapkg]
+    protected[this]    override def c8(): Unit = println("Inner12349c#c8()") // weaker access privileges
+                                    ^
+./pkg/t12349c.scala:28: error: method c1 overrides nothing
+                       override def c1(): Unit = println("Inner12349c#c1()") // overrides nothins(invisible)
+                                    ^
+./pkg/t12349c.scala:36: error: method c9 overrides nothing.
+Note: the super classes of class Inner12349c contain the following, non final members named c9:
+private[package javapkg] def c9(): Unit
+      private[this]    override def c9(): Unit = println("Inner12349c#c9()") // overrides nothins(invisible)
+                                    ^
+./pkg/t12349c.scala:38: error: method d1 overrides nothing
+                       override def d1(): Unit = println("Inner12349c#d1()") // overrides nothins
+                                    ^
+./pkg/t12349c.scala:39: error: method d2 overrides nothing
+    protected          override def d2(): Unit = println("Inner12349c#d2()") // overrides nothins
+                                    ^
+./pkg/t12349c.scala:40: error: method d3 overrides nothing
+      private          override def d3(): Unit = println("Inner12349c#d3()") // overrides nothins
+                                    ^
+./pkg/t12349c.scala:41: error: method d4 overrides nothing
+    protected[t12349c] override def d4(): Unit = println("Inner12349c#d4()") // overrides nothins
+                                    ^
+./pkg/t12349c.scala:42: error: method d5 overrides nothing
+      private[t12349c] override def d5(): Unit = println("Inner12349c#d5()") // overrides nothins
+                                    ^
+./pkg/t12349c.scala:43: error: method d6 overrides nothing
+    protected[pkg]     override def d6(): Unit = println("Inner12349c#d6()") // overrides nothins
+                                    ^
+./pkg/t12349c.scala:44: error: method d7 overrides nothing
+      private[pkg]     override def d7(): Unit = println("Inner12349c#d7()") // overrides nothins
+                                    ^
+./pkg/t12349c.scala:45: error: method d8 overrides nothing
+    protected[this]    override def d8(): Unit = println("Inner12349c#d8()") // overrides nothins
+                                    ^
+./pkg/t12349c.scala:46: error: method d9 overrides nothing
+      private[this]    override def d9(): Unit = println("Inner12349c#d9()") // overrides nothins
+                                    ^
+28 errors

--- a/test/files/neg/t12349/javapkg/t12349a.java
+++ b/test/files/neg/t12349/javapkg/t12349a.java
@@ -1,0 +1,45 @@
+package javapkg;
+
+public class t12349a {
+
+       public void a1() { System.out.println("t12349a#a1()"); }
+       public void a2() { System.out.println("t12349a#a2()"); }
+       public void a3() { System.out.println("t12349a#a3()"); }
+       public void a4() { System.out.println("t12349a#a4()"); }
+       public void a5() { System.out.println("t12349a#a5()"); }
+       public void a6() { System.out.println("t12349a#a6()"); }
+       public void a7() { System.out.println("t12349a#a7()"); }
+       public void a8() { System.out.println("t12349a#a8()"); }
+       public void a9() { System.out.println("t12349a#a9()"); }
+
+    protected void b1() { System.out.println("t12349a#b1()"); }
+    protected void b2() { System.out.println("t12349a#b2()"); }
+    protected void b3() { System.out.println("t12349a#b3()"); }
+    protected void b4() { System.out.println("t12349a#b4()"); }
+    protected void b5() { System.out.println("t12349a#b5()"); }
+    protected void b6() { System.out.println("t12349a#b6()"); }
+    protected void b7() { System.out.println("t12349a#b7()"); }
+    protected void b8() { System.out.println("t12349a#b8()"); }
+    protected void b9() { System.out.println("t12349a#b9()"); }
+
+              void c1() { System.out.println("t12349a#c1()"); }
+              void c2() { System.out.println("t12349a#c2()"); }
+              void c3() { System.out.println("t12349a#c3()"); }
+              void c4() { System.out.println("t12349a#c4()"); }
+              void c5() { System.out.println("t12349a#c5()"); }
+              void c6() { System.out.println("t12349a#c6()"); }
+              void c7() { System.out.println("t12349a#c7()"); }
+              void c8() { System.out.println("t12349a#c8()"); }
+              void c9() { System.out.println("t12349a#c9()"); }
+
+      private void d1() { System.out.println("t12349a#d1()"); }
+      private void d2() { System.out.println("t12349a#d2()"); }
+      private void d3() { System.out.println("t12349a#d3()"); }
+      private void d4() { System.out.println("t12349a#d4()"); }
+      private void d5() { System.out.println("t12349a#d5()"); }
+      private void d6() { System.out.println("t12349a#d6()"); }
+      private void d7() { System.out.println("t12349a#d7()"); }
+      private void d8() { System.out.println("t12349a#d8()"); }
+      private void d9() { System.out.println("t12349a#d9()"); }
+
+}

--- a/test/files/neg/t12349/javapkg/t12349b.scala
+++ b/test/files/neg/t12349/javapkg/t12349b.scala
@@ -1,0 +1,47 @@
+package javapkg
+
+object t12349b {
+
+  class Inner12349b extends t12349a {
+                       override def a1(): Unit = println("Inner12349b#a1()")
+    protected          override def a2(): Unit = println("Inner12349b#a2()") // weaker access privileges
+      private          override def a3(): Unit = println("Inner12349b#a3()") // weaker access privileges
+    protected[t12349b] override def a4(): Unit = println("Inner12349b#a4()") // weaker access privileges
+      private[t12349b] override def a5(): Unit = println("Inner12349b#a5()") // weaker access privileges
+    protected[javapkg] override def a6(): Unit = println("Inner12349b#a6()") // weaker access privileges
+      private[javapkg] override def a7(): Unit = println("Inner12349b#a7()") // weaker access privileges
+    protected[this]    override def a8(): Unit = println("Inner12349b#a8()") // weaker access privileges
+      private[this]    override def a9(): Unit = println("Inner12349b#a9()") // no effect on private[this] (will it be fixed?)
+
+                       override def b1(): Unit = println("Inner12349b#b1()")
+    protected          override def b2(): Unit = println("Inner12349b#b2()")
+      private          override def b3(): Unit = println("Inner12349b#b3()") // weaker access privileges
+    protected[t12349b] override def b4(): Unit = println("Inner12349b#b4()")
+      private[t12349b] override def b5(): Unit = println("Inner12349b#b5()") // weaker access privileges
+    protected[javapkg] override def b6(): Unit = println("Inner12349b#b6()")
+      private[javapkg] override def b7(): Unit = println("Inner12349b#b7()") // weaker access privileges
+    protected[this]    override def b8(): Unit = println("Inner12349b#b8()") // protected[this] seems to be another problem, so leave it as it is
+      private[this]    override def b9(): Unit = println("Inner12349b#b9()") // no effect on private[this] (will it be fixed?)
+
+                       override def c1(): Unit = println("Inner12349b#c1()")
+    protected          override def c2(): Unit = println("Inner12349b#c2()") // weaker access privileges
+      private          override def c3(): Unit = println("Inner12349b#c3()") // weaker access privileges
+    protected[t12349b] override def c4(): Unit = println("Inner12349b#c4()") // weaker access privileges
+      private[t12349b] override def c5(): Unit = println("Inner12349b#c5()") // weaker access privileges
+    protected[javapkg] override def c6(): Unit = println("Inner12349b#c6()")
+      private[javapkg] override def c7(): Unit = println("Inner12349b#c7()")
+    protected[this]    override def c8(): Unit = println("Inner12349b#c8()") // weaker access privileges
+      private[this]    override def c9(): Unit = println("Inner12349b#c9()") // no effect on private[this] (will it be fixed?)
+
+                       override def d1(): Unit = println("Inner12349b#d1()") // overrides nothins
+    protected          override def d2(): Unit = println("Inner12349b#d2()") // overrides nothins
+      private          override def d3(): Unit = println("Inner12349b#d3()") // overrides nothins
+    protected[t12349b] override def d4(): Unit = println("Inner12349b#d4()") // overrides nothins
+      private[t12349b] override def d5(): Unit = println("Inner12349b#d5()") // overrides nothins
+    protected[javapkg] override def d6(): Unit = println("Inner12349b#d6()") // overrides nothins
+      private[javapkg] override def d7(): Unit = println("Inner12349b#d7()") // overrides nothins
+    protected[this]    override def d8(): Unit = println("Inner12349b#d8()") // overrides nothins
+      private[this]    override def d9(): Unit = println("Inner12349b#d9()") // overrides nothins
+  }
+
+}

--- a/test/files/neg/t12349/pkg/t12349c.scala
+++ b/test/files/neg/t12349/pkg/t12349c.scala
@@ -1,0 +1,49 @@
+package pkg
+
+import javapkg.t12349a
+
+object t12349c {
+
+  class Inner12349c extends t12349a {
+                       override def a1(): Unit = println("Inner12349c#a1()")
+    protected          override def a2(): Unit = println("Inner12349c#a2()") // weaker access privileges
+      private          override def a3(): Unit = println("Inner12349c#a3()") // weaker access privileges
+    protected[t12349c] override def a4(): Unit = println("Inner12349c#a4()") // weaker access privileges
+      private[t12349c] override def a5(): Unit = println("Inner12349c#a5()") // weaker access privileges
+    protected[pkg]     override def a6(): Unit = println("Inner12349c#a6()") // weaker access privileges
+      private[pkg]     override def a7(): Unit = println("Inner12349c#a7()") // weaker access privileges
+    protected[this]    override def a8(): Unit = println("Inner12349c#a8()") // weaker access privileges
+      private[this]    override def a9(): Unit = println("Inner12349c#a9()") // weaker access privileges
+
+                       override def b1(): Unit = println("Inner12349c#b1()")
+    protected          override def b2(): Unit = println("Inner12349c#b2()")
+      private          override def b3(): Unit = println("Inner12349c#b3()") // weaker access privileges
+    protected[t12349c] override def b4(): Unit = println("Inner12349c#b4()")
+      private[t12349c] override def b5(): Unit = println("Inner12349c#b5()") // weaker access privileges
+    protected[pkg]     override def b6(): Unit = println("Inner12349c#b6()")
+      private[pkg]     override def b7(): Unit = println("Inner12349c#b7()") // weaker access privileges
+    protected[this]    override def b8(): Unit = println("Inner12349c#b8()") // protected[this] seems to be another problem, so leave it as it is
+      private[this]    override def b9(): Unit = println("Inner12349c#b9()") // weaker access privileges
+
+                       override def c1(): Unit = println("Inner12349c#c1()") // overrides nothins(invisible)
+    protected          override def c2(): Unit = println("Inner12349c#c2()") // weaker access privileges
+      private          override def c3(): Unit = println("Inner12349c#c3()") // weaker access privileges
+    protected[t12349c] override def c4(): Unit = println("Inner12349c#c4()") // weaker access privileges
+      private[t12349c] override def c5(): Unit = println("Inner12349c#c5()") // weaker access privileges
+    protected[pkg]     override def c6(): Unit = println("Inner12349c#c6()") // weaker access privileges
+      private[pkg]     override def c7(): Unit = println("Inner12349c#c7()") // weaker access privileges
+    protected[this]    override def c8(): Unit = println("Inner12349c#c8()") // weaker access privileges
+      private[this]    override def c9(): Unit = println("Inner12349c#c9()") // overrides nothins(invisible)
+
+                       override def d1(): Unit = println("Inner12349c#d1()") // overrides nothins
+    protected          override def d2(): Unit = println("Inner12349c#d2()") // overrides nothins
+      private          override def d3(): Unit = println("Inner12349c#d3()") // overrides nothins
+    protected[t12349c] override def d4(): Unit = println("Inner12349c#d4()") // overrides nothins
+      private[t12349c] override def d5(): Unit = println("Inner12349c#d5()") // overrides nothins
+    protected[pkg]     override def d6(): Unit = println("Inner12349c#d6()") // overrides nothins
+      private[pkg]     override def d7(): Unit = println("Inner12349c#d7()") // overrides nothins
+    protected[this]    override def d8(): Unit = println("Inner12349c#d8()") // overrides nothins
+      private[this]    override def d9(): Unit = println("Inner12349c#d9()") // overrides nothins
+  }
+
+}


### PR DESCRIPTION
Fixes scala/bug#12349  
Prohibit overriding with stricter modifiers than public or package access.  