### PR TITLE
Make restarr <-> reload switching faster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,10 @@
 local.sbt
 jitwatch.out
 
+# Used by the restarr/restarrFull commands as target directories
+/build-restarr/
+/target-restarr/
+
 # metals
 .metals
 .bloop

--- a/README.md
+++ b/README.md
@@ -152,8 +152,12 @@ distribution to your local artifact repository and then switch sbt to
 use that version as its new `scalaVersion`.  You may then revert back
 with `reload`.  Note `restarrFull` will also write the STARR version
 to `buildcharacter.properties` so you can switch back to it with
-`restarr` without republishing (though incremental compilation will
-recompile from scratch, sadly.)
+`restarr` without republishing.  This will switch the sbt session to
+use the `build-restarr` and `target-restarr` directories instead of
+`build` and `target`, which avoids wiping out classfiles and
+incremental metadata.  IntelliJ will continue to be configured to
+compile and run tests using the starr version in
+`versions.properties`.
 
 For history on how the current scheme was arrived at, see
 https://groups.google.com/d/topic/scala-internals/gp5JsM1E0Fo/discussion.

--- a/build.sbt
+++ b/build.sbt
@@ -141,7 +141,7 @@ lazy val commonSettings = instanceSettings ++ clearSourceAndResourceDirectories 
   Global / excludeLintKeys ++= Set(scalaSource),
   // each subproject has to ask specifically for files they want to include
   Compile / unmanagedResources / includeFilter := NothingFilter,
-  target := (ThisBuild / baseDirectory).value / "target" / thisProject.value.id,
+  target := (ThisBuild / target).value / thisProject.value.id,
   Compile / classDirectory := buildDirectory.value / "quick/classes" / thisProject.value.id,
   Compile / doc / target := buildDirectory.value / "scaladoc" / thisProject.value.id,
   // given that classDirectory and doc target are overridden to be _outside_ of target directory, we have
@@ -1091,7 +1091,7 @@ lazy val dist = (project in file("dist"))
       (ThisBuild / buildDirectory).value / "quick"
     }.dependsOn((distDependencies.map(_ / Runtime / products) :+ mkBin): _*).value,
     mkPack := Def.task { (ThisBuild / buildDirectory).value / "pack" }.dependsOn(Compile / packageBin / packagedArtifact, mkBin).value,
-    target := (ThisBuild / baseDirectory).value / "target" / thisProject.value.id,
+    target := (ThisBuild / target).value / thisProject.value.id,
     Compile / packageBin := {
       val targetDir = (ThisBuild / buildDirectory).value / "pack" / "lib"
       val jlineJAR = findJar((Compile / dependencyClasspath).value, jlineDep).get.data
@@ -1130,7 +1130,6 @@ def configureAsSubproject(project: Project, srcdir: Option[String] = None): Proj
     .settings(generatePropertiesFileSettings)
 }
 
-lazy val buildDirectory = settingKey[File]("The directory where all build products go. By default ./build")
 lazy val mkBin = taskKey[Seq[File]]("Generate shell script (bash or Windows batch).")
 lazy val mkQuick = taskKey[File]("Generate a full build, including scripts, in build/quick")
 lazy val mkPack = taskKey[File]("Generate a full build, including scripts, in build/pack")
@@ -1197,8 +1196,6 @@ def generateServiceProviderResources(services: (String, String)*): Setting[_] =
       f
     }
   }.taskValue
-
-ThisBuild / buildDirectory := (ThisBuild / baseDirectory).value / "build"
 
 // Add tab completion to partest
 commands += Command("partest")(_ => PartestUtil.partestParser((ThisBuild / baseDirectory).value, (ThisBuild / baseDirectory).value / "test")) { (state, parsed) =>

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -1,11 +1,20 @@
 package scala.build
 
-import sbt._
+import sbt._, Keys._
 
 /** This object defines keys that should be visible with an unqualified name in all .sbt files and the command line */
 object BuildSettings extends AutoPlugin {
+  override def trigger = allRequirements
+
   object autoImport {
     lazy val baseVersion = settingKey[String]("The base version number from which all others are derived")
     lazy val baseVersionSuffix = settingKey[String]("Identifies the kind of version to build")
+    lazy val buildDirectory = settingKey[File]("The directory where all build products go. By default ./build")
   }
+  import autoImport._
+
+  override def buildSettings = Def.settings(
+    ThisBuild / target         := (ThisBuild / baseDirectory).value / "target",
+    ThisBuild / buildDirectory := (ThisBuild / baseDirectory).value / "build",
+  )
 }

--- a/project/ScriptCommands.scala
+++ b/project/ScriptCommands.scala
@@ -4,6 +4,7 @@ import java.nio.file.Paths
 
 import sbt._
 import Keys._
+import sbt.complete.Parser._
 import sbt.complete.Parsers._
 
 import BuildSettings.autoImport._
@@ -115,12 +116,17 @@ object ScriptCommands {
 
   /** For local dev: sets `scalaVersion` to the version in `/buildcharacter.properties` or the given arg.
    * Running `reload` will re-read the build files, resetting `scalaVersion`. */
-  def restarr = Command("restarr")(_ => (Space ~> StringBasic).?) { (state, s) =>
-    val newVersion = s.getOrElse(readVersionFromPropsFile(state))
-    val x = Project.extract(state)
-    val sv = x.get(Global / scalaVersion)
-    state.log.info(s"Re-STARR'ing: setting scalaVersion from $sv to $newVersion (`reload` to undo)")
-    x.appendWithSession(Global / scalaVersion := newVersion, state) // don't use version.value or it'll be a wrong, new value
+  def restarr = Command("restarr")(_ => (Space ~> token(StringBasic, "scalaVersion")).?) { (state, argSv) =>
+    val x     = Project.extract(state)
+    val oldSv = x.get(Global / scalaVersion)
+    val newSv = argSv.getOrElse(readVersionFromPropsFile(state))
+    state.log.info(s"Re-STARR'ing: setting scalaVersion from $oldSv to $newSv (`reload` to undo; IntelliJ still uses $oldSv)")
+    val settings = Def.settings(
+      Global    / scalaVersion   := newSv, // don't use version.value or it'll be a wrong, new value
+      ThisBuild / target         := (ThisBuild / baseDirectory).value / "target-restarr",
+      ThisBuild / buildDirectory := (ThisBuild / baseDirectory).value /  "build-restarr",
+    )
+    x.appendWithSession(settings, state)
   }
 
   /** For local dev: publishes locally (without optimizing) & then sets the new `scalaVersion`.
@@ -134,7 +140,10 @@ object ScriptCommands {
   }
 
   private def readVersionFromPropsFile(state: State): String = {
-    val props = readProps(file("buildcharacter.properties"))
+    val propsFile = file("buildcharacter.properties")
+    if (!propsFile.exists())
+      throw new MessageOnlyException("No buildcharacter.properties found - try restarrFull")
+    val props = readProps(propsFile)
     val newVersion = props("maven.version.number")
     val fullVersion = props("version.number")
     state.log.info(s"Read STARR version from buildcharacter.properties: $newVersion (full version: $fullVersion)")


### PR DESCRIPTION
Define the `ThisBuild / target` key and rewire the build to it so the
`restarr` command can redefine it and `ThisBuild / buildDirectory`, which
is also used.  This allows switching between both versions much, much
faster.

When you make any source change you'll need to do the more time-consuming
`restarrFull` but the point is that switching back to the previous starr
(via `reload`) will be fast because the build products haven't been wiped
out in the process.

There's a small amount of projects that use "target" as their project base,
which is a harder value to change (requires a `reload` during
`restarr` which wipes out the session settings, so not 100% clear how to 
even do it).  Looking at them I think it might be fine and a small smoke 
test seems to show it is fine.