### PR TITLE
in user-facing contexts, call it REPL not interpreter

### DIFF
--- a/doc/README
+++ b/doc/README
@@ -9,7 +9,7 @@ We welcome contributions at https://github.com/scala/scala!
 Scala Tools
 -----------
 
-- scala       Scala interactive interpreter
+- scala       Scala REPL (interactive shell)
 - scalac      Scala compiler
 - fsc         Scala resident compiler
 - scaladoc    Scala API documentation generator

--- a/src/manual/scala/man1/scalac.scala
+++ b/src/manual/scala/man1/scalac.scala
@@ -94,7 +94,7 @@ object scalac extends Command {
             "Specify character encoding used by source files.",
             "The default value is platform-specific (Linux: " & Mono("\"UTF8\"") &
             ", Windows: " & Mono("\"Cp1252\"") & "). Executing the following " &
-            "code in the Scala interpreter will return the default value " &
+            "code in the Scala REPL will return the default value " &
             "on your system:",
             MBold("    scala> ") &
             Mono("new java.io.InputStreamReader(System.in).getEncoding"))),

--- a/src/manual/scala/man1/scaladoc.scala
+++ b/src/manual/scala/man1/scaladoc.scala
@@ -124,7 +124,7 @@ object scaladoc extends Command {
             "Specify character encoding used by source files.",
             "The default value is platform-specific (Linux: " & Mono("\"UTF8\"") &
             ", Windows: " & Mono("\"Cp1252\"") & "). Executing the following " &
-            "code in the Scala interpreter will return the default value " &
+            "code in the Scala REPL will return the default value " &
             "on your system:",
             MBold("    scala> ") &
             Mono("new java.io.InputStreamReader(System.in).getEncoding"))))))

--- a/src/partest/scala/tools/partest/nest/RunnerSpec.scala
+++ b/src/partest/scala/tools/partest/nest/RunnerSpec.scala
@@ -25,7 +25,7 @@ trait RunnerSpec extends Spec with Meta.StdOpts with Interpolation {
   heading("Test categories:")
   val optPos          = "pos"          / "run compilation tests (success)"   --?
   val optNeg          = "neg"          / "run compilation tests (failure)"   --?
-  val optRun          = "run"          / "run interpreter and backend tests" --?
+  val optRun          = "run"          / "run REPL and backend tests" --?
   val optJvm          = "jvm"          / "run JVM backend tests"             --?
   val optRes          = "res"          / "run resident compiler tests"       --?
   val optScalap       = "scalap"       / "run scalap tests"                  --?

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
@@ -200,10 +200,10 @@ class ILoop(config: ShellConfig, inOverride: BufferedReader = null,
     cmd("load", "<path>", "interpret lines in a file", loadCommand, fileCompletion),
     cmd("paste", "[-raw] [path]", "enter paste mode or paste a file", pasteCommand, fileCompletion),
     nullary("power", "enable power user mode", () => powerCmd()),
-    nullary("quit", "exit the interpreter", () => Result(keepRunning = false, None)),
-    cmd("replay", "[options]", "reset the repl and replay all previous commands", replayCommand, settingsCompletion),
+    nullary("quit", "exit the REPL", () => Result(keepRunning = false, None)),
+    cmd("replay", "[options]", "reset the REPL and replay all previous commands", replayCommand, settingsCompletion),
     cmd("require", "<path>", "add a jar to the classpath", require),
-    cmd("reset", "[options]", "reset the repl to its initial state, forgetting all session entries", resetCommand, settingsCompletion),
+    cmd("reset", "[options]", "reset the REPL to its initial state, forgetting all session entries", resetCommand, settingsCompletion),
     cmd("save", "<path>", "save replayable session to a file", saveCommand, fileCompletion),
     shCommand,
     cmd("settings", "<options>", "update compiler options, if possible; see reset", changeSettings, settingsCompletion),
@@ -512,7 +512,7 @@ class ILoop(config: ShellConfig, inOverride: BufferedReader = null,
    */
   def resetCommand(line: String): Unit = {
     def run(destructive: Boolean): Unit = {
-      echo("Resetting interpreter state.")
+      echo("Resetting REPL state.")
       if (replayCommandStack.nonEmpty) {
         echo("Forgetting this session history:\n")
         replayCommands foreach echo

--- a/test/files/run/repl-no-imports-no-predef.check
+++ b/test/files/run/repl-no-imports-no-predef.check
@@ -251,7 +251,7 @@ scala> x1 + x2 + x3
 val res35: Int = 6
 
 scala> :reset
-Resetting interpreter state.
+Resetting REPL state.
 Forgetting this session history:
 
 1

--- a/test/files/run/repl-reset.check
+++ b/test/files/run/repl-reset.check
@@ -15,7 +15,7 @@ scala> x1 + x2 + x3
 val res0: Int = 6
 
 scala> :reset
-Resetting interpreter state.
+Resetting REPL state.
 Forgetting this session history:
 
 val x1 = 1

--- a/test/files/run/t7747-repl.check
+++ b/test/files/run/t7747-repl.check
@@ -153,7 +153,7 @@ scala> x1 + x2 + x3
 val res23: Int = 6
 
 scala> :reset
-Resetting interpreter state.
+Resetting REPL state.
 Forgetting this session history:
 
 var x = 10


### PR DESCRIPTION
"Interpreter" is antiquated and not-actually-accurate terminology. Code entered in the Scala REPL is compiled, not interpreted. The use of "interpreter" to refer to any programming language's interactive shell is a relic of an era when interpreted languages had REPLs and compiled languages didn't.

thx @deanwampler for noticing this