### PR TITLE
Drop old ScalaVersions

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1154,9 +1154,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
     keepPhaseStack = settings.log.isSetByUser
 
     // We hit these checks regularly. They shouldn't change inside the same run, so cache the comparisons here.
-    val isScala212: Boolean = settings.isScala212
-    val isScala213: Boolean = settings.isScala213
-    val isScala3: Boolean   = settings.isScala3
+    val isScala3 = settings.isScala3
 
     // used in sbt
     def uncheckedWarnings: List[(Position, String)]   = reporting.uncheckedWarnings

--- a/src/compiler/scala/tools/nsc/Parsing.scala
+++ b/src/compiler/scala/tools/nsc/Parsing.scala
@@ -22,7 +22,6 @@ trait Parsing { self : Positions with Reporting =>
 
   trait RunParsing {
     val parsing: PerRunParsing = new PerRunParsing
-    def isScala213: Boolean
   }
 
   class PerRunParsing {

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2366,14 +2366,7 @@ self =>
         if (vds.isEmpty)
           syntaxError(start, s"case classes must have a parameter list; try 'case class $name()' or 'case object $name'")
         else if (vds.head.nonEmpty && vds.head.head.mods.isImplicit) {
-          if (currentRun.isScala213)
-            syntaxError(start, s"case classes must have a non-implicit parameter list; try 'case class $name()$elliptical'")
-          else {
-            deprecationWarning(start, s"case classes should have a non-implicit parameter list; adapting to 'case class $name()$elliptical'", "2.12.2")
-            vds.insert(0, List.empty[ValDef])
-            vds(1) = vds(1).map(vd => copyValDef(vd)(mods = vd.mods & ~Flags.CASEACCESSOR))
-            if (implicitSection != -1) implicitSection += 1
-          }
+          syntaxError(start, s"case classes must have a non-implicit parameter list; try 'case class $name()$elliptical'")
         }
       }
       if (implicitSection != -1 && implicitSection != vds.length - 1)

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -670,11 +670,9 @@ trait Scanners extends ScannersCommon {
               val isEmptyCharLit = (ch == '\'')
               getLitChar()
               if (ch == '\'') {
-                if (isEmptyCharLit && currentRun.isScala213)
+                if (isEmptyCharLit)
                   syntaxError("empty character literal (use '\\'' for single quote)")
                 else {
-                  if (isEmptyCharLit)
-                    deprecationWarning("deprecated syntax for character literal (use '\\'' for single quote)", "2.12.2")
                   nextChar()
                   token = CHARLIT
                   setStrVal()

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -92,18 +92,6 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
   } withAbbreviation "--release"
   def releaseValue: Option[String] = Option(release.value).filter(_ != "")
 
-  /*
-   * The previous "-Xsource" option is intended to be used mainly
-   * though this helper.
-   */
-  private[this] val version212 = ScalaVersion("2.12.0")
-  def isScala212: Boolean = source.value >= version212
-  private[this] val version213 = ScalaVersion("2.13.0")
-  def isScala213: Boolean = source.value >= version213
-  private[this] val version214 = ScalaVersion("2.14.0")
-  private[this] val version3 = ScalaVersion("3.0.0")
-  def isScala3: Boolean = source.value >= version3
-
   /**
    * -X "Advanced" settings
    */
@@ -145,10 +133,16 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
   val mainClass          = StringSetting       ("-Xmain-class", "path", "Class for manifest's Main-Class entry (only useful with -d <jar>)", "")
   val sourceReader       = StringSetting       ("-Xsource-reader", "classname", "Specify a custom method for reading source files.", "")
   val reporter           = StringSetting       ("-Xreporter", "classname", "Specify a custom subclass of FilteringReporter for compiler messages.", "scala.tools.nsc.reporters.ConsoleReporter")
-  val source             = ScalaVersionSetting ("-Xsource", "version", "Enable features that will be available in a future version of Scala, for purposes of early migration and alpha testing.", initial = version213).withPostSetHook { s =>
-      if (s.value < version213) errorFn.apply(s"-Xsource must be at least the current major version (${version213.versionString})")
-      if (s.value >= version214 && s.value < version3) s.withDeprecationMessage("instead of -Xsource:2.14, use -Xsource:3").value = version3
+  val source             = ScalaVersionSetting ("-Xsource", "version", "Enable features that will be available in a future version of Scala, for purposes of early migration and alpha testing.", initial = ScalaVersion("2.13")).withPostSetHook { s =>
+    if (s.value >= ScalaVersion("3"))
+      isScala3.value = true
+    else if (s.value >= ScalaVersion("2.14"))
+      s.withDeprecationMessage("instead of -Xsource:2.14, use -Xsource:3").value = ScalaVersion("3")
+    else if (s.value < ScalaVersion("2.13"))
+      errorFn.apply(s"-Xsource must be at least the current major version (${ScalaVersion("2.13").versionString})")
   }
+  val isScala3           = BooleanSetting      ("isScala3", "Is -Xsource Scala 3?").internalOnly()
+  // The previous "-Xsource" option is intended to be used mainly though ^ helper
 
   val XnoPatmatAnalysis = BooleanSetting ("-Xno-patmat-analysis", "Don't perform exhaustivity/unreachability analysis. Also, ignore @switch annotation.")
 

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -445,7 +445,7 @@ abstract class UnCurry extends InfoTransform
           if (sym.isMethod) level < settings.elidebelow.value
           else {
             // TODO: report error? It's already done in RefChecks. https://github.com/scala/scala/pull/5539#issuecomment-331376887
-            if (currentRun.isScala213) reporter.error(sym.pos, s"${sym.name}: Only methods can be marked @elidable.")
+            reporter.error(sym.pos, s"${sym.name}: Only methods can be marked @elidable.")
             false
           }
         }

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -107,7 +107,7 @@ trait ContextErrors {
     def issueTypeError(err: AbsTypeError)(implicit context: Context): Unit = { context.issue(err) }
 
     def typeErrorMsg(context: Context, found: Type, req: Type) =
-      if (context.openImplicits.nonEmpty && !settings.XlogImplicits.value && currentRun.isScala213)
+      if (context.openImplicits.nonEmpty && !settings.XlogImplicits.value)
          // OPT: avoid error string creation for errors that won't see the light of day, but predicate
         //       this on -Xsource:2.13 for bug compatibility with https://github.com/scala/scala/pull/7147#issuecomment-418233611
         "type mismatch"

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1058,7 +1058,7 @@ trait Contexts { self: Analyzer =>
       ) &&
       !(imported && {
         val e = scope.lookupEntry(name)
-        (e ne null) && (e.owner == scope) && (!currentRun.isScala212 || e.sym.exists)
+        (e ne null) && (e.owner == scope) && e.sym.exists
       })
 
     /** Do something with the symbols with name `name` imported via the import in `imp`,

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1724,7 +1724,7 @@ trait Namers extends MethodSynthesis {
               val valOwner = owner.owner
               // there's no overriding outside of classes, and we didn't use to do this in 2.11, so provide opt-out
 
-              if (!currentRun.isScala212 || !valOwner.isClass) WildcardType
+              if (!valOwner.isClass) WildcardType
               else {
                 // normalize to getter so that we correctly consider a val overriding a def
                 // (a val's name ends in a " ", so can't compare to def)

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1486,7 +1486,7 @@ abstract class RefChecks extends Transform {
           reporter.error(sym.pos, s"${sym.name}: Only concrete methods can be marked @elidable.$rest")
         }
       }
-      if (currentRun.isScala213) checkIsElidable(tree.symbol)
+      checkIsElidable(tree.symbol)
 
       def checkMember(sym: Symbol): Unit = {
         sym.setAnnotations(applyChecks(sym.annotations))

--- a/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
@@ -168,7 +168,7 @@ trait Unapplies extends ast.TreeDSL {
       case _                                                          => nme.unapply
     }
     val cparams = List(ValDef(Modifiers(PARAM | SYNTHETIC), unapplyParamName, classType(cdef, tparams), EmptyTree))
-    val resultType = if (!currentRun.isScala212) TypeTree() else { // fix for scala/bug#6541 under -Xsource:2.12
+    val resultType = { // fix for scala/bug#6541 under -Xsource:2.12
       def repeatedToSeq(tp: Tree) = tp match {
         case AppliedTypeTree(Select(_, tpnme.REPEATED_PARAM_CLASS_NAME), tps) => AppliedTypeTree(gen.rootScalaDot(tpnme.Seq), tps)
         case _                                                                => tp

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -995,7 +995,6 @@ trait Definitions extends api.StandardDefinitions {
       (sym eq PartialFunctionClass) || (sym eq AbstractPartialFunctionClass)
     }
 
-    private[this] val doSam = settings.isScala212
     private[this] val samCache = perRunCaches.newAnyRefMap[Symbol, Symbol]()
     /** The single abstract method declared by type `tp` (or `NoSymbol` if it cannot be found).
       *
@@ -1008,7 +1007,7 @@ trait Definitions extends api.StandardDefinitions {
       * It's kind of strange that erasure sees deferredMembers that typer does not (see commented out assert below)
       */
     def samOf(tp: Type): Symbol =
-      if (doSam && isNonRefinementClassType(unwrapToClass(tp))) { // TODO: is this really faster than computing tpSym below? how about just `tp.typeSymbol.isClass` (and !tpSym.isRefinementClass)?
+      if (isNonRefinementClassType(unwrapToClass(tp))) { // TODO: is this really faster than computing tpSym below? how about just `tp.typeSymbol.isClass` (and !tpSym.isRefinementClass)?
         // look at erased type because we (only) care about what ends up in bytecode
         // (e.g., an alias type is fine as long as is compiles to a single-abstract-method)
         val tpSym: Symbol = erasure.javaErasure(tp).typeSymbol

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3620,7 +3620,7 @@ trait Types
               // This is a higher-kinded type var with same arity as tp.
               // If so (see scala/bug#7517), side effect: adds the type constructor itself as a bound.
               isSubArgs(lhs, rhs, params, AnyDepth) && {addBound(tp.typeConstructor); true}
-            } else if (settings.isScala213 && numCaptured > 0) {
+            } else if (numCaptured > 0) {
               // Simple algorithm as suggested by Paul Chiusano in the comments on scala/bug#2712
               //
               //   https://github.com/scala/bug/issues/2712#issuecomment-292374655

--- a/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
+++ b/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
@@ -63,9 +63,6 @@ abstract class MutableSettings extends AbsSettings {
   def YstatisticsEnabled: BooleanSetting
 
   def Yrecursion: IntSetting
-
-  def isScala212: Boolean
-  private[scala] def isScala213: Boolean
 }
 
 object MutableSettings {

--- a/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
@@ -404,7 +404,7 @@ trait TypeComparers {
     }
 
     def isSub(tp1: Type, tp2: Type) =
-      settings.isScala213 && isSubHKTypeVar(tp1, tp2) ||
+      isSubHKTypeVar(tp1, tp2) ||
         isSub2(tp1.normalize, tp2.normalize)  // @M! normalize reduces higher-kinded typeref to PolyType
 
     def isSub2(ntp1: Type, ntp2: Type) = (ntp1, ntp2) match {

--- a/src/reflect/scala/reflect/runtime/Settings.scala
+++ b/src/reflect/scala/reflect/runtime/Settings.scala
@@ -60,7 +60,7 @@ private[reflect] class Settings extends MutableSettings {
   val YhotStatisticsEnabled = new BooleanSetting(false)
   val YstatisticsEnabled    = new BooleanSetting(false)
 
-  val Yrecursion        = new IntSetting(0)
-  def isScala212        = true
-  private[scala] def isScala213 = true
+  val Yrecursion = new IntSetting(0)
+  def isScala212 = true
+  def isScala213 = true
 }


### PR DESCRIPTION
With

    if (s.value < version213) errorFn.apply(s"-Xsource must be at least the current major version (${version213.versionString})")

I think -Xsource can never be < 2.13.0.  So all those isScala212 and
isScala213 are trues in disguise.  Let's get rid of them.

Also we can cache the isScala3 comparison in a boolean setting that is
managed by Xsource's postSetHook.