### PR TITLE
Fully JIT inlinable settings/statistics enabled checks

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
@@ -19,7 +19,7 @@ import java.io.IOException
 import scala.reflect.internal.MissingRequirementError
 import scala.reflect.io.{AbstractFile, NoAbstractFile}
 import scala.tools.nsc.util.{ClassPath, ClassRepresentation}
-import scala.reflect.internal.util.{ReusableInstance, StatisticsStatics}
+import scala.reflect.internal.util.ReusableInstance
 import scala.tools.nsc.Reporting.WarningCategory
 
 /** This class ...
@@ -337,11 +337,11 @@ abstract class SymbolLoaders {
     protected def description = "class file "+ classfile.toString
 
     protected def doComplete(root: Symbol): Unit = {
-      val start = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.startTimer(statistics.classReadNanos) else null
+      val start = if (settings.areStatisticsEnabled) statistics.startTimer(statistics.classReadNanos) else null
       classfileParser.parse(classfile, clazz, module)
       if (clazz.associatedFile eq NoAbstractFile) clazz.associatedFile = classfile
       if (module.associatedFile eq NoAbstractFile) module.associatedFile = classfile
-      if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopTimer(statistics.classReadNanos, start)
+      if (settings.areStatisticsEnabled) statistics.stopTimer(statistics.classReadNanos, start)
     }
     override def sourcefile: Option[AbstractFile] = classfileParser.srcfile
     override def associatedFile(self: Symbol): AbstractFile = classfile

--- a/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
@@ -16,7 +16,7 @@ package tools.nsc.transform.patmat
 import scala.collection.mutable
 import scala.collection.immutable.ArraySeq
 import scala.reflect.internal.util.Collections._
-import scala.reflect.internal.util.{HashSet, StatisticsStatics}
+import scala.reflect.internal.util.HashSet
 
 trait Logic extends Debugging {
   import global._
@@ -408,7 +408,7 @@ trait Logic extends Debugging {
     //       V1 = Nil implies -(V2 = Ci) for all Ci in V2's domain (i.e., it is unassignable)
     // may throw an AnalysisBudget.Exception
     def removeVarEq(props: List[Prop], modelNull: Boolean = false): (Prop, List[Prop]) = {
-      val start = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.startTimer(statistics.patmatAnaVarEq) else null
+      val start = if (settings.areStatisticsEnabled) statistics.startTimer(statistics.patmatAnaVarEq) else null
 
       val vars = new mutable.LinkedHashSet[Var]
 
@@ -491,7 +491,7 @@ trait Logic extends Debugging {
       debug.patmat(s"eqAxioms:\n${eqAxiomsSeq.mkString("\n")}")
       debug.patmat(s"pure:${pure.mkString("\n")}")
 
-      if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopTimer(statistics.patmatAnaVarEq, start)
+      if (settings.areStatisticsEnabled) statistics.stopTimer(statistics.patmatAnaVarEq, start)
 
       (And(eqAxiomsSeq: _*), pure)
     }

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -14,7 +14,6 @@ package scala.tools.nsc.transform.patmat
 
 import scala.annotation.tailrec
 import scala.collection.mutable
-import scala.reflect.internal.util.StatisticsStatics
 import scala.tools.nsc.Reporting.WarningCategory
 
 trait TreeAndTypeAnalysis extends Debugging {
@@ -459,7 +458,7 @@ trait MatchAnalysis extends MatchApproximation {
     // or, equivalently, P \/ -C, or C => P
     def unreachableCase(prevBinder: Symbol, cases: List[List[TreeMaker]], pt: Type): Option[Int] = {
       debug.patmat("reachability analysis")
-      val start = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.startTimer(statistics.patmatAnaReach) else null
+      val start = if (settings.areStatisticsEnabled) statistics.startTimer(statistics.patmatAnaReach) else null
 
       // use the same approximator so we share variables,
       // but need different conditions depending on whether we're conservatively looking for failure or success
@@ -503,7 +502,7 @@ trait MatchAnalysis extends MatchApproximation {
           }
         }
 
-        if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopTimer(statistics.patmatAnaReach, start)
+        if (settings.areStatisticsEnabled) statistics.stopTimer(statistics.patmatAnaReach, start)
 
         if (reachable) None else Some(caseIndex)
       } catch {
@@ -521,7 +520,7 @@ trait MatchAnalysis extends MatchApproximation {
       // - approximate the pattern `List()` (unapplySeq on List with empty length) as `Nil`,
       //   otherwise the common (xs: List[Any]) match { case List() => case x :: xs => } is deemed unexhaustive
       // - back off (to avoid crying exhaustive too often) in unhandled cases
-      val start = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.startTimer(statistics.patmatAnaExhaust) else null
+      val start = if (settings.areStatisticsEnabled) statistics.startTimer(statistics.patmatAnaExhaust) else null
       var backoff = false
       val strict = !settings.nonStrictPatmatAnalysis.value
 
@@ -578,7 +577,7 @@ trait MatchAnalysis extends MatchApproximation {
           // and make sure the strings are distinct, see Shmeez & TestSequence06 in run/patmatnew.scala
           val pruned = CounterExample.prune(counterExamples.sortBy(_.toString)).map(_.toString).distinct
 
-          if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopTimer(statistics.patmatAnaExhaust, start)
+          if (settings.areStatisticsEnabled) statistics.stopTimer(statistics.patmatAnaExhaust, start)
           pruned
         } catch {
           case ex: AnalysisBudget.Exception =>

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
@@ -12,8 +12,6 @@
 
 package scala.tools.nsc.transform.patmat
 
-import scala.reflect.internal.util.StatisticsStatics
-
 /** Translate typed Trees that represent pattern matches into the patternmatching IR, defined by TreeMakers.
  */
 trait MatchTranslation {
@@ -209,7 +207,7 @@ trait MatchTranslation {
 
       debug.patmat("translating "+ cases.mkString("{", "\n", "}"))
 
-      val start = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.startTimer(statistics.patmatNanos) else null
+      val start = if (settings.areStatisticsEnabled) statistics.startTimer(statistics.patmatNanos) else null
 
       val selectorTp = repeatedToSeq(elimAnonymousClass(selector.tpe.withoutAnnotations))
 
@@ -225,7 +223,7 @@ trait MatchTranslation {
       // pt = Any* occurs when compiling test/files/pos/annotDepMethType.scala
       val combined = combineCases(selector, selectorSym, nonSyntheticCases map translateCase(selectorSym, pt), pt, selectorPos, matchOwner, defaultOverride, getSuppression(selector))
 
-      if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopTimer(statistics.patmatNanos, start)
+      if (settings.areStatisticsEnabled) statistics.stopTimer(statistics.patmatNanos, start)
       combined
     }
 

--- a/src/compiler/scala/tools/nsc/transform/patmat/Solving.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Solving.scala
@@ -15,7 +15,6 @@ package scala.tools.nsc.transform.patmat
 import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.{immutable, mutable}
-import scala.reflect.internal.util.StatisticsStatics
 
 /** Solve pattern matcher exhaustivity problem via DPLL. */
 trait Solving extends Logic {
@@ -479,12 +478,12 @@ trait Solving extends Logic {
     def hasModel(solvable: Solvable): Boolean = findTseitinModelFor(solvable.cnf) != NoTseitinModel
 
     def findTseitinModelFor(clauses: Array[Clause]): TseitinModel = {
-      val start = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.startTimer(statistics.patmatAnaDPLL) else null
+      val start = if (settings.areStatisticsEnabled) statistics.startTimer(statistics.patmatAnaDPLL) else null
 
       debug.patmat(s"DPLL\n${cnfString(clauses)}")
       val satisfiableWithModel = findTseitinModel0((java.util.Arrays.copyOf(clauses, clauses.length), Nil) :: Nil)
 
-      if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopTimer(statistics.patmatAnaDPLL, start)
+      if (settings.areStatisticsEnabled) statistics.stopTimer(statistics.patmatAnaDPLL, start)
       satisfiableWithModel
     }
 

--- a/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
@@ -13,8 +13,6 @@
 package scala.tools.nsc
 package typechecker
 
-import scala.reflect.internal.util.StatisticsStatics
-
 /** Defines the sub-components for the namer, packageobjects, and typer phases.
  */
 trait Analyzer extends AnyRef
@@ -96,7 +94,7 @@ trait Analyzer extends AnyRef
       // compiler run). This is good enough for the resident compiler, which was the most affected.
       undoLog.clear()
       override def run(): Unit = {
-        val start = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.startTimer(statistics.typerNanos) else null
+        val start = if (settings.areStatisticsEnabled) statistics.startTimer(statistics.typerNanos) else null
         global.echoPhaseSummary(this)
         val units = currentRun.units
         while (units.hasNext) {
@@ -106,7 +104,7 @@ trait Analyzer extends AnyRef
         finishComputeParamAlias()
         // defensive measure in case the bookkeeping in deferred macro expansion is buggy
         clearDelayed()
-        if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopTimer(statistics.typerNanos, start)
+        if (settings.areStatisticsEnabled) statistics.stopTimer(statistics.typerNanos, start)
       }
       def apply(unit: CompilationUnit): Unit = {
         try {

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -24,7 +24,7 @@ import scala.collection.mutable
 import mutable.{LinkedHashMap, ListBuffer}
 import scala.util.matching.Regex
 import symtab.Flags._
-import scala.reflect.internal.util.{ReusableInstance, Statistics, StatisticsStatics, TriState}
+import scala.reflect.internal.util.{ReusableInstance, Statistics, TriState}
 import scala.reflect.internal.TypesStats
 import scala.language.implicitConversions
 import scala.tools.nsc.Reporting.WarningCategory
@@ -99,9 +99,9 @@ trait Implicits extends splain.SplainData {
     // Note that the isInvalidConversionTarget seems to make a lot more sense right here, before all the
     // work is performed, than at the point where it presently exists.
     val shouldPrint     = printTypings && !context.undetparams.isEmpty
-    val findMemberStart = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.startCounter(findMemberImpl) else null
-    val subtypeStart    = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.startCounter(subtypeImpl) else null
-    val start           = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.startTimer(implicitNanos) else null
+    val findMemberStart = if (settings.areStatisticsEnabled) statistics.startCounter(findMemberImpl) else null
+    val subtypeStart    = if (settings.areStatisticsEnabled) statistics.startCounter(subtypeImpl) else null
+    val start           = if (settings.areStatisticsEnabled) statistics.startTimer(implicitNanos) else null
     if (shouldPrint)
       typingStack.printTyping(tree, "typing implicit: %s %s".format(tree, context.undetparamsString))
     val implicitSearchContext = context.makeImplicit(reportAmbiguous)
@@ -123,9 +123,9 @@ trait Implicits extends splain.SplainData {
     //         and then filter out any which *were* inferred and are part of the substitutor in the implicit search result.
     context.undetparams = ((context.undetparams ++ result.undetparams) filterNot result.subst.from.contains).distinct
 
-    if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopTimer(implicitNanos, start)
-    if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopCounter(findMemberImpl, findMemberStart)
-    if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopCounter(subtypeImpl, subtypeStart)
+    if (settings.areStatisticsEnabled) statistics.stopTimer(implicitNanos, start)
+    if (settings.areStatisticsEnabled) statistics.stopCounter(findMemberImpl, findMemberStart)
+    if (settings.areStatisticsEnabled) statistics.stopCounter(subtypeImpl, subtypeStart)
 
     if (result.isSuccess && settings.lintImplicitRecursion && result.tree.symbol != null) {
       val s =
@@ -422,7 +422,7 @@ trait Implicits extends splain.SplainData {
     }
 
     import infer._
-    if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(implicitSearchCount)
+    if (settings.areStatisticsEnabled) statistics.incCounter(implicitSearchCount)
 
     /** The type parameters to instantiate */
     val undetParams = if (isView) Nil else context.outer.undetparams
@@ -452,12 +452,12 @@ trait Implicits extends splain.SplainData {
     /** Is implicit info `info1` better than implicit info `info2`?
      */
     def improves(info1: ImplicitInfo, info2: ImplicitInfo) = {
-      if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(improvesCount)
+      if (settings.areStatisticsEnabled) statistics.incCounter(improvesCount)
       (info2 == NoImplicitInfo) ||
       (info1 != NoImplicitInfo) && {
         if (info1.sym.isStatic && info2.sym.isStatic) {
           improvesCache get ((info1, info2)) match {
-            case Some(b) => if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(improvesCachedCount); b
+            case Some(b) => if (settings.areStatisticsEnabled) statistics.incCounter(improvesCachedCount); b
             case None =>
               val result = isStrictlyMoreSpecific(info1.tpe, info2.tpe, info1.sym, info2.sym)
               improvesCache((info1, info2)) = result
@@ -650,14 +650,14 @@ trait Implicits extends splain.SplainData {
      *  This method is performance critical: 5-8% of typechecking time.
      */
     private def matchesPt(tp: Type, pt: Type, undet: List[Symbol]): Boolean = {
-      val start = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.startTimer(matchesPtNanos) else null
+      val start = if (settings.areStatisticsEnabled) statistics.startTimer(matchesPtNanos) else null
       val result = normSubType(tp, pt) || isView && {
         pt match {
           case Function1(arg1, arg2) => matchesPtView(tp, arg1, arg2, undet)
           case _                     => false
         }
       }
-      if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopTimer(matchesPtNanos, start)
+      if (settings.areStatisticsEnabled) statistics.stopTimer(matchesPtNanos, start)
       result
     }
     private def matchesPt(info: ImplicitInfo): Boolean = (
@@ -684,7 +684,7 @@ trait Implicits extends splain.SplainData {
      }
 
     private def matchesPtInst(info: ImplicitInfo): Boolean = {
-      if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(matchesPtInstCalls)
+      if (settings.areStatisticsEnabled) statistics.incCounter(matchesPtInstCalls)
         info.tpe match {
           case PolyType(tparams, restpe) =>
             try {
@@ -693,7 +693,7 @@ trait Implicits extends splain.SplainData {
               val tp = ApproximateDependentMap(restpe)
               val tpInstantiated = tp.instantiateTypeParams(allUndetparams, tvars)
               if(!matchesPt(tpInstantiated, wildPt, allUndetparams)) {
-                if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(matchesPtInstMismatch1)
+                if (settings.areStatisticsEnabled) statistics.incCounter(matchesPtInstMismatch1)
                 false
               } else {
                 // we can't usefully prune views any further because we would need to type an application
@@ -703,7 +703,7 @@ trait Implicits extends splain.SplainData {
                 val adjusted = adjustTypeArgs(allUndetparams, tvars, targs)
                 val tpSubst = deriveTypeWithWildcards(adjusted.undetParams)(tp.instantiateTypeParams(adjusted.okParams, adjusted.okArgs))
                 if(!matchesPt(tpSubst, wildPt, adjusted.undetParams)) {
-                  if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(matchesPtInstMismatch2)
+                  if (settings.areStatisticsEnabled) statistics.incCounter(matchesPtInstMismatch2)
                   false
                 } else true
               }
@@ -801,7 +801,7 @@ trait Implicits extends splain.SplainData {
       }
 
     private def typedImplicit0(info: ImplicitInfo, ptChecked: Boolean, isLocalToCallsite: Boolean): SearchResult = {
-      if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(plausiblyCompatibleImplicits)
+      if (settings.areStatisticsEnabled) statistics.incCounter(plausiblyCompatibleImplicits)
       val ok = ptChecked || matchesPt(info) && {
         def word = if (isLocalToCallsite) "local " else ""
         typingLog("match", s"$word$info")
@@ -811,7 +811,7 @@ trait Implicits extends splain.SplainData {
     }
 
     private def typedImplicit1(info: ImplicitInfo, isLocalToCallsite: Boolean): SearchResult = {
-      if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(matchingImplicits)
+      if (settings.areStatisticsEnabled) statistics.incCounter(matchingImplicits)
 
       // workaround for deficient context provided by ModelFactoryImplicitSupport#makeImplicitConstraints
       val isScaladoc = context.tree == EmptyTree
@@ -867,7 +867,7 @@ trait Implicits extends splain.SplainData {
           case None      =>
         }
 
-        if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(typedImplicits)
+        if (settings.areStatisticsEnabled) statistics.incCounter(typedImplicits)
 
         val itree3 = if (isView) treeInfo.dissectApplied(itree2).callee
                      else adapt(itree2, EXPRmode, wildPt)
@@ -961,7 +961,7 @@ trait Implicits extends splain.SplainData {
                 fail("typing TypeApply reported errors for the implicit tree: " + err.errMsg)
               case None      =>
                 val result = new SearchResult(unsuppressMacroExpansion(itree3), subst, context.undetparams)
-                if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(foundImplicits)
+                if (settings.areStatisticsEnabled) statistics.incCounter(foundImplicits)
                 typingLog("success", s"inferred value of type $ptInstantiated is $result")
                 result
             }
@@ -1280,11 +1280,11 @@ trait Implicits extends splain.SplainData {
      *  @return                  map from infos to search results
      */
     def applicableInfos(iss: Infoss, isLocalToCallsite: Boolean): mutable.LinkedHashMap[ImplicitInfo, SearchResult] = {
-      val start       = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.startCounter(subtypeAppInfos) else null
+      val start       = if (settings.areStatisticsEnabled) statistics.startCounter(subtypeAppInfos) else null
       val computation = new ImplicitComputation(iss, isLocalToCallsite) { }
       val applicable  = computation.findAll()
 
-      if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopCounter(subtypeAppInfos, start)
+      if (settings.areStatisticsEnabled) statistics.stopCounter(subtypeAppInfos, start)
       applicable
     }
 
@@ -1428,13 +1428,13 @@ trait Implicits extends splain.SplainData {
      *  such that some part of `tp` has C as one of its superclasses.
      */
     private def implicitsOfExpectedType: Infoss = {
-      if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(implicitCacheAccs)
+      if (settings.areStatisticsEnabled) statistics.incCounter(implicitCacheAccs)
       implicitsCache get pt match {
         case Some(implicitInfoss) =>
-          if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(implicitCacheHits)
+          if (settings.areStatisticsEnabled) statistics.incCounter(implicitCacheHits)
           implicitInfoss
         case None =>
-          val start = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.startTimer(subtypeETNanos) else null
+          val start = if (settings.areStatisticsEnabled) statistics.startTimer(subtypeETNanos) else null
           //        val implicitInfoss = companionImplicits(pt)
           val implicitInfoss1 = companionImplicitMap(pt).valuesIterator.toList
           //        val is1 = implicitInfoss.flatten.toSet
@@ -1443,7 +1443,7 @@ trait Implicits extends splain.SplainData {
           //          if (!(is2 contains i)) println("!!! implicit infos of "+pt+" differ, new does not contain "+i+",\nold: "+implicitInfoss+",\nnew: "+implicitInfoss1)
           //        for (i <- is2)
           //          if (!(is1 contains i)) println("!!! implicit infos of "+pt+" differ, old does not contain "+i+",\nold: "+implicitInfoss+",\nnew: "+implicitInfoss1)
-          if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopTimer(subtypeETNanos, start)
+          if (settings.areStatisticsEnabled) statistics.stopTimer(subtypeETNanos, start)
           implicitsCache(pt) = implicitInfoss1
           if (implicitsCache.size >= sizeLimit)
             implicitsCache -= implicitsCache.keysIterator.next()
@@ -1689,7 +1689,7 @@ trait Implicits extends splain.SplainData {
      *  If all fails return SearchFailure
      */
     def bestImplicit: SearchResult = {
-      val stats = StatisticsStatics.areSomeColdStatsEnabled
+      val stats = settings.areStatisticsEnabled
       val failstart = if (stats) statistics.startTimer(inscopeFailNanos) else null
       val succstart = if (stats) statistics.startTimer(inscopeSucceedNanos) else null
 

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -18,7 +18,7 @@ import java.lang.Math.min
 import symtab.Flags._
 import scala.reflect.internal.util.ScalaClassLoader
 import scala.reflect.runtime.ReflectionUtils
-import scala.reflect.internal.util.{Statistics, StatisticsStatics}
+import scala.reflect.internal.util.Statistics
 import scala.reflect.internal.TypesStats
 import scala.reflect.macros.util._
 import scala.util.control.ControlThrowable
@@ -562,8 +562,8 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
       if (macroDebugVerbose) println(s"macroExpand: ${summary()}")
       linkExpandeeAndDesugared(expandee, desugared)
 
-      val start = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.startTimer(statistics.macroExpandNanos) else null
-      if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(statistics.macroExpandCount)
+      val start = if (settings.areStatisticsEnabled) statistics.startTimer(statistics.macroExpandNanos) else null
+      if (settings.areStatisticsEnabled) statistics.incCounter(statistics.macroExpandCount)
       try {
         withInfoLevel(nodePrinters.InfoLevel.Quiet) { // verbose printing might cause recursive macro expansions
           if (expandee.symbol.isErroneous || (expandee exists (_.isErroneous))) {
@@ -596,7 +596,7 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
           }
         }
       } finally {
-        if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopTimer(statistics.macroExpandNanos, start)
+        if (settings.areStatisticsEnabled) statistics.stopTimer(statistics.macroExpandNanos, start)
       }
     }
   }

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -17,7 +17,7 @@ package typechecker
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.reflect.internal.{Chars, TypesStats}
-import scala.reflect.internal.util.{FreshNameCreator, ListOfNil, Statistics, StatisticsStatics}
+import scala.reflect.internal.util.{FreshNameCreator, ListOfNil, Statistics}
 import scala.tools.nsc.Reporting.{MessageFilter, Suppression, WConf, WarningCategory}
 import scala.util.chaining._
 import mutable.ListBuffer
@@ -672,13 +672,13 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     def silent[T](op: Typer => T,
                   reportAmbiguousErrors: Boolean = context.ambiguousErrors,
                   newtree: Tree = context.tree): SilentResult[T] = {
-      val findMemberStart = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.startCounter(findMemberFailed) else null
-      val subtypeStart = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.startCounter(subtypeFailed) else null
-      val failedSilentStart = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.startTimer(failedSilentNanos) else null
+      val findMemberStart = if (settings.areStatisticsEnabled) statistics.startCounter(findMemberFailed) else null
+      val subtypeStart = if (settings.areStatisticsEnabled) statistics.startCounter(subtypeFailed) else null
+      val failedSilentStart = if (settings.areStatisticsEnabled) statistics.startTimer(failedSilentNanos) else null
       def stopStats() = {
-        if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopCounter(findMemberFailed, findMemberStart)
-        if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopCounter(subtypeFailed, subtypeStart)
-        if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopTimer(failedSilentNanos, failedSilentStart)
+        if (settings.areStatisticsEnabled) statistics.stopCounter(findMemberFailed, findMemberStart)
+        if (settings.areStatisticsEnabled) statistics.stopCounter(subtypeFailed, subtypeStart)
+        if (settings.areStatisticsEnabled) statistics.stopTimer(failedSilentNanos, failedSilentStart)
       }
       @inline def wrapResult(reporter: ContextReporter, result: T) =
         if (reporter.hasErrors) {
@@ -4205,9 +4205,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
     def isCapturedExistential(sym: Symbol) =
       (sym hasAllFlags EXISTENTIAL | CAPTURED) && {
-        val start = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.startTimer(isReferencedNanos) else null
+        val start = if (settings.areStatisticsEnabled) statistics.startTimer(isReferencedNanos) else null
         try !isReferencedFrom(context, sym)
-        finally if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopTimer(isReferencedNanos, start)
+        finally if (settings.areStatisticsEnabled) statistics.stopTimer(isReferencedNanos, start)
       }
 
     def packCaptured(tpe: Type): Type = {
@@ -4930,10 +4930,10 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
        * insert an implicit conversion.
        */
       def tryTypedApply(fun: Tree, args: List[Tree]): Tree = {
-        val start = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.startTimer(failedApplyNanos) else null
+        val start = if (settings.areStatisticsEnabled) statistics.startTimer(failedApplyNanos) else null
 
         def onError(typeErrors: Seq[AbsTypeError], warnings: Seq[(Position, String, WarningCategory, Symbol)]): Tree = {
-          if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopTimer(failedApplyNanos, start)
+          if (settings.areStatisticsEnabled) statistics.stopTimer(failedApplyNanos, start)
 
           // If the problem is with raw types, convert to existentials and try again.
           // See #4712 for a case where this situation arises,
@@ -5014,8 +5014,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         // TODO: replace `fun.symbol.isStable` by `treeInfo.isStableIdentifierPattern(fun)`
         val stableApplication = (fun.symbol ne null) && fun.symbol.isMethod && fun.symbol.isStable
         val funpt = if (mode.inPatternMode) pt else WildcardType
-        val appStart = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.startTimer(failedApplyNanos) else null
-        val opeqStart = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.startTimer(failedOpEqNanos) else null
+        val appStart = if (settings.areStatisticsEnabled) statistics.startTimer(failedApplyNanos) else null
+        val opeqStart = if (settings.areStatisticsEnabled) statistics.startTimer(failedOpEqNanos) else null
 
         def isConversionCandidate(qual: Tree, name: Name): Boolean =
           !mode.inPatternMode && nme.isOpAssignmentName(TermName(name.decode)) && !qual.exists(_.isErroneous)
@@ -5045,7 +5045,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           case Select(qual, name) if isConversionCandidate(qual, name) =>
             val qual1 = typedQualifier(qual)
             if (treeInfo.isVariableOrGetter(qual1)) {
-              if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopTimer(failedOpEqNanos, opeqStart)
+              if (settings.areStatisticsEnabled) statistics.stopTimer(failedOpEqNanos, opeqStart)
               val erred = qual1.exists(_.isErroneous) || args.exists(_.isErroneous)
               if (erred) reportError(error) else {
                 val convo = convertToAssignment(fun, qual1, name, args)
@@ -5057,7 +5057,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                 }
               }
             } else {
-              if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopTimer(failedApplyNanos, appStart)
+              if (settings.areStatisticsEnabled) statistics.stopTimer(failedApplyNanos, appStart)
               val Apply(Select(qual2, _), args2) = tree: @unchecked
               val erred = qual2.exists(_.isErroneous) || args2.exists(_.isErroneous)
               reportError {
@@ -5065,7 +5065,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               }
             }
           case _ =>
-            if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopTimer(failedApplyNanos, appStart)
+            if (settings.areStatisticsEnabled) statistics.stopTimer(failedApplyNanos, appStart)
             reportError(error)
         }
         val silentResult = silent(
@@ -5076,7 +5076,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         silentResult match {
           case SilentResultValue(fun1) =>
             val fun2 = if (stableApplication) stabilizeFun(fun1, mode, pt) else fun1
-            if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(typedApplyCount)
+            if (settings.areStatisticsEnabled) statistics.incCounter(typedApplyCount)
             val noSecondTry = (
                  isPastTyper
               || context.inSecondTry
@@ -5404,7 +5404,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               else UnstableTreeError(qualTyped)
             typedSelect(tree, qualStableOrError, name)
           } else {
-            if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(typedSelectCount)
+            if (settings.areStatisticsEnabled) statistics.incCounter(typedSelectCount)
             val qualTyped = checkDead(context, typedQualifier(qual, mode))
             val tree1 = typedSelect(tree, qualTyped, name)
 
@@ -5511,7 +5511,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
       def typedIdentOrWildcard(tree: Ident) = {
         val name = tree.name
-        if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(typedIdentCount)
+        if (settings.areStatisticsEnabled) statistics.incCounter(typedIdentCount)
         if (!tree.isBackquoted &&
             ((name == nme.WILDCARD && mode.typingPatternNotConstructor) ||
              (name == tpnme.WILDCARD && mode.inTypeMode)))
@@ -6003,9 +6003,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
     def typed(tree: Tree, mode: Mode, pt: Type): Tree = {
       lastTreeToTyper = tree
-      val statsEnabled = StatisticsStatics.areSomeHotStatsEnabled && settings.areStatisticsEnabled && settings.YhotStatisticsEnabled
-      val startByType = if (statsEnabled) statistics.pushTimer(byTypeStack, byTypeNanos(tree.getClass)) else null
-      if (statsEnabled) statistics.incCounter(visitsByType, tree.getClass)
+      val startByType = if (settings.areHotStatisticsEnabled) statistics.pushTimer(byTypeStack, byTypeNanos(tree.getClass)) else null
+      if (settings.areHotStatisticsEnabled) statistics.incCounter(visitsByType, tree.getClass)
       val shouldPrintTyping = printTypings && !phase.erasedTypes && !noPrintTyping(tree)
       val shouldPopTypingStack = shouldPrintTyping && typingStack.beforeNextTyped(tree, mode, pt, context)
 
@@ -6091,7 +6090,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           throw ex
       } finally {
         if (shouldPopTypingStack) typingStack.pop(tree)
-        if (statsEnabled) statistics.popTimer(byTypeStack, startByType)
+        if (settings.areHotStatisticsEnabled) statistics.popTimer(byTypeStack, startByType)
         if (shouldInsertStabilizers) context.pendingStabilizers = savedPendingStabilizer
       }
     }

--- a/src/reflect/scala/reflect/internal/BaseTypeSeqs.scala
+++ b/src/reflect/scala/reflect/internal/BaseTypeSeqs.scala
@@ -16,7 +16,7 @@ package internal
 
 // todo implement in terms of BitSet
 import scala.collection.mutable
-import util.{Statistics, StatisticsStatics}
+import util.Statistics
 
 /** A base type sequence (BaseTypeSeq) is an ordered sequence spanning all the base types
  *  of a type. It characterized by the following two laws:
@@ -50,8 +50,8 @@ trait BaseTypeSeqs {
    */
   class BaseTypeSeq protected[reflect] (private[BaseTypeSeqs] val parents: List[Type], private[BaseTypeSeqs] val elems: Array[Type]) {
   self =>
-    if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(baseTypeSeqCount)
-    if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(baseTypeSeqLenTotal, elems.length)
+    if (settings.areStatisticsEnabled) statistics.incCounter(baseTypeSeqCount)
+    if (settings.areStatisticsEnabled) statistics.incCounter(baseTypeSeqLenTotal, elems.length)
     private[this] val typeSymbols = {
       val tmp = new Array[Int](elems.length)
       var i = 0

--- a/src/reflect/scala/reflect/internal/Scopes.scala
+++ b/src/reflect/scala/reflect/internal/Scopes.scala
@@ -17,7 +17,7 @@ package internal
 import scala.annotation.tailrec
 import scala.collection.{AbstractIterable, AbstractIterator}
 import scala.collection.mutable.Clearable
-import scala.reflect.internal.util.{Statistics, StatisticsStatics}
+import scala.reflect.internal.util.Statistics
 
 trait Scopes extends api.Scopes { self: SymbolTable =>
 
@@ -515,22 +515,22 @@ trait Scopes extends api.Scopes { self: SymbolTable =>
 
   /** Create a new scope nested in another one with which it shares its elements */
   final def newNestedScope(outer: Scope): Scope = {
-    val startTime = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.startTimer(statistics.scopePopulationTime) else null
+    val startTime = if (settings.areStatisticsEnabled) statistics.startTimer(statistics.scopePopulationTime) else null
     val nested = newScope // not `new Scope`, we must allow the runtime reflection universe to mixin SynchronizedScopes!
     nested.elems = outer.elems
     nested.nestinglevel = outer.nestinglevel + 1
     if (outer.hashtable ne null)
       nested.hashtable = java.util.Arrays.copyOf(outer.hashtable, outer.hashtable.length)
-    if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopTimer(statistics.scopePopulationTime, startTime)
+    if (settings.areStatisticsEnabled) statistics.stopTimer(statistics.scopePopulationTime, startTime)
     nested
   }
 
   /** Create a new scope with given initial elements */
   def newScopeWith(elems: Symbol*): Scope = {
-    val startTime = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.startTimer(statistics.scopePopulationTime) else null
+    val startTime = if (settings.areStatisticsEnabled) statistics.startTimer(statistics.scopePopulationTime) else null
     val scope = newScope
     elems foreach scope.enter
-    if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopTimer(statistics.scopePopulationTime, startTime)
+    if (settings.areStatisticsEnabled) statistics.stopTimer(statistics.scopePopulationTime, startTime)
     scope
   }
 

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -20,7 +20,7 @@ package internal
 
 import scala.collection.immutable
 import scala.collection.mutable.ListBuffer
-import util.{ Statistics, shortClassOfInstance, StatisticsStatics }
+import util.{ Statistics, shortClassOfInstance }
 import Flags._
 import scala.annotation.tailrec
 import scala.reflect.io.{AbstractFile, NoAbstractFile}
@@ -3278,7 +3278,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
      * info for T in Test1 should be >: Nothing <: Test3[_]
      */
 
-    if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(typeSymbolCount)
+    if (settings.areStatisticsEnabled) statistics.incCounter(typeSymbolCount)
   }
   implicit val TypeSymbolTag = ClassTag[TypeSymbol](classOf[TypeSymbol])
 
@@ -3498,7 +3498,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       else super.toString
     )
 
-    if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(classSymbolCount)
+    if (settings.areStatisticsEnabled) statistics.incCounter(classSymbolCount)
   }
   implicit val ClassSymbolTag = ClassTag[ClassSymbol](classOf[ClassSymbol])
 

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -22,7 +22,7 @@ import mutable.{ListBuffer, LinkedHashSet}
 import Flags._
 import scala.util.control.ControlThrowable
 import scala.annotation.{tailrec, unused}
-import util.{Statistics, StatisticsStatics}
+import util.Statistics
 import util.ThreeValues._
 import Variance._
 import Depth._
@@ -692,7 +692,7 @@ trait Types
      *      = Int
      */
     def asSeenFrom(pre: Type, clazz: Symbol): Type = {
-      val start = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.pushTimer(typeOpsStack, asSeenFromNanos)  else null
+      val start = if (settings.areStatisticsEnabled) statistics.pushTimer(typeOpsStack, asSeenFromNanos)  else null
       try {
         val trivial = (
              this.isTrivial
@@ -708,7 +708,7 @@ trait Types
           if (m.capturedSkolems.isEmpty) tp1
           else deriveType(m.capturedSkolems, _.cloneSymbol setFlag CAPTURED)(tp1)
         }
-      } finally if (StatisticsStatics.areSomeColdStatsEnabled) statistics.popTimer(typeOpsStack, start)
+      } finally if (settings.areStatisticsEnabled) statistics.popTimer(typeOpsStack, start)
     }
 
     /** The info of `sym`, seen as a member of this type.
@@ -814,7 +814,7 @@ trait Types
 
     /** Is this type a subtype of that type? */
     def <:<(that: Type): Boolean = {
-      if (StatisticsStatics.areSomeColdStatsEnabled) stat_<:<(that)
+      if (settings.areStatisticsEnabled) stat_<:<(that)
       else {
         (this eq that) ||
         (if (explainSwitch) explain("<:", isSubType(_: Type, _: Type), this, that)
@@ -846,26 +846,26 @@ trait Types
     })
 
     def stat_<:<(that: Type): Boolean = {
-      if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(subtypeCount)
-      val start = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.pushTimer(typeOpsStack, subtypeNanos) else null
+      if (settings.areStatisticsEnabled) statistics.incCounter(subtypeCount)
+      val start = if (settings.areStatisticsEnabled) statistics.pushTimer(typeOpsStack, subtypeNanos) else null
       val result =
         (this eq that) ||
         (if (explainSwitch) explain("<:", isSubType(_: Type, _: Type), this, that)
          else isSubType(this, that))
-      if (StatisticsStatics.areSomeColdStatsEnabled) statistics.popTimer(typeOpsStack, start)
+      if (settings.areStatisticsEnabled) statistics.popTimer(typeOpsStack, start)
       result
     }
 
     /** Is this type a weak subtype of that type? True also for numeric types, i.e. Int weak_<:< Long.
      */
     def weak_<:<(that: Type): Boolean = {
-      if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(subtypeCount)
-      val start = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.pushTimer(typeOpsStack, subtypeNanos) else null
+      if (settings.areStatisticsEnabled) statistics.incCounter(subtypeCount)
+      val start = if (settings.areStatisticsEnabled) statistics.pushTimer(typeOpsStack, subtypeNanos) else null
       val result =
         ((this eq that) ||
          (if (explainSwitch) explain("weak_<:", isWeakSubType, this, that)
           else isWeakSubType(this, that)))
-      if (StatisticsStatics.areSomeColdStatsEnabled) statistics.popTimer(typeOpsStack, start)
+      if (settings.areStatisticsEnabled) statistics.popTimer(typeOpsStack, start)
       result
     }
 
@@ -1760,8 +1760,8 @@ trait Types
 
           tpe.baseTypeSeqCache = tpWithoutTypeVars.baseTypeSeq lateMap paramToVar
         } else {
-          if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(compoundBaseTypeSeqCount)
-          val start = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.pushTimer(typeOpsStack, baseTypeSeqNanos) else null
+          if (settings.areStatisticsEnabled) statistics.incCounter(compoundBaseTypeSeqCount)
+          val start = if (settings.areStatisticsEnabled) statistics.pushTimer(typeOpsStack, baseTypeSeqNanos) else null
           try {
             tpe.baseTypeSeqCache = undetBaseTypeSeq
             tpe.baseTypeSeqCache =
@@ -1770,7 +1770,7 @@ trait Types
               else
                 compoundBaseTypeSeq(tpe)
           } finally {
-            if (StatisticsStatics.areSomeColdStatsEnabled) statistics.popTimer(typeOpsStack, start)
+            if (settings.areStatisticsEnabled) statistics.popTimer(typeOpsStack, start)
           }
           // [Martin] suppressing memoization solves the problem with "same type after erasure" errors
           // when compiling with
@@ -1793,13 +1793,13 @@ trait Types
     if (period != currentPeriod) {
       tpe.baseClassesPeriod = currentPeriod
       if (!isValidForBaseClasses(period)) {
-        val start = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.pushTimer(typeOpsStack, baseClassesNanos) else null
+        val start = if (settings.areStatisticsEnabled) statistics.pushTimer(typeOpsStack, baseClassesNanos) else null
         try {
           tpe.baseClassesCache = null
           tpe.baseClassesCache = tpe.memo(computeBaseClasses(tpe))(tpe.typeSymbol :: _.baseClasses.tail)
         }
         finally {
-          if (StatisticsStatics.areSomeColdStatsEnabled) statistics.popTimer(typeOpsStack, start)
+          if (settings.areStatisticsEnabled) statistics.popTimer(typeOpsStack, start)
         }
       }
     }
@@ -2796,13 +2796,13 @@ trait Types
     if (period != currentPeriod) {
       tpe.baseTypeSeqPeriod = currentPeriod
       if (!isValidForBaseClasses(period)) {
-        if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(typerefBaseTypeSeqCount)
-        val start = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.pushTimer(typeOpsStack, baseTypeSeqNanos) else null
+        if (settings.areStatisticsEnabled) statistics.incCounter(typerefBaseTypeSeqCount)
+        val start = if (settings.areStatisticsEnabled) statistics.pushTimer(typeOpsStack, baseTypeSeqNanos) else null
         try {
           tpe.baseTypeSeqCache = undetBaseTypeSeq
           tpe.baseTypeSeqCache = tpe.baseTypeSeqImpl
         } finally {
-          if (StatisticsStatics.areSomeColdStatsEnabled) statistics.popTimer(typeOpsStack, start)
+          if (settings.areStatisticsEnabled) statistics.popTimer(typeOpsStack, start)
         }
       }
     }

--- a/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
+++ b/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
@@ -73,8 +73,9 @@ object MutableSettings {
   @inline implicit def reflectSettingToBoolean(s: MutableSettings#BooleanSetting): Boolean = s.value
 
   implicit class SettingsOps(private val settings: MutableSettings) extends AnyVal {
-    @inline final def areStatisticsEnabled = StatisticsStatics.areSomeColdStatsEnabled && settings.YstatisticsEnabled
-    @inline final def isDebug: Boolean     = StatisticsStatics.isDebug                 && settings.debug
-    @inline final def isDeveloper: Boolean = StatisticsStatics.isDeveloper             && settings.developer
+    @inline final def areStatisticsEnabled = (StatisticsStatics.COLD_STATS_GETTER.invokeExact(): Boolean) && settings.YstatisticsEnabled
+    @inline final def areHotStatisticsEnabled = (StatisticsStatics.HOT_STATS_GETTER.invokeExact(): Boolean) && settings.YhotStatisticsEnabled
+    @inline final def isDebug: Boolean     = (StatisticsStatics.DEBUG_GETTER.invokeExact(): Boolean) && settings.debug
+    @inline final def isDeveloper: Boolean = (StatisticsStatics.DEVELOPER_GETTER.invokeExact(): Boolean) && settings.developer
   }
 }

--- a/src/reflect/scala/reflect/internal/tpe/FindMembers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/FindMembers.scala
@@ -13,7 +13,7 @@
 package scala.reflect.internal
 package tpe
 
-import util.{ReusableInstance, StatisticsStatics}
+import util.ReusableInstance
 import Flags._
 import scala.runtime.Statics.releaseFence
 
@@ -51,10 +51,10 @@ trait FindMembers {
 
     // Main entry point
     def apply(): T = {
-      if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(findMemberCount)
-      val start = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.pushTimer(typeOpsStack, findMemberNanos) else null
+      if (settings.areStatisticsEnabled) statistics.incCounter(findMemberCount)
+      val start = if (settings.areStatisticsEnabled) statistics.pushTimer(typeOpsStack, findMemberNanos) else null
       try searchConcreteThenDeferred
-      finally if (StatisticsStatics.areSomeColdStatsEnabled) statistics.popTimer(typeOpsStack, start)
+      finally if (settings.areStatisticsEnabled) statistics.popTimer(typeOpsStack, start)
     }
 
     protected def result: T
@@ -316,11 +316,11 @@ trait FindMembers {
     // Assemble the result from the hand-rolled ListBuffer
     protected def result: Symbol = if (members eq null) {
       if (member0 == NoSymbol) {
-        if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(noMemberCount)
+        if (settings.areStatisticsEnabled) statistics.incCounter(noMemberCount)
         NoSymbol
       } else member0
     } else {
-      if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(multMemberCount)
+      if (settings.areStatisticsEnabled) statistics.incCounter(multMemberCount)
       lastM.next = Nil
       releaseFence()
       initBaseClasses.head.newOverloaded(tpe, members)

--- a/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
+++ b/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
@@ -17,7 +17,6 @@ package tpe
 
 import scala.collection.mutable
 import scala.annotation.tailrec
-import scala.reflect.internal.util.StatisticsStatics
 import Variance._
 
 private[internal] trait GlbLubs {
@@ -278,8 +277,8 @@ private[internal] trait GlbLubs {
     case Nil      => NothingTpe
     case t :: Nil => t
     case _        =>
-      if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(lubCount)
-      val start = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.pushTimer(typeOpsStack, lubNanos) else null
+      if (settings.areStatisticsEnabled) statistics.incCounter(lubCount)
+      val start = if (settings.areStatisticsEnabled) statistics.pushTimer(typeOpsStack, lubNanos) else null
       try {
         val res = lub(ts, lubDepth(ts))
         // If the number of unapplied type parameters in all incoming
@@ -297,7 +296,7 @@ private[internal] trait GlbLubs {
       finally {
         lubResults.clear()
         glbResults.clear()
-        if (StatisticsStatics.areSomeColdStatsEnabled) statistics.popTimer(typeOpsStack, start)
+        if (settings.areStatisticsEnabled) statistics.popTimer(typeOpsStack, start)
       }
   }
 
@@ -420,7 +419,7 @@ private[internal] trait GlbLubs {
       indent = indent + "  "
       assert(indent.length <= 100, "LUB is highly indented")
     }
-    if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(nestedLubCount)
+    if (settings.areStatisticsEnabled) statistics.incCounter(nestedLubCount)
     val res = lub0(ts)
     if (printLubs) {
       indent = indent stripSuffix "  "
@@ -445,14 +444,14 @@ private[internal] trait GlbLubs {
     case List() => AnyTpe
     case List(t) => t
     case ts0 =>
-      if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(lubCount)
-      val start = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.pushTimer(typeOpsStack, lubNanos) else null
+      if (settings.areStatisticsEnabled) statistics.incCounter(lubCount)
+      val start = if (settings.areStatisticsEnabled) statistics.pushTimer(typeOpsStack, lubNanos) else null
       try {
         glbNorm(ts0, lubDepth(ts0))
       } finally {
         lubResults.clear()
         glbResults.clear()
-        if (StatisticsStatics.areSomeColdStatsEnabled) statistics.popTimer(typeOpsStack, start)
+        if (settings.areStatisticsEnabled) statistics.popTimer(typeOpsStack, start)
       }
   }
 
@@ -575,7 +574,7 @@ private[internal] trait GlbLubs {
       }
     }
     // if (settings.debug.value) { println(indent + "glb of " + ts + " at depth "+depth); indent = indent + "  " } //DEBUG
-    if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(nestedLubCount)
+    if (settings.areStatisticsEnabled) statistics.incCounter(nestedLubCount)
     glb0(ts)
     // if (settings.debug.value) { indent = indent.substring(0, indent.length() - 2); log(indent + "glb of " + ts + " is " + res) }//DEBUG
   }

--- a/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
@@ -18,7 +18,6 @@ package tpe
 import scala.collection.mutable
 import util.TriState
 import scala.annotation.tailrec
-import scala.reflect.internal.util.StatisticsStatics
 
 trait TypeComparers {
   self: SymbolTable =>
@@ -104,7 +103,7 @@ trait TypeComparers {
 
   /** Do `tp1` and `tp2` denote equivalent types? */
   def isSameType(tp1: Type, tp2: Type): Boolean = try {
-    if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(sametypeCount)
+    if (settings.areStatisticsEnabled) statistics.incCounter(sametypeCount)
     subsametypeRecursions += 1
     //OPT cutdown on Function0 allocation
     //was:

--- a/src/reflect/scala/reflect/internal/util/StatisticsStatics.java
+++ b/src/reflect/scala/reflect/internal/util/StatisticsStatics.java
@@ -26,15 +26,10 @@ public final class StatisticsStatics {
   private static final AlmostFinalValue DEBUG      = new AlmostFinalValue();
   private static final AlmostFinalValue DEVELOPER  = new AlmostFinalValue();
 
-  private static final MethodHandle COLD_STATS_GETTER = COLD_STATS.invoker;
-  private static final MethodHandle  HOT_STATS_GETTER =  HOT_STATS.invoker;
-  private static final MethodHandle      DEBUG_GETTER =      DEBUG.invoker;
-  private static final MethodHandle  DEVELOPER_GETTER =  DEVELOPER.invoker;
-
-  public static boolean areSomeColdStatsEnabled() throws Throwable { return (boolean) COLD_STATS_GETTER.invokeExact(); }
-  public static boolean areSomeHotStatsEnabled()  throws Throwable { return (boolean)  HOT_STATS_GETTER.invokeExact(); }
-  public static boolean isDebug()                 throws Throwable { return (boolean)      DEBUG_GETTER.invokeExact(); }
-  public static boolean isDeveloper()             throws Throwable { return (boolean)  DEVELOPER_GETTER.invokeExact(); }
+  public static final MethodHandle COLD_STATS_GETTER = COLD_STATS.invoker;
+  public static final MethodHandle  HOT_STATS_GETTER =  HOT_STATS.invoker;
+  public static final MethodHandle      DEBUG_GETTER =      DEBUG.invoker;
+  public static final MethodHandle  DEVELOPER_GETTER =  DEVELOPER.invoker;
 
   public static void enableColdStatsAndDeoptimize() { COLD_STATS.toggleOnAndDeoptimize(); }
   public static void  enableHotStatsAndDeoptimize() {  HOT_STATS.toggleOnAndDeoptimize(); }

--- a/src/reflect/scala/reflect/io/AbstractFile.scala
+++ b/src/reflect/scala/reflect/io/AbstractFile.scala
@@ -121,7 +121,7 @@ abstract class AbstractFile extends AbstractIterable[AbstractFile] {
 
   /** Does this abstract file denote an existing file? */
   def exists: Boolean = {
-    //if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(IOStats.fileExistsCount)
+    //if (settings.areStatisticsEnabled) statistics.incCounter(IOStats.fileExistsCount)
     (file eq null) || file.exists
   }
 

--- a/src/reflect/scala/reflect/io/Path.scala
+++ b/src/reflect/scala/reflect/io/Path.scala
@@ -64,12 +64,12 @@ object Path {
   def apply(path: String): Path = apply(new JFile(path))
   def apply(jfile: JFile): Path = try {
     def isFile = {
-      //if (StatisticsStatics.areSomeColdStatsEnabled) Statistics.incCounter(IOStats.fileIsFileCount)
+      //if (settings.areStatisticsEnabled) Statistics.incCounter(IOStats.fileIsFileCount)
       jfile.isFile
     }
 
     def isDirectory = {
-      //if (StatisticsStatics.areSomeColdStatsEnabled) Statistics.incCounter(IOStats.fileIsDirectoryCount)
+      //if (settings.areStatisticsEnabled) Statistics.incCounter(IOStats.fileIsDirectoryCount)
       jfile.isDirectory
     }
 
@@ -206,16 +206,16 @@ class Path private[io] (val jfile: JFile) {
   def canRead = jfile.canRead()
   def canWrite = jfile.canWrite()
   def exists = {
-    //if (StatisticsStatics.areSomeColdStatsEnabled) Statistics.incCounter(IOStats.fileExistsCount)
+    //if (settings.areStatisticsEnabled) Statistics.incCounter(IOStats.fileExistsCount)
     try jfile.exists() catch { case ex: SecurityException => false }
   }
 
   def isFile = {
-    //if (StatisticsStatics.areSomeColdStatsEnabled) Statistics.incCounter(IOStats.fileIsFileCount)
+    //if (settings.areStatisticsEnabled) Statistics.incCounter(IOStats.fileIsFileCount)
     try jfile.isFile() catch { case ex: SecurityException => false }
   }
   def isDirectory = {
-    //if (StatisticsStatics.areSomeColdStatsEnabled) Statistics.incCounter(IOStats.fileIsDirectoryCount)
+    //if (settings.areStatisticsEnabled) Statistics.incCounter(IOStats.fileIsDirectoryCount)
     try jfile.isDirectory() catch { case ex: SecurityException => jfile.getPath == "." }
   }
   def isAbsolute = jfile.isAbsolute()


### PR DESCRIPTION
Wrapping the method handle invocation in a static method relies
on that method being JIT inlined. Otherwise, an unlucky caller
can still incur the machine-code subroutine call overhead to
a no-op method.

Example:

```
[info]                                    \-> TypeProfile (34723/34723 counts) = scala/tools/nsc/Global$GlobalMirror
[info]                                     @ 1   scala.reflect.internal.Mirrors$Roots::RootClass (21 bytes)   inline (hot)
[info]                !m                     @ 12   scala.reflect.internal.Mirrors$Roots::RootClass$lzycompute (49 bytes)   inline (hot)
[info]                                         @ 19   scala.reflect.internal.Mirrors$Roots$RootClass::<init> (61 bytes)   inline (hot)
[info]                                           @ 13   scala.reflect.internal.Mirrors$Roots::scala$reflect$internal$Mirrors$Roots$$$outer (5 bytes)   accessor
[info]                                           @ 21   scala.reflect.internal.Mirrors$Roots::scala$reflect$internal$Mirrors$Roots$$$outer (5 bytes)   accessor
[info]                                           @ 24   scala.reflect.internal.SymbolTable::NoPosition (5 bytes)   accessor
[info]                                           @ 28   scala.reflect.internal.Mirrors$Roots::scala$reflect$internal$Mirrors$Roots$$$outer (5 bytes)   accessor
[info]                                           @ 31   scala.reflect.internal.SymbolTable::tpnme (16 bytes)   inline (hot)
[info]                !m                           @ 8   scala.reflect.internal.SymbolTable::tpnme$lzycompute$1 (27 bytes)   inline (hot)
[info]                                               @ 15   scala.reflect.internal.StdNames$tpnme$::<init> (6 bytes)   inline (hot)
[info]                                                 @ 2   scala.reflect.internal.StdNames$TypeNames::<init> (757 bytes)   hot method too big
[info]                                           @ 34   scala.reflect.internal.StdNames$CommonNames::ROOT (5 bytes)   accessor
[info]                                           @ 40   scala.reflect.internal.Symbols$PackageClassSymbol::<init> (10 bytes)   inline (hot)
[info]                                             @ 6   scala.reflect.internal.Symbols$ModuleClassSymbol::<init> (41 bytes)   inline (hot)
[info]                                               @ 11   scala.reflect.internal.Symbols$ClassSymbol::<init> (164 bytes)   inline (hot)
[info]                                                 @ 6   scala.reflect.internal.Symbols$TypeSymbol::<init> (145 bytes)   inline (hot)
[info]                                                   @ 6   scala.reflect.internal.Symbols$Symbol::<init> (168 bytes)   inlining too deep
[info]                                                   @ 11   scala.reflect.internal.SymbolTable::NoSymbol (22 bytes)   inlining too deep
[info]                                                   @ 14   scala.reflect.internal.Symbols$Symbol::privateWithin_$eq (6 bytes)   inlining too deep
[info]                                                   @ 32   scala.reflect.internal.util.StatisticsStatics::areSomeColdStatsEnabled (7 bytes)   inlining too deep
```

Instead, push the `invokeExact` into the `@inline` checker methods,
and use these pervasively.