### PR TITLE
check private[this] members in override checking

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/OverridingPairs.scala
+++ b/src/compiler/scala/tools/nsc/transform/OverridingPairs.scala
@@ -37,7 +37,7 @@ abstract class OverridingPairs extends SymbolPairs {
      *  including bridges. But it may be refined in subclasses.
      */
     override protected def exclude(sym: Symbol) = (
-         sym.isPrivateLocal
+        (sym.isPrivateLocal && sym.isParamAccessor)
       || sym.isArtifact
       || sym.isConstructor
       || (sym.isPrivate && sym.owner != base) // Privates aren't inherited. Needed for pos/t7475a.scala

--- a/src/partest/scala/tools/partest/ScaladocModelTest.scala
+++ b/src/partest/scala/tools/partest/ScaladocModelTest.scala
@@ -85,15 +85,15 @@ abstract class ScaladocModelTest extends DirectTest {
     System.setErr(prevErr)
   }
 
-  private[this] var settings: doc.Settings = null
+  private[this] var docSettings: doc.Settings = null
 
   // create a new scaladoc compiler
   def newDocFactory: DocFactory = {
-    settings = new doc.Settings(_ => ())
-    settings.scaladocQuietRun = true // yaay, no more "model contains X documentable templates"!
+    docSettings = new doc.Settings(_ => ())
+    docSettings.scaladocQuietRun = true // yaay, no more "model contains X documentable templates"!
     val args = extraSettings + " " + scaladocSettings
-    new ScalaDoc.Command((CommandLineParser tokenize (args)), settings) // side-effecting, I think
-    val docFact = new DocFactory(new ConsoleReporter(settings), settings)
+    new ScalaDoc.Command((CommandLineParser tokenize (args)), docSettings) // side-effecting, I think
+    val docFact = new DocFactory(new ConsoleReporter(docSettings), docSettings)
     docFact
   }
 

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -3508,7 +3508,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
    */
   class ModuleClassSymbol protected[Symbols] (owner: Symbol, pos: Position, name: TypeName)
   extends ClassSymbol(owner, pos, name) {
-    private[this] var module: Symbol        = _
+    private[this] var moduleSymbol: Symbol  = _
     private[this] var typeOfThisCache: Type = _
     private[this] var typeOfThisPeriod      = NoPeriod
 
@@ -3541,8 +3541,8 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       implicitMembersCacheValue
     }
     // The null check seems to be necessary for the reifier.
-    override def sourceModule = if (module ne null) module else companionModule
-    override def sourceModule_=(module: Symbol): Unit = { this.module = module }
+    override def sourceModule = if (moduleSymbol ne null) moduleSymbol else companionModule
+    override def sourceModule_=(module: Symbol): Unit = { this.moduleSymbol = module }
   }
 
   class PackageObjectClassSymbol protected[Symbols] (owner0: Symbol, pos0: Position)

--- a/test/files/neg/t12349.check
+++ b/test/files/neg/t12349.check
@@ -33,6 +33,11 @@ def a8(): Unit (defined in class t12349a)
   override should be public
     protected[this]    override def a8(): Unit = println("Inner12349b#a8()") // weaker access privileges
                                     ^
+t12349b.scala:14: error: weaker access privileges in overriding
+def a9(): Unit (defined in class t12349a)
+  override should not be private
+      private[this]    override def a9(): Unit = println("Inner12349b#a9()") // weaker access privileges
+                                    ^
 t12349b.scala:18: error: weaker access privileges in overriding
 protected[package t12349] def b3(): Unit (defined in class t12349a)
   override should not be private
@@ -47,6 +52,11 @@ t12349b.scala:22: error: weaker access privileges in overriding
 protected[package t12349] def b7(): Unit (defined in class t12349a)
   override should at least be protected[t12349]
       private[t12349]  override def b7(): Unit = println("Inner12349b#b7()") // weaker access privileges
+                                    ^
+t12349b.scala:24: error: weaker access privileges in overriding
+protected[package t12349] def b9(): Unit (defined in class t12349a)
+  override should not be private
+      private[this]    override def b9(): Unit = println("Inner12349b#b9()") // weaker access privileges
                                     ^
 t12349b.scala:27: error: weaker access privileges in overriding
 private[package t12349] def c2(): Unit (defined in class t12349a)
@@ -72,6 +82,11 @@ t12349b.scala:33: error: weaker access privileges in overriding
 private[package t12349] def c8(): Unit (defined in class t12349a)
   override should at least be private[t12349]
     protected[this]    override def c8(): Unit = println("Inner12349b#c8()") // weaker access privileges
+                                    ^
+t12349b.scala:34: error: weaker access privileges in overriding
+private[package t12349] def c9(): Unit (defined in class t12349a)
+  override should not be private
+      private[this]    override def c9(): Unit = println("Inner12349b#c9()") // weaker access privileges
                                     ^
 t12349b.scala:36: error: method d1 overrides nothing
                        override def d1(): Unit = println("Inner12349b#d1()") // overrides nothing
@@ -135,6 +150,11 @@ def a8(): Unit (defined in class t12349a)
   override should be public
       protected[this]    override def a8(): Unit = println("Inner12349c#a8()") // weaker access privileges
                                       ^
+t12349c.scala:18: error: weaker access privileges in overriding
+def a9(): Unit (defined in class t12349a)
+  override should not be private
+        private[this]    override def a9(): Unit = println("Inner12349c#a9()") // weaker access privileges
+                                      ^
 t12349c.scala:22: error: weaker access privileges in overriding
 protected[package t12349] def b3(): Unit (defined in class t12349a)
   override should not be private
@@ -149,6 +169,11 @@ t12349c.scala:26: error: weaker access privileges in overriding
 protected[package t12349] def b7(): Unit (defined in class t12349a)
   override should at least be protected[t12349]
         private[pkg]     override def b7(): Unit = println("Inner12349c#b7()") // weaker access privileges
+                                      ^
+t12349c.scala:28: error: weaker access privileges in overriding
+protected[package t12349] def b9(): Unit (defined in class t12349a)
+  override should not be private
+        private[this]    override def b9(): Unit = println("Inner12349c#b9()") // weaker access privileges
                                       ^
 t12349c.scala:31: error: weaker access privileges in overriding
 private[package t12349] def c2(): Unit (defined in class t12349a)
@@ -185,13 +210,13 @@ private[package t12349] def c8(): Unit (defined in class t12349a)
   override should at least be private[t12349]
       protected[this]    override def c8(): Unit = println("Inner12349c#c8()") // weaker access privileges
                                       ^
+t12349c.scala:38: error: weaker access privileges in overriding
+private[package t12349] def c9(): Unit (defined in class t12349a)
+  override should not be private
+        private[this]    override def c9(): Unit = println("Inner12349c#c9()") // overrides nothing (invisible)
+                                      ^
 t12349c.scala:30: error: method c1 overrides nothing
                          override def c1(): Unit = println("Inner12349c#c1()") // overrides nothing (invisible)
-                                      ^
-t12349c.scala:38: error: method c9 overrides nothing.
-Note: the super classes of class Inner12349c contain the following, non final members named c9:
-private[package t12349] def c9(): Unit
-        private[this]    override def c9(): Unit = println("Inner12349c#c9()") // overrides nothing (invisible)
                                       ^
 t12349c.scala:40: error: method d1 overrides nothing
                          override def d1(): Unit = println("Inner12349c#d1()") // overrides nothing
@@ -220,4 +245,4 @@ t12349c.scala:47: error: method d8 overrides nothing
 t12349c.scala:48: error: method d9 overrides nothing
         private[this]    override def d9(): Unit = println("Inner12349c#d9()") // overrides nothing
                                       ^
-52 errors
+57 errors

--- a/test/files/neg/t12349/t12349b.scala
+++ b/test/files/neg/t12349/t12349b.scala
@@ -11,7 +11,7 @@ object t12349b {
     protected[t12349]  override def a6(): Unit = println("Inner12349b#a6()") // weaker access privileges
       private[t12349]  override def a7(): Unit = println("Inner12349b#a7()") // weaker access privileges
     protected[this]    override def a8(): Unit = println("Inner12349b#a8()") // weaker access privileges
-      private[this]    override def a9(): Unit = println("Inner12349b#a9()") // [#9334]
+      private[this]    override def a9(): Unit = println("Inner12349b#a9()") // weaker access privileges
 
                        override def b1(): Unit = println("Inner12349b#b1()")
     protected          override def b2(): Unit = println("Inner12349b#b2()")
@@ -21,7 +21,7 @@ object t12349b {
     protected[t12349]  override def b6(): Unit = println("Inner12349b#b6()")
       private[t12349]  override def b7(): Unit = println("Inner12349b#b7()") // weaker access privileges
     protected[this]    override def b8(): Unit = println("Inner12349b#b8()") // [#12349] - not fixed by PR #9525
-      private[this]    override def b9(): Unit = println("Inner12349b#b9()") // [#9334]
+      private[this]    override def b9(): Unit = println("Inner12349b#b9()") // weaker access privileges
 
                        override def c1(): Unit = println("Inner12349b#c1()")
     protected          override def c2(): Unit = println("Inner12349b#c2()") // weaker access privileges
@@ -31,7 +31,7 @@ object t12349b {
     protected[t12349]  override def c6(): Unit = println("Inner12349b#c6()")
       private[t12349]  override def c7(): Unit = println("Inner12349b#c7()")
     protected[this]    override def c8(): Unit = println("Inner12349b#c8()") // weaker access privileges
-      private[this]    override def c9(): Unit = println("Inner12349b#c9()") // [#9334]
+      private[this]    override def c9(): Unit = println("Inner12349b#c9()") // weaker access privileges
 
                        override def d1(): Unit = println("Inner12349b#d1()") // overrides nothing
     protected          override def d2(): Unit = println("Inner12349b#d2()") // overrides nothing

--- a/test/files/neg/t12349/t12349c.scala
+++ b/test/files/neg/t12349/t12349c.scala
@@ -15,7 +15,7 @@ package pkg {
       protected[pkg]     override def a6(): Unit = println("Inner12349c#a6()") // weaker access privileges
         private[pkg]     override def a7(): Unit = println("Inner12349c#a7()") // weaker access privileges
       protected[this]    override def a8(): Unit = println("Inner12349c#a8()") // weaker access privileges
-        private[this]    override def a9(): Unit = println("Inner12349c#a9()") // [#9334]
+        private[this]    override def a9(): Unit = println("Inner12349c#a9()") // weaker access privileges
 
                          override def b1(): Unit = println("Inner12349c#b1()")
       protected          override def b2(): Unit = println("Inner12349c#b2()")
@@ -25,7 +25,7 @@ package pkg {
       protected[pkg]     override def b6(): Unit = println("Inner12349c#b6()")
         private[pkg]     override def b7(): Unit = println("Inner12349c#b7()") // weaker access privileges
       protected[this]    override def b8(): Unit = println("Inner12349c#b8()") // [#12349] - not fixed by PR #9525
-        private[this]    override def b9(): Unit = println("Inner12349c#b9()") // [#9334]
+        private[this]    override def b9(): Unit = println("Inner12349c#b9()") // weaker access privileges
 
                          override def c1(): Unit = println("Inner12349c#c1()") // overrides nothing (invisible)
       protected          override def c2(): Unit = println("Inner12349c#c2()") // weaker access privileges

--- a/test/files/neg/t4762.check
+++ b/test/files/neg/t4762.check
@@ -4,6 +4,10 @@ t4762.scala:17: warning: private[this] value x in class B shadows mutable x inhe
 t4762.scala:50: warning: private[this] value x in class Derived shadows mutable x inherited from class Base.  Changes to x will not be visible within class Derived - you may want to give them distinct names.
   class Derived( x : Int ) extends Base( x ) { override def toString = x.toString }
                                                                        ^
-error: No warnings can be incurred under -Werror.
+t4762.scala:13: error: weaker access privileges in overriding
+val y: Int (defined in class A)
+  override should not be private
+  private[this] def y: Int = 99
+                    ^
 2 warnings
 1 error

--- a/test/files/neg/t9334.check
+++ b/test/files/neg/t9334.check
@@ -1,0 +1,6 @@
+t9334.scala:5: error: weaker access privileges in overriding
+def aaa: Int (defined in class A)
+  override should not be private
+  private[this] def aaa: Int = 42
+                    ^
+1 error

--- a/test/files/neg/t9334.scala
+++ b/test/files/neg/t9334.scala
@@ -1,0 +1,6 @@
+class A {
+  def aaa: Int = 10
+}
+class B extends A {
+  private[this] def aaa: Int = 42
+}


### PR DESCRIPTION
Previously, `private[this]` members were not considered in override checking, so a subclass could have a `private[this]` member `x` while also inheriting a member `x`, which leads to an `IllegalAccessError` at runtime

```
scala> class C { def f = 1 }; object D extends C { private[this] def f = 2; def g = f }
class C
object D

scala> D.f
java.lang.IllegalAccessError: tried to access method D$.f()I from class $iw
```

With this PR, the `private[this]` "overrides" are rejected ("error: weaker access privileges in overriding")

Fixes https://github.com/scala/bug/issues/9334