### PR TITLE
Fix regression in repl printing

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/ReplReporter.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplReporter.scala
@@ -72,7 +72,7 @@ class ReplReporter(intp: IMain) extends ConsoleReporter(intp.settings, Console.i
   }
 
   // shift indentation for source text entered at prompt
-  def print(pos: Position, msg: String, severity: Severity): Unit = {
+  override protected def display(pos: Position, msg: String, severity: Severity): Unit = {
     val adjusted =
       if (pos.source.file.name == "<console>")
         new OffsetPosition(pos.source, pos.offset.getOrElse(0)) {
@@ -80,7 +80,7 @@ class ReplReporter(intp: IMain) extends ConsoleReporter(intp.settings, Console.i
           override def lineCaret   = s"${indentation}${super.lineCaret}"
         }
       else pos
-    super.info0(adjusted, msg, severity, force = false)
+    super.display(adjusted, msg, severity)
   }
 
   override def printMessage(msg: String): Unit = {

--- a/test/files/jvm/interpreter.check
+++ b/test/files/jvm/interpreter.check
@@ -34,8 +34,8 @@ scala> val bogus: anotherint = "hello"
  found   : String("hello")
  required: anotherint
     (which expands to)  Int
-val bogus: anotherint = "hello"
-                        ^
+       val bogus: anotherint = "hello"
+                               ^
 
 scala> trait PointlessTrait
 defined trait PointlessTrait
@@ -278,13 +278,13 @@ scala> // both of the following should abort immediately:
 
 scala> def x => y => z
 <console>:1: error: '=' expected but '=>' found.
-def x => y => z
-      ^
+       def x => y => z
+             ^
 
 scala> [1,2,3]
 <console>:1: error: illegal start of definition
-[1,2,3]
-^
+       [1,2,3]
+       ^
 
 scala> 
 
@@ -355,8 +355,8 @@ scala> def f(e: Exp) = e match {  // non-exhaustive warning here
 }
 <console>:18: warning: match may not be exhaustive.
 It would fail on the following inputs: Exp(), Term()
-def f(e: Exp) = e match {  // non-exhaustive warning here
-                ^
+       def f(e: Exp) = e match {  // non-exhaustive warning here
+                       ^
 f: (e: Exp)Int
 
 scala> :quit
@@ -364,5 +364,5 @@ plusOne: (x: Int)Int
 res0: Int = 6
 res0: String = after reset
 <console>:12: error: not found: value plusOne
-plusOne(5) // should be undefined now
-^
+       plusOne(5) // should be undefined now
+       ^

--- a/test/files/run/constrained-types.check
+++ b/test/files/run/constrained-types.check
@@ -134,16 +134,16 @@ scala>
 
 scala> val x = 3 : Int @Annot(e+f+g+h) // should have a graceful error message
 <console>:12: error: not found: value e
-val x = 3 : Int @Annot(e+f+g+h) // should have a graceful error message
-                       ^
+       val x = 3 : Int @Annot(e+f+g+h) // should have a graceful error message
+                              ^
 <console>:12: error: not found: value f
-val x = 3 : Int @Annot(e+f+g+h) // should have a graceful error message
-                         ^
+       val x = 3 : Int @Annot(e+f+g+h) // should have a graceful error message
+                                ^
 <console>:12: error: not found: value g
-val x = 3 : Int @Annot(e+f+g+h) // should have a graceful error message
-                           ^
+       val x = 3 : Int @Annot(e+f+g+h) // should have a graceful error message
+                                  ^
 <console>:12: error: not found: value h
-val x = 3 : Int @Annot(e+f+g+h) // should have a graceful error message
-                             ^
+       val x = 3 : Int @Annot(e+f+g+h) // should have a graceful error message
+                                    ^
 
 scala> :quit

--- a/test/files/run/reify-repl-fail-gracefully.check
+++ b/test/files/run/reify-repl-fail-gracefully.check
@@ -9,7 +9,7 @@ scala>
 
 scala> reify
 <console>:16: error: too few argument lists for macro invocation
-reify
-^
+       reify
+       ^
 
 scala> :quit

--- a/test/files/run/reify_newimpl_22.check
+++ b/test/files/run/reify_newimpl_22.check
@@ -16,8 +16,8 @@ scala> {
   println(code.eval)
 }
 <console>:19: free term: Ident(TermName("x")) defined by res0  in <console>:18:7
-  val code = reify {
-                   ^
+         val code = reify {
+                          ^
 2
 
 scala> :quit

--- a/test/files/run/reify_newimpl_23.check
+++ b/test/files/run/reify_newimpl_23.check
@@ -15,8 +15,8 @@ scala> def foo[T]{
   println(code.eval)
 }
 <console>:17: free type: Ident(TypeName("T")) defined by foo in <console>:16:9
-  val code = reify {
-                   ^
+         val code = reify {
+                          ^
 foo: [T]=> Unit
 
 scala> :quit

--- a/test/files/run/reify_newimpl_25.check
+++ b/test/files/run/reify_newimpl_25.check
@@ -6,8 +6,8 @@ scala> {
   println(tt)
 }
 <console>:15: free term: Ident(TermName("x")) defined by res0  in <console>:14:7
-  val tt = implicitly[TypeTag[x.type]]
-                     ^
+         val tt = implicitly[TypeTag[x.type]]
+                            ^
 TypeTag[x.type]
 
 scala> :quit

--- a/test/files/run/reify_newimpl_26.check
+++ b/test/files/run/reify_newimpl_26.check
@@ -5,8 +5,8 @@ scala> def foo[T]{
   println(tt)
 }
 <console>:13: free type: Ident(TypeName("T")) defined by foo in <console>:11:9
-  val tt = implicitly[WeakTypeTag[List[T]]]
-                     ^
+         val tt = implicitly[WeakTypeTag[List[T]]]
+                            ^
 foo: [T]=> Unit
 
 scala> foo[Int]

--- a/test/files/run/repl-bare-expr.check
+++ b/test/files/run/repl-bare-expr.check
@@ -1,14 +1,14 @@
 
 scala> 2 ; 3
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-2 ;;
-^
+       2 ;;
+       ^
 res0: Int = 3
 
 scala> { 2 ; 3 }
 <console>:12: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
-{ 2 ; 3 }
-  ^
+       { 2 ; 3 }
+         ^
 res1: Int = 3
 
 scala> 5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
@@ -16,17 +16,17 @@ scala> 5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Mooo
   2 +
   3 } ; bippy+88+11
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
-^
+       5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+       ^
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
-    ^
+       5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+           ^
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
-                           ^
+       5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+                                  ^
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
-                                                                                  ^
+       5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+                                                                                         ^
 defined object Cow
 defined class Moo
 bippy: Int

--- a/test/files/run/repl-class-based-outer-pointers.check
+++ b/test/files/run/repl-class-based-outer-pointers.check
@@ -9,8 +9,8 @@ defined object Value
 
 scala> class C { final case class Num(value: Double) } // here it should still warn
 <console>:11: warning: The outer reference in this type test cannot be checked at run time.
-class C { final case class Num(value: Double) } // here it should still warn
-                           ^
+       class C { final case class Num(value: Double) } // here it should still warn
+                                  ^
 defined class C
 
 scala> :quit

--- a/test/files/run/repl-class-based-term-macros.check
+++ b/test/files/run/repl-class-based-term-macros.check
@@ -44,64 +44,64 @@ scala> def fooBBC: Unit    = macro implBBC
 macro [<static object>].<method name>[[<type args>]] or
 macro [<macro bundle>].<method name>[[<type args>]]
 note: macro definition is not supported in the REPL when using -Yrepl-classbased.
-def fooBBC: Unit    = macro implBBC
-                            ^
+       def fooBBC: Unit    = macro implBBC
+                                   ^
 
 scala> def fooWBC: Unit    = macro implWBC
 <console>:16: error: macro implementation reference has wrong shape. required:
 macro [<static object>].<method name>[[<type args>]] or
 macro [<macro bundle>].<method name>[[<type args>]]
 note: macro definition is not supported in the REPL when using -Yrepl-classbased.
-def fooWBC: Unit    = macro implWBC
-                            ^
+       def fooWBC: Unit    = macro implWBC
+                                   ^
 
 scala> def fooRBBC: Unit   = macro implRBBC
 <console>:16: error: macro implementation reference has wrong shape. required:
 macro [<static object>].<method name>[[<type args>]] or
 macro [<macro bundle>].<method name>[[<type args>]]
 note: macro definition is not supported in the REPL when using -Yrepl-classbased.
-def fooRBBC: Unit   = macro implRBBC
-                            ^
+       def fooRBBC: Unit   = macro implRBBC
+                                   ^
 
 scala> def fooRWBC: Unit   = macro implRWBC
 <console>:16: error: macro implementation reference has wrong shape. required:
 macro [<static object>].<method name>[[<type args>]] or
 macro [<macro bundle>].<method name>[[<type args>]]
 note: macro definition is not supported in the REPL when using -Yrepl-classbased.
-def fooRWBC: Unit   = macro implRWBC
-                            ^
+       def fooRWBC: Unit   = macro implRWBC
+                                   ^
 
 scala> def fooSRBBC: Unit  = macro implSRBBC
 <console>:16: error: macro implementation reference has wrong shape. required:
 macro [<static object>].<method name>[[<type args>]] or
 macro [<macro bundle>].<method name>[[<type args>]]
 note: macro definition is not supported in the REPL when using -Yrepl-classbased.
-def fooSRBBC: Unit  = macro implSRBBC
-                            ^
+       def fooSRBBC: Unit  = macro implSRBBC
+                                   ^
 
 scala> def fooSRWBC: Unit  = macro implSRWBC
 <console>:16: error: macro implementation reference has wrong shape. required:
 macro [<static object>].<method name>[[<type args>]] or
 macro [<macro bundle>].<method name>[[<type args>]]
 note: macro definition is not supported in the REPL when using -Yrepl-classbased.
-def fooSRWBC: Unit  = macro implSRWBC
-                            ^
+       def fooSRWBC: Unit  = macro implSRWBC
+                                   ^
 
 scala> def fooRSRBBC: Unit = macro implRSRBBC
 <console>:16: error: macro implementation reference has wrong shape. required:
 macro [<static object>].<method name>[[<type args>]] or
 macro [<macro bundle>].<method name>[[<type args>]]
 note: macro definition is not supported in the REPL when using -Yrepl-classbased.
-def fooRSRBBC: Unit = macro implRSRBBC
-                            ^
+       def fooRSRBBC: Unit = macro implRSRBBC
+                                   ^
 
 scala> def fooRSRWBC: Unit = macro implRSRWBC
 <console>:16: error: macro implementation reference has wrong shape. required:
 macro [<static object>].<method name>[[<type args>]] or
 macro [<macro bundle>].<method name>[[<type args>]]
 note: macro definition is not supported in the REPL when using -Yrepl-classbased.
-def fooRSRWBC: Unit = macro implRSRWBC
-                            ^
+       def fooRSRWBC: Unit = macro implRSRWBC
+                                   ^
 
 scala> 
 
@@ -144,64 +144,64 @@ scala> def barBBC: Unit    = macro MacrosModule.implBBC
 macro [<static object>].<method name>[[<type args>]] or
 macro [<macro bundle>].<method name>[[<type args>]]
 note: macro definition is not supported in the REPL when using -Yrepl-classbased.
-def barBBC: Unit    = macro MacrosModule.implBBC
-                                         ^
+       def barBBC: Unit    = macro MacrosModule.implBBC
+                                                ^
 
 scala> def barWBC: Unit    = macro MacrosModule.implWBC
 <console>:16: error: macro implementation reference has wrong shape. required:
 macro [<static object>].<method name>[[<type args>]] or
 macro [<macro bundle>].<method name>[[<type args>]]
 note: macro definition is not supported in the REPL when using -Yrepl-classbased.
-def barWBC: Unit    = macro MacrosModule.implWBC
-                                         ^
+       def barWBC: Unit    = macro MacrosModule.implWBC
+                                                ^
 
 scala> def barRBBC: Unit   = macro MacrosModule.implRBBC
 <console>:16: error: macro implementation reference has wrong shape. required:
 macro [<static object>].<method name>[[<type args>]] or
 macro [<macro bundle>].<method name>[[<type args>]]
 note: macro definition is not supported in the REPL when using -Yrepl-classbased.
-def barRBBC: Unit   = macro MacrosModule.implRBBC
-                                         ^
+       def barRBBC: Unit   = macro MacrosModule.implRBBC
+                                                ^
 
 scala> def barRWBC: Unit   = macro MacrosModule.implRWBC
 <console>:16: error: macro implementation reference has wrong shape. required:
 macro [<static object>].<method name>[[<type args>]] or
 macro [<macro bundle>].<method name>[[<type args>]]
 note: macro definition is not supported in the REPL when using -Yrepl-classbased.
-def barRWBC: Unit   = macro MacrosModule.implRWBC
-                                         ^
+       def barRWBC: Unit   = macro MacrosModule.implRWBC
+                                                ^
 
 scala> def barSRBBC: Unit  = macro MacrosModule.implSRBBC
 <console>:16: error: macro implementation reference has wrong shape. required:
 macro [<static object>].<method name>[[<type args>]] or
 macro [<macro bundle>].<method name>[[<type args>]]
 note: macro definition is not supported in the REPL when using -Yrepl-classbased.
-def barSRBBC: Unit  = macro MacrosModule.implSRBBC
-                                         ^
+       def barSRBBC: Unit  = macro MacrosModule.implSRBBC
+                                                ^
 
 scala> def barSRWBC: Unit  = macro MacrosModule.implSRWBC
 <console>:16: error: macro implementation reference has wrong shape. required:
 macro [<static object>].<method name>[[<type args>]] or
 macro [<macro bundle>].<method name>[[<type args>]]
 note: macro definition is not supported in the REPL when using -Yrepl-classbased.
-def barSRWBC: Unit  = macro MacrosModule.implSRWBC
-                                         ^
+       def barSRWBC: Unit  = macro MacrosModule.implSRWBC
+                                                ^
 
 scala> def barRSRBBC: Unit = macro MacrosModule.implRSRBBC
 <console>:16: error: macro implementation reference has wrong shape. required:
 macro [<static object>].<method name>[[<type args>]] or
 macro [<macro bundle>].<method name>[[<type args>]]
 note: macro definition is not supported in the REPL when using -Yrepl-classbased.
-def barRSRBBC: Unit = macro MacrosModule.implRSRBBC
-                                         ^
+       def barRSRBBC: Unit = macro MacrosModule.implRSRBBC
+                                                ^
 
 scala> def barRSRWBC: Unit = macro MacrosModule.implRSRWBC
 <console>:16: error: macro implementation reference has wrong shape. required:
 macro [<static object>].<method name>[[<type args>]] or
 macro [<macro bundle>].<method name>[[<type args>]]
 note: macro definition is not supported in the REPL when using -Yrepl-classbased.
-def barRSRWBC: Unit = macro MacrosModule.implRSRWBC
-                                         ^
+       def barRSRWBC: Unit = macro MacrosModule.implRSRWBC
+                                                ^
 
 scala> 
 
@@ -254,50 +254,50 @@ scala>
 scala> def bazBBC: Unit    = macro MacroBundleBBC.impl
 <console>:16: error: macro bundles must be static
 note: macro definition is not supported in the REPL when using -Yrepl-classbased.
-def bazBBC: Unit    = macro MacroBundleBBC.impl
-                            ^
+       def bazBBC: Unit    = macro MacroBundleBBC.impl
+                                   ^
 
 scala> def bazWBC: Unit    = macro MacroBundleWBC.impl
 <console>:16: error: macro bundles must be static
 note: macro definition is not supported in the REPL when using -Yrepl-classbased.
-def bazWBC: Unit    = macro MacroBundleWBC.impl
-                            ^
+       def bazWBC: Unit    = macro MacroBundleWBC.impl
+                                   ^
 
 scala> def bazRBBC: Unit   = macro MacroBundleRBBC.impl
 <console>:16: error: macro bundles must be static
 note: macro definition is not supported in the REPL when using -Yrepl-classbased.
-def bazRBBC: Unit   = macro MacroBundleRBBC.impl
-                            ^
+       def bazRBBC: Unit   = macro MacroBundleRBBC.impl
+                                   ^
 
 scala> def bazRWBC: Unit   = macro MacroBundleRWBC.impl
 <console>:16: error: macro bundles must be static
 note: macro definition is not supported in the REPL when using -Yrepl-classbased.
-def bazRWBC: Unit   = macro MacroBundleRWBC.impl
-                            ^
+       def bazRWBC: Unit   = macro MacroBundleRWBC.impl
+                                   ^
 
 scala> def bazSRBBC: Unit  = macro MacroBundleSRBBC.impl
 <console>:16: error: macro bundles must be static
 note: macro definition is not supported in the REPL when using -Yrepl-classbased.
-def bazSRBBC: Unit  = macro MacroBundleSRBBC.impl
-                            ^
+       def bazSRBBC: Unit  = macro MacroBundleSRBBC.impl
+                                   ^
 
 scala> def bazSRWBC: Unit  = macro MacroBundleSRWBC.impl
 <console>:16: error: macro bundles must be static
 note: macro definition is not supported in the REPL when using -Yrepl-classbased.
-def bazSRWBC: Unit  = macro MacroBundleSRWBC.impl
-                            ^
+       def bazSRWBC: Unit  = macro MacroBundleSRWBC.impl
+                                   ^
 
 scala> def bazRSRBBC: Unit = macro MacroBundleRSRBBC.impl
 <console>:16: error: macro bundles must be static
 note: macro definition is not supported in the REPL when using -Yrepl-classbased.
-def bazRSRBBC: Unit = macro MacroBundleRSRBBC.impl
-                            ^
+       def bazRSRBBC: Unit = macro MacroBundleRSRBBC.impl
+                                   ^
 
 scala> def bazRSRWBC: Unit = macro MacroBundleRSRWBC.impl
 <console>:16: error: macro bundles must be static
 note: macro definition is not supported in the REPL when using -Yrepl-classbased.
-def bazRSRWBC: Unit = macro MacroBundleRSRWBC.impl
-                            ^
+       def bazRSRWBC: Unit = macro MacroBundleRSRWBC.impl
+                                   ^
 
 scala> //
 

--- a/test/files/run/repl-colon-type.check
+++ b/test/files/run/repl-colon-type.check
@@ -1,8 +1,8 @@
 
 scala> :type List[1, 2, 3]
 <console>:1: error: identifier expected but integer literal found.
-List[1, 2, 3]
-     ^
+       List[1, 2, 3]
+            ^
 
 scala> :type List(1, 2, 3)
 List[Int]
@@ -38,8 +38,8 @@ scala> :type protected lazy val f = 5
  Access to protected lazy value f not permitted because
  enclosing object $eval in package $line13 is not a subclass of
  object $iw where target is defined
-  lazy val $result = f
-                                                    ^
+         lazy val $result = f
+                                                           ^
 
 scala> :type def f = 5
 => Int

--- a/test/files/run/repl-no-imports-no-predef.check
+++ b/test/files/run/repl-no-imports-no-predef.check
@@ -23,13 +23,13 @@ res6: (Int, Int) = (1,2)
 
 scala> 1 -> 2
 <console>:12: error: value -> is not a member of Int
-1 -> 2
-  ^
+       1 -> 2
+         ^
 
 scala> 1 → 2
 <console>:12: error: value → is not a member of Int
-1 → 2
-  ^
+       1 → 2
+         ^
 
 scala> 
 
@@ -41,8 +41,8 @@ res9: String = answer: 42
 
 scala> s"answer: $answer"
 <console>:13: error: not found: value StringContext
-s"answer: $answer"
-^
+       s"answer: $answer"
+       ^
 
 scala> 
 
@@ -56,8 +56,8 @@ res12: String = trueabc
 
 scala> true + "abc"
 <console>:12: error: value + is not a member of Boolean
-true + "abc"
-     ^
+       true + "abc"
+            ^
 
 scala> 
 
@@ -77,14 +77,14 @@ scala>
 
 scala> 2 ; 3
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-2 ;;
-^
+       2 ;;
+       ^
 res14: Int = 3
 
 scala> { 2 ; 3 }
 <console>:12: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
-{ 2 ; 3 }
-  ^
+       { 2 ; 3 }
+         ^
 res15: Int = 3
 
 scala> 5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
@@ -93,17 +93,17 @@ bippy = {
   2 +
   3 } ; bippy+88+11
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
-^
+       5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
+       ^
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
-    ^
+       5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
+           ^
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
-                           ^
+       5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
+                                  ^
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
-                                                                                  ^
+       5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def
+                                                                                         ^
 defined object Cow
 defined class Moo
 bippy: Int
@@ -144,11 +144,11 @@ res24: Int = 4
 
 scala> 5 ;   (  (2 + 2 )  ) ; ((5))
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-5 ;   (  (2 + 2 )  ) ;;
-^
+       5 ;   (  (2 + 2 )  ) ;;
+       ^
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-5 ;   (  (2 + 2 )  ) ;;
-            ^
+       5 ;   (  (2 + 2 )  ) ;;
+                   ^
 res25: Int = 5
 
 scala> (((2 + 2)), ((2 + 2)))
@@ -164,17 +164,17 @@ scala>
 
 scala> 55 ; ((2 + 2)) ; (1, 2, 3)
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-55 ; ((2 + 2)) ;;
-^
+       55 ; ((2 + 2)) ;;
+       ^
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-55 ; ((2 + 2)) ;;
-         ^
+       55 ; ((2 + 2)) ;;
+                ^
 res29: (Int, Int, Int) = (1,2,3)
 
 scala> 55 ; (x: scala.Int) => x + 1 ; () => ((5))
 <console>:12: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-55 ; (x: scala.Int) => x + 1 ;;
-^
+       55 ; (x: scala.Int) => x + 1 ;;
+       ^
 res30: () => Int = <function>
 
 scala> 
@@ -184,8 +184,8 @@ res31: () => Int = <function>
 
 scala> 55 ; () => 5
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-55 ;;
-^
+       55 ;;
+       ^
 res32: () => Int = <function>
 
 scala> () => { class X ; new X }
@@ -334,22 +334,22 @@ Forgetting defined types: BippyBungus, C, D, Dingus, Moo, Ruminant
 
 scala> x1 + x2 + x3
 <console>:12: error: not found: value x1
-x1 + x2 + x3
-^
+       x1 + x2 + x3
+       ^
 <console>:12: error: not found: value x2
-x1 + x2 + x3
-     ^
+       x1 + x2 + x3
+            ^
 <console>:12: error: not found: value x3
-x1 + x2 + x3
-          ^
+       x1 + x2 + x3
+                 ^
 
 scala> val x1 = 4
 x1: Int = 4
 
 scala> new BippyBungus
 <console>:12: error: not found: type BippyBungus
-new BippyBungus
-    ^
+       new BippyBungus
+           ^
 
 scala> class BippyBungus() { def f = 5 }
 defined class BippyBungus

--- a/test/files/run/repl-parens.check
+++ b/test/files/run/repl-parens.check
@@ -19,11 +19,11 @@ res5: Int = 4
 
 scala> 5 ;   (  (2 + 2 )  ) ; ((5))
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-5 ;   (  (2 + 2 )  ) ;;
-^
+       5 ;   (  (2 + 2 )  ) ;;
+       ^
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-5 ;   (  (2 + 2 )  ) ;;
-            ^
+       5 ;   (  (2 + 2 )  ) ;;
+                   ^
 res6: Int = 5
 
 scala> (((2 + 2)), ((2 + 2)))
@@ -39,17 +39,17 @@ scala>
 
 scala> 55 ; ((2 + 2)) ; (1, 2, 3)
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-55 ; ((2 + 2)) ;;
-^
+       55 ; ((2 + 2)) ;;
+       ^
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-55 ; ((2 + 2)) ;;
-         ^
+       55 ; ((2 + 2)) ;;
+                ^
 res10: (Int, Int, Int) = (1,2,3)
 
 scala> 55 ; (x: Int) => x + 1 ; () => ((5))
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-55 ; (x: Int) => x + 1 ;;
-^
+       55 ; (x: Int) => x + 1 ;;
+       ^
 res11: () => Int = <function>
 
 scala> 
@@ -59,8 +59,8 @@ res12: () => Int = <function>
 
 scala> 55 ; () => 5
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-55 ;;
-^
+       55 ;;
+       ^
 res13: () => Int = <function>
 
 scala> () => { class X ; new X }

--- a/test/files/run/repl-paste-2.check
+++ b/test/files/run/repl-paste-2.check
@@ -43,8 +43,8 @@ res1: Int = 690
 
 scala> val x = dingus
 <console>:11: error: not found: value dingus
-val x = dingus
-        ^
+       val x = dingus
+               ^
 
 scala> val x = "dingus"
 x: String = dingus

--- a/test/files/run/repl-reset.check
+++ b/test/files/run/repl-reset.check
@@ -29,22 +29,22 @@ Forgetting defined types: BippyBungus
 
 scala> x1 + x2 + x3
 <console>:12: error: not found: value x1
-x1 + x2 + x3
-^
+       x1 + x2 + x3
+       ^
 <console>:12: error: not found: value x2
-x1 + x2 + x3
-     ^
+       x1 + x2 + x3
+            ^
 <console>:12: error: not found: value x3
-x1 + x2 + x3
-          ^
+       x1 + x2 + x3
+                 ^
 
 scala> val x1 = 4
 x1: Int = 4
 
 scala> new BippyBungus
 <console>:12: error: not found: type BippyBungus
-new BippyBungus
-    ^
+       new BippyBungus
+           ^
 
 scala> class BippyBungus() { def f = 5 }
 defined class BippyBungus

--- a/test/files/run/t11402.check
+++ b/test/files/run/t11402.check
@@ -6,8 +6,8 @@ This can be achieved by adding the import clause 'import scala.language.postfixO
 or by setting the compiler option -language:postfixOps.
 See the Scaladoc for value scala.language.postfixOps for a discussion
 why the feature should be explicitly enabled.
-import scala.concurrent.duration._; val t = 1 second
-                                              ^
+       import scala.concurrent.duration._; val t = 1 second
+                                                     ^
 import scala.concurrent.duration._
 t: scala.concurrent.duration.FiniteDuration = 1 second
 

--- a/test/files/run/t12354.check
+++ b/test/files/run/t12354.check
@@ -1,14 +1,14 @@
 
 scala> case class C(implicit x: Int)
 <console>:11: warning: case classes should have a non-implicit parameter list; adapting to 'case class C()(...)'
-case class C(implicit x: Int)
-            ^
+       case class C(implicit x: Int)
+                   ^
 defined class C
 
 scala> for {x <- Nil; val y = 1} yield y
 <console>:12: warning: val keyword in for comprehension is deprecated
-for {x <- Nil; val y = 1} yield y
-                     ^
+       for {x <- Nil; val y = 1} yield y
+                            ^
 res0: List[Int] = List()
 
 scala> :quit

--- a/test/files/run/t12354.check
+++ b/test/files/run/t12354.check
@@ -1,0 +1,14 @@
+
+scala> case class C(implicit x: Int)
+<console>:11: warning: case classes should have a non-implicit parameter list; adapting to 'case class C()(...)'
+case class C(implicit x: Int)
+            ^
+defined class C
+
+scala> for {x <- Nil; val y = 1} yield y
+<console>:12: warning: val keyword in for comprehension is deprecated
+for {x <- Nil; val y = 1} yield y
+                     ^
+res0: List[Int] = List()
+
+scala> :quit

--- a/test/files/run/t12354.scala
+++ b/test/files/run/t12354.scala
@@ -1,0 +1,10 @@
+
+import scala.tools.nsc.Settings
+import scala.tools.partest.SessionTest
+
+object Test extends SessionTest {
+  override def transformSettings(ss: Settings) = {
+    ss.deprecation.value = true
+    ss
+  }
+}

--- a/test/files/run/t1931.check
+++ b/test/files/run/t1931.check
@@ -10,8 +10,8 @@ import Predef.{any2stringadd=>_, _}
 
 scala> x + " works"
 <console>:14: error: value + is not a member of Any
-x + " works"
-  ^
+       x + " works"
+         ^
 
 scala> import Predef._
 import Predef._
@@ -27,8 +27,8 @@ import Predef._
 
 scala> f
 <console>:14: error: not found: value f
-f
-^
+       f
+       ^
 
 scala> Predef.f
 res4: Int = 42

--- a/test/files/run/t4542.check
+++ b/test/files/run/t4542.check
@@ -6,8 +6,8 @@ defined class Foo
 
 scala> val f = new Foo
 <console>:12: warning: class Foo is deprecated (since ReplTest version 1.0-FINAL): foooo
-val f = new Foo
-            ^
+       val f = new Foo
+                   ^
 f: Foo = Bippy
 
 scala> :quit

--- a/test/files/run/t4594-repl-settings.check
+++ b/test/files/run/t4594-repl-settings.check
@@ -10,8 +10,8 @@ scala> :settings -deprecation
 
 scala> def b = depp
 <console>:12: warning: method depp is deprecated (since Time began.): Please don't do that.
-def b = depp
-        ^
+       def b = depp
+               ^
 b: String
 
 scala> :quit

--- a/test/files/run/t5655.check
+++ b/test/files/run/t5655.check
@@ -10,15 +10,15 @@ scala> x
 it is imported twice in the same scope by
 import x._
 and import x
-x
-^
+       x
+       ^
 
 scala> x
 <console>:16: error: reference to x is ambiguous;
 it is imported twice in the same scope by
 import x._
 and import x
-x
-^
+       x
+       ^
 
 scala> :quit

--- a/test/files/run/t7319.check
+++ b/test/files/run/t7319.check
@@ -20,20 +20,20 @@ scala> convert(Some[Int](0))
 argument expression's type is not compatible with formal parameter type;
  found   : Some[Int]
  required: ?F[_$1] forSome { type _$1 <: ?F[_$2] forSome { type _$2 } }
-convert(Some[Int](0))
-^
+       convert(Some[Int](0))
+       ^
 <console>:15: error: type mismatch;
  found   : Some[Int]
  required: F[_ <: F[_]]
-convert(Some[Int](0))
-                 ^
+       convert(Some[Int](0))
+                        ^
 
 scala> Range(1,2).toArray: Seq[_]
 <console>:14: error: polymorphic expression cannot be instantiated to expected type;
  found   : [B >: Int]Array[B]
  required: Seq[_]
-Range(1,2).toArray: Seq[_]
-           ^
+       Range(1,2).toArray: Seq[_]
+                  ^
 
 scala> 0
 res2: Int = 0

--- a/test/files/run/t7747-repl.check
+++ b/test/files/run/t7747-repl.check
@@ -16,14 +16,14 @@ z: Int = 156
 
 scala> 2 ; 3
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-2 ;;
-^
+       2 ;;
+       ^
 res0: Int = 3
 
 scala> { 2 ; 3 }
 <console>:12: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
-{ 2 ; 3 }
-  ^
+       { 2 ; 3 }
+         ^
 res1: Int = 3
 
 scala> 5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
@@ -31,17 +31,17 @@ scala> 5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Mooo
   2 +
   3 } ; bippy+88+11
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
-^
+       5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+       ^
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
-    ^
+       5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+           ^
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
-                           ^
+       5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+                                  ^
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
-                                                                                  ^
+       5 ; 10 ; case object Cow ; 20 ; class Moo { override def toString = "Moooooo" } ; 30 ; def bippy = {
+                                                                                         ^
 defined object Cow
 defined class Moo
 bippy: Int
@@ -82,11 +82,11 @@ res10: Int = 4
 
 scala> 5 ;   (  (2 + 2 )  ) ; ((5))
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-5 ;   (  (2 + 2 )  ) ;;
-^
+       5 ;   (  (2 + 2 )  ) ;;
+       ^
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-5 ;   (  (2 + 2 )  ) ;;
-            ^
+       5 ;   (  (2 + 2 )  ) ;;
+                   ^
 res11: Int = 5
 
 scala> (((2 + 2)), ((2 + 2)))
@@ -102,17 +102,17 @@ scala>
 
 scala> 55 ; ((2 + 2)) ; (1, 2, 3)
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-55 ; ((2 + 2)) ;;
-^
+       55 ; ((2 + 2)) ;;
+       ^
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-55 ; ((2 + 2)) ;;
-         ^
+       55 ; ((2 + 2)) ;;
+                ^
 res15: (Int, Int, Int) = (1,2,3)
 
 scala> 55 ; (x: Int) => x + 1 ; () => ((5))
 <console>:12: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-55 ; (x: Int) => x + 1 ;;
-^
+       55 ; (x: Int) => x + 1 ;;
+       ^
 res16: () => Int = <function>
 
 scala> 
@@ -122,8 +122,8 @@ res17: () => Int = <function>
 
 scala> 55 ; () => 5
 <console>:11: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-55 ;;
-^
+       55 ;;
+       ^
 res18: () => Int = <function>
 
 scala> () => { class X ; new X }
@@ -210,22 +210,22 @@ Forgetting defined types: BippyBungus, Moo, Ruminant
 
 scala> x1 + x2 + x3
 <console>:12: error: not found: value x1
-x1 + x2 + x3
-^
+       x1 + x2 + x3
+       ^
 <console>:12: error: not found: value x2
-x1 + x2 + x3
-     ^
+       x1 + x2 + x3
+            ^
 <console>:12: error: not found: value x3
-x1 + x2 + x3
-          ^
+       x1 + x2 + x3
+                 ^
 
 scala> val x1 = 4
 x1: Int = 4
 
 scala> new BippyBungus
 <console>:12: error: not found: type BippyBungus
-new BippyBungus
-    ^
+       new BippyBungus
+           ^
 
 scala> class BippyBungus() { def f = 5 }
 defined class BippyBungus

--- a/test/files/run/t8918-unary-ids.check
+++ b/test/files/run/t8918-unary-ids.check
@@ -10,13 +10,13 @@ res0: Int = -42
 
 scala> - if (true) 1 else 2
 <console>:1: error: illegal start of simple expression
-- if (true) 1 else 2
-  ^
+       - if (true) 1 else 2
+         ^
 
 scala> - - 1
 <console>:1: error: ';' expected but integer literal found.
-- - 1
-    ^
+       - - 1
+           ^
 
 scala> -.-(1)
 res1: Int = 41

--- a/test/files/run/t9170.check
+++ b/test/files/run/t9170.check
@@ -4,16 +4,16 @@ scala> object Y { def f[A](a: => A) = 1 ; def f[A](a: => Either[Exception, A]) =
 def f[A](a: => A): Int at line 11 and
 def f[A](a: => Either[Exception,A]): Int at line 11
 have same type after erasure: (a: Function0)Int
-object Y { def f[A](a: => A) = 1 ; def f[A](a: => Either[Exception, A]) = 2 }
-                                       ^
+       object Y { def f[A](a: => A) = 1 ; def f[A](a: => Either[Exception, A]) = 2 }
+                                              ^
 
 scala> object Y { def f[A](a: => A) = 1 ; def f[A](a: => Either[Exception, A]) = 2 }
 <console>:11: error: double definition:
 def f[A](a: => A): Int at line 11 and
 def f[A](a: => Either[Exception,A]): Int at line 11
 have same type after erasure: (a: Function0)Int
-object Y { def f[A](a: => A) = 1 ; def f[A](a: => Either[Exception, A]) = 2 }
-                                       ^
+       object Y { def f[A](a: => A) = 1 ; def f[A](a: => Either[Exception, A]) = 2 }
+                                              ^
 
 scala> object Y {
      |   def f[A](a: =>  A) = 1
@@ -23,8 +23,8 @@ scala> object Y {
 def f[A](a: => A): Int at line 12 and
 def f[A](a: => Either[Exception,A]): Int at line 13
 have same type after erasure: (a: Function0)Int
-  def f[A](a: => Either[Exception, A]) = 2
-      ^
+         def f[A](a: => Either[Exception, A]) = 2
+             ^
 
 scala> :pa
 // Entering paste mode (ctrl-D to finish)

--- a/test/files/run/t9206.check
+++ b/test/files/run/t9206.check
@@ -3,14 +3,14 @@ scala> val i: Int = "foo"
 <console>:11: error: type mismatch;
  found   : String("foo")
  required: Int
-val i: Int = "foo"
-             ^
+       val i: Int = "foo"
+                    ^
 
 scala> { val j = 42 ; val i: Int = "foo" + j }
 <console>:12: error: type mismatch;
  found   : String
  required: Int
-{ val j = 42 ; val i: Int = "foo" + j }
-                                  ^
+       { val j = 42 ; val i: Int = "foo" + j }
+                                         ^
 
 scala> :quit

--- a/test/files/run/xMigration.check
+++ b/test/files/run/xMigration.check
@@ -12,8 +12,8 @@ scala> :setting -Xmigration:any
 scala> Map(1 -> "eis").values    // warn
 <console>:12: warning: method values in trait MapLike has changed semantics in version 2.8.0:
 `values` returns `Iterable[V]` rather than `Iterator[V]`.
-Map(1 -> "eis").values    // warn
-                ^
+       Map(1 -> "eis").values    // warn
+                       ^
 res2: Iterable[String] = MapLike.DefaultValuesIterable(eis)
 
 scala> :setting -Xmigration:2.8
@@ -26,8 +26,8 @@ scala> :setting -Xmigration:2.7
 scala> Map(1 -> "eis").values    // warn
 <console>:12: warning: method values in trait MapLike has changed semantics in version 2.8.0:
 `values` returns `Iterable[V]` rather than `Iterator[V]`.
-Map(1 -> "eis").values    // warn
-                ^
+       Map(1 -> "eis").values    // warn
+                       ^
 res4: Iterable[String] = MapLike.DefaultValuesIterable(eis)
 
 scala> :setting -Xmigration:2.11
@@ -40,8 +40,8 @@ scala> :setting -Xmigration      // same as :any
 scala> Map(1 -> "eis").values    // warn
 <console>:12: warning: method values in trait MapLike has changed semantics in version 2.8.0:
 `values` returns `Iterable[V]` rather than `Iterator[V]`.
-Map(1 -> "eis").values    // warn
-                ^
+       Map(1 -> "eis").values    // warn
+                       ^
 res6: Iterable[String] = MapLike.DefaultValuesIterable(eis)
 
 scala> :quit


### PR DESCRIPTION
Silence warnings until compiling code template.

Insert spaces in messages so quoted text aligns with the prompt line. (2.13 doesn't repeat the source text.)

Fixes scala/bug#12354