### PR TITLE
[nomerge] Reuse `tasksupport` in CombinerFactory

### DIFF
--- a/src/library/scala/collection/parallel/ParIterableLike.scala
+++ b/src/library/scala/collection/parallel/ParIterableLike.scala
@@ -574,7 +574,11 @@ self: ParIterableLike[T, Repr, Sequential] =>
       def apply() = shared
       def doesShareCombiners = true
     } else new CombinerFactory[T, Repr] {
-      def apply() = newCombiner
+      def apply() = {
+        val r = newCombiner
+        r.combinerTaskSupport = tasksupport
+        r
+      }
       def doesShareCombiners = false
     }
   }
@@ -587,7 +591,11 @@ self: ParIterableLike[T, Repr, Sequential] =>
       def apply() = shared
       def doesShareCombiners = true
     } else new CombinerFactory[S, That] {
-      def apply() = cbf()
+      def apply() = {
+        val r = cbf()
+        r.combinerTaskSupport = tasksupport
+        r
+      }
       def doesShareCombiners = false
     }
   }

--- a/test/junit/scala/collection/parallel/TaskTest.scala
+++ b/test/junit/scala/collection/parallel/TaskTest.scala
@@ -27,4 +27,13 @@ class TaskTest {
 
     for (x <- one ; y <- two) assert(Thread.currentThread.getName == "two")
   }
+
+  @Test // https://github.com/scala/scala-parallel-collections/issues/152
+  def `propagate tasksupport through CombinerFactory`(): Unit = {
+    val myTs = new ExecutionContextTaskSupport()
+    val c = List(1).par
+    c.tasksupport = myTs
+    val r = c.filter(_ != 0).map(_ + 1)
+    assert(myTs eq r.tasksupport)
+  }
 }


### PR DESCRIPTION
Reported in https://github.com/scala/scala-parallel-collections/issues/152.

2.13+ version at https://github.com/scala/scala-parallel-collections/pull/161