### PR TITLE
Parse `+_` and `-_` in types as identifiers under `-Xsource:3` to support Scala 3.2 placeholder syntax

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1140,7 +1140,7 @@ self =>
               else
                 atPos(start)(makeSafeTupleType(inParens(types())))
             case _      =>
-              if ((in.name == raw.PLUS || in.name == raw.MINUS) && lookingAhead(in.token == USCORE)) {
+              if (settings.isScala3 && (in.name == raw.PLUS || in.name == raw.MINUS) && lookingAhead(in.token == USCORE)) {
                 val start = in.offset
                 val identName = in.name.encode.append("_").toTypeName
                 in.nextToken()

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1127,6 +1127,12 @@ self =>
           val start = in.offset
           in.nextToken()
           atPos(start)(SingletonTypeTree(literal(isNegated = true, start = start)))
+        } else if ((in.name == raw.PLUS || in.name == raw.MINUS) && lookingAhead(in.token == USCORE)) {
+          val start = in.offset
+          val identName = in.name.encode.append("_").toTypeName
+          in.nextToken()
+          in.nextToken()
+          atPos(start)(Ident(identName))
         } else {
           val start = in.offset
           simpleTypeRest(in.token match {

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1127,12 +1127,6 @@ self =>
           val start = in.offset
           in.nextToken()
           atPos(start)(SingletonTypeTree(literal(isNegated = true, start = start)))
-        } else if ((in.name == raw.PLUS || in.name == raw.MINUS) && lookingAhead(in.token == USCORE)) {
-          val start = in.offset
-          val identName = in.name.encode.append("_").toTypeName
-          in.nextToken()
-          in.nextToken()
-          atPos(start)(Ident(identName))
         } else {
           val start = in.offset
           simpleTypeRest(in.token match {
@@ -1146,7 +1140,13 @@ self =>
               else
                 atPos(start)(makeSafeTupleType(inParens(types())))
             case _      =>
-              if (isWildcardType)
+              if ((in.name == raw.PLUS || in.name == raw.MINUS) && lookingAhead(in.token == USCORE)) {
+                val start = in.offset
+                val identName = in.name.encode.append("_").toTypeName
+                in.nextToken()
+                in.nextToken()
+                atPos(start)(Ident(identName))
+              } else if (isWildcardType)
                 wildcardType(in.skipToken())
               else
                 path(thisOK = false, typeOK = true) match {

--- a/test/files/neg/variant-placeholders-future.check
+++ b/test/files/neg/variant-placeholders-future.check
@@ -1,0 +1,7 @@
+variant-placeholders-future.scala:2: error: `=`, `>:`, or `<:` expected
+  type -_ = Int // error -_ not allowed as a type def name without backticks
+        ^
+variant-placeholders-future.scala:3: error: `=`, `>:`, or `<:` expected
+  type +_ = Int // error +_ not allowed as a type def name without backticks
+        ^
+2 errors

--- a/test/files/neg/variant-placeholders-future.check
+++ b/test/files/neg/variant-placeholders-future.check
@@ -1,7 +1,7 @@
-variant-placeholders-future.scala:2: error: `=`, `>:`, or `<:` expected
+variant-placeholders-future.scala:4: error: `=`, `>:`, or `<:` expected
   type -_ = Int // error -_ not allowed as a type def name without backticks
         ^
-variant-placeholders-future.scala:3: error: `=`, `>:`, or `<:` expected
+variant-placeholders-future.scala:5: error: `=`, `>:`, or `<:` expected
   type +_ = Int // error +_ not allowed as a type def name without backticks
         ^
 2 errors

--- a/test/files/neg/variant-placeholders-future.scala
+++ b/test/files/neg/variant-placeholders-future.scala
@@ -1,0 +1,4 @@
+object Test {
+  type -_ = Int // error -_ not allowed as a type def name without backticks
+  type +_ = Int // error +_ not allowed as a type def name without backticks
+}

--- a/test/files/neg/variant-placeholders-future.scala
+++ b/test/files/neg/variant-placeholders-future.scala
@@ -1,3 +1,5 @@
+// scalac: -Xsource:3
+//
 object Test {
   type -_ = Int // error -_ not allowed as a type def name without backticks
   type +_ = Int // error +_ not allowed as a type def name without backticks

--- a/test/files/neg/variant-placeholders-nofuture.check
+++ b/test/files/neg/variant-placeholders-nofuture.check
@@ -1,0 +1,7 @@
+variant-placeholders-nofuture.scala:5: error: ';' expected but '_' found.
+  val fnMinusPlus1: -_ => +_ = (_: Int).toLong // error -_/+_ won't parse without -Xsource:3
+                     ^
+variant-placeholders-nofuture.scala:6: error: ')' expected but '_' found.
+  val fnMinusPlus2: (-_) => +_ = fnMinusPlus1  // error -_/+_ won't parse without -Xsource:3
+                      ^
+2 errors

--- a/test/files/neg/variant-placeholders-nofuture.scala
+++ b/test/files/neg/variant-placeholders-nofuture.scala
@@ -1,0 +1,8 @@
+object Test {
+  type `-_` = Int
+  type `+_` = Long
+
+  val fnMinusPlus1: -_ => +_ = (_: Int).toLong // error -_/+_ won't parse without -Xsource:3
+  val fnMinusPlus2: (-_) => +_ = fnMinusPlus1  // error -_/+_ won't parse without -Xsource:3
+  val fnMinusPlus3: -_ => (+_) = fnMinusPlus2  // error -_/+_ won't parse without -Xsource:3
+}

--- a/test/files/pos/variant-placeholders-future.scala
+++ b/test/files/pos/variant-placeholders-future.scala
@@ -1,0 +1,27 @@
+object Test {
+  type `-_` = Int
+  type `+_` = Long
+
+  val fnMinusPlus1: -_ => +_ = (_: Int).toLong
+  val fnMinusPlus2: (-_) => +_ = fnMinusPlus1
+  val fnMinusPlus3: -_ => (+_) = fnMinusPlus2
+
+  val fnTupMinusPlus2: (=> -_, -_) => +_ = (a, b) => ((a: Int) + (b: Int)).toLong
+  def defMinusPlus2(byname: => -_, vararg: -_*): +_ = ((vararg.sum: Int) + (byname: -_)).toLong
+  val infixMinusPlus2: -_ Either +_ = Right[-_, +_](1L)
+
+  val optPlus: Option[+_] = Some[ + _ ](1L)  // spaces allowed
+  optPlus match {
+    case opt: Option[ + _ ] =>
+      val opt1: + _ = opt.get
+      val opt2: Long = opt1
+  }
+
+  val optMinus: Option[-_] = Some[ - _ ](1)  // spaces allowed
+  optMinus match {
+    case opt: Option[ - _ ] =>
+      val opt1: `-_` = opt.get
+      val optErr: - _ = opt.get
+      val opt2: Int = opt1
+  }
+}

--- a/test/files/pos/variant-placeholders-future.scala
+++ b/test/files/pos/variant-placeholders-future.scala
@@ -24,4 +24,10 @@ object Test {
       val optErr: - _ = opt.get
       val opt2: Int = opt1
   }
+
+  locally {
+    type `-_`[A] = A
+    type `+_`[A] = Option[A]
+    val optOpt: Option[ + _ [+_[-_[Int]]]] = Some(Some(Some(1)))
+  }
 }

--- a/test/files/pos/variant-placeholders-future.scala
+++ b/test/files/pos/variant-placeholders-future.scala
@@ -1,3 +1,5 @@
+// scalac: -Xsource:3
+//
 object Test {
   type `-_` = Int
   type `+_` = Long


### PR DESCRIPTION
This change allows `kind-projector` plugin to rewrite `+_` and `-_` tokens to type lambdas,
in line with proposed syntax for Scala 3.2 in http://dotty.epfl.ch/docs/reference/changed-features/wildcards.html

See also https://scalacenter.github.io/scala-3-migration-guide/docs/tutorials/kind-projector.html (Soon on https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html)

When used in conjunction with `-Xsource:3` this will let the user use `?` for wildcards and `_` for placeholders, letting the user cross-compile the same sources with Scala 3 with `-source:3.2` flag.

This change is not source breaking since currently `+_` and `-_` fail to parse entirely,
this change also does not allow the user to declare types with these names without backticks,
they can only be used as part of a type tree.

This does not add a special error when these symbols are used without kind-projector plugin – just "identifier not found", which is however in line with the behavior of other symbols currently used as placeholders in kind-projector – `?` & `*`

See also:

* Original issue in `kind-projector` repository https://github.com/typelevel/kind-projector/issues/120