### PR TITLE
Avoid classfile parsing of specialized variants just to unlink them

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -603,14 +603,22 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
        * specialized subclass of "clazz" throughout this file.
        */
 
+      val clazzName = specializedName(clazz, env0).toTypeName
       // scala/bug#5545: Eliminate classes with the same name loaded from the bytecode already present - all we need to do is
       // to force .info on them, as their lazy type will be evaluated and the symbols will be eliminated. Unfortunately
       // evaluating the info after creating the specialized class will mess the specialized class signature, so we'd
-      // better evaluate it before creating the new class symbol
-      val clazzName = specializedName(clazz, env0).toTypeName
+      // better unlink the the class-file backed symbol before creating the new class symbol
       val bytecodeClazz = clazz.owner.info.decl(clazzName)
       // debuglog("Specializing " + clazz + ", but found " + bytecodeClazz + " already there")
-      bytecodeClazz.info
+      def unlink(sym: Symbol): Unit = if (sym != NoSymbol) {
+        devWarningIf(sym.hasCompleteInfo)("Stale specialized symbol has been accessed: " + sym)
+        sym.setInfo(NoType)
+        sym.owner.info.decls.unlink(sym)
+      }
+      unlink(bytecodeClazz)
+      val companionModule = bytecodeClazz.companionModule
+      unlink(companionModule.moduleClass)
+      unlink(companionModule)
 
       val sClass = clazz.owner.newClass(clazzName, clazz.pos, (clazz.flags | SPECIALIZED) & ~CASE)
       sClass.setAnnotations(clazz.annotations) // scala/bug#8574 important that the subclass picks up @SerialVersionUID, @strictfp, etc.


### PR DESCRIPTION
Since 8ae0fdab, the specializion phase eagerly info transforms
all of FunctionN and TupleN. This was done to let us turn off
needless specialization info transforms (which incurs classfile parsing
up the base classes looking for @specialized annotations) of types after
the specialization tree transform is done.

However, in combination with an old fix for scala/bug#5545, we end
up parsing all of the class files of all the variants, just to
unlink them in favour of the info-transformed types.

I note that the test for scala/bug#5545 no longer crashes if the fix
is removed. I have have not investigated the reason.

This commit reworks the scala/bug#5545 to just unlink the stale
symbols directly, rather than calling `.info` to parse them and
do the same after noticing the ScalaRaw attribute.