### PR TITLE
REPL: improve tab-completion of `:`-prefixed commands (fixes scala/bug#12264)

### DIFF
--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/Completion.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/Completion.scala
@@ -20,16 +20,16 @@ object NoCompletion extends Completion {
   def complete(buffer: String, cursor: Int) = NoCompletions
 }
 
-case class CompletionResult(cursor: Int, candidates: List[CompletionCandidate]) {
+case class CompletionResult(line: String, cursor: Int, candidates: List[CompletionCandidate]) {
   final def orElse(other: => CompletionResult): CompletionResult =
     if (candidates.nonEmpty) this else other
 }
 object CompletionResult {
   val empty: CompletionResult = NoCompletions
 }
-object NoCompletions extends CompletionResult(-1, Nil)
+object NoCompletions extends CompletionResult("", -1, Nil)
 
 case class MultiCompletion(underlying: Completion*) extends Completion {
   override def complete(buffer: String, cursor: Int) =
-    underlying.foldLeft(CompletionResult.empty)((r,c) => r.orElse(c.complete(buffer, cursor)))
+    underlying.foldLeft(CompletionResult.empty)((r, c) => r.orElse(c.complete(buffer, cursor)))
 }

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/LoopCommands.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/LoopCommands.scala
@@ -138,12 +138,12 @@ trait LoopCommands {
             val completion = if (cmd.isInstanceOf[NullaryCmd] || cursor < line.length) cmd.name else cmd.name + " "
             new Completion {
               def complete(buffer: String, cursor: Int) =
-                CompletionResult(cursor = 1, List(CompletionCandidate(completion)))
+                CompletionResult(buffer, cursor = 1, List(CompletionCandidate(completion)))
             }
           case cmd :: rest =>
             new Completion {
               def complete(buffer: String, cursor: Int) =
-                CompletionResult(cursor = 1, cmds.map(cmd => CompletionCandidate(cmd.name)))
+                CompletionResult(buffer, cursor = 1, cmds.map(cmd => CompletionCandidate(cmd.name)))
             }
         }
       case _ => NoCompletion

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/ReplCompletion.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/ReplCompletion.scala
@@ -14,8 +14,6 @@ package scala.tools.nsc.interpreter
 package shell
 
 import scala.util.control.NonFatal
-import scala.tools.nsc.interpreter.Repl
-import scala.tools.nsc.interpreter.Naming
 
 /** Completion for the REPL.
  */
@@ -50,17 +48,17 @@ class ReplCompletion(intp: Repl, val accumulator: Accumulator = new Accumulator)
         case Left(_) => NoCompletions
         case Right(result) => try {
           buf match {
-            case slashPrint() if cursor == buf.length =>
-              CompletionResult(cursor, CompletionCandidate.fromStrings("" :: Naming.unmangle(result.print) :: Nil))
-            case slashPrintRaw() if cursor == buf.length =>
-              CompletionResult(cursor, CompletionCandidate.fromStrings("" :: result.print :: Nil))
+            case slashPrint() if cursor == buf.length            =>
+              CompletionResult(buf, cursor, CompletionCandidate.fromStrings("" :: Naming.unmangle(result.print) :: Nil))
+            case slashPrintRaw() if cursor == buf.length         =>
+              CompletionResult(buf, cursor, CompletionCandidate.fromStrings("" :: result.print :: Nil))
             case slashTypeAt(start, end) if cursor == buf.length =>
-              CompletionResult(cursor, CompletionCandidate.fromStrings("" :: result.typeAt(start.toInt, end.toInt) :: Nil))
-            case _ =>
+              CompletionResult(buf, cursor, CompletionCandidate.fromStrings("" :: result.typeAt(start.toInt, end.toInt) :: Nil))
+            case _                                               =>
               // under JLine 3, we no longer use the tabCount concept, so tabCount is always 1
               // which always gives us all completions
               val (c, r) = result.completionCandidates(tabCount = 1)
-              CompletionResult(c, r)
+              CompletionResult(buf, c, r)
           }
         } finally result.cleanup()
       }

--- a/test/junit/scala/tools/nsc/interpreter/CompletionTest.scala
+++ b/test/junit/scala/tools/nsc/interpreter/CompletionTest.scala
@@ -1,10 +1,9 @@
 package scala.tools.nsc.interpreter
 
-import java.io.{PrintWriter, StringWriter}
-
 import org.junit.Assert.{assertEquals, assertTrue}
 import org.junit.Test
 
+import java.io.{PrintWriter, StringWriter}
 import scala.reflect.internal.util.{BatchSourceFile, SourceFile}
 import scala.tools.nsc.Settings
 import scala.tools.nsc.interpreter.shell._
@@ -34,6 +33,28 @@ class CompletionTest {
     val acc = new Accumulator
     val completer = new ReplCompletion(intp, acc)
     (completer, intp, acc)
+  }
+
+  private def commandInterpretLines(): (Completion, Repl, Accumulator) = {
+    val intp = newIMain()
+    class CommandMock extends LoopCommands {
+      override protected def echo(msg: String): Unit = ???
+      override protected def out: PrintWriter = ???
+      override def commands: List[LoopCommand] = {
+        val default = (string: String) => Result.default
+        List(
+          LoopCommand.cmd("paste", "[-raw] [path]", "enter paste mode or paste a file", default),
+          LoopCommand.cmd("paste", "[-raw] [path]", "enter paste mode or paste a file", default)// Other commands
+          )
+      }
+    }
+    val acc             = new Accumulator
+    val shellCompletion = new Completion {
+      override def complete(buffer: String, cursor: Int) =
+        if (buffer.startsWith(":")) new CommandMock().colonCompletion(buffer, cursor).complete(buffer, cursor)
+        else NoCompletions
+    }
+    (shellCompletion, intp, acc)
   }
 
   implicit class BeforeAfterCompletion(completion: Completion) {
@@ -229,6 +250,17 @@ class CompletionTest {
     val candidates2 = completer.complete("Stuff.that").candidates
     assertEquals(2, candidates2.size)
     assertTrue(candidates2.last.defString.contains("deprecated"))
+  }
+
+  @Test
+  def jline3Matcher(): Unit = {
+    val (completer, _, _) = commandInterpretLines()
+    val candidates1 = completer.complete(":p").candidates
+    assertEquals(2, candidates1.size)
+
+    // Save the line to the CompletionResult of the matcher, and select the command to match successfully.
+    val completionResult = completer.complete(":p")
+    assertEquals(completionResult.line, ":p")
   }
 
   @Test


### PR DESCRIPTION
Valid only for question mark commands. The question mark command has separate parsing logic and uses the Jline3 default parser. and Jline3 will parse it into `word`  `:p`. Jline3 uses `prefix` matching or `contains` matching, so `:p` cannot be matched to candidate, because the value of candidate is `paste` and `power`.

The input and output of `: p` can be matched because the `word` parsed by Jline3 is `p`, and it's collaborator think Jline3 is designed correctly. We should modify the candidate.