### PR TITLE
Do not add self-invoke evidence in parser

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2863,8 +2863,7 @@ self =>
           t = Apply(t, argumentExprs())
           newLineOptWhenFollowedBy(LBRACE)
         }
-        if (classContextBounds.isEmpty) t
-        else Apply(t, vparamss.last.map(vp => Ident(vp.name)))
+        t
       }
 
     /** {{{

--- a/test/files/neg/t12233.check
+++ b/test/files/neg/t12233.check
@@ -1,0 +1,7 @@
+t12233.scala:4: error: ambiguous implicit values:
+ both value hehe of type TypeClass[T]
+ and value evidence$2 of type TypeClass[T]
+ match expected type TypeClass[T]
+  def this(i: Int)(implicit hehe: TypeClass[T], j: Int) = this(i, j)
+                                                          ^
+1 error

--- a/test/files/neg/t12233.scala
+++ b/test/files/neg/t12233.scala
@@ -1,0 +1,20 @@
+
+trait TypeClass[T]
+class Hehe[T: TypeClass](i: Int, j: Int) {
+  def this(i: Int)(implicit hehe: TypeClass[T], j: Int) = this(i, j)
+}
+
+/* was
+t12233.scala:4: error: too many arguments (found 3, expected 1) for constructor Hehe: (implicit evidence$1: TypeClass[T]): Hehe[T]
+  def this(i: Int)(implicit hehe: TypeClass[T], j: Int) = this(i, j)
+                                                          ^
+1 error
+ * now
+t12233.scala:4: error: ambiguous implicit values:
+ both value hehe of type TypeClass[T]
+ and value evidence$2 of type TypeClass[T]
+ match expected type TypeClass[T]
+  def this(i: Int)(implicit hehe: TypeClass[T], j: Int) = this(i, j)
+                                                          ^
+1 error
+ */

--- a/test/files/pos/t12233.scala
+++ b/test/files/pos/t12233.scala
@@ -1,0 +1,12 @@
+
+trait TypeClass[T]
+class Hehe[T: TypeClass](i: Int, j: Int) {
+  def this(i: Int)(implicit j: Int) = this(i, j)
+}
+
+/* was
+test/files/pos/t12233.scala:4: error: too many arguments (found 2, expected 1) for constructor Hehe: (implicit evidence$1: TypeClass[T]): Hehe[T]
+  def this(i: Int)(implicit j: Int) = this(i, j)
+                                      ^
+1 error
+ */


### PR DESCRIPTION
The RHS of an auxiliary constructor should have
implicit args supplied by typer as usual,
not using current args in parser, which could
only work if all alternatives of the overloaded
constructor have the same implicit parameters.

Fixes scala/bug#12233