### PR TITLE
Fix broken doc link in jdk.Accumulator

### DIFF
--- a/src/library/scala/jdk/Accumulator.scala
+++ b/src/library/scala/jdk/Accumulator.scala
@@ -54,7 +54,8 @@ import scala.language.implicitConversions
   * There are two possibilities to process elements of a primitive Accumulator without boxing:
   * specialized operations of the Accumulator, or the Stepper interface. The most common collection
   * operations are overloaded or overridden in the primitive Accumulator classes, for example
-  * [[IntAccumulator.map(f: Int => Int)* IntAccumulator.map]] or [[IntAccumulator.exists]]. Thanks to Scala's function specialization,
+  * [[IntAccumulator.map(f:Int=>Int)* IntAccumulator.map]] or [[IntAccumulator.exists]].
+  * Thanks to Scala's function specialization,
   * `intAcc.exists(x => testOn(x))` does not incur boxing.
   *
   * The [[scala.collection.Stepper]] interface provides iterator-like `hasStep` and `nextStep` methods, and is


### PR DESCRIPTION
https://www.scala-lang.org/api/2.13.5/scala/jdk/Accumulator.html

Currently shows:

> The most common collection operations are overloaded or overridden in the primitive Accumulator classes, for example Int => Int)* IntAccumulator.map or IntAccumulator.exists. 

Should be:

> The most common collection operations are overloaded or overridden in the primitive Accumulator classes, for example IntAccumulator.map or IntAccumulator.exists. 