### PR TITLE
remove references to Bintray and JCenter

### DIFF
--- a/scripts/common
+++ b/scripts/common
@@ -18,7 +18,6 @@ integrationRepoUrl=${integrationRepoUrl-"https://scala-ci.typesafe.com/artifacto
 
 # only used on jenkins
 sbtRepositoryConfig="$WORKSPACE/scripts/sbt-repositories-config"
-jcenterCacheUrl=${jcenterCacheUrl-"https://scala-ci.typesafe.com/artifactory/jcenter/"}
 
 # used by `checkAvailability`
 TMP_ROOT_DIR=$(mktemp -d -t pr-scala.XXXX)
@@ -92,11 +91,9 @@ function generateRepositoriesConfig() {
   fi
 
   cat >> "$sbtRepositoryConfig" << EOF
-  jcenter-cache: $jcenterCacheUrl
   local
   maven-central
-  typesafe-ivy-releases-boot: https://repo.lightbend.com/typesafe/ivy-releases/, [organisation]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
-  typesafe-ivy-releases: https://dl.bintray.com/typesafe/ivy-releases/, [organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
+  typesafe-ivy-releases: https://repo.lightbend.com/typesafe/ivy-releases/, [organisation]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
   sbt-plugin-releases: https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/, [organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
 EOF
 }


### PR DESCRIPTION
throwing this out there for review, in any case anyone thinks they remember something about this. if nobody remembers I think we could just merge it and hope for the best

one certainly hopes we weren't actually hitting the JCenter cache for anything, hopefully that's just leftover cruft from the dark ages. it was added by Adriaan in 2015 as part of #4496, back in the Ant era

as for the typesafe-ivy-releases-boot vs typesafe-ivy-releases thing, that came into the repo in 2014: 30d3712038c3972dc4baf36870f8a69e2893ce3f, but may be even older since it was copied from elsewhere, according to the commit message

we'll find out first if PR validation is still okay, and then we'll find out if nightlies still publish, and eventually we'll find out if real releases are still okay

Note that Travis-CI still does `source scripts/common`, so that's at least one way in which our old Jenkins stuff and our newer Travis-CI stuff remain entangled

@retronym I've submitted this to 2.13.x, but as you're building 2.12.14 you might keep this in the back of your mind. 2.13.x is on sbt 1.5, while 2.12.x is on sbt 1.3, so it's possible that could affect something, perhaps during sbt startup. (sbt 1.5 release notes: "Coursier-based launcher")