### PR TITLE
Fix bad performance on complex patmat

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
@@ -43,8 +43,8 @@ trait MatchOptimization extends MatchTreeMaking with MatchAnalysis {
       val testss = approximateMatchConservative(prevBinder, cases)
 
       // interpret:
-      val dependencies    = new mutable.LinkedHashMap[Test, Set[Prop]]
-      val tested          = new mutable.HashSet[Prop]
+      val dependencies    = new mutable.LinkedHashMap[Test, mutable.LinkedHashSet[Prop]]
+      val tested          = new mutable.LinkedHashSet[Prop]
       val reusesMap       = new mutable.LinkedHashMap[Int, Test]
       val reusesTest      = { (test: Test) => reusesMap.get(test.id) }
       val registerReuseBy = { (priorTest: Test, later: Test) =>
@@ -57,32 +57,32 @@ trait MatchOptimization extends MatchTreeMaking with MatchAnalysis {
         val cond = test.prop
 
         def simplify(c: Prop): Set[Prop] = c match {
-          case And(ops)                   => ops.toSet flatMap simplify
+          case And(ops)                   => ops flatMap simplify
           case Or(ops)                    => Set(False) // TODO: make more precise
-          case Not(Eq(Var(_), NullConst)) => Set(True) // not worth remembering
+          case Not(Eq(Var(_), NullConst)) => Set.empty  // not worth remembering
+          case True                       => Set.empty  // same
           case _                          => Set(c)
         }
         val conds = simplify(cond)
 
         if (conds(False)) false // stop when we encounter a definite "no" or a "not sure"
         else {
-          val nonTrivial = conds - True
-          if (!nonTrivial.isEmpty) {
-            tested ++= nonTrivial
+          if (!conds.isEmpty) {
+            tested ++= conds
 
             // is there an earlier test that checks our condition and whose dependencies are implied by ours?
             dependencies find {
               case (priorTest, deps) =>
-                ((simplify(priorTest.prop) == nonTrivial) || // our conditions are implied by priorTest if it checks the same thing directly
-                 (nonTrivial subsetOf deps)                  // or if it depends on a superset of our conditions
-                ) && (deps subsetOf tested)                 // the conditions we've tested when we are here in the match satisfy the prior test, and hence what it tested
+                ((simplify(priorTest.prop) == conds) || // our conditions are implied by priorTest if it checks the same thing directly
+                    (conds subsetOf deps)               // or if it depends on a superset of our conditions
+                ) && (deps subsetOf tested)             // the conditions we've tested when we are here in the match satisfy the prior test, and hence what it tested
             } foreach {
               case (priorTest, _) =>
                 // if so, note the dependency in both tests
                 registerReuseBy(priorTest, test)
             }
 
-            dependencies(test) = tested.toSet // copies
+            dependencies(test) = tested.clone()
           }
           true
         }
@@ -108,7 +108,7 @@ trait MatchOptimization extends MatchTreeMaking with MatchAnalysis {
       val collapsed = testss map { tests =>
         // map tests to the equivalent list of treemakers, replacing shared prefixes by a reusing treemaker
         // if there's no sharing, simply map to the tree makers corresponding to the tests
-        var currDeps = Set[Prop]()
+        var currDeps = mutable.LinkedHashSet.empty[Prop]
         val (sharedPrefix, suffix) = tests span { test =>
           (test.prop == True) || (for(
               reusedTest <- reusesTest(test);

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
@@ -145,7 +145,7 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
       // mutable case class fields need to be stored regardless (scala/bug#5158, scala/bug#6070) -- see override in ProductExtractorTreeMaker
       // sub patterns bound to wildcard (_) are never stored as they can't be referenced
       // dirty debuggers will have to get dirty to see the wildcards
-      lazy val storedBinders: Set[Symbol] =
+      private lazy val storedBinders: Set[Symbol] =
         (if (debugInfoEmitVars) subPatBinders.toSet else Set.empty) ++ extraStoredBinders diff ignoredSubPatBinders
 
       // e.g., mutable fields of a case class in ProductExtractorTreeMaker

--- a/test/files/neg/t12237.check
+++ b/test/files/neg/t12237.check
@@ -1,0 +1,10 @@
+t12237.scala:24: warning: Exhaustivity analysis reached max recursion depth, not all missing cases are reported.
+(Please try with scalac -Ypatmat-exhaust-depth 40 or -Ypatmat-exhaust-depth off.)
+    (pq: PathAndQuery) match {
+       ^
+t12237.scala:24: warning: match may not be exhaustive.
+    (pq: PathAndQuery) match {
+       ^
+error: No warnings can be incurred under -Werror.
+2 warnings
+1 error

--- a/test/files/neg/t12237.scala
+++ b/test/files/neg/t12237.scala
@@ -1,0 +1,30 @@
+// scalac: -Werror
+sealed trait PathAndQuery
+sealed trait Path  extends PathAndQuery
+sealed trait Query extends PathAndQuery
+
+object PathAndQuery {
+  case object Root                        extends Path
+  case class /(prev: Path, value: String) extends Path
+
+  case class ===(k: String, v: String)    extends Query
+  case class :&(prev: Query, next: (===)) extends Query
+  case class +?(path: Path,  next: (===)) extends Query
+}
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    import PathAndQuery._
+
+    val path = /(/(Root, "page"), "1")
+    val q1   = ===("k1", "v1")
+    val q2   = ===("k2", "v2")
+    val pq   = :&(+?(path, q1), q2)
+
+    (pq: PathAndQuery) match {
+      case Root / "page" / "1"                                       => println("match 1")
+      case Root / "page" / "1" +? ("k1" === "v1")                    => println("match 2")
+      case Root / "page" / "1" +? ("k1" === "v1") :& ("k2" === "v2") => println("match 3")
+    }
+  }
+}


### PR DESCRIPTION
AnalysisBudget.maxDPLLdepth is already working to limit the initial SAT
solving.  But given enough unassigned symbols, like the test case, the
compiler can end up spending the rest of eternity and all its memory
expanding the model.  So apply the limit where it hurts most (the
cartesian product part).

The ordered sets and various sortings, instead, are to stabilise the
results.

Fixes https://github.com/scala/bug/issues/12237