### PR TITLE
Support `?` as wildcard marker under -Xsource:3

### DIFF
--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -960,6 +960,7 @@ trait StdNames {
       final val PLUS : NameType  = nameType("+")
       final val STAR : NameType  = nameType("*")
       final val TILDE: NameType  = nameType("~")
+      final val QMARK: NameType  = nameType("?")
 
       final val isUnary: Set[Name] = Set(MINUS, PLUS, TILDE, BANG)
     }

--- a/test/files/pos/wildcards-future.scala
+++ b/test/files/pos/wildcards-future.scala
@@ -1,0 +1,21 @@
+// scalac: -Xsource:3
+//
+object Test {
+  val xs: List[?] = List(1, 2, 3)
+  val ys: Map[? <: AnyRef, ? >: Null] = Map()
+
+  def foo(x: Any) = x match {
+    case x: List[?] => x
+    case _ => x
+  }
+
+  // Only allowed in Scala 3 under -source 3.0-migration
+  type ? = Int
+
+  val xs2: List[`?`] = List(1)
+  val xs3: List[Int] = xs2
+
+  def foo2(x: List[`?`]): List[Int] = x match {
+    case x: List[`?`] => x
+  }
+}


### PR DESCRIPTION
Like in Scala 3.0, this allows `?` to be used as a type argument in all
situations where `_` could be used as a wildcard previously. This should
allow us to deprecate the use of `_` as a wildcard in Scala 3 to be able
to eventually repurpose it as explained in
http://dotty.epfl.ch/docs/reference/changed-features/wildcards.html

This is a source-breaking change since a type named `?` is legal in
Scala 2 (but not in Scala 3 unless -source 3.0-migration is used).
`?` also has a special meaning when the kind-projector plugin is used,
but that usage has been deprecated in favor of `*` for a while now.