### PR TITLE
Support Scala 3 wildcard and renaming imports under -Xsource:3

### DIFF
--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -658,6 +658,9 @@ trait StdNames {
     val long2Long: NameType       = nameType("long2Long")
     val boolean2Boolean: NameType = nameType("boolean2Boolean")
 
+    // Scala 3 import syntax
+    val as: NameType              = nameType("as")
+
     // Compiler utilized names
 
     val AnnotatedType: NameType        = nameType("AnnotatedType")

--- a/test/files/neg/import-future.check
+++ b/test/files/neg/import-future.check
@@ -1,0 +1,4 @@
+import-future.scala:15: error: not found: value unrelated
+    unrelated(1) // error
+    ^
+1 error

--- a/test/files/neg/import-future.scala
+++ b/test/files/neg/import-future.scala
@@ -1,0 +1,27 @@
+// scalac: -Xsource:3
+//
+
+class D {
+  def *(y: Int): Int = y
+  def unrelated(y: Int): Int = y
+}
+
+object Test {
+  val d = new D
+
+  def one: Int = {
+    import d.`*`
+
+    unrelated(1) // error
+
+    *(1)
+  }
+
+  def two: Int = {
+    import d.*
+
+    unrelated(1)
+
+    *(1)
+  }
+}

--- a/test/files/pos/import-future.scala
+++ b/test/files/pos/import-future.scala
@@ -1,0 +1,25 @@
+// scalac: -Xsource:3
+//
+
+import java.io as jio
+import scala.{collection as c}
+
+import c.mutable as mut
+import mut.ArrayBuffer as Buf
+
+object O {
+  val x: jio.IOException = ???
+  val y = Buf(1, 2, 3)
+
+  type OString = String
+  def foo22(x: Int) = x
+}
+
+class C {
+  import O.{ foo22 as foo, OString as OS }
+  println(foo(22))
+  val s: OS = ""
+
+  import mut.*
+  val ab = ArrayBuffer(1)
+}


### PR DESCRIPTION
Instead of:

    import foo._

One can now write:

    import foo.*

and instead of:

    import foo.{bar => baz}

One can now write:

    import foo.{bar as baz}

As well as:

    import foo.bar as baz

This will let us deprecate the old syntax in a future release of Scala
3 (it's currently only deprecated under `-source future`).

See http://dotty.epfl.ch/docs/reference/changed-features/imports.html for
details but note that unlike Scala 3 this commit does not implement
support for:

    import java as j

As that would require deeper changes in the compiler.