### PR TITLE
Differentiate Scala 2 and Scala 3 wildcard identifier names

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -723,9 +723,8 @@ self =>
     def isRawBar   = isRawIdent && in.name == raw.BAR
     def isRawIdent = in.token == IDENTIFIER
 
-    def isWildcardType =
-      in.token == USCORE ||
-      settings.isScala3 && isRawIdent && in.name == raw.QMARK
+    def isWildcardType = in.token == USCORE || isScala3WildcardType
+    def isScala3WildcardType = settings.isScala3 && isRawIdent && in.name == raw.QMARK
 
     def isIdent = in.token == IDENTIFIER || in.token == BACKQUOTED_IDENT
     def isMacro = in.token == IDENTIFIER && in.name == nme.MACROkw
@@ -1140,8 +1139,10 @@ self =>
               else
                 atPos(start)(makeSafeTupleType(inParens(types())))
             case _      =>
-              if (isWildcardType)
-                wildcardType(in.skipToken())
+              if (isWildcardType) {
+                val scala3Wildcard = isScala3WildcardType
+                wildcardType(in.skipToken(), scala3Wildcard)
+              }
               else
                 path(thisOK = false, typeOK = true) match {
                   case r @ SingletonTypeTree(_) => r
@@ -1540,8 +1541,8 @@ self =>
      *  WildcardType ::= `_` TypeBounds
      *  }}}
      */
-    def wildcardType(start: Offset) = {
-      val pname = freshTypeName("_$")
+    def wildcardType(start: Offset, qmark: Boolean) = {
+      val pname = if (qmark) freshTypeName("?$") else freshTypeName("_$")
       val t = atPos(start)(Ident(pname))
       val bounds = typeBounds()
       val param = atPos(t.pos union bounds.pos) { makeSyntheticTypeParam(pname, bounds) }
@@ -2056,8 +2057,9 @@ self =>
       final def argType(): Tree = {
         val start = in.offset
         if (isWildcardType) {
+            val scala3Wildcard = isScala3WildcardType
             in.nextToken()
-            if (in.token == SUBTYPE || in.token == SUPERTYPE) wildcardType(start)
+            if (in.token == SUBTYPE || in.token == SUPERTYPE) wildcardType(start, scala3Wildcard)
             else atPos(start) { Bind(tpnme.WILDCARD, EmptyTree) }
         } else
           typ() match {

--- a/test/files/neg/wildcards-future.check
+++ b/test/files/neg/wildcards-future.check
@@ -1,0 +1,11 @@
+wildcards-future.scala:7: error: type mismatch;
+ found   : Map[_$1,_$2] where type _$2 >: Null, type _$1 <: AnyRef
+ required: Map[String,String]
+  underscores : Map[String, String] // error wildcard variables starting with `_`
+  ^
+wildcards-future.scala:9: error: type mismatch;
+ found   : Map[?$1,?$2] where type ?$2 >: Null, type ?$1 <: AnyRef
+ required: Map[String,String]
+  qmarks : Map[String, String] // error – wildcard variables should start with `?` to differentiate from the old syntax
+  ^
+2 errors

--- a/test/files/neg/wildcards-future.scala
+++ b/test/files/neg/wildcards-future.scala
@@ -1,0 +1,11 @@
+// scalac: -Xsource:3
+//
+object Test {
+  val underscores: Map[_ <: AnyRef, _ >: Null] = Map()
+  val qmarks: Map[? <: AnyRef, ? >: Null] = Map()
+
+  underscores : Map[String, String] // error wildcard variables starting with `_`
+
+  qmarks : Map[String, String] // error – wildcard variables should start with `?` to differentiate from the old syntax
+                               // (and have a mildly more readable error...)
+}


### PR DESCRIPTION
This change names wildcards written with Scala 3 `?` syntax with `?$N` pattern instead of `_$N` used for Scala 2 wildcards

There are two reasons for it:

- To allow `kind-projector` to implement Scala 3 underscore syntax for type lambdas by transforming old-style underscores, but leaving Scala 3 underscores intact
- To show a mildly more relevant error message, since a wildcard introduced by `?` will now also have a name with `?` in the error message

See also:

* Original issue in kind-projector repository typelevel/kind-projector#120
