### PR TITLE
spec: include pattern matching function in block expression

### DIFF
--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -590,6 +590,9 @@ Evaluation of the block entails evaluation of its
 statement sequence, followed by an evaluation of the final expression
 ´e´, which defines the result of the block.
 
+A block expression `{´c_1´; ´\ldots´; ´c_n´; ´}` where ´s_1 , \ldots , s_n´ are
+case clauses forms a [pattern matching anonymous function](08-pattern-matching.html#pattern-matching-anonymous-functions).
+
 ###### Example
 Assuming a class `Ref[T](x: T)`, the block
 


### PR DESCRIPTION
Pattern matching anonymous functions are specced later, in pattern matching, but since they are the other possible block expression, they should also be mentioned here I think.