### PR TITLE
Recognize calls to generic Array.apply with primitive arguments in CleanUp

### DIFF
--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1784,6 +1784,18 @@ trait Definitions extends api.StandardDefinitions {
       lazy val arrayClassMethod       = getMemberMethod(ScalaRunTimeModule, nme.arrayClass)
       lazy val wrapVarargsRefArrayMethod = getMemberMethod(ScalaRunTimeModule, nme.wrapRefArray)
       lazy val genericWrapVarargsRefArrayMethod = getMemberMethod(ScalaRunTimeModule, nme.genericWrapArray)
+      lazy val primitiveWrapArrayMethod = Seq[Symbol](
+        getMemberMethod(ScalaRunTimeModule, nme.wrapBooleanArray),
+        getMemberMethod(ScalaRunTimeModule, nme.wrapByteArray),
+        getMemberMethod(ScalaRunTimeModule, nme.wrapCharArray),
+        getMemberMethod(ScalaRunTimeModule, nme.wrapIntArray),
+        getMemberMethod(ScalaRunTimeModule, nme.wrapDoubleArray),
+        getMemberMethod(ScalaRunTimeModule, nme.wrapFloatArray),
+        getMemberMethod(ScalaRunTimeModule, nme.wrapLongArray),
+        getMemberMethod(ScalaRunTimeModule, nme.wrapShortArray),
+        getMemberMethod(ScalaRunTimeModule, nme.wrapUnitArray)
+      )
+
 
       lazy val RuntimeStatics_ioobe = getMemberMethod(RuntimeStaticsModule, nme.ioobe)
 

--- a/test/files/instrumented/t12201.check
+++ b/test/files/instrumented/t12201.check
@@ -1,0 +1,3 @@
+Method call statistics:
+    1  scala/runtime/BoxedUnit.<clinit>()V
+    1  scala/runtime/BoxedUnit.<init>()V

--- a/test/files/instrumented/t12201.scala
+++ b/test/files/instrumented/t12201.scala
@@ -1,0 +1,29 @@
+import scala.tools.partest.instrumented.Instrumentation._
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    startProfiling()
+
+    // to optimized
+    val x = Array[Double](1)
+    val y = Array[Double](1.0)
+
+    // Currently correctly optimized
+    val i                = Array(1.0)
+    val j: Array[Double] = Array(1)
+
+    //others case
+    val a: Array[Double] = Array[Double](1.0)
+    val b: Array[Double] = Array[Double](1)
+    val c: Array[Double] = Array[Double](1: Double)
+    val d: Array[Double] = Array(1: Double)
+    val e                = Array(1: Double)
+    val f                = Array(1: Int)
+    val g                = Array[Int](1)
+    val h                = Array(1)
+    val k                = Array[Unit](())
+
+    stopProfiling()
+    printStatistics()
+  }
+}


### PR DESCRIPTION
`Array[Double](1.0)` targets the generic `Array.apply` overload. This case was not handled by CleanUp and therefore not emitted as an array literal in bytecode.

Fixes https://github.com/scala/bug/issues/12201
