### PR TITLE
Revise workaround from ScalaCheck 1.15.1

### DIFF
--- a/test/scalacheck/scala/collection/FloatFormatTest.scala
+++ b/test/scalacheck/scala/collection/FloatFormatTest.scala
@@ -81,8 +81,8 @@ object FloatFormatTest extends Properties("FloatFormat") {
         10 -> right
       ))
     
-    // type annotation shouldn't be necessary? see typelevel/scalacheck#721
-    Gen.sequence[List[String], String](bogoparts).map(_.mkString)
+    import scala.jdk.CollectionConverters._
+    Gen.sequence(bogoparts).map(_.asScala.mkString)
   }
 
   //compare NaN equal

--- a/test/scalacheck/scala/collection/IntegralParseTest.scala
+++ b/test/scalacheck/scala/collection/IntegralParseTest.scala
@@ -120,8 +120,11 @@ object NumericStringGenerators {
       if (n >= 0) Gen.oneOf(digitsByValue(n))
       else Gen.const(ch)
     })
-    // type annotation shouldn't be necessary? see typelevel/scalacheck#721
-    Gen.sequence[List[Char], Char](listOfGens).map(_.mkString)
+
+    import scala.jdk.CollectionConverters._
+
+    val sequenced = Gen.sequence(listOfGens)
+    sequenced.map(_.asScala.mkString)
   }
 
 }


### PR DESCRIPTION
After upgrading to 1.15.4 in #9604, a workaround added in #9301 for ScalaCheck 1.15.1 is no longer necessary.