### PR TITLE
Support async trees fsm() as a sibling of class statemachine

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/async/AsyncTransformStates.scala
+++ b/src/compiler/scala/tools/nsc/transform/async/AsyncTransformStates.scala
@@ -25,6 +25,7 @@ trait AsyncTransformStates extends TypingTransformers {
                             val postAnfTransform: Block => Block,
                             val dotDiagram: (Symbol, Tree) => Option[String => Unit],
                             val typingTransformer: TypingTransformer,
+                            val exteralFsmSelfParam: Symbol,
                             val applyTrParam: Symbol,
                             val asyncType: Type,
                             val asyncNames: AsyncNames[global.type]) {
@@ -39,7 +40,7 @@ trait AsyncTransformStates extends TypingTransformers {
     val applySym: Symbol = applyTr.owner
     var currentPos: Position = applySym.pos
 
-    lazy val stateMachineClass: Symbol = applySym.owner
+    lazy val stateMachineClass: Symbol = if (exteralFsmSelfParam != NoSymbol) exteralFsmSelfParam.info.typeSymbol else applySym.owner
     lazy val stateGetter: Symbol = stateMachineMember(nme.state)
     lazy val stateSetter: Symbol = stateMachineMember(nme.state.setterName)
     lazy val stateOnComplete: Symbol = stateMachineMember(TermName("onComplete"))
@@ -52,7 +53,15 @@ trait AsyncTransformStates extends TypingTransformers {
     def stateMachineMember(name: TermName): Symbol =
       stateMachineClass.info.member(name)
     def memberRef(sym: Symbol): Tree =
-      gen.mkAttributedRef(stateMachineClass.typeConstructor, sym)
+      if (exteralFsmSelfParam == NoSymbol)
+        gen.mkAttributedRef(stateMachineClass.typeConstructor, sym)
+      else
+        gen.mkAttributedSelect(gen.mkAttributedIdent(exteralFsmSelfParam), sym)
+    def stateMachineRef(): Tree =
+      if (exteralFsmSelfParam == NoSymbol)
+        gen.mkAttributedThis(stateMachineClass)
+      else
+        gen.mkAttributedIdent(exteralFsmSelfParam)
   }
 
 }

--- a/src/compiler/scala/tools/nsc/transform/async/ExprBuilder.scala
+++ b/src/compiler/scala/tools/nsc/transform/async/ExprBuilder.scala
@@ -51,7 +51,7 @@ trait ExprBuilder extends TransformUtils with AsyncAnalysis {
       val stats1 = mutable.ListBuffer[Tree]()
       def addNullAssigments(syms: Iterator[Symbol]): Unit = {
         for (fieldSym <- syms) {
-          stats1 += typed(Assign(gen.mkAttributedStableRef(fieldSym.owner.thisPrefix, fieldSym), gen.mkZero(fieldSym.info)))
+          stats1 += typed(Assign(currentTransformState.memberRef(fieldSym), gen.mkZero(fieldSym.info)))
         }
       }
       // Add pre-state null assigments at the beginning.
@@ -539,7 +539,7 @@ trait ExprBuilder extends TransformUtils with AsyncAnalysis {
       val tempVd = ValDef(temp, gen.mkMethodCall(currentTransformState.memberRef(currentTransformState.stateTryGet), tryyReference :: Nil))
       typed(Block(
         tempVd :: Nil,
-        If(Apply(gen.mkAttributedSelect(gen.mkAttributedThis(currentTransformState.stateMachineClass), definitions.Any_==), gen.mkAttributedIdent(temp) :: Nil),
+        If(Apply(gen.mkAttributedSelect(currentTransformState.stateMachineRef(), definitions.Any_==), gen.mkAttributedIdent(temp) :: Nil),
           Return(literalUnit),
           gen.mkCast(gen.mkAttributedIdent(temp), tempVd.symbol.info)
         )
@@ -598,7 +598,7 @@ trait ExprBuilder extends TransformUtils with AsyncAnalysis {
         // (_without_ consuming an extra stack frome!)
 
         def callOnComplete(fut: Tree): Tree =
-          Apply(Select(This(currentTransformState.stateMachineClass), transformState.stateOnComplete), fut :: Nil)
+          Apply(currentTransformState.memberRef(transformState.stateOnComplete), fut :: Nil)
 
         val runCompletedOnSameThread = transformState.stateGetCompleted != NoSymbol
         if (runCompletedOnSameThread) {

--- a/test/async/jvm/lazyval.scala
+++ b/test/async/jvm/lazyval.scala
@@ -5,9 +5,11 @@ package scala.async.run.lazyval {
 
   import org.junit.Test
   import org.junit.Assert._
+
   import scala.concurrent._
   import scala.concurrent.duration._
   import ExecutionContext.Implicits.global
+  import scala.collection.mutable.ListBuffer
   import scala.tools.partest.async.Async.{async, await}
   object TestUtil {
     import language.implicitConversions
@@ -32,6 +34,34 @@ package scala.async.run.lazyval {
       })
 
       assertEquals(43, result)
+    }
+
+    @Test
+    def localObject(): Unit = {
+      val result = block(async {
+        val log = ListBuffer[String]()
+        object O {
+          log += "O"
+        }
+        await(1)
+        O
+        await(1)
+        O
+        var i = 0
+        while (i <= 2) {
+          object W {
+            log += "W(" + i + ")"
+          }
+          await(1)
+          W
+          await(1)
+          W
+          i += 1
+        }
+        log.mkString(",")
+      })
+
+      assertEquals("O,W(0),W(1),W(2)", result)
     }
   }
 

--- a/test/junit/scala/tools/nsc/async/AnnotationDrivenAsync.scala
+++ b/test/junit/scala/tools/nsc/async/AnnotationDrivenAsync.scala
@@ -448,11 +448,9 @@ class AnnotationDrivenAsync {
       }
     } catch {
       case ve: VerifyError =>
-        val asm = out.listFiles().filter(_.getName.contains("stateMachine")).flatMap { file =>
-          import scala.sys.process._
-          val javap = List("/usr/local/bin/javap", "-v", file.getAbsolutePath).!!
+        val asm = out.listFiles().flatMap { file =>
           val asmp = AsmUtils.textify(AsmUtils.readClass(file.getAbsolutePath))
-          javap :: asmp :: Nil
+          asmp :: Nil
         }.mkString("\n\n")
         throw new AssertionError(asm, ve)
     } finally {
@@ -490,17 +488,32 @@ abstract class AnnotationDrivenAsyncPlugin extends Plugin {
           case dd: DefDef if dd.symbol.hasAnnotation(customAsyncSym) =>
             deriveDefDef(dd) {
               rhs =>
-                val applyMethod =
-                  q"""def apply(tr: _root_.scala.util.Either[_root_.scala.Throwable, _root_.scala.AnyRef]): _root_.scala.Unit = $rhs"""
-                val applyMethodMarked = global.async.markForAsyncTransform(dd.symbol, applyMethod, awaitSym, Map.empty)
+                val fsmImplName = currentUnit.freshTermName("fsm$")
+                val externalFsmMethod = true
                 val name = TypeName("stateMachine$async")
-                val wrapped =
+                val wrapped = if (!externalFsmMethod) {
+                  val applyMethod       =
+                    q"""def apply(tr: _root_.scala.util.Either[_root_.scala.Throwable, _root_.scala.AnyRef]): _root_.scala.Unit = $rhs"""
+                  val applyMethodMarked = global.async.markForAsyncTransform(dd.symbol, applyMethod, awaitSym, Map.empty)
                   q"""
                     class $name extends _root_.scala.tools.nsc.async.CustomFutureStateMachine {
-                     $applyMethodMarked
+                      $applyMethodMarked
                     }
                     new $name().start()
                    """
+                } else {
+                  val applyMethod       =
+                    q"""def $fsmImplName(self: $name, tr: _root_.scala.util.Either[_root_.scala.Throwable, _root_.scala.AnyRef]): _root_.scala.Unit = $rhs"""
+                  val applyMethodMarked = global.async.markForAsyncTransform(dd.symbol, applyMethod, awaitSym, Map.empty)
+                  q"""
+                    $applyMethodMarked
+                    class $name extends _root_.scala.tools.nsc.async.CustomFutureStateMachine {
+                       def apply(tr: _root_.scala.util.Either[_root_.scala.Throwable, _root_.scala.AnyRef]): _root_.scala.Unit =
+                         $fsmImplName(this, tr)
+                    }
+                    new $name().start()
+                   """
+                }
 
                 val tree =
                   q"""


### PR DESCRIPTION
This aligns closely with the tree shape of lambdas and sets the stage for a
post-async compiler transform to turn the anonymous inner class into a
invokedynamic metafactory call.