### PR TITLE
fix #12357: all inline defs from tasty are treated as macros

### DIFF
--- a/src/compiler/scala/tools/nsc/tasty/bridge/ContextOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/ContextOps.scala
@@ -146,7 +146,7 @@ trait ContextOps { self: TastyUniverse =>
     final def ignoreAnnotations: Boolean = u.settings.YtastyNoAnnotations
     final def verboseDebug: Boolean = u.settings.debug
 
-    def requiresLatentEntry(decl: Symbol): Boolean = decl.isScala3Macro
+    def requiresLatentEntry(decl: Symbol): Boolean = decl.isScala3Inline
     def neverEntered(decl: Symbol): Boolean = decl.isPureMixinCtor
 
     def canEnterOverload(decl: Symbol): Boolean = {

--- a/src/compiler/scala/tools/nsc/tasty/bridge/SymbolOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/SymbolOps.scala
@@ -46,7 +46,6 @@ trait SymbolOps { self: TastyUniverse =>
 
   implicit final class SymbolDecorator(val sym: Symbol) {
 
-    def isScala3Macro: Boolean = repr.originalFlagSet.is(Inline | Macro)
     def isScala3Inline: Boolean = repr.originalFlagSet.is(Inline)
     def isScala2Macro: Boolean = repr.originalFlagSet.is(Erased | Macro)
 

--- a/src/compiler/scala/tools/nsc/tasty/bridge/TreeOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/TreeOps.scala
@@ -116,6 +116,7 @@ trait TreeOps { self: TastyUniverse =>
         val sym = tree.tpe match {
           case u.SingleType(_, sym) => sym
           case u.TypeRef(_, sym, _) => sym
+          case u.ThisType(sym)      => sym
           case x                    => throw new MatchError(x)
         }
         if (tree.tpe.prefix === u.NoPrefix && (sym.hasFlag(Flags.PACKAGE) && !sym.isPackageObjectOrClass || sym.isLocalToBlock)) {

--- a/test/tasty/neg/src-2/TestHello.check
+++ b/test/tasty/neg/src-2/TestHello.check
@@ -32,4 +32,7 @@ List's type parameters do not match type F's expected parameters:
 type A is covariant, but type _ is declared contravariant
   HelloWorld.higherBounded6[List]
                            ^
-8 errors
+TestHello_fail.scala:12: error: Unsupported Scala 3 inline value msg1; found in object helloworld.HelloWorld.
+  HelloWorld.msg1
+             ^
+9 errors

--- a/test/tasty/neg/src-2/TestHello_2.check
+++ b/test/tasty/neg/src-2/TestHello_2.check
@@ -1,0 +1,7 @@
+TestHello_2_fail.scala:4: error: Unsupported Scala 3 inline value msg1; found in object helloworld.HelloWorld.
+  HelloWorld.acceptsOnlyMsg1(HelloWorld.msg1)
+                            ^
+TestHello_2_fail.scala:5: error: Unsupported Scala 3 inline method inlineMethod; found in object helloworld.HelloWorld.
+  HelloWorld.inlineMethod(1)
+             ^
+2 errors

--- a/test/tasty/neg/src-2/TestHello_2_fail.scala
+++ b/test/tasty/neg/src-2/TestHello_2_fail.scala
@@ -1,0 +1,6 @@
+package helloworld
+
+object TestHello_2 {
+  HelloWorld.acceptsOnlyMsg1(HelloWorld.msg1)
+  HelloWorld.inlineMethod(1)
+}

--- a/test/tasty/neg/src-2/TestHello_fail.scala
+++ b/test/tasty/neg/src-2/TestHello_fail.scala
@@ -9,4 +9,5 @@ object TestHello {
 
   HelloWorld.higherBounded5[Show]
   HelloWorld.higherBounded6[List]
+  HelloWorld.msg1
 }

--- a/test/tasty/neg/src-3/HelloWorld.scala
+++ b/test/tasty/neg/src-3/HelloWorld.scala
@@ -1,11 +1,12 @@
 package helloworld
 
 object HelloWorld {
-  final val msg1 = "Hello, World!"
+  inline val msg1 = "Hello, World!"
   def acceptsOnlyMsg1(m: msg1.type): String = m + m
   def higherBounded2[T <: List[_ <: Int]](f: T): T = f
   def higherBounded3[T <: List[List[_ <: Int]]](f: T): T = f
   def higherBounded4[T <: Either[_ <: Int, String]](f: T): T = f
   def higherBounded5[F[+_]] = ???
   def higherBounded6[F[-_]] = ???
+  inline def inlineMethod(inline i: Int): Int = i
 }

--- a/test/tasty/run/src-2/tastytest/TestInlineCompat.scala
+++ b/test/tasty/run/src-2/tastytest/TestInlineCompat.scala
@@ -1,0 +1,7 @@
+package tastytest
+
+import InlineCompat._
+
+object TestInlineCompat extends Suite("TestInlineCompat") {
+  test(assert(foo("Hello, World!") == "Hello, World!"))
+}

--- a/test/tasty/run/src-2/tastytest/TestInlineCompat2.scala
+++ b/test/tasty/run/src-2/tastytest/TestInlineCompat2.scala
@@ -1,0 +1,7 @@
+package tastytest
+
+import InlineCompat2._
+
+object TestInlineCompat2 extends Suite("TestInlineCompat2") {
+  test(assert(foo("Hello, World!") == "Hello, World!"))
+}

--- a/test/tasty/run/src-3/tastytest/InlineCompat.scala
+++ b/test/tasty/run/src-3/tastytest/InlineCompat.scala
@@ -1,0 +1,16 @@
+package tastytest
+
+import scala.language.experimental.macros
+
+import scala.reflect.macros.blackbox.Context
+
+object InlineCompat {
+
+  def foo(code: String): String = macro InlineCompatScala2Macro.foo
+  inline def foo(inline code: String): String = code // inline method, not macro
+
+}
+
+object InlineCompatScala2Macro {
+  def foo(c: Context)(code: c.Tree): c.Tree = code
+}

--- a/test/tasty/run/src-3/tastytest/InlineCompat2.scala
+++ b/test/tasty/run/src-3/tastytest/InlineCompat2.scala
@@ -1,0 +1,16 @@
+package tastytest
+
+import scala.language.experimental.macros
+
+import scala.reflect.macros.blackbox.Context
+
+object InlineCompat2 {
+
+  def foo(code: String): String = macro InnerScala2MacroImpl.fooImpl
+  inline def foo(inline code: String): String = code // inline method, not macro
+
+  object InnerScala2MacroImpl {
+    def fooImpl(c: Context)(code: c.Tree): c.Tree = code
+  }
+
+}


### PR DESCRIPTION
The issue here was that in order to erase a scala 3 macro that matches a scala 2 macro we have to wait until we have seen all definitions in the scope - before this PR, only Scala 3 macros were considered for eviction, now all inline methods are.

fixes https://github.com/scala/bug/issues/12357