### PR TITLE
Avoid attempt to load plugin from empty path

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -157,6 +157,7 @@ lazy val commonSettings = instanceSettings ++ clearSourceAndResourceDirectories 
   // we don't want optimizer warnings to interfere with `-Werror`. we have hundreds of such warnings
   // when the optimizer is enabled (as it is in CI and release builds, though not in local development)
   Compile / scalacOptions += "-Wconf:cat=optimizer:is",
+  Compile / scalacOptions ++= Seq("-deprecation", "-feature"),
   Compile / doc / scalacOptions ++= Seq(
     "-doc-footer", "epfl",
     "-diagrams",
@@ -743,6 +744,7 @@ lazy val tasty = project.in(file("test") / "tasty")
 lazy val scalacheck = project.in(file("test") / "scalacheck")
   .dependsOn(library, reflect, compiler, scaladoc)
   .settings(commonSettings)
+  .settings(fatalWarningsSettings)
   .settings(disableDocs)
   .settings(publish / skip := true)
   .settings(
@@ -755,7 +757,7 @@ lazy val scalacheck = project.in(file("test") / "scalacheck")
       // Full stack trace on failure:
       "-verbosity", "2"
     ),
-    libraryDependencies ++= Seq(scalacheckDep),
+    libraryDependencies ++= Seq(scalacheckDep, junitDep),
     Compile / unmanagedSourceDirectories := Nil,
     Test / unmanagedSourceDirectories := List(baseDirectory.value)
   )
@@ -813,6 +815,7 @@ def osgiTestProject(p: Project, framework: ModuleID) = p
 
 lazy val partestJavaAgent = Project("partestJavaAgent", file(".") / "src" / "partest-javaagent")
   .settings(commonSettings)
+  .settings(fatalWarningsSettings)
   .settings(generatePropertiesFileSettings)
   .settings(disableDocs)
   .settings(

--- a/test/scalacheck/CheckEither.scala
+++ b/test/scalacheck/CheckEither.scala
@@ -4,8 +4,16 @@ import org.scalacheck.Gen.oneOf
 import org.scalacheck.Prop._
 import org.scalacheck.Test.check
 import Function.tupled
+import scala.util.Either.LeftProjection
 
+@annotation.nowarn("cat=deprecation")
 object CheckEitherTest extends Properties("Either") {
+  implicit class Failing[A, B](val e: Either[A, B]) {
+    def orFail = e.getOrElse(???)
+  }
+  implicit class FailingLeft[A, B](val e: LeftProjection[A, B]) {
+    def orFail = e.getOrElse(???)
+  }
   implicit def arbitraryEither[X, Y](implicit xa: Arbitrary[X], ya: Arbitrary[Y]): Arbitrary[Either[X, Y]] =
     Arbitrary[Either[X, Y]](oneOf(arbitrary[X].map(Left(_)), arbitrary[Y].map(Right(_))))
 
@@ -14,14 +22,14 @@ object CheckEitherTest extends Properties("Either") {
   val prop_either2 = forAll((n: Int) => Right(n).fold(a => sys.error("fail"), x => x) == n)
 
   val prop_swap = forAll((e: Either[Int, Int]) => e match {
-    case Left(a) => e.swap.right.get == a
-    case Right(b) => e.swap.left.get == b
+    case Left(a) => e.swap.orFail == a
+    case Right(b) => e.swap.left.orFail == b
   })
 
   val prop_isLeftRight = forAll((e: Either[Int, Int]) => e.isLeft != e.isRight)
 
   object CheckLeftProjection {
-    val prop_value = forAll((n: Int) => Left(n).left.get == n)
+    val prop_value = forAll((n: Int) => Left(n).left.orFail == n)
 
     val prop_getOrElse = forAll((e: Either[Int, Int], or: Int) => e.left.getOrElse(or) == (e match {
       case Left(a) => a
@@ -29,10 +37,10 @@ object CheckEitherTest extends Properties("Either") {
     }))
 
     val prop_forall = forAll((e: Either[Int, Int]) =>
-      e.left.forall(_ % 2 == 0) == (e.isRight || e.left.get % 2 == 0))
+      e.left.forall(_ % 2 == 0) == (e.isRight || e.left.orFail % 2 == 0))
 
     val prop_exists = forAll((e: Either[Int, Int]) =>
-      e.left.exists(_ % 2 == 0) == (e.isLeft && e.left.get % 2 == 0))
+      e.left.exists(_ % 2 == 0) == (e.isLeft && e.left.orFail % 2 == 0))
 
     val prop_flatMapLeftIdentity = forAll((e: Either[Int, Int], n: Int, s: String) => {
       def f(x: Int) = if(x % 2 == 0) Left(s) else Right(s)
@@ -53,7 +61,7 @@ object CheckEitherTest extends Properties("Either") {
       e.left.map(x => f(g(x))) == e.left.map(x => g(x)).left.map(f(_))})
 
     val prop_filterToOption = forAll((e: Either[Int, Int], x: Int) => e.left.filterToOption(_ % 2 == 0) ==
-      (if(e.isRight || e.left.get % 2 != 0) None else Some(e)))
+      (if(e.isRight || e.left.orFail % 2 != 0) None else Some(e)))
 
     val prop_seq = forAll((e: Either[Int, Int]) => e.left.toSeq == (e match {
       case Left(a) => Seq(a)
@@ -67,46 +75,46 @@ object CheckEitherTest extends Properties("Either") {
   }
 
   object CheckRightProjection {
-    val prop_value = forAll((n: Int) => Right(n).right.get == n)
+    val prop_value = forAll((n: Int) => Right(n).orFail == n)
 
-    val prop_getOrElse = forAll((e: Either[Int, Int], or: Int) => e.right.getOrElse(or) == (e match {
+    val prop_getOrElse = forAll((e: Either[Int, Int], or: Int) => e.getOrElse(or) == (e match {
       case Left(_) => or
       case Right(b) => b
     }))
 
     val prop_forall = forAll((e: Either[Int, Int]) =>
-      e.right.forall(_ % 2 == 0) == (e.isLeft || e.right.get % 2 == 0))
+      e.forall(_ % 2 == 0) == (e.isLeft || e.orFail % 2 == 0))
 
     val prop_exists = forAll((e: Either[Int, Int]) =>
-      e.right.exists(_ % 2 == 0) == (e.isRight && e.right.get % 2 == 0))
+      e.exists(_ % 2 == 0) == (e.isRight && e.orFail % 2 == 0))
 
     val prop_flatMapLeftIdentity = forAll((e: Either[Int, Int], n: Int, s: String) => {
       def f(x: Int) = if(x % 2 == 0) Left(s) else Right(s)
-      Right(n).right.flatMap(f(_)) == f(n)})
+      Right(n).flatMap(f(_)) == f(n)})
 
-    val prop_flatMapRightIdentity = forAll((e: Either[Int, Int]) => e.right.flatMap(Right(_)) == e)
+    val prop_flatMapRightIdentity = forAll((e: Either[Int, Int]) => e.flatMap(Right(_)) == e)
 
     val prop_flatMapComposition = forAll((e: Either[Int, Int]) => {
       def f(x: Int) = if(x % 2 == 0) Left(x) else Right(x)
       def g(x: Int) = if(x % 7 == 0) Right(x) else Left(x)
-      e.right.flatMap(f(_)).right.flatMap(g(_)) == e.right.flatMap(f(_).right.flatMap(g(_)))})
+      e.flatMap(f(_)).flatMap(g(_)) == e.flatMap(f(_).flatMap(g(_)))})
 
-    val prop_mapIdentity = forAll((e: Either[Int, Int]) => e.right.map(x => x) == e)
+    val prop_mapIdentity = forAll((e: Either[Int, Int]) => e.map(x => x) == e)
 
     val prop_mapComposition = forAll((e: Either[Int, String]) => {
       def f(s: String) = s.toLowerCase
       def g(s: String) = s.reverse
-      e.right.map(x => f(g(x))) == e.right.map(x => g(x)).right.map(f(_))})
+      e.map(x => f(g(x))) == e.map(x => g(x)).map(f(_))})
 
     val prop_filterToOption = forAll((e: Either[Int, Int], x: Int) => e.right.filterToOption(_ % 2 == 0) ==
-      (if(e.isLeft || e.right.get % 2 != 0) None else Some(e)))
+      (if(e.isLeft || e.orFail % 2 != 0) None else Some(e)))
 
-    val prop_seq = forAll((e: Either[Int, Int]) => e.right.toSeq == (e match {
+    val prop_seq = forAll((e: Either[Int, Int]) => e.toSeq == (e match {
       case Left(_) => Seq.empty
       case Right(b) => Seq(b)
     }))
 
-    val prop_option = forAll((e: Either[Int, Int]) => e.right.toOption == (e match {
+    val prop_option = forAll((e: Either[Int, Int]) => e.toOption == (e match {
       case Left(_) => None
       case Right(b) => Some(b)
     }))
@@ -114,7 +122,7 @@ object CheckEitherTest extends Properties("Either") {
 
   val prop_Either_left = forAll((n: Int) => Left(n).left.get == n)
 
-  val prop_Either_right = forAll((n: Int) => Right(n).right.get == n)
+  val prop_Either_right = forAll((n: Int) => Right(n).orFail == n)
 
   val prop_Either_joinLeft = forAll((e: Either[Either[Int, Int], Int]) => e match {
     case Left(ee) => e.joinLeft == ee

--- a/test/scalacheck/Ctrie.scala
+++ b/test/scalacheck/Ctrie.scala
@@ -3,8 +3,7 @@ import Prop._
 import org.scalacheck.Gen._
 import collection._
 import collection.concurrent.TrieMap
-
-
+import scala.language.reflectiveCalls
 
 case class Wrap(i: Int) {
   override def hashCode = i // * 0x9e3775cd
@@ -192,8 +191,8 @@ object CtrieTest extends Properties("concurrent.TrieMap") {
       idx =>
       (0 until sz) foreach {
         i =>
-        val v = ct.getOrElseUpdate(Wrap(i), idx + ":" + i)
-        if (v == idx + ":" + i) totalInserts.incrementAndGet()
+        val v = ct.getOrElseUpdate(Wrap(i), s"$idx:$i")
+        if (v == s"$idx:$i") totalInserts.incrementAndGet()
       }
     }
 

--- a/test/scalacheck/concurrent-map.scala
+++ b/test/scalacheck/concurrent-map.scala
@@ -1,6 +1,6 @@
 import java.util.concurrent._
 import scala.collection._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import org.scalacheck._
 import org.scalacheck.Prop._
 import org.scalacheck.Gen._
@@ -26,6 +26,7 @@ object ConcurrentMapTest extends Properties("concurrent.TrieMap") {
   /* helpers */
 
   def inParallel[T](totalThreads: Int)(body: Int => T): Seq[T] = {
+    import scala.language.reflectiveCalls
     val threads = for (idx <- 0 until totalThreads) yield new Thread {
       setName("ParThread-" + idx)
       private var res: T = _

--- a/test/scalacheck/range.scala
+++ b/test/scalacheck/range.scala
@@ -43,9 +43,9 @@ abstract class RangeTest(kind: String) extends Properties("Range "+kind) {
     size <- choose(1, 100)
     step <- choose(1, 101)
   } yield {
-    val signum = if (boundary == 0) 1 else boundary.signum
-    if (isStart) Range(boundary, boundary - size * boundary.signum, - step * signum)
-    else         Range(boundary - size * boundary.signum, boundary, step * signum)
+    val signum = if (boundary == 0) 1 else boundary.sign
+    if (isStart) Range(boundary, boundary - size * boundary.sign, - step * signum)
+    else         Range(boundary - size * boundary.sign, boundary, step * signum)
   }
 
 

--- a/test/scalacheck/redblacktree.scala
+++ b/test/scalacheck/redblacktree.scala
@@ -24,7 +24,7 @@ abstract class RedBlackTreeTest(tname: String) extends Properties(tname) with Re
   import RB._
 
   def nodeAt[A](tree: Tree[String, A], n: Int): Option[(String, A)] = if (n < iterator(tree).size && n >= 0)
-    Some(iterator(tree).drop(n).next)
+    Some(iterator(tree).drop(n).next())
   else
     None
 

--- a/test/scalacheck/scala/ArrayTest.scala
+++ b/test/scalacheck/scala/ArrayTest.scala
@@ -25,9 +25,9 @@ object ArrayTest extends Properties("Array") {
   property("fill") = forAll(
     Gen.choose(-10, 100),
   ) { len =>
-    val xs = Vector.fill(len)(Random.nextInt)
+    val xs = Vector.fill(len)(Random.nextInt())
     val i = xs.iterator
-    Array.fill(len)(i.next).toVector == xs
+    Array.fill(len)(i.next()).toVector == xs
   }
 
   property("tabulate") = forAll(

--- a/test/scalacheck/scala/collection/IndexOfSliceTest.scala
+++ b/test/scalacheck/scala/collection/IndexOfSliceTest.scala
@@ -8,6 +8,7 @@ object IndexOfSliceTest extends Properties("indexOfSlice") {
 
   // The default arbitrary[Seq[Int]] picks only one Seq implementation.
   // Here we explicitly list all the implementations we want to test
+  @annotation.nowarn("msg=type WrappedArray")
   val genDifferentSeqs =
     Gen.oneOf[Seq[Int]](
       Arbitrary.arbitrary[collection.immutable.List[Int]],

--- a/test/scalacheck/scala/collection/IteratorProperties.scala
+++ b/test/scalacheck/scala/collection/IteratorProperties.scala
@@ -34,12 +34,12 @@ object IteratorProperties extends Properties("Iterator") {
     val indexed = s.toIndexedSeq // IndexedSeqs and their Iterators have a knownSize
     val simple = new SimpleIterable(s) // SimpleIterable and its Iterator don't
     val stream = LazyList.from(s) // Lazy
-    val indexed1 = f(indexed, n).toSeq
-    val indexed2 = f(indexed.iterator, n).toSeq
-    val simple1 = f(simple, n).toSeq
-    val simple2 = f(simple.iterator, n).toSeq
-    val stream1 = f(stream, n).toSeq
-    val stream2 = f(stream.iterator, n).toSeq
+    val indexed1 = f(indexed, n).iterator.to(Seq)
+    val indexed2 = f(indexed.iterator, n).iterator.to(Seq)
+    val simple1 = f(simple, n).iterator.to(Seq)
+    val simple2 = f(simple.iterator, n).iterator.to(Seq)
+    val stream1 = f(stream, n).iterator.to(Seq)
+    val stream2 = f(stream.iterator, n).iterator.to(Seq)
     (indexed1 == indexed2) :| s"indexed: $indexed1 != $indexed2" &&
       (simple1 == simple2) :| s"simple: $simple1 != $simple2" &&
       (stream1 == stream2) :| s"stream: $stream1 != $stream2" &&

--- a/test/scalacheck/scala/collection/StringOpsProps.scala
+++ b/test/scalacheck/scala/collection/StringOpsProps.scala
@@ -6,7 +6,7 @@ import java.io.{BufferedReader, StringReader}
 import org.scalacheck.{Gen, Properties}, Gen.{oneOf, listOf}
 import org.scalacheck.Prop._
 
-import JavaConverters._
+import scala.jdk.CollectionConverters._
 
 object StringOpsTest extends Properties("StringOps") {
 

--- a/test/scalacheck/scala/collection/immutable/ImmutableChampHashMapProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/ImmutableChampHashMapProperties.scala
@@ -33,7 +33,7 @@ object ImmutableChampHashMapProperties extends Properties("HashMap") {
     val builder = HashMap.newBuilder[K, V]
     inputMap.foreach(builder.addOne)
 
-    val duplicateMap = builder.result
+    val duplicateMap = builder.result()
     inputMap == duplicateMap
   }
 
@@ -72,7 +72,7 @@ object ImmutableChampHashMapProperties extends Properties("HashMap") {
 
   property("adding elems twice to builder is the same as adding them once") = forAll { seq: Seq[(K, V)] =>
     val b = HashMap.newBuilder[K, V].addAll(seq)
-    b.result == b.addAll(seq).result()
+    b.result() == b.addAll(seq).result()
   }
 
   property("(xs ++ ys).toMap == xs.toMap ++ ys.toMap") = forAll { (xs: Seq[(K, V)],ys: Seq[(K, V)]) =>

--- a/test/scalacheck/scala/collection/immutable/ImmutableChampHashSetProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/ImmutableChampHashSetProperties.scala
@@ -38,7 +38,7 @@ object ImmutableChampHashSetProperties extends Properties("immutable.HashSet") {
     val builder = HashSet.newBuilder[K]
     inputSet.foreach(builder.addOne)
 
-    val duplicateSet = builder.result
+    val duplicateSet = builder.result()
     inputSet == duplicateSet
   }
 
@@ -64,7 +64,7 @@ object ImmutableChampHashSetProperties extends Properties("immutable.HashSet") {
     val builder = HashSet.newBuilder[K]
     inputShared.foreach(builder.addOne)
 
-    val duplicateSet = builder.result
+    val duplicateSet = builder.result()
     inputShared == inputShared.intersect(duplicateSet)
   }
 
@@ -121,7 +121,7 @@ object ImmutableChampHashSetProperties extends Properties("immutable.HashSet") {
     val builder = HashSet.newBuilder[K]
     inputShared.foreach(builder.addOne)
 
-    val duplicateSet = builder.result
+    val duplicateSet = builder.result()
     inputShared == inputShared.union(duplicateSet)
   }
 
@@ -166,7 +166,7 @@ object ImmutableChampHashSetProperties extends Properties("immutable.HashSet") {
     val builder = HashSet.newBuilder[K]
     inputShared.foreach(builder.addOne)
 
-    val duplicateSet = builder.result
+    val duplicateSet = builder.result()
     HashSet.empty[K] == inputShared.diff(duplicateSet)
   }
 
@@ -240,7 +240,7 @@ object ImmutableChampHashSetProperties extends Properties("immutable.HashSet") {
   }
   property("adding elems twice to builder is the same as adding them once") = forAll { seq: Seq[K] =>
     val b = HashSet.newBuilder[K].addAll(seq)
-    b.result == b.addAll(seq).result()
+    b.result() == b.addAll(seq).result()
   }
   property("(xs ++ ys).toSet == xs.toSet ++ ys.toSet") = forAll { (xs: Seq[K],ys: Seq[K]) =>
     (xs ++ ys).toSet =? xs.toSet ++ ys.toSet

--- a/test/scalacheck/scala/collection/immutable/SeqProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/SeqProperties.scala
@@ -11,6 +11,7 @@ import scala.util.{Success, Try}
 import org.scalacheck.Properties
 
 
+@annotation.nowarn("cat=deprecation&msg=Stream")
 object SeqProperties extends Properties("immutable.Seq builder implementations"){
 
   type A = Int

--- a/test/scalacheck/scala/collection/immutable/SetProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/SetProperties.scala
@@ -7,8 +7,8 @@ import org.scalacheck.commands.Commands
 import scala.collection.mutable
 import scala.util.{Success, Try}
 
-
-object SetProperties extends Properties("immutable.Set builder implementations"){
+@annotation.nowarn("cat=deprecation&msg=Stream")
+object SetProperties extends Properties("immutable.Set builder implementations") {
 
   type A = Int
 
@@ -60,6 +60,7 @@ class SetBuilderStateProperties[A, To <: Set[A]](newBuilder: => mutable.Builder[
 
   override def genCommand(state: State): Gen[Command] = _genCommand
 
+  @annotation.nowarn("cat=deprecation&msg=Stream")
   override def shrinkState = Shrink.apply[State]( set => set.to(Stream).map(set - _) )
 
   case object Clear extends UnitCommand {

--- a/test/scalacheck/scala/collection/mutable/MapProperties.scala
+++ b/test/scalacheck/scala/collection/mutable/MapProperties.scala
@@ -33,6 +33,7 @@ object MapProperties extends Properties("mutable.Map") {
     override def addOne(elem: (K, V)): this.type = { _elems += elem; this }
   }
 
+  @annotation.nowarn("cat=deprecation&msg=ListMap")
   implicit val arbMap: Arbitrary[Map[K, V]] =
     Arbitrary {
       for {

--- a/test/scalacheck/scala/collection/mutable/RedBlackTree.scala
+++ b/test/scalacheck/scala/collection/mutable/RedBlackTree.scala
@@ -24,7 +24,7 @@ abstract class RedBlackTreeTest(tname: String) extends Properties(tname) with Re
   import RB._
 
   def nodeAt[A](tree: Tree[String, A], n: Int): Option[(String, A)] = if (n < iterator(tree).size && n >= 0)
-    Some(iterator(tree).drop(n).next)
+    Some(iterator(tree).drop(n).next())
   else
     None
 

--- a/test/scalacheck/scala/reflect/quasiquotes/ArbitraryTreesAndNames.scala
+++ b/test/scalacheck/scala/reflect/quasiquotes/ArbitraryTreesAndNames.scala
@@ -1,6 +1,7 @@
 package scala.reflect.quasiquotes
 
 import org.scalacheck._, Prop._, Gen._, Arbitrary._
+import scala.language.implicitConversions
 import scala.reflect.runtime.universe._, internal._, Flag._
 
 trait ArbitraryTreesAndNames {

--- a/test/scalacheck/scala/reflect/quasiquotes/DefinitionConstructionProps.scala
+++ b/test/scalacheck/scala/reflect/quasiquotes/DefinitionConstructionProps.scala
@@ -1,6 +1,7 @@
 package scala.reflect.quasiquotes
 
 import org.scalacheck._, Prop._, Gen._, Arbitrary._
+import scala.language.reflectiveCalls
 import scala.reflect.runtime.universe._, Flag._, internal.reificationSupport.ScalaDot
 
 object DefinitionConstructionProps
@@ -34,6 +35,7 @@ trait ClassConstruction { self: QuasiquoteProperties =>
   val emptyConstructor =
     DefDef(Modifiers(), termNames.CONSTRUCTOR, List(),
       List(List()), TypeTree(), Block(List(pendingSuperCall), Literal(Constant(()))))
+  @annotation.nowarn("cat=deprecation&msg=emptyValDef")
   def classWith(name: TypeName, parents: List[Tree] = List(anyRef), body: List[DefDef] = Nil) =
     ClassDef(
       Modifiers(), name, List(),

--- a/test/scalacheck/scala/reflect/quasiquotes/DeprecationProps.scala
+++ b/test/scalacheck/scala/reflect/quasiquotes/DeprecationProps.scala
@@ -3,6 +3,7 @@ package scala.reflect.quasiquotes
 import org.scalacheck._, Prop._, Gen._, Arbitrary._
 import scala.reflect.runtime.universe._
 
+@annotation.nowarn("cat=deprecation")
 object DeprecationProps extends QuasiquoteProperties("deprecation") {
   val tname = TypeName("Foo")
   val tpt = tq"Foo"

--- a/test/scalacheck/scala/reflect/quasiquotes/UnliftableProps.scala
+++ b/test/scalacheck/scala/reflect/quasiquotes/UnliftableProps.scala
@@ -1,8 +1,10 @@
 package scala.reflect.quasiquotes
 
+import org.junit.Assert.{assertEquals, assertTrue}
 import org.scalacheck._, Prop._, Gen._, Arbitrary._
 import scala.reflect.runtime.universe._, Flag._
 
+@annotation.nowarn("msg=deprecated adaptation")
 object UnliftableProps extends QuasiquoteProperties("unliftable") {
   property("unlift name") = test {
     val termname0 = TermName("foo")
@@ -74,7 +76,9 @@ object UnliftableProps extends QuasiquoteProperties("unliftable") {
 
   property("unlift scala.symbol") = test {
     val q"${s: scala.Symbol}" = q"'foo"
-    assert(s.isInstanceOf[scala.Symbol] && s == 'foo)
+    //assert(s.isInstanceOf[scala.Symbol] && s == Symbol("foo"))
+    assertTrue(s.isInstanceOf[scala.Symbol])
+    assertEquals(Symbol("foo"), s)
   }
 
   implicit def unliftList[T: Unliftable]: Unliftable[List[T]] = Unliftable {

--- a/test/scalacheck/t2460.scala
+++ b/test/scalacheck/t2460.scala
@@ -12,11 +12,11 @@ object SI2460Test extends Properties("Regex : Ticket 2460") {
   }
 
   val numberOfGroup = forAll(vowel) {
-    (s: String) => "\\s*([a-z])\\s*([a-z])\\s*".r("data").findAllMatchIn((1 to 20).map(_ => s).mkString).next.groupCount == 2
+    (s: String) => "\\s*([a-z])\\s*([a-z])\\s*".r("data").findAllMatchIn((1 to 20).map(_ => s).mkString).next().groupCount == 2
   }
 
   val nameOfGroup = forAll(vowel) {
-    (s: String) => "([a-z])".r("data").findAllMatchIn(s).next.group("data") == s
+    (s: String) => "([a-z])".r("data").findAllMatchIn(s).next().group("data") == s
   }
 
   val tests = List(

--- a/test/scalacheck/treemap.scala
+++ b/test/scalacheck/treemap.scala
@@ -71,21 +71,21 @@ object TreeMapTest extends Properties("TreeMap") {
   property("minAfter") = forAll { (elements: List[Int]) => elements.nonEmpty ==> {
     val half = elements.take(elements.size / 2)
     val subject = TreeMap((half zip half): _*)
-    elements.forall{e => {
-      val temp = subject.from(e)
+    elements.forall { e =>
+      val temp = subject.rangeFrom(e)
       if (temp.isEmpty) subject.minAfter(e).isEmpty
       else subject.minAfter(e).get == temp.min
-    }}
+    }
   }}
 
   property("maxBefore") = forAll { (elements: List[Int]) => elements.nonEmpty ==> {
     val half = elements.take(elements.size / 2)
     val subject = TreeMap((half zip half): _*)
-    elements.forall{e => {
-      val temp = subject.until(e)
+    elements.forall { e =>
+      val temp = subject.rangeUntil(e)
       if (temp.isEmpty) subject.maxBefore(e).isEmpty
       else subject.maxBefore(e).get == temp.max
-    }}
+    }
   }}
 
   property("head/tail identity") = forAll { (subject: TreeMap[Int, String]) => subject.nonEmpty ==> {
@@ -146,7 +146,7 @@ object TreeMapTest extends Properties("TreeMap") {
   property("from is inclusive") = forAll { (subject: TreeMap[Int, String]) => subject.nonEmpty ==> {
     val n = choose(0, subject.size - 1).sample.get
     val from = subject.drop(n).firstKey
-    subject.from(from).firstKey == from && subject.from(from).forall(_._1 >= from)
+    subject.rangeFrom(from).firstKey == from && subject.rangeFrom(from).forall(_._1 >= from)
   }}
 
   property("to is inclusive") = forAll { (subject: TreeMap[Int, String]) => subject.nonEmpty ==> {
@@ -158,7 +158,7 @@ object TreeMapTest extends Properties("TreeMap") {
   property("until is exclusive") = forAll { (subject: TreeMap[Int, String]) => subject.size > 1 ==> {
     val n = choose(1, subject.size - 1).sample.get
     val until = subject.drop(n).firstKey
-    subject.until(until).lastKey == subject.take(n).lastKey && subject.until(until).forall(_._1 <= until)
+    subject.rangeUntil(until).lastKey == subject.take(n).lastKey && subject.rangeUntil(until).forall(_._1 <= until)
   }}
 
   property("remove single") = forAll { (subject: TreeMap[Int, String]) => subject.nonEmpty ==> {

--- a/test/scalacheck/treeset.scala
+++ b/test/scalacheck/treeset.scala
@@ -70,7 +70,7 @@ object TreeSetTest extends Properties("TreeSet") {
     val half = elements.take(elements.size / 2)
     val subject = TreeSet(half: _*)
     elements.forall{e => {
-      val temp = subject.from(e)
+      val temp = subject.rangeFrom(e)
       if (temp.isEmpty) subject.minAfter(e).isEmpty
       else subject.minAfter(e).get == temp.min
     }}
@@ -80,7 +80,7 @@ object TreeSetTest extends Properties("TreeSet") {
     val half = elements.take(elements.size / 2)
     val subject = TreeSet(half: _*)
     elements.forall{e => {
-      val temp = subject.from(e)
+      val temp = subject.rangeFrom(e)
       if (temp.isEmpty) subject.minAfter(e).isEmpty
       else subject.minAfter(e).get == temp.min
     }}
@@ -144,7 +144,7 @@ object TreeSetTest extends Properties("TreeSet") {
   property("from is inclusive") = forAll { (subject: TreeSet[Int]) => subject.nonEmpty ==> {
     val n = choose(0, subject.size - 1).sample.get
     val from = subject.drop(n).firstKey
-    subject.from(from).firstKey == from && subject.from(from).forall(_ >= from)
+    subject.rangeFrom(from).firstKey == from && subject.rangeFrom(from).forall(_ >= from)
   }}
 
   property("to is inclusive") = forAll { (subject: TreeSet[Int]) => subject.nonEmpty ==> {
@@ -156,7 +156,7 @@ object TreeSetTest extends Properties("TreeSet") {
   property("until is exclusive") = forAll { (subject: TreeSet[Int]) => subject.size > 1 ==> {
     val n = choose(1, subject.size - 1).sample.get
     val until = subject.drop(n).firstKey
-    subject.until(until).lastKey == subject.take(n).lastKey && subject.until(until).forall(_ <= until)
+    subject.rangeUntil(until).lastKey == subject.take(n).lastKey && subject.rangeUntil(until).forall(_ <= until)
   }}
 
   property("remove single") = forAll { (subject: TreeSet[Int]) => subject.nonEmpty ==> {


### PR DESCRIPTION
Noticed at scala.tools.nsc.GlobalCustomizeClassloaderTest.test
which would print a complaint which went unheeded.

There is a code comment to ignore dirs with no plugins, but this
case is where there are no dirs.

Fixes scala/scala-dev#737