### PR TITLE
Fix warning about doc variable in LazyList

### DIFF
--- a/src/library/scala/collection/immutable/LazyList.scala
+++ b/src/library/scala/collection/immutable/LazyList.scala
@@ -68,7 +68,7 @@ import scala.runtime.Statics
   *    val fibs: LazyList[BigInt] =
   *      BigInt(0) #:: BigInt(1) #::
   *        fibs.zip(fibs.tail).map{ n =>
-  *          println(s"Adding ${n._1} and ${n._2}")
+  *          println(s"Adding \${n._1} and \${n._2}")
   *          n._1 + n._2
   *        }
   *    fibs.take(5).foreach(println)


### PR DESCRIPTION
Scaladoc has a variable system and so it flags interpolation as an issue.

```
[warn] src/library/scala/collection/immutable/LazyList.scala:71:32: Variable n._1 undefined in comment for class LazyList in class LazyList
[warn]   *          println(s"Adding ${n._1} and ${n._2}")
[warn]                                ^
[warn] src/library/scala/collection/immutable/LazyList.scala:71:44: Variable n._2 undefined in comment for class LazyList in class LazyList
[warn]   *          println(s"Adding ${n._1} and ${n._2}")
[warn]                                            ^
```