### PR TITLE
Add null check for getURLs-method

### DIFF
--- a/src/reflect/scala/reflect/runtime/ReflectionUtils.scala
+++ b/src/reflect/scala/reflect/runtime/ReflectionUtils.scala
@@ -47,7 +47,7 @@ object ReflectionUtils {
       isAbstractFileClassLoader(clazz.getSuperclass)
     }
     def inferClasspath(cl: ClassLoader): String = cl match {
-      case cl: java.net.URLClassLoader =>
+      case cl: java.net.URLClassLoader if cl.getURLs != null =>
         (cl.getURLs mkString ",")
       case cl if cl != null && isAbstractFileClassLoader(cl.getClass) =>
         cl.asInstanceOf[{val root: scala.reflect.io.AbstractFile}].root.canonicalPath

--- a/test/junit/scala/reflect/runtime/ReflectionUtilsShowTest.scala
+++ b/test/junit/scala/reflect/runtime/ReflectionUtilsShowTest.scala
@@ -1,0 +1,19 @@
+package scala.reflect.runtime
+
+import java.net.{URL, URLClassLoader}
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class ReflectionUtilsShowTest {
+  @Test def testGetUrlsCanReturnNull(): Unit = {
+    val sut = new MyClassLoader(Array.empty[URL])
+    assert(ReflectionUtils.show(sut).contains("<unknown>"))
+  }
+}
+
+class MyClassLoader(urls: Array[URL]) extends URLClassLoader(urls) {
+  override def getURLs: Array[URL] = null
+}


### PR DESCRIPTION
Applying this PR will add a null check for when the getUrls-method returns `null`. Fixes https://github.com/scala/bug/issues/12376. I targeted scala 2.12, because the milestone of the bug is set to 2.12.14. If 2.13 is preferred I can rebase.