### PR TITLE
SI-12290: support JDK15 text blocks in Java parser

### DIFF
--- a/test/files/neg/text-blocks.check
+++ b/test/files/neg/text-blocks.check
@@ -1,0 +1,13 @@
+text-blocks/Invalid1.java:4: error: illegal text block open delimiter sequence, missing line terminator
+    public static final String badOpeningDelimiter = """non-whitespace
+                                                        ^
+text-blocks/Invalid1.java:4: error: <identifier> expected
+    public static final String badOpeningDelimiter = """non-whitespace
+                                                           ^
+text-blocks/Invalid1.java:6: error: illegal text block open delimiter sequence, missing line terminator
+    """;
+       ^
+text-blocks/Invalid2.java:6: error: unclosed string literal
+      foo"""";
+            ^
+4 errors

--- a/test/files/neg/text-blocks/Invalid1.java
+++ b/test/files/neg/text-blocks/Invalid1.java
@@ -1,0 +1,7 @@
+// javaVersion: 15+
+class Invalid1 {
+
+    public static final String badOpeningDelimiter = """non-whitespace
+      foo
+    """;
+}

--- a/test/files/neg/text-blocks/Invalid2.java
+++ b/test/files/neg/text-blocks/Invalid2.java
@@ -1,0 +1,7 @@
+// javaVersion: 15+
+class Invalid2 {
+
+    // Closing delimiter is first three eligible `"""`, not last
+    public static final String closingDelimiterIsNotScalas = """
+      foo"""";
+}

--- a/test/files/run/t12290.check
+++ b/test/files/run/t12290.check
@@ -1,0 +1,61 @@
+====
+A text
+
+====
+<html>
+    <body>
+        <p>Hello, world</p>
+    </body>
+</html>
+
+====
+SELECT "EMP_ID", "LAST_NAME" FROM "EMPLOYEE_TB"
+WHERE "CITY" = 'INDIANAPOLIS'
+ORDER BY "EMP_ID", "LAST_NAME";
+
+====
+<html>
+    <body>
+        <p>Hello, world</p>
+    </body>
+</html>
+
+====
+                            <html>
+                                <body>
+                                    <p>Hello, world</p>
+                                </body>
+                            </html>
+
+====
+<html>
+    <body>
+        <p>Hello, world</p>
+    </body>
+
+</html>
+
+====
+<html>
+
+    <body>        <p>Hello ,	world</p>
+    </body>
+</html>
+
+====
+   this line has 4 tabs before it
+ this line has 5 spaces before it and space after it
+ this line has 2 tabs and 3 spaces before it
+  this line has 6 spaces before it
+
+====
+String text = """
+    A text block inside a text block
+""";
+
+====
+foo	bar
+baz
+====
+
+====

--- a/test/files/run/t12290/Test.scala
+++ b/test/files/run/t12290/Test.scala
@@ -1,0 +1,30 @@
+// javaVersion: 15+
+/* Using `valueOf` is a way to check that the Java string literals were properly
+ * parsed, since the parsed value is what the Scala compiler will use when
+ * resolving the singleton types
+ */
+object Test extends App {
+  println("====")
+  println(valueOf[TextBlocks.aText.type])
+  println("====")
+  println(valueOf[TextBlocks.html1.type])
+  println("====")
+  println(valueOf[TextBlocks.query.type])
+  println("====")
+  println(valueOf[TextBlocks.html2.type])
+  println("====")
+  println(valueOf[TextBlocks.html3.type])
+  println("====")
+  println(valueOf[TextBlocks.html4.type])
+  println("====")
+  println(valueOf[TextBlocks.html5.type])
+  println("====")
+  println(valueOf[TextBlocks.mixedIndents.type])
+  println("====")
+  println(valueOf[TextBlocks.code.type])
+  println("====")
+  println(valueOf[TextBlocks.simpleString.type])
+  println("====")
+  println(valueOf[TextBlocks.emptyString.type])
+  println("====")
+}

--- a/test/files/run/t12290/TextBlocks.java
+++ b/test/files/run/t12290/TextBlocks.java
@@ -1,0 +1,78 @@
+// javaVersion: 15+
+class TextBlocks {
+
+    final static String aText = """
+      A text
+      """;
+
+    final static String html1 = """
+                                <html>
+                                    <body>
+                                        <p>Hello, world</p>
+                                    </body>
+                                </html>
+                                """;
+
+    // quote characters are unescaped
+    final static String query = """
+                                SELECT "EMP_ID", "LAST_NAME" FROM "EMPLOYEE_TB"
+                                WHERE "CITY" = 'INDIANAPOLIS'
+                                ORDER BY "EMP_ID", "LAST_NAME";
+                                """;
+
+    // incidental trailing spaces
+    final static String html2 = """
+                                <html>   
+                                    <body>
+                                        <p>Hello, world</p>    
+                                    </body> 
+                                </html>   
+                                """;
+
+    // trailing delimiter influences
+    final static String html3 = """
+                                <html>
+                                    <body>
+                                        <p>Hello, world</p>
+                                    </body>
+                                </html>
+    """;
+
+    // blank line does not affect 
+    final static String html4 = """
+                                <html>
+                                    <body>
+                                        <p>Hello, world</p>
+                                    </body>
+
+                                </html>
+                                    """;
+
+    // escape sequences
+    final static String html5 = """
+                                <html>\n
+                                    <body>\
+                                        <p>Hello\s,\tworld</p>
+                                    </body>
+                                </html>
+                                """;
+
+    // mixed indentation
+		final static String mixedIndents = """
+				\s  this line has 4 tabs before it
+     this line has 5 spaces before it and space after it \u0020 \u000C\u0020 \u001E
+  		 this line has 2 tabs and 3 spaces before it
+\u0020 \u000C\u0020 \u001E this line has 6 spaces before it
+								""";
+
+    final static String code =
+        """
+        String text = \"""
+            A text block inside a text block
+        \""";
+        """;
+
+    final static String simpleString = "foo\tbar\nbaz";
+
+    final static String emptyString = "";
+}


### PR DESCRIPTION
JDK15 introduced text blocks (JEP 378) for writing multiline strings.
This adds support for parsing these strings in the Java parser.

The logic for interpretting the literals is a little complicated, but
follows from the "3.10.6. Text Blocks" of the Java language specification.
The test cases include examples from there and from the JEP.

Fixes scala/bug#12290