### PR TITLE
Align leading infix operator with Scala 3 improvements

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -13,6 +13,7 @@
 package scala.tools.nsc
 package ast.parser
 
+import scala.tools.nsc.settings.ScalaVersion
 import scala.tools.nsc.util.{CharArrayReader, CharArrayReaderData}
 import scala.reflect.internal.util._
 import scala.reflect.internal.Chars._
@@ -403,6 +404,9 @@ trait Scanners extends ScannersCommon {
       sepRegions = sepRegions.tail
     }
 
+    /** True to warn about migration change in infix syntax. */
+    private val infixMigration = settings.Xmigration.value <= ScalaVersion("2.13.2")
+
     /** Produce next token, filling TokenData fields of Scanner.
      */
     def nextToken(): Unit = {
@@ -487,7 +491,7 @@ trait Scanners extends ScannersCommon {
                        |will be taken as an infix expression continued from the previous line.
                        |To force the previous interpretation as a separate statement,
                        |add an explicit `;`, add an empty line, or remove spaces after the operator."""
-          deprecationWarning(msg.stripMargin, "2.13.2")
+          if (infixMigration) deprecationWarning(msg.stripMargin, "2.13.2")
           insertNL(NEWLINE)
         }
       }

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -448,11 +448,11 @@ trait Scanners extends ScannersCommon {
        */
       def isLeadingInfixOperator =
         allowLeadingInfixOperators &&
-        (token == BACKQUOTED_IDENT ||
-         token == IDENTIFIER && isOperatorPart(name.charAt(name.length - 1))) &&
-        (ch == ' ') && lookingAhead {
+        (token == BACKQUOTED_IDENT || token == IDENTIFIER && isOperatorPart(name.charAt(name.length - 1))) &&
+        ch <= ' ' && lookingAhead {
           // force a NEWLINE after current token if it is on its own line
-          isSimpleExprIntroToken(token)
+          isSimpleExprIntroToken(token) ||
+          token == NEWLINE && { nextToken() ; isSimpleExprIntroToken(token) }
         }
 
       /* Insert NEWLINE or NEWLINES if

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -469,8 +469,8 @@ trait Scanners extends ScannersCommon {
           val msg = """|Line starts with an operator that in future
                        |will be taken as an infix expression continued from the previous line.
                        |To force the previous interpretation as a separate statement,
-                       |add an explicit `;`, add an empty line, or remove spaces after the operator.""".stripMargin
-          deprecationWarning(msg, "2.13.2")
+                       |add an explicit `;`, add an empty line, or remove spaces after the operator."""
+          deprecationWarning(msg.stripMargin, "2.13.2")
           insertNL(NEWLINE)
         }
       }

--- a/test/files/neg/multiLineOps.check
+++ b/test/files/neg/multiLineOps.check
@@ -1,5 +1,5 @@
 multiLineOps.scala:6: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-    +3 // error: Expected a toplevel definition (or pure expr warning, here)
+    +3 // warning: a pure expression does nothing in statement position
     ^
 error: No warnings can be incurred under -Werror.
 1 warning

--- a/test/files/neg/multiLineOps.check
+++ b/test/files/neg/multiLineOps.check
@@ -1,5 +1,5 @@
 multiLineOps.scala:6: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
-    +3 // error: Expected a toplevel definition
+    +3 // error: Expected a toplevel definition (or pure expr warning, here)
     ^
 error: No warnings can be incurred under -Werror.
 1 warning

--- a/test/files/neg/multiLineOps.scala
+++ b/test/files/neg/multiLineOps.scala
@@ -1,7 +1,7 @@
-// scalac: -Werror -Xsource:3
+// scalac: -Werror -Xlint -Xsource:3
 
 class Test {
   val x = 1
     + 2
-    +3 // error: Expected a toplevel definition
+    +3 // error: Expected a toplevel definition (or pure expr warning, here)
 }

--- a/test/files/neg/multiLineOps.scala
+++ b/test/files/neg/multiLineOps.scala
@@ -3,5 +3,5 @@
 class Test {
   val x = 1
     + 2
-    +3 // error: Expected a toplevel definition (or pure expr warning, here)
+    +3 // warning: a pure expression does nothing in statement position
 }

--- a/test/files/neg/stmt-expr-discard.check
+++ b/test/files/neg/stmt-expr-discard.check
@@ -1,15 +1,3 @@
-stmt-expr-discard.scala:5: warning: Line starts with an operator that in future
-will be taken as an infix expression continued from the previous line.
-To force the previous interpretation as a separate statement,
-add an explicit `;`, add an empty line, or remove spaces after the operator.
-    + 2
-    ^
-stmt-expr-discard.scala:6: warning: Line starts with an operator that in future
-will be taken as an infix expression continued from the previous line.
-To force the previous interpretation as a separate statement,
-add an explicit `;`, add an empty line, or remove spaces after the operator.
-    - 4
-    ^
 stmt-expr-discard.scala:5: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
     + 2
     ^
@@ -17,5 +5,5 @@ stmt-expr-discard.scala:6: warning: a pure expression does nothing in statement 
     - 4
     ^
 error: No warnings can be incurred under -Werror.
-4 warnings
+2 warnings
 1 error

--- a/test/files/neg/t12071.check
+++ b/test/files/neg/t12071.check
@@ -7,6 +7,10 @@ This can be achieved by adding the import clause 'import scala.language.postfixO
 or by setting the compiler option -language:postfixOps.
 See the Scaladoc for value scala.language.postfixOps for a discussion
 why the feature needs to be explicitly enabled.
+Line starts with an operator that in future
+will be taken as an infix expression continued from the previous line.
+To force the previous interpretation as a separate statement,
+add an explicit `;`, add an empty line, or remove spaces after the operator.
     `c c` i
           ^
 t12071.scala:20: warning: Line starts with an operator that in future

--- a/test/files/neg/t12071.check
+++ b/test/files/neg/t12071.check
@@ -1,0 +1,37 @@
+t12071.scala:15: error: not found: value c c
+    `c c` i
+    ^
+t12071.scala:15: error: postfix operator i needs to be enabled
+by making the implicit value scala.language.postfixOps visible.
+This can be achieved by adding the import clause 'import scala.language.postfixOps'
+or by setting the compiler option -language:postfixOps.
+See the Scaladoc for value scala.language.postfixOps for a discussion
+why the feature needs to be explicitly enabled.
+    `c c` i
+          ^
+t12071.scala:20: warning: Line starts with an operator that in future
+will be taken as an infix expression continued from the previous line.
+To force the previous interpretation as a separate statement,
+add an explicit `;`, add an empty line, or remove spaces after the operator.
+    + 2
+    ^
+t12071.scala:25: warning: Line starts with an operator that in future
+will be taken as an infix expression continued from the previous line.
+To force the previous interpretation as a separate statement,
+add an explicit `;`, add an empty line, or remove spaces after the operator.
+    + 1
+    ^
+t12071.scala:28: warning: Line starts with an operator that in future
+will be taken as an infix expression continued from the previous line.
+To force the previous interpretation as a separate statement,
+add an explicit `;`, add an empty line, or remove spaces after the operator.
+    `test-1` + `test-2`
+    ^
+t12071.scala:31: warning: Line starts with an operator that in future
+will be taken as an infix expression continued from the previous line.
+To force the previous interpretation as a separate statement,
+add an explicit `;`, add an empty line, or remove spaces after the operator.
+    `compareTo` (2 - 1)
+    ^
+4 warnings
+2 errors

--- a/test/files/neg/t12071.scala
+++ b/test/files/neg/t12071.scala
@@ -34,9 +34,18 @@ object C {
   def `test-2`: Int = 42
   def compareTo(x: Int) = println("lol")
 
-  var `test-3`: List[Int] = Nil
+  def yy = 1
+  /* fails in scala 3
+    +
+    `test-1`
+    +
+    `test-2`
+   */
+}
 
-  // since ++ is not unary, test-3 is not taken as an operator; this test doesn't fix y above.
-  def yy = List.empty[Int] ++
-    `test-3` ++ `test-3`
+object Test extends App {
+  println(C.x)
+  println(C.y)
+  println(C.z)
+  println(C.yy)
 }

--- a/test/files/neg/t12071.scala
+++ b/test/files/neg/t12071.scala
@@ -1,0 +1,36 @@
+// scalac: -Werror -Xlint
+
+class C {
+  def `c c`(n: Int): Int = n + 1
+}
+
+// backticked operator is candidate for multiline infix,
+// but backticked value is an innocent bystander.
+//
+class t12071 {
+  def c: C = ???
+  def i: Int = 42
+  def `n n`: Int = 17
+  def f = c
+    `c c` i
+  def g = i +
+    `n n`
+  def basic =
+      1
+    + 2
+}
+
+object C {
+  def x = 42
+    + 1
+
+  def y = 1 +
+    `test-1` + `test-2`
+
+  def z = 2
+    `compareTo` (2 - 1)
+
+  def `test-1`: Int = 23
+  def `test-2`: Int = 42
+  def compareTo(x: Int) = println("lol")
+}

--- a/test/files/neg/t12071.scala
+++ b/test/files/neg/t12071.scala
@@ -1,4 +1,4 @@
-// scalac: -Werror -Xlint
+// scalac: -Werror -Xlint -Xmigration:2.13
 
 class C {
   def `c c`(n: Int): Int = n + 1

--- a/test/files/neg/t12071.scala
+++ b/test/files/neg/t12071.scala
@@ -33,4 +33,10 @@ object C {
   def `test-1`: Int = 23
   def `test-2`: Int = 42
   def compareTo(x: Int) = println("lol")
+
+  var `test-3`: List[Int] = Nil
+
+  // since ++ is not unary, test-3 is not taken as an operator; this test doesn't fix y above.
+  def yy = List.empty[Int] ++
+    `test-3` ++ `test-3`
 }

--- a/test/files/neg/t9847.check
+++ b/test/files/neg/t9847.check
@@ -1,15 +1,3 @@
-t9847.scala:10: warning: Line starts with an operator that in future
-will be taken as an infix expression continued from the previous line.
-To force the previous interpretation as a separate statement,
-add an explicit `;`, add an empty line, or remove spaces after the operator.
-  + 1
-  ^
-t9847.scala:14: warning: Line starts with an operator that in future
-will be taken as an infix expression continued from the previous line.
-To force the previous interpretation as a separate statement,
-add an explicit `;`, add an empty line, or remove spaces after the operator.
-  + 1
-  ^
 t9847.scala:6: warning: discarded non-Unit value
   def f(): Unit = 42
                   ^
@@ -47,5 +35,5 @@ t9847.scala:24: warning: a pure expression does nothing in statement position; m
   class D { 42 ; 17 }
                  ^
 error: No warnings can be incurred under -Werror.
-14 warnings
+12 warnings
 1 error

--- a/test/files/pos/i11371.scala
+++ b/test/files/pos/i11371.scala
@@ -1,0 +1,21 @@
+// scalac: -Xsource:3
+//
+object HelloWorld {
+  def whileLoop: Int = {
+    var i = 0
+    var acc = 0
+    while (i < 3) {
+      var `i'` = 0
+      while (`i'` < 4) {
+        acc += (i * `i'`)
+        `i'` += 1
+      }
+      i += 1
+    }
+    acc
+  }
+
+  def main(args: Array[String]): Unit = {
+    println(s"hello world: ${whileLoop}")
+  }
+}

--- a/test/files/pos/leading-infix-op.scala
+++ b/test/files/pos/leading-infix-op.scala
@@ -1,0 +1,19 @@
+
+// scalac: -Xsource:3
+
+trait T {
+  def f(x: Int): Boolean =
+    x < 0
+    ||
+    x > 0
+    &&
+    x != 3
+
+  def g(x: Option[Int]) = x match {
+    case Some(err) =>
+      println("hi")
+      ???
+    case None =>
+      ???
+  }
+}

--- a/test/files/run/multiLineOps.scala
+++ b/test/files/run/multiLineOps.scala
@@ -6,8 +6,10 @@
 object Test extends App {
   val a = 7
   val x = 1
-    + //
-    `a` * 6
+    +
+    `a`
+    *
+    6
 
-  assert(x == 1 + 42, x)  // was: 1
+  assert(x == 1 + 7 * 6, x)  // was: 1, now: successor(42)
 }

--- a/test/files/run/multiLineOps.scala
+++ b/test/files/run/multiLineOps.scala
@@ -1,6 +1,7 @@
 // scalac: -Xsource:3
 //
-// without backticks, "not found: value +"
+// was: without backticks, "not found: value +" (but parsed here as +a * 6, where backticks fool the lexer)
+// now: + is taken as "solo" infix op
 //
 object Test extends App {
   val a = 7
@@ -8,5 +9,5 @@ object Test extends App {
     + //
     `a` * 6
 
-  assert(x == 1)
+  assert(x == 1 + 42, x)  // was: 1
 }

--- a/test/files/run/t12071.scala
+++ b/test/files/run/t12071.scala
@@ -1,0 +1,28 @@
+// scalac: -Werror -Xlint -Xsource:3
+
+class C {
+  def `c c`(n: Int): Int = n + 1
+}
+
+// backticked operator is candidate for multiline infix,
+// but backticked value is an innocent bystander.
+//
+class t12071 {
+  def c: C = new C
+  def i: Int = 42
+  def `n n`: Int = 27
+  def f = c
+    `c c` i
+  def g = i +
+    `n n`
+  def basic =
+      1
+    + 2
+}
+
+object Test extends App {
+  val t = new t12071
+  assert(t.f == 43)
+  assert(t.g == 69)
+  assert(t.basic == 3)
+}


### PR DESCRIPTION
Align "leading infix operator" with Scala 3. The feature is available under `-Xsource:3`, and a migration warning is available under `-Xmigration:2.13`.

Improvements include allowing an infix operator on a line by itself, and a better heuristic for whether to take a back-quoted identifier as an infix operator.

Fixes scala/bug#12071