### PR TITLE
Replace 0.asInstanceOf[B] with null.asInstanceOf[B]

### DIFF
--- a/src/library/scala/collection/TraversableOnce.scala
+++ b/src/library/scala/collection/TraversableOnce.scala
@@ -224,7 +224,7 @@ trait TraversableOnce[+A] extends Any with GenTraversableOnce[A] {
     //avoid the LazyRef as we don't have an @eager object
     class reducer extends AbstractFunction1[A, Unit] {
       var first = true
-      var acc: B = 0.asInstanceOf[B]
+      var acc: B = null.asInstanceOf[B]
 
       override def apply(x: A): Unit =
         if (first) {


### PR DESCRIPTION
- This seems to be the only place `0.asInstanceOf[T]` is used, usually it is expressed as `null.asInstanceOf[T]`.
- Emulates [Expression for all zero bits #8767](https://github.com/scala/scala/pull/8767) and tries to address comment https://github.com/scala/scala/pull/8767#pullrequestreview-366753955
- Some related discussion:
  - [What is happening with 0.asInstanceOf[B] in Scala reduceLeft implementation](https://stackoverflow.com/questions/8465356/what-is-happening-with-0-asinstanceofb-in-scala-reduceleft-implementation)
  - [Scala reduceLeft: 0.asInstanceOf[B]](https://stackoverflow.com/questions/66989225/scala-reduceleft-0-asinstanceofb)