### PR TITLE
Don't error (only warn) on symbol literals under -Xsource:3

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1421,8 +1421,7 @@ self =>
       else if (in.token == SYMBOLLIT) {
         def msg(what: String) =
           s"""symbol literal is $what; use Symbol("${in.strVal}") instead"""
-        if (settings.isScala3) syntaxError(in.offset, msg("unsupported"))
-        else deprecationWarning(in.offset, msg("deprecated"), "2.13.0")
+        deprecationWarning(in.offset, msg("deprecated"), "2.13.0")
         Apply(scalaDot(nme.Symbol), List(finish(in.strVal)))
       }
       else finish(in.token match {

--- a/test/files/neg/symbol-literal-removal.check
+++ b/test/files/neg/symbol-literal-removal.check
@@ -1,4 +1,0 @@
-symbol-literal-removal.scala:4: error: symbol literal is unsupported; use Symbol("TestSymbol") instead
-  val foo = 'TestSymbol
-            ^
-1 error

--- a/test/files/neg/symbol-literal-removal.scala
+++ b/test/files/neg/symbol-literal-removal.scala
@@ -1,5 +1,0 @@
-// scalac: -Xsource:3
-//
-abstract class Foo {
-  val foo = 'TestSymbol
-}


### PR DESCRIPTION
Scala 3 still supports symbol literals even if they require a language
import now (cf https://github.com/lampepfl/dotty/pull/11588), so don't
emit an error if we find one under -Xsource:3 as that could
unnecessarily impede cross-compilation as discovered in
https://github.com/scala/scala-dev/issues/769.