### PR TITLE
Two fixes for mixing in Java interfaces that refine a member's type

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -652,7 +652,7 @@ abstract class Erasure extends InfoTransform
       val rhs = member.tpe match {
         case MethodType(Nil, FoldableConstantType(c)) => Literal(c)
         case _                                =>
-          val sel: Tree    = Select(This(root), member)
+          val sel: Tree    = gen.mkAttributedSelect(gen.mkAttributedThis(root), member)
           val bridgingCall = bridge.paramss.foldLeft(sel)((fun, vparams) => Apply(fun, vparams map Ident))
 
           maybeWrap(bridgingCall)

--- a/src/compiler/scala/tools/nsc/transform/OverridingPairs.scala
+++ b/src/compiler/scala/tools/nsc/transform/OverridingPairs.scala
@@ -53,9 +53,6 @@ abstract class OverridingPairs extends SymbolPairs {
       && !exclude(low)                 // this admits private, as one can't have a private member that matches a less-private member.
       && (lowMemberType matches (self memberType high))
     ) // TODO we don't call exclude(high), should we?
-
-    override def skipOwnerPair(lowClass: Symbol, highClass: Symbol): Boolean =
-      lowClass.isJavaDefined && highClass.isJavaDefined // javac is already checking this better than we could
   }
 
   private def bothJavaOwnedAndEitherIsField(low: Symbol, high: Symbol): Boolean = {

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -383,7 +383,7 @@ abstract class RefChecks extends Transform {
           def isOverrideAccessOK = member.isPublic || {      // member is public, definitely same or relaxed access
             (!other.isProtected || member.isProtected) &&    // if o is protected, so is m
             ((!isRootOrNone(ob) && ob.hasTransOwner(mb)) ||  // m relaxes o's access boundary
-            (other.isJavaDefined && other.isProtected))      // overriding a protected java member, see #3946 #12349
+             (other.isJavaDefined && (member.isJavaDefined || other.isProtected))) // overriding a protected java member, see #3946 #12349
           }
           if (!isOverrideAccessOK) {
             overrideAccessError()

--- a/test/files/neg/t12380.check
+++ b/test/files/neg/t12380.check
@@ -1,0 +1,8 @@
+Test.scala:1: error: incompatible type in overriding
+def m(): String (defined in trait I)
+  with def m(): Object (defined in class C);
+ found   : (): Object
+ required: (): String
+object Test extends p.J.C with p.J.I {
+       ^
+1 error

--- a/test/files/neg/t12380/J.java
+++ b/test/files/neg/t12380/J.java
@@ -1,0 +1,14 @@
+package p;
+
+public class J {
+  public static class C {
+    public Object m() { return new Object(); }
+  }
+  public interface I {
+    public String m();
+  }
+
+  public static class Test extends C implements I {
+    @Override public String m() { return ""; }
+   }
+}

--- a/test/files/neg/t12380/Test.scala
+++ b/test/files/neg/t12380/Test.scala
@@ -1,0 +1,5 @@
+object Test extends p.J.C with p.J.I {
+  def main(args: Array[String]): Unit = {
+    println((this: p.J.I).m.trim)
+  }
+}

--- a/test/files/pos/t12349b/A.java
+++ b/test/files/pos/t12349b/A.java
@@ -1,0 +1,7 @@
+package p;
+
+public class A {
+  public static class R { }
+
+  /* package-protected */ R foo() { return null; }
+}

--- a/test/files/pos/t12349b/B.java
+++ b/test/files/pos/t12349b/B.java
@@ -1,0 +1,7 @@
+package q;
+
+public class B extends p.A {
+  public static class RR extends p.A.R { }
+
+  /* package-protected */ RR foo() { return null; }
+}

--- a/test/files/pos/t12349b/Test.scala
+++ b/test/files/pos/t12349b/Test.scala
@@ -1,0 +1,1 @@
+class Test extends q.B

--- a/test/files/run/t12380/A.java
+++ b/test/files/run/t12380/A.java
@@ -1,0 +1,28 @@
+// filter: unchecked
+
+package p;
+
+public class A {
+  public static interface I {
+    public I w();
+  }
+
+  public static interface J<R extends J<R>> extends I {
+    @Override public R w();
+  }
+
+  public static interface K extends I {
+    @Override public K w();
+
+    public default String mK() { return "K"; }
+  }
+
+  /* package-private */ static class B<R extends J<R>> implements J<R> {
+    @Override public R w() { return (R) this; }
+  }
+
+  public static class C<R extends J<R>> extends B<R> implements J<R> { }
+
+  // OK in Java, also OK in Scala
+  public static class Test extends C<Test> implements K { }
+}

--- a/test/files/run/t12380/Test.scala
+++ b/test/files/run/t12380/Test.scala
@@ -1,0 +1,7 @@
+class Test extends p.A.C[Test] with p.A.K
+object Test {
+  def main(args: Array[String]): Unit = {
+    assert((new Test).w.mK == "K")
+    assert((new p.A.Test).w.mK == "K")
+  }
+}


### PR DESCRIPTION
The first commit refines https://github.com/scala/scala/pull/9525 to skip access boundry checks between two Java members.

This PR fixes two bugs when mixing in a Java interface that refines the type of a member
  - The override check was incorrectly skipped, allowing the concrete method to have a weaker type than requried by the interface
  - For correct types, the generated bridge method AST didn't have a Type assigned, leading to an NPE

Fixes https://github.com/scala/bug/issues/12380

Reverts the second commit of https://github.com/scala/scala/pull/8643

Follow-up in https://github.com/scala/scala/pull/9629