### PR TITLE
[backport] Support writing `&` instead of `with` in types under `-Xsource:3`

### DIFF
--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -319,6 +319,9 @@ trait StdNames {
 
     final val scala_ : NameType = "scala"
 
+    // Scala 3 special type
+    val AND: NameType = nme.AND.toTypeName
+
     def dropSingletonName(name: Name): TypeName = (name dropRight SINGLETON_SUFFIX.length).toTypeName
     def singletonName(name: Name): TypeName     = (name append SINGLETON_SUFFIX).toTypeName
   }

--- a/test/files/neg/and-future.check
+++ b/test/files/neg/and-future.check
@@ -1,0 +1,7 @@
+and-future.scala:9: error: Cannot parse infix type combining `&` and `Map`, please use `Map` as the head of a regular type application.
+  val b: Int Map X & Int Map Y = Map[Int, X & Y]() // error: unsupported
+             ^
+and-future.scala:13: error: Cannot parse infix type combining `&` and `Map`, please use `Map` as the head of a regular type application.
+  val c: (Int Map X) & (Int Map Y) = Map[Int, X & Y]() // error: unsupported
+                            ^
+two errors found

--- a/test/files/neg/and-future.scala
+++ b/test/files/neg/and-future.scala
@@ -1,0 +1,14 @@
+// scalac: -Xsource:3
+//
+
+trait X
+trait Y
+
+class Test {
+  val a: Map[Int, X] & Map[Int, Y] = Map[Int, X & Y]() // ok
+  val b: Int Map X & Int Map Y = Map[Int, X & Y]() // error: unsupported
+
+  // This one is unambiguous but it's hard to check whether parens were present
+  // from the parser output so we also emit an error there.
+  val c: (Int Map X) & (Int Map Y) = Map[Int, X & Y]() // error: unsupported
+}

--- a/test/files/pos/and-future.scala
+++ b/test/files/pos/and-future.scala
@@ -1,0 +1,17 @@
+// scalac: -Xsource:3
+//
+
+trait X
+trait Y
+
+class Test[A, B <: A & AnyRef] {
+  def foo[T >: A & Null <: A & AnyRef & Any](x: T & String): String & T = x
+
+  val a: X & Y & AnyRef = new X with Y {}
+  val b: (X & Y) & AnyRef = new X with Y {}
+  val c: X & (Y & AnyRef) = new X with Y {}
+
+  val d: X & Y = c match {
+    case xy: (X & Y) => xy
+  }
+}


### PR DESCRIPTION
This backports https://github.com/scala/scala/pull/9594 (which has not been accepted yet).