### PR TITLE
Don't pickle `@nowarn` annotations...

### DIFF
--- a/src/reflect/scala/reflect/internal/AnnotationInfos.scala
+++ b/src/reflect/scala/reflect/internal/AnnotationInfos.scala
@@ -331,7 +331,7 @@ trait AnnotationInfos extends api.Annotations { self: SymbolTable =>
     /** Check whether the type or any of the arguments are erroneous */
     def isErroneous = atp.isErroneous || args.exists(_.isErroneous)
 
-    def isStatic = symbol isNonBottomSubClass StaticAnnotationClass
+    def isStatic = symbol.isNonBottomSubClass(StaticAnnotationClass) && symbol != NowarnClass
 
     /** Check whether any of the arguments mention a symbol */
     def refsSymbol(sym: Symbol) = hasArgWhich(_.symbol == sym)


### PR DESCRIPTION
...by special-casing them.

In principle we have `extends Annotation` vs `extends StaticAnnotation`
for that, but sadly `ClassfileAnnotation extends StaticAnnotation`, so
we don't get to choose for those :-/

Backport of 522a5c6e08

Fixes https://github.com/scala/bug/issues/12336