### PR TITLE
eliminate a deprecation warning on setAccessible

### DIFF
--- a/src/library/scala/reflect/package.scala
+++ b/src/library/scala/reflect/package.scala
@@ -57,13 +57,17 @@ package object reflect {
   def ensureAccessible[T <: jAccessibleObject](m: T): T = {
     // This calls `setAccessible` unnecessarily, because `isAccessible` is only `true` if `setAccessible(true)`
     // was called before, not if the reflected object is inherently accessible.
-    // TODO: replace by `canAccess` once we're on JDK 9+
-    if (!m.isAccessible: @nowarn("cat=deprecation")) {
-      try m setAccessible true
+    if (isAccessible(m): @nowarn("cat=deprecation")) {
+      try m.setAccessible(true)
       catch { case _: SecurityException => } // does nothing
     }
     m
   }
+
+  // TODO: replace by `canAccess` once we're on JDK 9+.  `isAccessible` isn't deprecated yet
+  // in 8, so we wrap the call in a method which is itself deprecated.
+  @deprecated("","") private def isAccessible(m: jAccessibleObject) =
+    m.isAccessible
 
   // anchor for the class tag materialization macro emitted during tag materialization in Implicits.scala
   // implementation is hardwired into `scala.reflect.reify.Taggers`


### PR DESCRIPTION
this is a small followup to #9579

going warning-free here is a bit tricky, because the method in question is only deprecated on JDK 9+. so on JDK 8 the old code was giving a "@nowarn annotation does not suppress any warnings" warning

@lrytz @NthPortal @som-snytt is this the best way to handle this?