### PR TITLE
Fix regression in ZipArchive

### DIFF
--- a/src/reflect/scala/reflect/io/ZipArchive.scala
+++ b/src/reflect/scala/reflect/io/ZipArchive.scala
@@ -139,7 +139,7 @@ abstract class ZipArchive(override val file: JFile, release: Option[String]) ext
     ensureDir(name)
   }
 
-  @volatile private[this] var lastDirName: String = ""
+  @volatile private[this] var lastDirName: String = RootEntry
   private def dirNameUsingLast(name: String): String = {
     val last = lastDirName
     if (name.length > last.length + 1 && name.startsWith(last) && name.charAt(last.length) == '/' && name.indexOf('/', last.length + 1) == -1) {

--- a/test/junit/scala/reflect/io/ZipArchiveTest.scala
+++ b/test/junit/scala/reflect/io/ZipArchiveTest.scala
@@ -29,6 +29,21 @@ class ZipArchiveTest {
   }
 
   @Test
+  def weirdFileAtRoot(): Unit = {
+    val f = Files.createTempFile("test", ".jar").tap {f =>
+      Using.resource(new JarOutputStream(Files.newOutputStream(f))) { jout =>
+        jout.putNextEntry(new JarEntry("/.hey.txt"))
+        val bytes = "hello, world".getBytes
+        jout.write(bytes, 0, bytes.length)
+        ()
+      }
+    }
+    Using.resources(ForDeletion(f), new FileZipArchive(f.toFile)){ (_, fza) =>
+      assertEquals(Seq(".hey.txt"), fza.iterator.toSeq.map(_.name))
+    }
+  }
+
+  @Test
   def missingFile(): Unit = {
     val f = Paths.get("xxx.does.not.exist")
     val fza = new FileZipArchive(f.toFile)


### PR DESCRIPTION
When I tried to upgrade from Scala 2.13.2 to Scala 2.13.3-5 I started to get strange compiler error.
After some debug I figured that some of our dependency jars in the root have files which names start with `/`.
So I added a simple unit test that on `2.13.x` fails with
```
java.lang.StringIndexOutOfBoundsException: String index out of range: -1

	at java.lang.String.charAt(String.java:658)
	at scala.reflect.io.ZipArchive$.splitPath(ZipArchive.scala:61)
	at scala.reflect.io.ZipArchive$.scala$reflect$io$ZipArchive$$dirName(ZipArchive.scala:58)
	at scala.reflect.io.ZipArchive.ensureDir$1(ZipArchive.scala:131)
	at scala.reflect.io.ZipArchive.getDir(ZipArchive.scala:139)
	at scala.reflect.io.FileZipArchive.root$lzycompute(ZipArchive.scala:219)
	at scala.reflect.io.FileZipArchive.root(ZipArchive.scala:204)
	at scala.reflect.io.FileZipArchive.iterator(ZipArchive.scala:242)
	at scala.reflect.io.ZipArchiveTest.$anonfun$weirdFileAtRoot$4(ZipArchiveTest.scala:42)
	at scala.reflect.io.ZipArchiveTest.$anonfun$weirdFileAtRoot$4$adapted(ZipArchiveTest.scala:41)
	at scala.util.Using$.$anonfun$resources$2(Using.scala:298)
	at scala.util.Using$.resource(Using.scala:261)
	at scala.util.Using$.$anonfun$resources$1(Using.scala:297)
	at scala.util.Using$.resource(Using.scala:261)
	at scala.util.Using$.resources(Using.scala:296)
	at scala.reflect.io.ZipArchiveTest.weirdFileAtRoot(ZipArchiveTest.scala:41)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
```
Which is exactly the error I get on 2.13.3+

Looks like this was introduced in https://github.com/scala/scala/commit/706858959e9f95a9cd03b92670658871a54d28d4#diff-3bf883c780984a2c8f1eda1e70bb6359c4696519142992a4ee7eedf7b6887000

I didn't find a bug like this reported, but maybe it exists.