### PR TITLE
Fix some cases of `instanceOf[X.type]`: rewrite TypeApply's type arguments to use explicit outer references

### DIFF
--- a/test/files/run/t12312.scala
+++ b/test/files/run/t12312.scala
@@ -1,0 +1,25 @@
+class A { object X }
+
+class C {
+  val a, b = new A; import a.X
+  class D {
+    def isInstanceOf_aX(z: AnyRef) = z.isInstanceOf[X.type]
+    class E {
+      def isInstanceOf_aX(z: AnyRef) = z.isInstanceOf[X.type]
+    }
+  }
+}
+
+object Test extends C {
+  def main(args: Array[String]): Unit = {
+    val d = new D()
+    assert(d.isInstanceOf_aX(a.X))
+    assert(!d.isInstanceOf_aX(b.X))
+    assert(!d.isInstanceOf_aX(new Object))
+
+    val e = new d.E()
+    assert(e.isInstanceOf_aX(a.X))
+    assert(!e.isInstanceOf_aX(b.X))
+    assert(!e.isInstanceOf_aX(new Object))
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/12312