### PR TITLE
Stricter override checking for protected Scala members which override Java members

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -383,7 +383,7 @@ abstract class RefChecks extends Transform {
           def isOverrideAccessOK = member.isPublic || {      // member is public, definitely same or relaxed access
             (!other.isProtected || member.isProtected) &&    // if o is protected, so is m
             ((!isRootOrNone(ob) && ob.hasTransOwner(mb)) ||  // m relaxes o's access boundary
-             other.isJavaDefined)                           // overriding a protected java member, see #3946
+            (other.isJavaDefined && other.isProtected))      // overriding a protected java member, see #3946 #12349
           }
           if (!isOverrideAccessOK) {
             overrideAccessError()

--- a/test/files/neg/t12349.check
+++ b/test/files/neg/t12349.check
@@ -1,7 +1,37 @@
+t12349b.scala:7: error: weaker access privileges in overriding
+def a2(): Unit (defined in class t12349a)
+  override should be public
+    protected          override def a2(): Unit = println("Inner12349b#a2()") // weaker access privileges
+                                    ^
 t12349b.scala:8: error: weaker access privileges in overriding
 def a3(): Unit (defined in class t12349a)
   override should not be private
       private          override def a3(): Unit = println("Inner12349b#a3()") // weaker access privileges
+                                    ^
+t12349b.scala:9: error: weaker access privileges in overriding
+def a4(): Unit (defined in class t12349a)
+  override should be public
+    protected[t12349b] override def a4(): Unit = println("Inner12349b#a4()") // weaker access privileges
+                                    ^
+t12349b.scala:10: error: weaker access privileges in overriding
+def a5(): Unit (defined in class t12349a)
+  override should be public
+      private[t12349b] override def a5(): Unit = println("Inner12349b#a5()") // weaker access privileges
+                                    ^
+t12349b.scala:11: error: weaker access privileges in overriding
+def a6(): Unit (defined in class t12349a)
+  override should be public
+    protected[t12349]  override def a6(): Unit = println("Inner12349b#a6()") // weaker access privileges
+                                    ^
+t12349b.scala:12: error: weaker access privileges in overriding
+def a7(): Unit (defined in class t12349a)
+  override should be public
+      private[t12349]  override def a7(): Unit = println("Inner12349b#a7()") // weaker access privileges
+                                    ^
+t12349b.scala:13: error: weaker access privileges in overriding
+def a8(): Unit (defined in class t12349a)
+  override should be public
+    protected[this]    override def a8(): Unit = println("Inner12349b#a8()") // weaker access privileges
                                     ^
 t12349b.scala:18: error: weaker access privileges in overriding
 protected[package t12349] def b3(): Unit (defined in class t12349a)
@@ -18,10 +48,30 @@ protected[package t12349] def b7(): Unit (defined in class t12349a)
   override should at least be protected[t12349]
       private[t12349]  override def b7(): Unit = println("Inner12349b#b7()") // weaker access privileges
                                     ^
+t12349b.scala:27: error: weaker access privileges in overriding
+private[package t12349] def c2(): Unit (defined in class t12349a)
+  override should at least be private[t12349]
+    protected          override def c2(): Unit = println("Inner12349b#c2()") // weaker access privileges
+                                    ^
 t12349b.scala:28: error: weaker access privileges in overriding
 private[package t12349] def c3(): Unit (defined in class t12349a)
   override should not be private
       private          override def c3(): Unit = println("Inner12349b#c3()") // weaker access privileges
+                                    ^
+t12349b.scala:29: error: weaker access privileges in overriding
+private[package t12349] def c4(): Unit (defined in class t12349a)
+  override should at least be private[t12349]
+    protected[t12349b] override def c4(): Unit = println("Inner12349b#c4()") // weaker access privileges
+                                    ^
+t12349b.scala:30: error: weaker access privileges in overriding
+private[package t12349] def c5(): Unit (defined in class t12349a)
+  override should at least be private[t12349]
+      private[t12349b] override def c5(): Unit = println("Inner12349b#c5()") // weaker access privileges
+                                    ^
+t12349b.scala:33: error: weaker access privileges in overriding
+private[package t12349] def c8(): Unit (defined in class t12349a)
+  override should at least be private[t12349]
+    protected[this]    override def c8(): Unit = println("Inner12349b#c8()") // weaker access privileges
                                     ^
 t12349b.scala:36: error: method d1 overrides nothing
                        override def d1(): Unit = println("Inner12349b#d1()") // overrides nothing
@@ -50,10 +100,40 @@ t12349b.scala:43: error: method d8 overrides nothing
 t12349b.scala:44: error: method d9 overrides nothing
       private[this]    override def d9(): Unit = println("Inner12349b#d9()") // overrides nothing
                                     ^
+t12349c.scala:11: error: weaker access privileges in overriding
+def a2(): Unit (defined in class t12349a)
+  override should be public
+      protected          override def a2(): Unit = println("Inner12349c#a2()") // weaker access privileges
+                                      ^
 t12349c.scala:12: error: weaker access privileges in overriding
 def a3(): Unit (defined in class t12349a)
   override should not be private
         private          override def a3(): Unit = println("Inner12349c#a3()") // weaker access privileges
+                                      ^
+t12349c.scala:13: error: weaker access privileges in overriding
+def a4(): Unit (defined in class t12349a)
+  override should be public
+      protected[t12349c] override def a4(): Unit = println("Inner12349c#a4()") // weaker access privileges
+                                      ^
+t12349c.scala:14: error: weaker access privileges in overriding
+def a5(): Unit (defined in class t12349a)
+  override should be public
+        private[t12349c] override def a5(): Unit = println("Inner12349c#a5()") // weaker access privileges
+                                      ^
+t12349c.scala:15: error: weaker access privileges in overriding
+def a6(): Unit (defined in class t12349a)
+  override should be public
+      protected[pkg]     override def a6(): Unit = println("Inner12349c#a6()") // weaker access privileges
+                                      ^
+t12349c.scala:16: error: weaker access privileges in overriding
+def a7(): Unit (defined in class t12349a)
+  override should be public
+        private[pkg]     override def a7(): Unit = println("Inner12349c#a7()") // weaker access privileges
+                                      ^
+t12349c.scala:17: error: weaker access privileges in overriding
+def a8(): Unit (defined in class t12349a)
+  override should be public
+      protected[this]    override def a8(): Unit = println("Inner12349c#a8()") // weaker access privileges
                                       ^
 t12349c.scala:22: error: weaker access privileges in overriding
 protected[package t12349] def b3(): Unit (defined in class t12349a)
@@ -70,31 +150,43 @@ protected[package t12349] def b7(): Unit (defined in class t12349a)
   override should at least be protected[t12349]
         private[pkg]     override def b7(): Unit = println("Inner12349c#b7()") // weaker access privileges
                                       ^
+t12349c.scala:31: error: weaker access privileges in overriding
+private[package t12349] def c2(): Unit (defined in class t12349a)
+  override should at least be private[t12349]
+      protected          override def c2(): Unit = println("Inner12349c#c2()") // weaker access privileges
+                                      ^
 t12349c.scala:32: error: weaker access privileges in overriding
 private[package t12349] def c3(): Unit (defined in class t12349a)
   override should not be private
         private          override def c3(): Unit = println("Inner12349c#c3()") // weaker access privileges
                                       ^
+t12349c.scala:33: error: weaker access privileges in overriding
+private[package t12349] def c4(): Unit (defined in class t12349a)
+  override should at least be private[t12349]
+      protected[t12349c] override def c4(): Unit = println("Inner12349c#c4()") // weaker access privileges
+                                      ^
+t12349c.scala:34: error: weaker access privileges in overriding
+private[package t12349] def c5(): Unit (defined in class t12349a)
+  override should at least be private[t12349]
+        private[t12349c] override def c5(): Unit = println("Inner12349c#c5()") // weaker access privileges
+                                      ^
+t12349c.scala:35: error: weaker access privileges in overriding
+private[package t12349] def c6(): Unit (defined in class t12349a)
+  override should at least be private[t12349]
+      protected[pkg]     override def c6(): Unit = println("Inner12349c#c6()") // weaker access privileges
+                                      ^
+t12349c.scala:36: error: weaker access privileges in overriding
+private[package t12349] def c7(): Unit (defined in class t12349a)
+  override should at least be private[t12349]
+        private[pkg]     override def c7(): Unit = println("Inner12349c#c7()") // weaker access privileges
+                                      ^
+t12349c.scala:37: error: weaker access privileges in overriding
+private[package t12349] def c8(): Unit (defined in class t12349a)
+  override should at least be private[t12349]
+      protected[this]    override def c8(): Unit = println("Inner12349c#c8()") // weaker access privileges
+                                      ^
 t12349c.scala:30: error: method c1 overrides nothing
                          override def c1(): Unit = println("Inner12349c#c1()") // overrides nothing (invisible)
-                                      ^
-t12349c.scala:31: error: method c2 overrides nothing
-      protected          override def c2(): Unit = println("Inner12349c#c2()") // [#12349]
-                                      ^
-t12349c.scala:33: error: method c4 overrides nothing
-      protected[t12349c] override def c4(): Unit = println("Inner12349c#c4()") // [#12349]
-                                      ^
-t12349c.scala:34: error: method c5 overrides nothing
-        private[t12349c] override def c5(): Unit = println("Inner12349c#c5()") // [#12349]
-                                      ^
-t12349c.scala:35: error: method c6 overrides nothing
-      protected[pkg]     override def c6(): Unit = println("Inner12349c#c6()") // [#12349]
-                                      ^
-t12349c.scala:36: error: method c7 overrides nothing
-        private[pkg]     override def c7(): Unit = println("Inner12349c#c7()") // [#12349]
-                                      ^
-t12349c.scala:37: error: method c8 overrides nothing
-      protected[this]    override def c8(): Unit = println("Inner12349c#c8()") // [#12349]
                                       ^
 t12349c.scala:38: error: method c9 overrides nothing.
 Note: the super classes of class Inner12349c contain the following, non final members named c9:
@@ -128,4 +220,4 @@ t12349c.scala:47: error: method d8 overrides nothing
 t12349c.scala:48: error: method d9 overrides nothing
         private[this]    override def d9(): Unit = println("Inner12349c#d9()") // overrides nothing
                                       ^
-36 errors
+52 errors

--- a/test/files/neg/t12349.check
+++ b/test/files/neg/t12349.check
@@ -1,0 +1,131 @@
+t12349b.scala:8: error: weaker access privileges in overriding
+def a3(): Unit (defined in class t12349a)
+  override should not be private
+      private          override def a3(): Unit = println("Inner12349b#a3()") // weaker access privileges
+                                    ^
+t12349b.scala:18: error: weaker access privileges in overriding
+protected[package t12349] def b3(): Unit (defined in class t12349a)
+  override should not be private
+      private          override def b3(): Unit = println("Inner12349b#b3()") // weaker access privileges
+                                    ^
+t12349b.scala:20: error: weaker access privileges in overriding
+protected[package t12349] def b5(): Unit (defined in class t12349a)
+  override should at least be protected[t12349]
+      private[t12349b] override def b5(): Unit = println("Inner12349b#b5()") // weaker access privileges
+                                    ^
+t12349b.scala:22: error: weaker access privileges in overriding
+protected[package t12349] def b7(): Unit (defined in class t12349a)
+  override should at least be protected[t12349]
+      private[t12349]  override def b7(): Unit = println("Inner12349b#b7()") // weaker access privileges
+                                    ^
+t12349b.scala:28: error: weaker access privileges in overriding
+private[package t12349] def c3(): Unit (defined in class t12349a)
+  override should not be private
+      private          override def c3(): Unit = println("Inner12349b#c3()") // weaker access privileges
+                                    ^
+t12349b.scala:36: error: method d1 overrides nothing
+                       override def d1(): Unit = println("Inner12349b#d1()") // overrides nothing
+                                    ^
+t12349b.scala:37: error: method d2 overrides nothing
+    protected          override def d2(): Unit = println("Inner12349b#d2()") // overrides nothing
+                                    ^
+t12349b.scala:38: error: method d3 overrides nothing
+      private          override def d3(): Unit = println("Inner12349b#d3()") // overrides nothing
+                                    ^
+t12349b.scala:39: error: method d4 overrides nothing
+    protected[t12349b] override def d4(): Unit = println("Inner12349b#d4()") // overrides nothing
+                                    ^
+t12349b.scala:40: error: method d5 overrides nothing
+      private[t12349b] override def d5(): Unit = println("Inner12349b#d5()") // overrides nothing
+                                    ^
+t12349b.scala:41: error: method d6 overrides nothing
+    protected[t12349]  override def d6(): Unit = println("Inner12349b#d6()") // overrides nothing
+                                    ^
+t12349b.scala:42: error: method d7 overrides nothing
+      private[t12349]  override def d7(): Unit = println("Inner12349b#d7()") // overrides nothing
+                                    ^
+t12349b.scala:43: error: method d8 overrides nothing
+    protected[this]    override def d8(): Unit = println("Inner12349b#d8()") // overrides nothing
+                                    ^
+t12349b.scala:44: error: method d9 overrides nothing
+      private[this]    override def d9(): Unit = println("Inner12349b#d9()") // overrides nothing
+                                    ^
+t12349c.scala:12: error: weaker access privileges in overriding
+def a3(): Unit (defined in class t12349a)
+  override should not be private
+        private          override def a3(): Unit = println("Inner12349c#a3()") // weaker access privileges
+                                      ^
+t12349c.scala:22: error: weaker access privileges in overriding
+protected[package t12349] def b3(): Unit (defined in class t12349a)
+  override should not be private
+        private          override def b3(): Unit = println("Inner12349c#b3()") // weaker access privileges
+                                      ^
+t12349c.scala:24: error: weaker access privileges in overriding
+protected[package t12349] def b5(): Unit (defined in class t12349a)
+  override should at least be protected[t12349]
+        private[t12349c] override def b5(): Unit = println("Inner12349c#b5()") // weaker access privileges
+                                      ^
+t12349c.scala:26: error: weaker access privileges in overriding
+protected[package t12349] def b7(): Unit (defined in class t12349a)
+  override should at least be protected[t12349]
+        private[pkg]     override def b7(): Unit = println("Inner12349c#b7()") // weaker access privileges
+                                      ^
+t12349c.scala:32: error: weaker access privileges in overriding
+private[package t12349] def c3(): Unit (defined in class t12349a)
+  override should not be private
+        private          override def c3(): Unit = println("Inner12349c#c3()") // weaker access privileges
+                                      ^
+t12349c.scala:30: error: method c1 overrides nothing
+                         override def c1(): Unit = println("Inner12349c#c1()") // overrides nothing (invisible)
+                                      ^
+t12349c.scala:31: error: method c2 overrides nothing
+      protected          override def c2(): Unit = println("Inner12349c#c2()") // [#12349]
+                                      ^
+t12349c.scala:33: error: method c4 overrides nothing
+      protected[t12349c] override def c4(): Unit = println("Inner12349c#c4()") // [#12349]
+                                      ^
+t12349c.scala:34: error: method c5 overrides nothing
+        private[t12349c] override def c5(): Unit = println("Inner12349c#c5()") // [#12349]
+                                      ^
+t12349c.scala:35: error: method c6 overrides nothing
+      protected[pkg]     override def c6(): Unit = println("Inner12349c#c6()") // [#12349]
+                                      ^
+t12349c.scala:36: error: method c7 overrides nothing
+        private[pkg]     override def c7(): Unit = println("Inner12349c#c7()") // [#12349]
+                                      ^
+t12349c.scala:37: error: method c8 overrides nothing
+      protected[this]    override def c8(): Unit = println("Inner12349c#c8()") // [#12349]
+                                      ^
+t12349c.scala:38: error: method c9 overrides nothing.
+Note: the super classes of class Inner12349c contain the following, non final members named c9:
+private[package t12349] def c9(): Unit
+        private[this]    override def c9(): Unit = println("Inner12349c#c9()") // overrides nothing (invisible)
+                                      ^
+t12349c.scala:40: error: method d1 overrides nothing
+                         override def d1(): Unit = println("Inner12349c#d1()") // overrides nothing
+                                      ^
+t12349c.scala:41: error: method d2 overrides nothing
+      protected          override def d2(): Unit = println("Inner12349c#d2()") // overrides nothing
+                                      ^
+t12349c.scala:42: error: method d3 overrides nothing
+        private          override def d3(): Unit = println("Inner12349c#d3()") // overrides nothing
+                                      ^
+t12349c.scala:43: error: method d4 overrides nothing
+      protected[t12349c] override def d4(): Unit = println("Inner12349c#d4()") // overrides nothing
+                                      ^
+t12349c.scala:44: error: method d5 overrides nothing
+        private[t12349c] override def d5(): Unit = println("Inner12349c#d5()") // overrides nothing
+                                      ^
+t12349c.scala:45: error: method d6 overrides nothing
+      protected[pkg]     override def d6(): Unit = println("Inner12349c#d6()") // overrides nothing
+                                      ^
+t12349c.scala:46: error: method d7 overrides nothing
+        private[pkg]     override def d7(): Unit = println("Inner12349c#d7()") // overrides nothing
+                                      ^
+t12349c.scala:47: error: method d8 overrides nothing
+      protected[this]    override def d8(): Unit = println("Inner12349c#d8()") // overrides nothing
+                                      ^
+t12349c.scala:48: error: method d9 overrides nothing
+        private[this]    override def d9(): Unit = println("Inner12349c#d9()") // overrides nothing
+                                      ^
+36 errors

--- a/test/files/neg/t12349/t12349a.java
+++ b/test/files/neg/t12349/t12349a.java
@@ -1,0 +1,45 @@
+package t12349;
+
+public class t12349a {
+
+       public void a1() { System.out.println("t12349a#a1()"); }
+       public void a2() { System.out.println("t12349a#a2()"); }
+       public void a3() { System.out.println("t12349a#a3()"); }
+       public void a4() { System.out.println("t12349a#a4()"); }
+       public void a5() { System.out.println("t12349a#a5()"); }
+       public void a6() { System.out.println("t12349a#a6()"); }
+       public void a7() { System.out.println("t12349a#a7()"); }
+       public void a8() { System.out.println("t12349a#a8()"); }
+       public void a9() { System.out.println("t12349a#a9()"); }
+
+    protected void b1() { System.out.println("t12349a#b1()"); }
+    protected void b2() { System.out.println("t12349a#b2()"); }
+    protected void b3() { System.out.println("t12349a#b3()"); }
+    protected void b4() { System.out.println("t12349a#b4()"); }
+    protected void b5() { System.out.println("t12349a#b5()"); }
+    protected void b6() { System.out.println("t12349a#b6()"); }
+    protected void b7() { System.out.println("t12349a#b7()"); }
+    protected void b8() { System.out.println("t12349a#b8()"); }
+    protected void b9() { System.out.println("t12349a#b9()"); }
+
+              void c1() { System.out.println("t12349a#c1()"); }
+              void c2() { System.out.println("t12349a#c2()"); }
+              void c3() { System.out.println("t12349a#c3()"); }
+              void c4() { System.out.println("t12349a#c4()"); }
+              void c5() { System.out.println("t12349a#c5()"); }
+              void c6() { System.out.println("t12349a#c6()"); }
+              void c7() { System.out.println("t12349a#c7()"); }
+              void c8() { System.out.println("t12349a#c8()"); }
+              void c9() { System.out.println("t12349a#c9()"); }
+
+      private void d1() { System.out.println("t12349a#d1()"); }
+      private void d2() { System.out.println("t12349a#d2()"); }
+      private void d3() { System.out.println("t12349a#d3()"); }
+      private void d4() { System.out.println("t12349a#d4()"); }
+      private void d5() { System.out.println("t12349a#d5()"); }
+      private void d6() { System.out.println("t12349a#d6()"); }
+      private void d7() { System.out.println("t12349a#d7()"); }
+      private void d8() { System.out.println("t12349a#d8()"); }
+      private void d9() { System.out.println("t12349a#d9()"); }
+
+}

--- a/test/files/neg/t12349/t12349b.scala
+++ b/test/files/neg/t12349/t12349b.scala
@@ -4,13 +4,13 @@ object t12349b {
 
   class Inner12349b extends t12349a {
                        override def a1(): Unit = println("Inner12349b#a1()")
-    protected          override def a2(): Unit = println("Inner12349b#a2()") // [#12349]
+    protected          override def a2(): Unit = println("Inner12349b#a2()") // weaker access privileges
       private          override def a3(): Unit = println("Inner12349b#a3()") // weaker access privileges
-    protected[t12349b] override def a4(): Unit = println("Inner12349b#a4()") // [#12349]
-      private[t12349b] override def a5(): Unit = println("Inner12349b#a5()") // [#12349]
-    protected[t12349]  override def a6(): Unit = println("Inner12349b#a6()") // [#12349]
-      private[t12349]  override def a7(): Unit = println("Inner12349b#a7()") // [#12349]
-    protected[this]    override def a8(): Unit = println("Inner12349b#a8()") // [#12349]
+    protected[t12349b] override def a4(): Unit = println("Inner12349b#a4()") // weaker access privileges
+      private[t12349b] override def a5(): Unit = println("Inner12349b#a5()") // weaker access privileges
+    protected[t12349]  override def a6(): Unit = println("Inner12349b#a6()") // weaker access privileges
+      private[t12349]  override def a7(): Unit = println("Inner12349b#a7()") // weaker access privileges
+    protected[this]    override def a8(): Unit = println("Inner12349b#a8()") // weaker access privileges
       private[this]    override def a9(): Unit = println("Inner12349b#a9()") // [#9334]
 
                        override def b1(): Unit = println("Inner12349b#b1()")
@@ -24,13 +24,13 @@ object t12349b {
       private[this]    override def b9(): Unit = println("Inner12349b#b9()") // [#9334]
 
                        override def c1(): Unit = println("Inner12349b#c1()")
-    protected          override def c2(): Unit = println("Inner12349b#c2()") // [#12349]
+    protected          override def c2(): Unit = println("Inner12349b#c2()") // weaker access privileges
       private          override def c3(): Unit = println("Inner12349b#c3()") // weaker access privileges
-    protected[t12349b] override def c4(): Unit = println("Inner12349b#c4()") // [#12349]
-      private[t12349b] override def c5(): Unit = println("Inner12349b#c5()") // [#12349]
+    protected[t12349b] override def c4(): Unit = println("Inner12349b#c4()") // weaker access privileges
+      private[t12349b] override def c5(): Unit = println("Inner12349b#c5()") // weaker access privileges
     protected[t12349]  override def c6(): Unit = println("Inner12349b#c6()")
       private[t12349]  override def c7(): Unit = println("Inner12349b#c7()")
-    protected[this]    override def c8(): Unit = println("Inner12349b#c8()") // [#12349]
+    protected[this]    override def c8(): Unit = println("Inner12349b#c8()") // weaker access privileges
       private[this]    override def c9(): Unit = println("Inner12349b#c9()") // [#9334]
 
                        override def d1(): Unit = println("Inner12349b#d1()") // overrides nothing

--- a/test/files/neg/t12349/t12349b.scala
+++ b/test/files/neg/t12349/t12349b.scala
@@ -1,0 +1,47 @@
+package t12349
+
+object t12349b {
+
+  class Inner12349b extends t12349a {
+                       override def a1(): Unit = println("Inner12349b#a1()")
+    protected          override def a2(): Unit = println("Inner12349b#a2()") // [#12349]
+      private          override def a3(): Unit = println("Inner12349b#a3()") // weaker access privileges
+    protected[t12349b] override def a4(): Unit = println("Inner12349b#a4()") // [#12349]
+      private[t12349b] override def a5(): Unit = println("Inner12349b#a5()") // [#12349]
+    protected[t12349]  override def a6(): Unit = println("Inner12349b#a6()") // [#12349]
+      private[t12349]  override def a7(): Unit = println("Inner12349b#a7()") // [#12349]
+    protected[this]    override def a8(): Unit = println("Inner12349b#a8()") // [#12349]
+      private[this]    override def a9(): Unit = println("Inner12349b#a9()") // [#9334]
+
+                       override def b1(): Unit = println("Inner12349b#b1()")
+    protected          override def b2(): Unit = println("Inner12349b#b2()")
+      private          override def b3(): Unit = println("Inner12349b#b3()") // weaker access privileges
+    protected[t12349b] override def b4(): Unit = println("Inner12349b#b4()")
+      private[t12349b] override def b5(): Unit = println("Inner12349b#b5()") // weaker access privileges
+    protected[t12349]  override def b6(): Unit = println("Inner12349b#b6()")
+      private[t12349]  override def b7(): Unit = println("Inner12349b#b7()") // weaker access privileges
+    protected[this]    override def b8(): Unit = println("Inner12349b#b8()") // [#12349] - not fixed by PR #9525
+      private[this]    override def b9(): Unit = println("Inner12349b#b9()") // [#9334]
+
+                       override def c1(): Unit = println("Inner12349b#c1()")
+    protected          override def c2(): Unit = println("Inner12349b#c2()") // [#12349]
+      private          override def c3(): Unit = println("Inner12349b#c3()") // weaker access privileges
+    protected[t12349b] override def c4(): Unit = println("Inner12349b#c4()") // [#12349]
+      private[t12349b] override def c5(): Unit = println("Inner12349b#c5()") // [#12349]
+    protected[t12349]  override def c6(): Unit = println("Inner12349b#c6()")
+      private[t12349]  override def c7(): Unit = println("Inner12349b#c7()")
+    protected[this]    override def c8(): Unit = println("Inner12349b#c8()") // [#12349]
+      private[this]    override def c9(): Unit = println("Inner12349b#c9()") // [#9334]
+
+                       override def d1(): Unit = println("Inner12349b#d1()") // overrides nothing
+    protected          override def d2(): Unit = println("Inner12349b#d2()") // overrides nothing
+      private          override def d3(): Unit = println("Inner12349b#d3()") // overrides nothing
+    protected[t12349b] override def d4(): Unit = println("Inner12349b#d4()") // overrides nothing
+      private[t12349b] override def d5(): Unit = println("Inner12349b#d5()") // overrides nothing
+    protected[t12349]  override def d6(): Unit = println("Inner12349b#d6()") // overrides nothing
+      private[t12349]  override def d7(): Unit = println("Inner12349b#d7()") // overrides nothing
+    protected[this]    override def d8(): Unit = println("Inner12349b#d8()") // overrides nothing
+      private[this]    override def d9(): Unit = println("Inner12349b#d9()") // overrides nothing
+  }
+
+}

--- a/test/files/neg/t12349/t12349c.scala
+++ b/test/files/neg/t12349/t12349c.scala
@@ -8,13 +8,13 @@ package pkg {
 
     class Inner12349c extends t12349a {
                          override def a1(): Unit = println("Inner12349c#a1()")
-      protected          override def a2(): Unit = println("Inner12349c#a2()") // [#12349]
+      protected          override def a2(): Unit = println("Inner12349c#a2()") // weaker access privileges
         private          override def a3(): Unit = println("Inner12349c#a3()") // weaker access privileges
-      protected[t12349c] override def a4(): Unit = println("Inner12349c#a4()") // [#12349]
-        private[t12349c] override def a5(): Unit = println("Inner12349c#a5()") // [#12349]
-      protected[pkg]     override def a6(): Unit = println("Inner12349c#a6()") // [#12349]
-        private[pkg]     override def a7(): Unit = println("Inner12349c#a7()") // [#12349]
-      protected[this]    override def a8(): Unit = println("Inner12349c#a8()") // [#12349]
+      protected[t12349c] override def a4(): Unit = println("Inner12349c#a4()") // weaker access privileges
+        private[t12349c] override def a5(): Unit = println("Inner12349c#a5()") // weaker access privileges
+      protected[pkg]     override def a6(): Unit = println("Inner12349c#a6()") // weaker access privileges
+        private[pkg]     override def a7(): Unit = println("Inner12349c#a7()") // weaker access privileges
+      protected[this]    override def a8(): Unit = println("Inner12349c#a8()") // weaker access privileges
         private[this]    override def a9(): Unit = println("Inner12349c#a9()") // [#9334]
 
                          override def b1(): Unit = println("Inner12349c#b1()")
@@ -28,13 +28,13 @@ package pkg {
         private[this]    override def b9(): Unit = println("Inner12349c#b9()") // [#9334]
 
                          override def c1(): Unit = println("Inner12349c#c1()") // overrides nothing (invisible)
-      protected          override def c2(): Unit = println("Inner12349c#c2()") // [#12349]
+      protected          override def c2(): Unit = println("Inner12349c#c2()") // weaker access privileges
         private          override def c3(): Unit = println("Inner12349c#c3()") // weaker access privileges
-      protected[t12349c] override def c4(): Unit = println("Inner12349c#c4()") // [#12349]
-        private[t12349c] override def c5(): Unit = println("Inner12349c#c5()") // [#12349]
-      protected[pkg]     override def c6(): Unit = println("Inner12349c#c6()") // [#12349]
-        private[pkg]     override def c7(): Unit = println("Inner12349c#c7()") // [#12349]
-      protected[this]    override def c8(): Unit = println("Inner12349c#c8()") // [#12349]
+      protected[t12349c] override def c4(): Unit = println("Inner12349c#c4()") // weaker access privileges
+        private[t12349c] override def c5(): Unit = println("Inner12349c#c5()") // weaker access privileges
+      protected[pkg]     override def c6(): Unit = println("Inner12349c#c6()") // weaker access privileges
+        private[pkg]     override def c7(): Unit = println("Inner12349c#c7()") // weaker access privileges
+      protected[this]    override def c8(): Unit = println("Inner12349c#c8()") // weaker access privileges
         private[this]    override def c9(): Unit = println("Inner12349c#c9()") // overrides nothing (invisible)
 
                          override def d1(): Unit = println("Inner12349c#d1()") // overrides nothing

--- a/test/files/neg/t12349/t12349c.scala
+++ b/test/files/neg/t12349/t12349c.scala
@@ -1,0 +1,53 @@
+package t12349
+
+import t12349.t12349a
+
+package pkg {
+
+  object t12349c {
+
+    class Inner12349c extends t12349a {
+                         override def a1(): Unit = println("Inner12349c#a1()")
+      protected          override def a2(): Unit = println("Inner12349c#a2()") // [#12349]
+        private          override def a3(): Unit = println("Inner12349c#a3()") // weaker access privileges
+      protected[t12349c] override def a4(): Unit = println("Inner12349c#a4()") // [#12349]
+        private[t12349c] override def a5(): Unit = println("Inner12349c#a5()") // [#12349]
+      protected[pkg]     override def a6(): Unit = println("Inner12349c#a6()") // [#12349]
+        private[pkg]     override def a7(): Unit = println("Inner12349c#a7()") // [#12349]
+      protected[this]    override def a8(): Unit = println("Inner12349c#a8()") // [#12349]
+        private[this]    override def a9(): Unit = println("Inner12349c#a9()") // [#9334]
+
+                         override def b1(): Unit = println("Inner12349c#b1()")
+      protected          override def b2(): Unit = println("Inner12349c#b2()")
+        private          override def b3(): Unit = println("Inner12349c#b3()") // weaker access privileges
+      protected[t12349c] override def b4(): Unit = println("Inner12349c#b4()")
+        private[t12349c] override def b5(): Unit = println("Inner12349c#b5()") // weaker access privileges
+      protected[pkg]     override def b6(): Unit = println("Inner12349c#b6()")
+        private[pkg]     override def b7(): Unit = println("Inner12349c#b7()") // weaker access privileges
+      protected[this]    override def b8(): Unit = println("Inner12349c#b8()") // [#12349] - not fixed by PR #9525
+        private[this]    override def b9(): Unit = println("Inner12349c#b9()") // [#9334]
+
+                         override def c1(): Unit = println("Inner12349c#c1()") // overrides nothing (invisible)
+      protected          override def c2(): Unit = println("Inner12349c#c2()") // [#12349]
+        private          override def c3(): Unit = println("Inner12349c#c3()") // weaker access privileges
+      protected[t12349c] override def c4(): Unit = println("Inner12349c#c4()") // [#12349]
+        private[t12349c] override def c5(): Unit = println("Inner12349c#c5()") // [#12349]
+      protected[pkg]     override def c6(): Unit = println("Inner12349c#c6()") // [#12349]
+        private[pkg]     override def c7(): Unit = println("Inner12349c#c7()") // [#12349]
+      protected[this]    override def c8(): Unit = println("Inner12349c#c8()") // [#12349]
+        private[this]    override def c9(): Unit = println("Inner12349c#c9()") // overrides nothing (invisible)
+
+                         override def d1(): Unit = println("Inner12349c#d1()") // overrides nothing
+      protected          override def d2(): Unit = println("Inner12349c#d2()") // overrides nothing
+        private          override def d3(): Unit = println("Inner12349c#d3()") // overrides nothing
+      protected[t12349c] override def d4(): Unit = println("Inner12349c#d4()") // overrides nothing
+        private[t12349c] override def d5(): Unit = println("Inner12349c#d5()") // overrides nothing
+      protected[pkg]     override def d6(): Unit = println("Inner12349c#d6()") // overrides nothing
+        private[pkg]     override def d7(): Unit = println("Inner12349c#d7()") // overrides nothing
+      protected[this]    override def d8(): Unit = println("Inner12349c#d8()") // overrides nothing
+        private[this]    override def d9(): Unit = println("Inner12349c#d9()") // overrides nothing
+    }
+
+  }
+
+}


### PR DESCRIPTION
Currently, a `protected`, `protected[x]` or `private[x]` Scala member is always allowed when overriding a `public` or package-protected (default access) Java member. (Overriding a `protected` Java member is already checked correctly).

Since scalac emits all `protected`, `protected[x]` and `private[x]` methods as `public` in bytecode, the generated classfiles are valid.

This PR tightens the checks, so that
  - a `public` Java member can only be overridden by a `public` Scala member
  - a package-protected Java member can only be overridden by a `public`, `protected[p]` or `private[p]` Scala member where `p` is the same package

Fixes part of scala/bug#12349.