### PR TITLE
JAR reading: more accurate and widespread caching, less read contention

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -28,6 +28,11 @@ object MimaFilters extends AutoPlugin {
 
     // #9166 add missing serialVersionUID
     ProblemFilters.exclude[MissingFieldProblem]("*.serialVersionUID"),
+
+    // private[scala] Internal API
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.reflect.io.FileZipArchive#LeakyEntry.this"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.reflect.io.FileZipArchive#LeakyEntry.this"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.reflect.io.FileZipArchive$zipFilePool$"),
   )
 
   override val buildSettings = Seq(

--- a/src/compiler/scala/tools/nsc/plugins/Plugin.scala
+++ b/src/compiler/scala/tools/nsc/plugins/Plugin.scala
@@ -112,7 +112,7 @@ object Plugin {
 
   val PluginXML = "scalac-plugin.xml"
 
-  private[nsc] val pluginClassLoadersCache = new FileBasedCache[ScalaClassLoader.URLClassLoader]()
+  private[nsc] val pluginClassLoadersCache = new FileBasedCache[Unit, ScalaClassLoader.URLClassLoader]()
 
   type AnyClass = Class[_]
 

--- a/src/compiler/scala/tools/nsc/plugins/Plugins.scala
+++ b/src/compiler/scala/tools/nsc/plugins/Plugins.scala
@@ -106,7 +106,7 @@ trait Plugins { global: Global =>
         closeableRegistry.registerClosable(loader)
         loader
       case Right(paths) =>
-        cache.getOrCreate(classpath.map(_.jfile.toPath()), newLoader, closeableRegistry, checkStamps)
+        cache.getOrCreate((), classpath.map(_.jfile.toPath()), newLoader, closeableRegistry, checkStamps)
     }
   }
 

--- a/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
@@ -199,15 +199,16 @@ abstract class SymbolLoaders {
     }
   }
   private def nameOf(classRep: ClassRepresentation): TermName = {
-    while(true) {
-      val len = classRep.nameChars(nameCharBuffer)
-      if (len == -1) nameCharBuffer = new Array[Char](nameCharBuffer.length * 2)
-      else return newTermName(nameCharBuffer, 0, len)
+    val name = classRep.name
+    val nameLength = name.length
+    if (nameLength <= nameCharBuffer.length) {
+      name.getChars(0, nameLength, nameCharBuffer, 0)
+      newTermName(nameCharBuffer, 0, nameLength)
+    } else {
+      newTermName(name)
     }
-    throw new IllegalStateException()
   }
-  private var nameCharBuffer = new Array[Char](256)
-
+  private val nameCharBuffer = new Array[Char](512)
 
   /**
    * A lazy type that completes itself by calling parameter doComplete.

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -96,7 +96,7 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
         closeableRegistry.registerClosable(loader)
         loader
       case Right(paths) =>
-        cache.getOrCreate(paths, newLoader, closeableRegistry, checkStamps)
+        cache.getOrCreate((), paths, newLoader, closeableRegistry, checkStamps)
     }
   }
 
@@ -973,7 +973,7 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
 
 object Macros {
   final val macroClassLoadersCache =
-    new scala.tools.nsc.classpath.FileBasedCache[ScalaClassLoader.URLClassLoader]()
+    new scala.tools.nsc.classpath.FileBasedCache[Unit, ScalaClassLoader.URLClassLoader]()
 }
 
 trait MacrosStats {

--- a/src/compiler/scala/tools/nsc/util/ClassPath.scala
+++ b/src/compiler/scala/tools/nsc/util/ClassPath.scala
@@ -204,17 +204,6 @@ object ClassPath {
 trait ClassRepresentation {
   def fileName: String
   def name: String
-  /** Low level way to extract the entry name without allocation. */
-  final def nameChars(buffer: Array[Char]): Int = {
-    val ix = fileName.lastIndexOf('.')
-    val nameLength = if (ix < 0) fileName.length else ix
-    if (nameLength > buffer.length)
-      -1
-    else {
-      fileName.getChars(0, fileName.lastIndexOf('.'), buffer, 0)
-      nameLength
-    }
-  }
   def binary: Option[AbstractFile]
   def source: Option[AbstractFile]
 }


### PR DESCRIPTION
Multithreaded users of the compiler can experience lock contention in
classpath reading. This occurs because a) scalac by default reuses a
`ZipFile` instance for a given JAR across concurrent compilers to reduce the
memory footprint, and b) because `j.u.ZipFile` contains does not support
concurrent reads.

Instead of having a 1-1 relationship between `ZipArchive` and `j.u.ZipFile`,
this PR uses an internal pool of `ZipFile` instances, which can be expanded
as needed to service concurrent reads a given JAR file.

While investigating this, I noticed that our caching layer was not
considering the value of the `-release` compiler option as part of the
cache key. This is now fixed. I also included Java 9+ classpath reposotories
(`JrtClassPath` and `CtSymClassPath` in the caching scheme.)

Profiling showed my that the attempt to reduce allocations when converting
the classpath entry names into symbol names was counter productive as it
bypassed `lazy val name` in `ClassFileEntryImpl` which was forced anyway on
other code paths.