### PR TITLE
Under `-Ymacro-annotations`, don't clash with a synthetic companion object

### DIFF
--- a/test/files/pos/macro-annot/t12366.check
+++ b/test/files/pos/macro-annot/t12366.check
@@ -1,0 +1,1 @@
+warning: 2 deprecations; re-run with -deprecation for details

--- a/test/files/pos/macro-annot/t12366.scala
+++ b/test/files/pos/macro-annot/t12366.scala
@@ -1,0 +1,15 @@
+// scalac: -Ymacro-annotations
+object Test extends App {
+
+  @deprecated
+  class Inner() {
+  }
+
+  lazy val Inner = new Inner()
+
+  @deprecated
+  class Inner2() {
+  }
+
+  val Inner2 = new Inner2()
+}


### PR DESCRIPTION
if there is exists conflicting value, we do not generate companion object.
scala/bug#12366