### PR TITLE
[backport] Follow JDK 11+ spec for signature polymorphic methods

### DIFF
--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -400,13 +400,17 @@ The final result of the transformation is a block of the form
 For invocations of signature polymorphic methods of the target platform `$f$($e_1 , \ldots , e_m$)`,
 the invoked method has a different method type `($p_1$:$T_1 , \ldots , p_n$:$T_n$)$U$` at each call
 site. The parameter types `$T_ , \ldots , T_n$` are the types of the argument expressions
-`$e_1 , \ldots , e_m$` and `$U$` is the expected type at the call site. If the expected type is
+`$e_1 , \ldots , e_m$`. If the declared return type `$R$` of the signature polymorphic method is
+any type other than `scala.AnyRef`, then the return type `$U$` is `$R$`.
+Otherwise, `$U$` is the expected type at the call site. If the expected type is
 undefined then `$U$` is `scala.AnyRef`. The parameter names `$p_1 , \ldots , p_n$` are fresh.
 
 ###### Note
 
-On the Java platform version 7 and later, the methods `invoke` and `invokeExact` in class
-`java.lang.invoke.MethodHandle` are signature polymorphic.
+On the Java platform version 11 and later, signature polymorphic methods are native,
+members of `java.lang.invoke.MethodHandle` or `java.lang.invoke.VarHandle`, and have a single
+repeated parameter of type `java.lang.Object*`.
+
 
 ## Method Values
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/BytecodeUtils.scala
@@ -125,6 +125,8 @@ object BytecodeUtils {
 
   def isNativeMethod(methodNode: MethodNode): Boolean = (methodNode.access & ACC_NATIVE) != 0
 
+  def isVarargsMethod(methodNode: MethodNode): Boolean = (methodNode.access & ACC_VARARGS) != 0
+
   // cross-jdk
   def hasCallerSensitiveAnnotation(methodNode: MethodNode): Boolean =
     methodNode.visibleAnnotations != null &&

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3526,7 +3526,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
         case _ if currentRun.runDefinitions.isPolymorphicSignature(fun.symbol) =>
           // Mimic's Java's treatment of polymorphic signatures as described in
-          // https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.12.3
+          // https://docs.oracle.com/javase/specs/jls/se11/html/jls-15.html#jls-15.12.3
           //
           // One can think of these methods as being infinitely overloaded. We create
           // a fictitious new cloned method symbol for each call site that takes on a signature
@@ -3534,7 +3534,10 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           val args1 = typedArgs(args, forArgMode(fun, mode))
           val clone = fun.symbol.cloneSymbol.withoutAnnotations
           val cloneParams = args1.map(arg => clone.newValueParameter(freshTermName()).setInfo(arg.tpe.deconst))
-          val resultType = if (isFullyDefined(pt)) pt else ObjectTpe
+          val resultType =
+            if (fun.symbol.tpe.resultType.typeSymbol != ObjectClass) fun.symbol.tpe.resultType
+            else if (isFullyDefined(pt)) pt
+            else ObjectTpe
           clone.modifyInfo(mt => copyMethodType(mt, cloneParams, resultType))
           val fun1 = fun.setSymbol(clone).setType(clone.info)
           doTypedApply(tree, fun1, args1, mode, resultType).setType(resultType)


### PR DESCRIPTION
No test case because JDK 11...

Backport of https://github.com/scala/scala/pull/9530