### PR TITLE
[backport] Another correct seeding of root entry

### DIFF
--- a/src/reflect/scala/reflect/io/ZipArchive.scala
+++ b/src/reflect/scala/reflect/io/ZipArchive.scala
@@ -124,7 +124,7 @@ abstract class ZipArchive(override val file: JFile, release: Option[String]) ext
     }
   }
 
-  @volatile private[this] var lastDirName: String = ""
+  @volatile private[this] var lastDirName: String = RootEntry
   private def dirNameUsingLast(name: String): String = {
     val last = lastDirName
     if (name.length > last.length + 1 && name.startsWith(last) && name.charAt(last.length) == '/' && name.indexOf('/', last.length + 1) == -1) {


### PR DESCRIPTION
backport https://github.com/scala/scala/pull/9535 while it's fresh