### PR TITLE
Shorten links in apidocs for Java

### DIFF
--- a/src/compiler/scala/tools/reflect/FormatInterpolator.scala
+++ b/src/compiler/scala/tools/reflect/FormatInterpolator.scala
@@ -69,7 +69,7 @@ abstract class FormatInterpolator {
    *  5) "...\${smth}%%" => okay, equivalent to "...\${smth}%s%%"
    *  6) "...\${smth}[%legalJavaConversion]" => okay*
    *  7) "...\${smth}[%illegalJavaConversion]" => error
-   *  *Legal according to [[https://docs.oracle.com/javase/8/docs/api/java/util/Formatter.html]]
+   *  *Legal according to [[java.util.Formatter]]
    */
   def interpolated(parts: List[Tree], args: List[Tree]) = {
     val fstring  = new StringBuilder

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -137,9 +137,8 @@ object Predef extends LowPriorityImplicits {
   @inline def valueOf[T](implicit vt: ValueOf[T]): T = vt.value
 
   /** The `String` type in Scala has all the methods of the underlying
-   *  `java.lang.String`, of which it is just an alias.
-   *  (See the documentation corresponding to your Java version,
-   *  for example [[https://docs.oracle.com/javase/8/docs/api/java/lang/String.html]].)
+   *  [[java.lang.String]], of which it is just an alias.
+   *
    *  In addition, extension methods in [[scala.collection.StringOps]]
    *  are added implicitly through the conversion [[augmentString]].
    *  @group aliases

--- a/src/library/scala/SerialVersionUID.scala
+++ b/src/library/scala/SerialVersionUID.scala
@@ -20,7 +20,7 @@ package scala
   * which the JVM's serialization mechanism uses to determine serialization
   * compatibility between different versions of a class.
   *
-  * @see [[https://docs.oracle.com/javase/8/docs/api/java/io/Serializable.html `java.io.Serializable`]]
+  * @see [[java.io.Serializable]]
   * @see [[Serializable]]
   */
 @deprecatedInheritance("Scheduled for being final in the future", "2.13.0")

--- a/src/library/scala/concurrent/ExecutionContext.scala
+++ b/src/library/scala/concurrent/ExecutionContext.scala
@@ -106,13 +106,13 @@ trait ExecutionContext {
 
 /**
  * An [[ExecutionContext]] that is also a
- * Java [[https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Executor.html Executor]].
+ * Java [[java.util.concurrent.Executor Executor]].
  */
 trait ExecutionContextExecutor extends ExecutionContext with Executor
 
 /**
  * An [[ExecutionContext]] that is also a
- * Java [[https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ExecutorService.html ExecutorService]].
+ * Java [[java.util.concurrent.ExecutorService ExecutorService]].
  */
 trait ExecutionContextExecutorService extends ExecutionContextExecutor with ExecutorService
 
@@ -287,7 +287,7 @@ object ExecutionContext {
    */
   def fromExecutor(e: Executor): ExecutionContextExecutor = fromExecutor(e, defaultReporter)
 
-  /** The default reporter simply prints the stack trace of the `Throwable` to [[https://docs.oracle.com/javase/8/docs/api/java/lang/System.html#err System.err]].
+  /** The default reporter simply prints the stack trace of the `Throwable` to [[java.lang.System#err System.err]].
    *
    *  @return the function for error reporting
    */

--- a/src/library/scala/util/matching/Regex.scala
+++ b/src/library/scala/util/matching/Regex.scala
@@ -33,7 +33,8 @@ import java.util.regex.{ Pattern, Matcher }
  *  and, if it does, to extract or transform the parts that match.
  *
  *  === Usage ===
- *  This class delegates to the [[java.util.regex]] package of the Java Platform.
+
+ *  This class delegates to the [[https://docs.oracle.com/javase/8/docs/api/java/util/regex/package-summary.html java.util.regex]] package of the Java Platform.
  *  See the documentation for [[java.util.regex.Pattern]] for details about
  *  the regular expression syntax for pattern strings.
  *


### PR DESCRIPTION
After #8284, there's no need to use URLs to link to JDK docs.

There is one place where I _expand_ one link, for the java.util.regex package, since linking to Java package summary pages isn't possible.