### PR TITLE
Support Scala 3 vararg splice syntax under -Xsource:3

### DIFF
--- a/test/files/pos/varargs-future.scala
+++ b/test/files/pos/varargs-future.scala
@@ -1,0 +1,22 @@
+// scalac: -Xsource:3
+//
+
+class Test {
+  def foo(xs: Int*): Seq[Int] = xs
+
+  val s: Seq[Int] = Seq(1, 2, 3)
+  foo(s*)
+
+  // not very useful, but supported by Scala 3 (and matches what works with `: _*` syntax)
+  foo(
+    s*,
+  )
+
+  s match {
+    case Seq(elems*) => println(elems)
+  }
+
+  s match {
+    case Seq(x, rest*) => println(rest)
+  }
+}


### PR DESCRIPTION
Instead of:

    foo(s: _*)

One can now write:

    foo(s*)

And instead of:

    case Seq(elems @ _*) =>

One can now write:

    case Seq(elems*) =>

See https://dotty.epfl.ch/docs/reference/changed-features/vararg-splices.html
for details.