### PR TITLE
REPL: Wrap annotated expressions in a "resN" result val

### DIFF
--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -794,12 +794,16 @@ class IMain(val settings: Settings, parentClassLoaderOverride: Option[ClassLoade
     }
 
     // Wrap last tree in a valdef to give user a nice handle for it (`resN`)
-    val trees: List[Tree] =
-      origTrees.init :+ (origTrees.last match {
-        case tree@(_: Assign) => tree
-        case tree@(_: RefTree | _: TermTree) => storeInVal(tree)
-        case tree => tree
-      })
+    val trees: List[Tree] = origTrees.init :+ {
+      val tree = origTrees.last
+      @tailrec def loop(scrut: Tree): Tree = scrut match {
+        case _: Assign                => tree
+        case _: RefTree | _: TermTree => storeInVal(tree)
+        case Annotated(_, arg)        => loop(arg)
+        case _                        => tree
+      }
+      loop(tree)
+    }
 
     /** handlers for each tree in this request */
     val handlers: List[MemberHandler] = trees map (memberHandlers chooseHandler _)

--- a/test/files/run/t12292.check
+++ b/test/files/run/t12292.check
@@ -1,0 +1,30 @@
+
+scala> import scala.annotation.nowarn
+import scala.annotation.nowarn
+
+scala> scala.#::.unapply(Stream(1))
+                 ^
+       warning: method unapply in object #:: is deprecated (since 2.13.0): Prefer LazyList instead
+                         ^
+       warning: value Stream in package scala is deprecated (since 2.13.0): Use LazyList instead of Stream
+val res0: Option[(Int, Stream[Int])] = Some((1,Stream()))
+
+scala> scala.#::.unapply(Stream(1)): @nowarn
+val res1: Option[(Int, Stream[Int])] @scala.annotation.nowarn = Some((1,Stream()))
+
+scala> (scala.#::.unapply(Stream(1)): @nowarn)
+val res2: Option[(Int, Stream[Int])] @scala.annotation.nowarn = Some((1,Stream()))
+
+scala> scala.#::.unapply(Stream(1)): @inline
+                 ^
+       warning: method unapply in object #:: is deprecated (since 2.13.0): Prefer LazyList instead
+                         ^
+       warning: value Stream in package scala is deprecated (since 2.13.0): Use LazyList instead of Stream
+                                      ^
+       warning: type Stream in package scala is deprecated (since 2.13.0): Use LazyList instead of Stream
+val res3: Option[(Int, Stream[Int])] @inline = Some((1,Stream()))
+
+scala> (scala.#::.unapply(Stream(1)): @nowarn).isEmpty
+val res4: Boolean = false
+
+scala> :quit

--- a/test/files/run/t12292.scala
+++ b/test/files/run/t12292.scala
@@ -1,0 +1,14 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  override def extraSettings = "-deprecation"
+
+  def code = """
+import scala.annotation.nowarn
+scala.#::.unapply(Stream(1))
+scala.#::.unapply(Stream(1)): @nowarn
+(scala.#::.unapply(Stream(1)): @nowarn)
+scala.#::.unapply(Stream(1)): @inline
+(scala.#::.unapply(Stream(1)): @nowarn).isEmpty
+"""
+}


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/12292