### PR TITLE
GitHub Actions: Windows CI: align with Travis-CI (simpler bootstrap) [ci: last-only]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,24 +37,11 @@ jobs:
             ~/.cache/coursier
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - name: Setup
-        run: |
-          source scripts/common
-          java -version
-          javac -version
-          generateRepositoriesConfig
-          # Pass these environment vars to subsequent steps
-          echo "SBT=sbt -Dsbt.override.build.repos=true -Dsbt.repository.config=${sbtRepositoryConfig}" >> $GITHUB_ENV
-          echo "COURSIER_HOME=$HOME/.coursier" >> "$GITHUB_ENV"
-          echo "COURSIER_CACHE=$HOME/.cache/coursier/v1" >> "$GITHUB_ENV"
-
       - name: Build
         run: |
-          source scripts/common
-          $SBT -warn setupPublishCore generateBuildCharacterPropertiesFile publishLocal
+          sbt setupPublishCore generateBuildCharacterPropertiesFile headerCheck publishLocal
 
       - name: Test
         run: |
-          source scripts/common
-          parseScalaProperties buildcharacter.properties
-          $SBT -Dstarr.version=$maven_version_number -warn setupValidateTest testAll
+          STARR=`cat buildcharacter.properties | grep ^maven.version.number | cut -d= -f2` && echo $STARR
+          sbt -Dstarr.version=$STARR setupValidateTest test:compile info testAll


### PR DESCRIPTION
as per discussion on #9496

the new script is identical to what we use for PR validation in `.travis.yml`, except I took out `-warn` which we already removed in 2.13.x