### PR TITLE
Clarify the semantics of `Map.equals` and `Set.equals` in Scaladoc

### DIFF
--- a/src/library/scala/collection/Map.scala
+++ b/src/library/scala/collection/Map.scala
@@ -63,8 +63,10 @@ trait Map[K, +V]
   override def equals(o: Any): Boolean =
     (this eq o.asInstanceOf[AnyRef]) || (o match {
       case map: Map[K, _] if map.canEqual(this) =>
-        (this.size == map.size) &&
-          this.forall(kv => map.getOrElse(kv._1, Map.DefaultSentinelFn()) == kv._2)
+        (this.size == map.size) && {
+          try this.forall(kv => map.getOrElse(kv._1, Map.DefaultSentinelFn()) == kv._2)
+          catch { case _: ClassCastException => false } // PR #9565 / scala/bug#12228
+        }
       case _ =>
         false
     })

--- a/src/library/scala/collection/Map.scala
+++ b/src/library/scala/collection/Map.scala
@@ -29,6 +29,37 @@ trait Map[K, +V]
 
   def canEqual(that: Any): Boolean = true
 
+  /**
+   * Equality of maps is implemented using the lookup method [[get]]. This method returns `true` if
+   *   - the argument `o` is a `Map`,
+   *   - the two maps have the same [[size]], and
+   *   - for every `(key, value)` pair in this map, `other.get(key) == Some(value)`.
+   *
+   * The implementation of `equals` checks the [[canEqual]] method, so subclasses of `Map` can narrow down the equality
+   * to specific map types. The `Map` implementations in the standard library can all be compared, their `canEqual`
+   * methods return `true`.
+   *
+   * Note: The `equals` method only respects the equality laws (symmetry, transitivity) if the two maps use the same
+   * key equivalence function in their lookup operation. For example, the key equivalence operation in a
+   * [[scala.collection.immutable.TreeMap]] is defined by its ordering. Comparing a `TreeMap` with a `HashMap` leads
+   * to unexpected results if `ordering.equiv(k1, k2)` (used for lookup in `TreeMap`) is different from `k1 == k2`
+   * (used for lookup in `HashMap`).
+   *
+   * {{{
+   *   scala> import scala.collection.immutable._
+   *   scala> val ord: Ordering[String] = _ compareToIgnoreCase _
+   *
+   *   scala> TreeMap("A" -> 1)(ord) == HashMap("a" -> 1)
+   *   val res0: Boolean = false
+   *
+   *   scala> HashMap("a" -> 1) == TreeMap("A" -> 1)(ord)
+   *   val res1: Boolean = true
+   * }}}
+   *
+   *
+   * @param o The map to which this map is compared
+   * @return `true` if the two maps are equal according to the description
+   */
   override def equals(o: Any): Boolean =
     (this eq o.asInstanceOf[AnyRef]) || (o match {
       case map: Map[K, _] if map.canEqual(this) =>

--- a/src/library/scala/collection/Set.scala
+++ b/src/library/scala/collection/Set.scala
@@ -28,6 +28,37 @@ trait Set[A]
 
   def canEqual(that: Any) = true
 
+  /**
+   * Equality of sets is implemented using the lookup method [[contains]]. This method returns `true` if
+   *   - the argument `that` is a `Set`,
+   *   - the two sets have the same [[size]], and
+   *   - for every `element` this set, `other.contains(element) == true`.
+   *
+   * The implementation of `equals` checks the [[canEqual]] method, so subclasses of `Set` can narrow down the equality
+   * to specific set types. The `Set` implementations in the standard library can all be compared, their `canEqual`
+   * methods return `true`.
+   *
+   * Note: The `equals` method only respects the equality laws (symmetry, transitivity) if the two sets use the same
+   * element equivalence function in their lookup operation. For example, the element equivalence operation in a
+   * [[scala.collection.immutable.TreeSet]] is defined by its ordering. Comparing a `TreeSet` with a `HashSet` leads
+   * to unexpected results if `ordering.equiv(e1, e2)` (used for lookup in `TreeSet`) is different from `e1 == e2`
+   * (used for lookup in `HashSet`).
+   *
+   * {{{
+   *   scala> import scala.collection.immutable._
+   *   scala> val ord: Ordering[String] = _ compareToIgnoreCase _
+   *
+   *   scala> TreeSet("A")(ord) == HashSet("a")
+   *   val res0: Boolean = false
+   *
+   *   scala> HashSet("a") == TreeSet("A")(ord)
+   *   val res1: Boolean = true
+   * }}}
+   *
+   *
+   * @param that The set to which this set is compared
+   * @return `true` if the two sets are equal according to the description
+   */
   override def equals(that: Any): Boolean =
     (this eq that.asInstanceOf[AnyRef]) || (that match {
       case set: Set[A] if set.canEqual(this) =>

--- a/src/library/scala/collection/Set.scala
+++ b/src/library/scala/collection/Set.scala
@@ -62,7 +62,10 @@ trait Set[A]
   override def equals(that: Any): Boolean =
     (this eq that.asInstanceOf[AnyRef]) || (that match {
       case set: Set[A] if set.canEqual(this) =>
-        (this.size == set.size) && this.subsetOf(set)
+        (this.size == set.size) && {
+          try this.subsetOf(set)
+          catch { case _: ClassCastException => false } // PR #9565 / scala/bug#12228
+        }
       case _ =>
         false
     })

--- a/src/library/scala/collection/SortedMap.scala
+++ b/src/library/scala/collection/SortedMap.scala
@@ -30,14 +30,17 @@ trait SortedMap[K, +V]
 
   override def equals(that: Any): Boolean = that match {
     case _ if this eq that.asInstanceOf[AnyRef] => true
-    case sm: SortedMap[k, v] if sm.ordering == this.ordering =>
+    case sm: SortedMap[K, _] if sm.ordering == this.ordering =>
       (sm canEqual this) &&
         (this.size == sm.size) && {
         val i1 = this.iterator
         val i2 = sm.iterator
         var allEqual = true
-        while (allEqual && i1.hasNext)
-          allEqual = i1.next() == i2.next()
+        while (allEqual && i1.hasNext) {
+          val kv1 = i1.next()
+          val kv2 = i2.next()
+          allEqual = ordering.equiv(kv1._1, kv2._1) && kv1._2 == kv2._2
+        }
         allEqual
       }
     case _ => super.equals(that)

--- a/src/library/scala/collection/SortedSet.scala
+++ b/src/library/scala/collection/SortedSet.scala
@@ -29,14 +29,14 @@ trait SortedSet[A] extends Set[A]
 
   override def equals(that: Any): Boolean = that match {
     case _ if this eq that.asInstanceOf[AnyRef] => true
-    case ss: SortedSet[_] if ss.ordering == this.ordering =>
+    case ss: SortedSet[A] if ss.ordering == this.ordering =>
       (ss canEqual this) &&
         (this.size == ss.size) && {
         val i1 = this.iterator
         val i2 = ss.iterator
         var allEqual = true
         while (allEqual && i1.hasNext)
-          allEqual = i1.next() == i2.next()
+          allEqual = ordering.equiv(i1.next(), i2.next())
         allEqual
       }
     case _ =>

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -254,7 +254,7 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
 
   override def equals(that: Any): Boolean =
     that match {
-      case map: HashMap[K, V] => (this eq map) || (this.rootNode == map.rootNode)
+      case map: HashMap[_, _] => (this eq map) || (this.rootNode == map.rootNode)
       case _ => super.equals(that)
     }
 

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -176,7 +176,7 @@ final class HashSet[A] private[immutable](private[immutable] val rootNode: Bitma
 
   override def equals(that: Any): Boolean =
     that match {
-      case set: HashSet[A] => (this eq set) || (this.rootNode == set.rootNode)
+      case set: HashSet[_] => (this eq set) || (this.rootNode == set.rootNode)
       case _ => super.equals(that)
     }
 

--- a/src/library/scala/collection/immutable/LongMap.scala
+++ b/src/library/scala/collection/immutable/LongMap.scala
@@ -63,9 +63,9 @@ object LongMap {
   private[immutable] case object Nil extends LongMap[Nothing] {
     // Important, don't remove this! See IntMap for explanation.
     override def equals(that : Any) = that match {
-      case (that: AnyRef) if (this eq that) => true
-      case (that: LongMap[_]) => false // The only empty LongMaps are eq Nil
-      case that => super.equals(that)
+      case _: this.type  => true
+      case _: LongMap[_] => false // The only empty LongMaps are eq Nil
+      case _             => super.equals(that)
     }
   }
 

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -283,7 +283,7 @@ final class TreeMap[K, +V] private (private val tree: RB.Tree[K, V])(implicit va
     }
   }
   override def equals(obj: Any): Boolean = obj match {
-    case that: TreeMap[K, V] if ordering == that.ordering => RB.entriesEqual(tree, that.tree)
+    case that: TreeMap[K, _] if ordering == that.ordering => RB.entriesEqual(tree, that.tree)
     case _ => super.equals(obj)
   }
 

--- a/test/junit/scala/collection/MapTest.scala
+++ b/test/junit/scala/collection/MapTest.scala
@@ -123,4 +123,9 @@ class MapTest {
     check(mutable.CollisionProofHashMap(1 -> 1))
   }
 
+  @Test
+  def t12228(): Unit = {
+    assertFalse(Set("") == immutable.BitSet(1))
+    assertFalse(Map("" -> 2) == scala.collection.immutable.LongMap(1L -> 2))
+  }
 }

--- a/test/junit/scala/collection/SortedSetMapEqualsTest.scala
+++ b/test/junit/scala/collection/SortedSetMapEqualsTest.scala
@@ -1,6 +1,7 @@
 package scala.collection
 
-import org.junit.{Assert, Test}, Assert.assertEquals
+import org.junit.{Assert, Test}
+import Assert.{assertEquals, assertNotEquals}
 
 class SortedSetMapEqualsTest {
   @Test
@@ -67,5 +68,61 @@ class SortedSetMapEqualsTest {
       m
     }
     assertEquals(m1, m2)
+  }
+
+  @Test
+  def compareSortedMapKeysByOrdering(): Unit = {
+    val ord: Ordering[String] = _ compareToIgnoreCase _
+
+    val itm1 = scala.collection.immutable.TreeMap("A" -> "2")(ord)
+    val itm2 = scala.collection.immutable.TreeMap("a" -> "2")(ord)
+    val mtm1 = scala.collection.mutable.TreeMap("A" -> "2")(ord)
+    val mtm2 = scala.collection.mutable.TreeMap("a" -> "2")(ord)
+
+    assertEquals(itm1, itm2)
+    assertEquals(mtm1, mtm2)
+
+    assertEquals(itm1, mtm2)
+    assertEquals(mtm1, itm2)
+
+    val m1 = Map("A" -> "2")
+    val m2 = Map("a" -> "2")
+
+    for (m <- List(m1, m2); tm <- List[Map[String, String]](itm1, itm2, mtm1, mtm2))
+      assertEquals(m, tm) // uses keys in `m` to look up values in `tm`, which always succeeds
+
+    assertEquals(itm1, m1)
+    assertEquals(mtm1, m1)
+
+    assertNotEquals(itm2, m1) // uses key in `itm2` ("a") to look up in `m1`, which fails
+    assertNotEquals(mtm2, m1)
+  }
+
+  @Test
+  def compareSortedSetsByOrdering(): Unit = {
+    val ord: Ordering[String] = _ compareToIgnoreCase _
+
+    val its1 = scala.collection.immutable.TreeSet("A")(ord)
+    val its2 = scala.collection.immutable.TreeSet("a")(ord)
+    val mts1 = scala.collection.mutable.TreeSet("A")(ord)
+    val mts2 = scala.collection.mutable.TreeSet("a")(ord)
+
+    assertEquals(its1, its2)
+    assertEquals(mts1, mts2)
+
+    assertEquals(its1, mts2)
+    assertEquals(mts1, its2)
+
+    val s1 = Set("A")
+    val s2 = Set("a")
+
+    for (m <- List(s1, s2); tm <- List[Set[String]](its1, its2, mts1, mts2))
+      assertEquals(m, tm) // uses keys in `m` to look up values in `tm`, which always succeeds
+
+    assertEquals(its1, s1)
+    assertEquals(mts1, s1)
+
+    assertNotEquals(its2, s1) // uses key in `its2` ("a") to look up in `s1`, which fails
+    assertNotEquals(mts2, s1)
   }
 }


### PR DESCRIPTION
Also change the overrides of `SortedMap.equals` and `SortedSet.equals`
to check for key equivalence according to the ordering, instead of
key equality.

Fixes https://github.com/scala/bug/issues/12228