### PR TITLE
Support JDK 16 records in Java sources

### DIFF
--- a/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
@@ -840,7 +840,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
       var generateCanonicalCtor = true
       var generateAccessors = header
         .view
-        .map { case ValDef(_, name, tpt, _) => name -> tpt }
+        .map { case ValDef(mods, name, tpt, _) => (name, (tpt, mods.annotations)) }
         .toMap
       for (DefDef(_, name, List(), List(params), _, _) <- body) {
         if (name == nme.CONSTRUCTOR && params.size == header.size) {
@@ -856,8 +856,8 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
 
       // Generate canonical constructor and accessors, if not already manually specified
       val accessors = generateAccessors
-        .map { case (name, tpt) =>
-          DefDef(Modifiers(Flags.JAVA), name, List(), List(), tpt.duplicate, blankExpr)
+        .map { case (name, (tpt, annots)) =>
+          DefDef(Modifiers(Flags.JAVA) withAnnotations annots, name, List(), List(), tpt.duplicate, blankExpr)
         }
         .toList
       val canonicalCtor = Option.when(generateCanonicalCtor) {

--- a/src/compiler/scala/tools/nsc/javac/JavaTokens.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaTokens.scala
@@ -20,6 +20,7 @@ object JavaTokens extends ast.parser.CommonTokens {
 
   /** identifiers */
   final val IDENTIFIER = 10
+  final val RECORD = 12 // restricted identifier, so not lexed directly
   def isIdentifier(code: Int) =
     code == IDENTIFIER
 

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1487,7 +1487,13 @@ trait Namers extends MethodSynthesis {
       }
 
       val methSig = deskolemizedPolySig(vparamSymssOrEmptyParamsFromOverride, resTp)
-      pluginsTypeSig(methSig, typer, ddef, resTpGiven)
+      val unlink = methOwner.isJava && meth.isSynthetic && meth.isConstructor && methOwner.superClass == JavaRecordClass &&
+        methOwner.info.decl(meth.name).alternatives.exists(c => c != meth && c.tpe.matches(methSig))
+      if (unlink) {
+        methOwner.info.decls.unlink(meth)
+        ErrorType
+      } else
+        pluginsTypeSig(methSig, typer, ddef, resTpGiven)
     }
 
     /**

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -411,6 +411,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val JavaEnumClass           = requiredClass[java.lang.Enum[_]]
     lazy val JavaUtilMap             = requiredClass[java.util.Map[_, _]]
     lazy val JavaUtilHashMap         = requiredClass[java.util.HashMap[_, _]]
+    lazy val JavaRecordClass         = getClassIfDefined("java.lang.Record")
 
     lazy val ByNameParamClass       = specialPolyClass(tpnme.BYNAME_PARAM_CLASS_NAME, COVARIANT)(_ => AnyTpe)
     lazy val JavaRepeatedParamClass = specialPolyClass(tpnme.JAVA_REPEATED_PARAM_CLASS_NAME, COVARIANT)(tparam => arrayType(tparam.tpe))

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -264,6 +264,7 @@ trait StdNames {
     final val Object: NameType          = nameType("Object")
     final val PrefixType: NameType      = nameType("PrefixType")
     final val Product: NameType         = nameType("Product")
+    final val Record: NameType          = nameType("Record")
     final val Serializable: NameType    = nameType("Serializable")
     final val Singleton: NameType       = nameType("Singleton")
     final val Throwable: NameType       = nameType("Throwable")

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -236,6 +236,7 @@ trait StdNames {
     final val keywords = kw.result
   } with CommonNames {
     final val javaKeywords = new JavaKeywords()
+    final val javaRestrictedIdentifiers = new JavaRestrictedIdentifiers()
   }
 
   abstract class TypeNames extends Keywords with TypeNamesApi {
@@ -1254,6 +1255,15 @@ trait StdNames {
     final val WHILEkw: TermName        = kw("while")
 
     final val keywords = kw.result
+  }
+
+  // "The identifiers var, yield, and record are restricted identifiers because they are not allowed in some contexts"
+  // A type identifier is an identifier that is not the character sequence var, yield, or record.
+  // An unqualified method identifier is an identifier that is not the character sequence yield.
+  class JavaRestrictedIdentifiers {
+    final val RECORD: TermName = TermName("record")
+    final val VAR: TermName = TermName("var")
+    final val YIELD: TermName = TermName("yield")
   }
 
   sealed abstract class SymbolNames {

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -290,6 +290,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.JavaEnumClass
     definitions.JavaUtilMap
     definitions.JavaUtilHashMap
+    definitions.JavaRecordClass
     definitions.ByNameParamClass
     definitions.JavaRepeatedParamClass
     definitions.RepeatedParamClass

--- a/test/files/pos/t11908/C.scala
+++ b/test/files/pos/t11908/C.scala
@@ -1,0 +1,55 @@
+// javaVersion: 16+
+object C {
+
+  def useR1 = {
+    // constructor signature
+    val r1 = new R1(123, "hello")
+
+    // accessors signature
+    val i: Int = r1.i
+    val s: String = r1.s
+
+    // method
+    val s2: String = r1.someMethod()
+
+    // supertype
+    val isRecord: java.lang.Record = r1
+
+    ()
+  }
+
+  def useR2 = {
+    // constructor signature
+    val r2 = new R2(123, "hello")
+
+    // accessors signature
+    val i: Int = r2.i
+    val s: String = r2.s
+
+    // method
+    val i2: Int = r2.getInt
+
+    // supertype
+    val isIntLike: IntLike = r2
+    val isRecord: java.lang.Record = r2
+
+    ()
+  }
+
+  def useR3 = {
+    // constructor signature
+    val r3 = new R3(123, 42L, "hi")
+    new R3("hi", 123)
+
+    // accessors signature
+    val i: Int = r3.i
+    val l: Long = r3.l
+    val s: String = r3.s
+
+    // method
+    val l2: Long = r3.l(43L, 44L)
+
+    // supertype
+    val isRecord: java.lang.Record = r3
+  }
+}

--- a/test/files/pos/t11908/C.scala
+++ b/test/files/pos/t11908/C.scala
@@ -20,7 +20,7 @@ object C {
 
   def useR2 = {
     // constructor signature
-    val r2 = new R2(123, "hello")
+    val r2 = new R2.R(123, "hello")
 
     // accessors signature
     val i: Int = r2.i

--- a/test/files/pos/t11908/IntLike.scala
+++ b/test/files/pos/t11908/IntLike.scala
@@ -1,0 +1,4 @@
+// javaVersion: 16+
+trait IntLike {
+  def getInt: Int
+}

--- a/test/files/pos/t11908/R1.java
+++ b/test/files/pos/t11908/R1.java
@@ -1,0 +1,7 @@
+// javaVersion: 16+
+record R1(int i, String s) {
+
+    public String someMethod() {
+        return s + "!";
+    }
+}

--- a/test/files/pos/t11908/R2.java
+++ b/test/files/pos/t11908/R2.java
@@ -1,12 +1,14 @@
 // javaVersion: 16+
-final record R2(int i, String s) implements IntLike {
-    public int getInt() {
-        return i;
-    }
+public class R2 {
+    final record R(int i, String s) implements IntLike {
+        public int getInt() {
+            return i;
+        }
 
-    // Canonical constructor
-    public R2(int i, String s) {
-        this.i = i;
-        this.s = s.intern();
+        // Canonical constructor
+        public R(int i, String s) {
+            this.i = i;
+            this.s = s.intern();
+        }
     }
 }

--- a/test/files/pos/t11908/R2.java
+++ b/test/files/pos/t11908/R2.java
@@ -6,7 +6,7 @@ public class R2 {
         }
 
         // Canonical constructor
-        public R(int i, String s) {
+        public R(int i, java.lang.String s) {
             this.i = i;
             this.s = s.intern();
         }

--- a/test/files/pos/t11908/R2.java
+++ b/test/files/pos/t11908/R2.java
@@ -1,0 +1,12 @@
+// javaVersion: 16+
+final record R2(int i, String s) implements IntLike {
+    public int getInt() {
+        return i;
+    }
+
+    // Canonical constructor
+    public R2(int i, String s) {
+        this.i = i;
+        this.s = s.intern();
+    }
+}

--- a/test/files/pos/t11908/R3.java
+++ b/test/files/pos/t11908/R3.java
@@ -1,0 +1,23 @@
+// javaVersion: 16+
+public record R3(int i, long l, String s) {
+
+    // User-specified accessor
+    public int i() {
+        return i + 1; // evil >:)
+    }
+
+    // Not an accessor - too many parameters
+    public long l(long a1, long a2) {
+        return a1 + a2;
+    }
+
+    // Secondary constructor
+    public R3(String s, int i) {
+        this(i, 42L, s);
+    }
+
+    // Compact constructor
+    public R3 {
+        s = s.intern();
+    }
+}


### PR DESCRIPTION
JDK16 introduced records (JEP 395) for reducing the boilerplate associated with small immutable classes. This new construct automatically

  * makes fields `private`/`final` and generates accessors for them
  * overrides `equals`/`hashCode`/`toString`
  * creates a `final` class that extends `java.lang.Record`

The details are in "8.10. Record Classes" of the Java language specification.

Fixes scala/bug#11908