### PR TITLE
Tasty Reader support 3.0.0 final

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -616,9 +616,7 @@ lazy val tastytest = configureAsSubproject(project)
   .settings(
     name := "scala-tastytest",
     description := "Scala TASTy Integration Testing Tool",
-    libraryDependencies ++= List(
-      diffUtilsDep,
-    ),
+    libraryDependencies += diffUtilsDep,
     Compile / scalacOptions ++= Seq("-feature", "-Xlint"),
   )
 
@@ -751,14 +749,14 @@ lazy val tasty = project.in(file("test") / "tasty")
     ),
     javaOptions ++= {
       import java.io.File.pathSeparator
-      val lib = (library / Compile / classDirectory).value.getAbsoluteFile()
-      val ref = (reflect / Compile / classDirectory).value.getAbsoluteFile()
-      val classpath = (TastySupport.CompilerClasspath / managedClasspath).value.seq.map(_.data) :+ lib
-      val libraryClasspath = (TastySupport.LibraryClasspath / managedClasspath).value.seq.map(_.data) :+ lib
+      val scalaLibrary = (library / Compile / classDirectory).value.getAbsoluteFile()
+      val scalaReflect = (reflect / Compile / classDirectory).value.getAbsoluteFile()
+      val dottyCompiler = (TastySupport.CompilerClasspath / managedClasspath).value.seq.map(_.data) :+ scalaLibrary
+      val dottyLibrary = (TastySupport.LibraryClasspath / managedClasspath).value.seq.map(_.data) :+ scalaLibrary
       Seq(
-        s"-Dtastytest.classpaths.dottyCompiler=${classpath.mkString(pathSeparator)}",
-        s"-Dtastytest.classpaths.dottyLibrary=${libraryClasspath.mkString(pathSeparator)}",
-        s"-Dtastytest.classpaths.scalaReflect=${ref}",
+        s"-Dtastytest.classpaths.dottyCompiler=${dottyCompiler.mkString(pathSeparator)}",
+        s"-Dtastytest.classpaths.dottyLibrary=${dottyLibrary.mkString(pathSeparator)}",
+        s"-Dtastytest.classpaths.scalaReflect=$scalaReflect",
       )
     },
   )

--- a/project/DottySupport.scala
+++ b/project/DottySupport.scala
@@ -12,9 +12,9 @@ import sbt.librarymanagement.{
   * Settings to support validation of TastyUnpickler against the release of dotty with the matching TASTy version
   */
 object TastySupport {
-  val supportedTASTyRelease = "3.0.0-RC3" // TASTy version 28.0.3
-  val scala3Compiler = "org.scala-lang" % "scala3-compiler_3.0.0-RC3" % supportedTASTyRelease
-  val scala3Library = "org.scala-lang" % "scala3-library_3.0.0-RC3" % supportedTASTyRelease
+  val supportedTASTyRelease = "3.0.0" // TASTy version 28.0-0
+  val scala3Compiler = "org.scala-lang" % "scala3-compiler_3" % supportedTASTyRelease
+  val scala3Library = "org.scala-lang" % "scala3-library_3" % supportedTASTyRelease
 
   val CompilerClasspath = Configuration.of("TastySupport.CompilerClasspath", "TastySupport.CompilerClasspath")
   val LibraryClasspath = Configuration.of("TastySupport.LibraryClasspath", "TastySupport.LibraryClasspath")

--- a/project/DottySupport.scala
+++ b/project/DottySupport.scala
@@ -12,8 +12,12 @@ import sbt.librarymanagement.{
   * Settings to support validation of TastyUnpickler against the release of dotty with the matching TASTy version
   */
 object TastySupport {
-  val supportedTASTyRelease = "3.0.0-RC1" // TASTy version 28.0.1
-  val scala3Compiler = "org.scala-lang" % "scala3-compiler_3.0.0-RC1" % supportedTASTyRelease
+  val supportedTASTyRelease = "3.0.0-RC3" // TASTy version 28.0.3
+  val scala3Compiler = "org.scala-lang" % "scala3-compiler_3.0.0-RC3" % supportedTASTyRelease
+  val scala3Library = "org.scala-lang" % "scala3-library_3.0.0-RC3" % supportedTASTyRelease
+
+  val CompilerClasspath = Configuration.of("TastySupport.CompilerClasspath", "TastySupport.CompilerClasspath")
+  val LibraryClasspath = Configuration.of("TastySupport.LibraryClasspath", "TastySupport.LibraryClasspath")
 }
 
 /** Settings needed to compile with Dotty,

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeBodyBuilder.scala
@@ -953,12 +953,11 @@ abstract class BCodeBodyBuilder extends BCodeSkelBuilder {
             mbt.descriptor
           )
         }
-        module.attachments.get[DottyEnumSingleton] match { // TODO [tasty]: dotty enum singletons are not modules.
-          case Some(enumAttach) =>
-            val enumCompanion = symInfoTK(module.originalOwner).asClassBType
-            visitAccess(enumCompanion, enumAttach.name)
-
-          case _ => visitAccess(mbt, strMODULE_INSTANCE_FIELD)
+        if (module.isScala3Defined && module.hasAttachment[DottyEnumSingleton.type]) { // TODO [tasty]: dotty enum singletons are not modules.
+          val enumCompanion = symInfoTK(module.originalOwner).asClassBType
+          visitAccess(enumCompanion, module.rawname.toString)
+        } else {
+          visitAccess(mbt, strMODULE_INSTANCE_FIELD)
         }
       }
     }

--- a/src/compiler/scala/tools/nsc/tasty/TreeUnpickler.scala
+++ b/src/compiler/scala/tools/nsc/tasty/TreeUnpickler.scala
@@ -752,7 +752,6 @@ class TreeUnpickler[Tasty <: TastyUniverse](
         }
         val valueParamss = normalizeIfConstructor(vparamss, isCtor)
         val resType = effectiveResultType(sym, typeParams, tpt.tpe)
-        ctx.markAsMethod(sym)
         ctx.setInfo(sym, defn.DefDefType(if (isCtor) Nil else typeParams, valueParamss, resType))
       }
 
@@ -824,6 +823,9 @@ class TreeUnpickler[Tasty <: TastyUniverse](
           case VALDEF              => ValDef(repr, localCtx)
           case TYPEDEF | TYPEPARAM => TypeDef(repr, localCtx)
           case PARAM               => TermParam(repr, localCtx)
+        }
+        if (sym.isTerm) {
+          ctx.markAsTerm(sym)
         }
       }
 
@@ -906,6 +908,7 @@ class TreeUnpickler[Tasty <: TastyUniverse](
         }
         val parentTypes = ctx.adjustParents(cls, parents)
         setInfoWithParents(tparams, parentTypes)
+        ctx.markAsClass(cls)
       }
 
       inIndexScopedStatsContext(traverseTemplate()(_))

--- a/src/compiler/scala/tools/nsc/tasty/TreeUnpickler.scala
+++ b/src/compiler/scala/tools/nsc/tasty/TreeUnpickler.scala
@@ -581,7 +581,6 @@ class TreeUnpickler[Tasty <: TastyUniverse](
         }
         nextByte match {
           case PRIVATE => addFlag(Private)
-          case INTERNAL => addFlag(Internal)
           case PROTECTED => addFlag(Protected)
           case ABSTRACT =>
             readByte()

--- a/src/compiler/scala/tools/nsc/tasty/TreeUnpickler.scala
+++ b/src/compiler/scala/tools/nsc/tasty/TreeUnpickler.scala
@@ -765,12 +765,7 @@ class TreeUnpickler[Tasty <: TastyUniverse](
           if (repr.originalFlagSet.is(FlagSets.SingletonEnum)) {
             val enumClass = sym.objectImplementation
             val selfTpe = defn.SingleType(sym.owner.thisPrefix, sym)
-            val ctor = ctx.unsafeNewSymbol(
-              owner = enumClass,
-              name  = TastyName.Constructor,
-              flags = FlagSets.Creation.CtorDef,
-              info  = defn.DefDefType(Nil, Nil :: Nil, selfTpe)
-            )
+            val ctor = ctx.newConstructor(enumClass, selfTpe)
             enumClass.typeOfThis = selfTpe
             ctx.setInfo(enumClass, defn.ClassInfoType(intersectionParts(tpe), ctor :: Nil, enumClass))
             prefixedRef(sym.owner.thisPrefix, enumClass)

--- a/src/compiler/scala/tools/nsc/tasty/bridge/ContextOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/ContextOps.scala
@@ -379,6 +379,7 @@ trait ContextOps { self: TastyUniverse =>
             if (decl.isParamAccessor) decl.makeNotPrivate(cls)
             if (!decl.isClassConstructor) {
               val extensionMeth = decl.newExtensionMethodSymbol(cls.companion, u.NoPosition)
+              markAsTerm(extensionMeth)
               extensionMeth setInfo u.extensionMethInfo(cls, extensionMeth, decl.info, cls)
             }
           }
@@ -429,8 +430,11 @@ trait ContextOps { self: TastyUniverse =>
     final def markAsEnumSingleton(sym: Symbol): Unit =
       sym.updateAttachment(new u.DottyEnumSingleton(sym.name.toString))
 
-    final def markAsMethod(sym: Symbol): Unit =
-      sym.updateAttachment(u.DottyMethod)
+    final def markAsTerm(sym: Symbol): Unit =
+      sym.updateAttachment(u.DottyTerm)
+
+    final def markAsClass(sym: Symbol): Unit =
+      sym.updateAttachment(u.DottyClass)
 
     final def markAsOpaqueType(sym: Symbol, alias: Type): Unit =
       sym.updateAttachment(new u.DottyOpaqueTypeAlias(alias))

--- a/src/compiler/scala/tools/nsc/tasty/bridge/ContextOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/ContextOps.scala
@@ -429,6 +429,9 @@ trait ContextOps { self: TastyUniverse =>
     final def markAsEnumSingleton(sym: Symbol): Unit =
       sym.updateAttachment(new u.DottyEnumSingleton(sym.name.toString))
 
+    final def markAsMethod(sym: Symbol): Unit =
+      sym.updateAttachment(u.DottyMethod)
+
     final def markAsOpaqueType(sym: Symbol, alias: Type): Unit =
       sym.updateAttachment(new u.DottyOpaqueTypeAlias(alias))
 

--- a/src/compiler/scala/tools/nsc/tasty/bridge/ContextOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/ContextOps.scala
@@ -397,11 +397,8 @@ trait ContextOps { self: TastyUniverse =>
       parentTypes
     }
 
-    final def removeFlags(symbol: Symbol, flags: TastyFlagSet): symbol.type =
-      symbol.resetFlag(unsafeEncodeTastyFlagSet(flags))
-
-    final def addFlags(symbol: Symbol, flags: TastyFlagSet): symbol.type =
-      symbol.setFlag(unsafeEncodeTastyFlagSet(flags))
+    private[bridge] final def resetFlag0(symbol: Symbol, flags: u.FlagSet): symbol.type =
+      symbol.resetFlag(flags)
 
     final def redefineSymbol(symbol: Symbol, flags: TastyFlagSet, completer: TastyCompleter, privateWithin: Symbol): symbol.type = {
       symbol.flags = newSymbolFlagSet(flags)

--- a/src/compiler/scala/tools/nsc/tasty/bridge/FlagOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/FlagOps.scala
@@ -34,6 +34,7 @@ trait FlagOps { self: TastyUniverse =>
     val SingletonEnumFlags: TastyFlagSet = SingletonEnumInitFlags | Stable
     val FieldAccessorFlags: TastyFlagSet = FieldAccessor | Stable
     val LocalFieldFlags: TastyFlagSet = Private | Local
+    val Scala2MacroFlags: TastyFlagSet = Erased | Macro
   }
 
   /**encodes a `TastyFlagSet` as `scala.reflect` flags and will ignore flags that can't be converted, such as

--- a/src/compiler/scala/tools/nsc/tasty/bridge/FlagOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/FlagOps.scala
@@ -16,8 +16,8 @@ import scala.tools.tasty.TastyFlags._
 import scala.tools.nsc.tasty.TastyUniverse
 import scala.reflect.internal.{Flags, ModifierFlags}
 
-/**Handles encoding of `TastyFlagSet` to `scala.reflect` flags and witnessing which flags do not map directly
- * from TASTy.
+/** Handles encoding of `TastyFlagSet` to `scala.reflect` flags and witnessing which flags do not map directly
+ *  from TASTy.
  */
 trait FlagOps { self: TastyUniverse =>
   import self.{symbolTable => u}
@@ -26,7 +26,7 @@ trait FlagOps { self: TastyUniverse =>
 
     val TastyOnlyFlags: TastyFlagSet = (
       Erased | Internal | Inline | InlineProxy | Opaque | Extension | Given | Exported | Transparent
-      | Enum | Infix | Open | ParamAlias | Invisible
+        | Enum | Infix | Open | ParamAlias | Invisible
     )
 
     object Creation {
@@ -52,14 +52,17 @@ trait FlagOps { self: TastyUniverse =>
   implicit final class SymbolFlagOps(val sym: Symbol) {
     def reset(tflags: TastyFlagSet)(implicit ctx: Context): sym.type =
       ctx.resetFlag0(sym, unsafeEncodeTastyFlagSet(tflags))
-    def isOneOf(mask: TastyFlagSet): Boolean = sym.hasFlag(unsafeEncodeTastyFlagSet(mask))
-    def is(mask: TastyFlagSet): Boolean = sym.hasAllFlags(unsafeEncodeTastyFlagSet(mask))
+    def isOneOf(mask: TastyFlagSet): Boolean =
+      sym.hasFlag(unsafeEncodeTastyFlagSet(mask))
+    def is(mask: TastyFlagSet): Boolean =
+      sym.hasAllFlags(unsafeEncodeTastyFlagSet(mask))
     def is(mask: TastyFlagSet, butNot: TastyFlagSet): Boolean =
       if (!butNot)
         sym.is(mask)
       else
         sym.is(mask) && sym.not(butNot)
-    def not(mask: TastyFlagSet): Boolean = sym.hasNoFlags(unsafeEncodeTastyFlagSet(mask))
+    def not(mask: TastyFlagSet): Boolean =
+      sym.hasNoFlags(unsafeEncodeTastyFlagSet(mask))
   }
 
   /** encodes a `TastyFlagSet` as a `symbolTable.FlagSet`, the flags in `FlagSets.TastyOnlyFlags` are ignored.

--- a/src/compiler/scala/tools/nsc/tasty/bridge/FlagOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/FlagOps.scala
@@ -32,11 +32,11 @@ trait FlagOps { self: TastyUniverse =>
     object Creation {
       val ObjectDef: TastyFlagSet = Object | Lazy | Final | Stable
       val ObjectClassDef: TastyFlagSet = Object | Final
-      val CtorDef: TastyFlagSet = Method | Stable
-      val HKTyParam: u.FlagSet = newSymbolFlagSet(Deferred)
-      val TyParam: u.FlagSet = HKTyParam
-      val Wildcard: u.FlagSet = newSymbolFlagSet(EmptyTastyFlags)
+      val Default: u.FlagSet = newSymbolFlagSet(EmptyTastyFlags)
+      val BoundedType: u.FlagSet = newSymbolFlagSet(Deferred)
     }
+    def withAccess(flags: TastyFlagSet, inheritedAccess: TastyFlagSet): TastyFlagSet =
+      flags | (inheritedAccess & (Private | Local | Protected))
     val SingletonEnum: TastyFlagSet = Case | Static | Enum | Stable
     val TermParamOrAccessor: TastyFlagSet = Param | ParamSetter
     val FieldGetter: TastyFlagSet = FieldAccessor | Stable

--- a/src/compiler/scala/tools/nsc/tasty/bridge/FlagOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/FlagOps.scala
@@ -25,7 +25,7 @@ trait FlagOps { self: TastyUniverse =>
   object FlagSets {
 
     val TastyOnlyFlags: TastyFlagSet = (
-      Erased | Internal | Inline | InlineProxy | Opaque | Extension | Given | Exported | Transparent
+      Erased | Inline | InlineProxy | Opaque | Extension | Given | Exported | Transparent
         | Enum | Infix | Open | ParamAlias | Invisible
     )
 
@@ -108,7 +108,6 @@ trait FlagOps { self: TastyUniverse =>
     else {
       val sb = collection.mutable.ArrayBuffer.empty[String]
       if (flags.is(Erased))      sb += "erased"
-      if (flags.is(Internal))    sb += "<internal>"
       if (flags.is(Inline))      sb += "inline"
       if (flags.is(InlineProxy)) sb += "<inlineproxy>"
       if (flags.is(Opaque))      sb += "opaque"

--- a/src/compiler/scala/tools/nsc/tasty/bridge/FlagOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/FlagOps.scala
@@ -39,7 +39,8 @@ trait FlagOps { self: TastyUniverse =>
     }
     val SingletonEnum: TastyFlagSet = Case | Static | Enum | Stable
     val TermParamOrAccessor: TastyFlagSet = Param | ParamSetter
-    val FieldAccessor: TastyFlagSet = FieldAccessor | Stable
+    val FieldGetter: TastyFlagSet = FieldAccessor | Stable
+    val ParamGetter: TastyFlagSet = FieldGetter | ParamSetter
     val LocalField: TastyFlagSet = Private | Local
     val Scala2Macro: TastyFlagSet = Erased | Macro
   }

--- a/src/compiler/scala/tools/nsc/tasty/bridge/FlagOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/FlagOps.scala
@@ -24,13 +24,14 @@ trait FlagOps { self: TastyUniverse =>
 
   object FlagSets {
     val TastyOnlyFlags: TastyFlagSet = (
-      Erased | Internal | Inline | InlineProxy | Opaque | Extension | Given | Exported | Transparent | Enum | Infix
-      | Open | ParamAlias
+      Erased | Internal | Inline | InlineProxy | Opaque | Extension | Given | Exported | Transparent
+      | Enum | Infix | Open | ParamAlias | Invisible
     )
     val TermParamOrAccessor: TastyFlagSet = Param | ParamSetter
     val ObjectCreationFlags: TastyFlagSet = Object | Lazy | Final | Stable
     val ObjectClassCreationFlags: TastyFlagSet = Object | Final
-    val SingletonEnumFlags: TastyFlagSet = Case | Static | Enum | Stable
+    val SingletonEnumInitFlags: TastyFlagSet = Case | Static | Enum
+    val SingletonEnumFlags: TastyFlagSet = SingletonEnumInitFlags | Stable
     val FieldAccessorFlags: TastyFlagSet = FieldAccessor | Stable
     val LocalFieldFlags: TastyFlagSet = Private | Local
   }
@@ -90,6 +91,7 @@ trait FlagOps { self: TastyUniverse =>
       if (flags.is(Open))        sb += "open"
       if (flags.is(ParamAlias))  sb += "<paramalias>"
       if (flags.is(Infix))       sb += "infix"
+      if (flags.is(Invisible))   sb += "<invisible>"
       sb.mkString(" | ")
     }
   }

--- a/src/compiler/scala/tools/nsc/tasty/bridge/SymbolOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/SymbolOps.scala
@@ -48,7 +48,7 @@ trait SymbolOps { self: TastyUniverse =>
   implicit final class SymbolDecorator(val sym: Symbol) {
 
     def isScala3Inline: Boolean = repr.originalFlagSet.is(Inline)
-    def isScala2Macro: Boolean = repr.originalFlagSet.is(Erased | Macro)
+    def isScala2Macro: Boolean = repr.originalFlagSet.is(FlagSets.Scala2MacroFlags)
 
     def isPureMixinCtor: Boolean = isMixinCtor && repr.originalFlagSet.is(Stable)
     def isMixinCtor: Boolean = u.nme.MIXIN_CONSTRUCTOR == sym.name && sym.owner.isTrait

--- a/src/compiler/scala/tools/nsc/tasty/bridge/SymbolOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/SymbolOps.scala
@@ -197,5 +197,5 @@ trait SymbolOps { self: TastyUniverse =>
   }
 
   def showSig(sig: MethodSignature[ErasedTypeRef]): String = sig.map(_.signature).show
-  def showSym(sym: Symbol): String = s"Symbol($sym, #${sym.id})"
+  def showSym(sym: Symbol): String = s"Symbol(${sym.accurateKindString} ${sym.name}, #${sym.id})"
 }

--- a/src/compiler/scala/tools/nsc/tasty/bridge/SymbolOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/SymbolOps.scala
@@ -85,18 +85,6 @@ trait SymbolOps { self: TastyUniverse =>
     def termRef: Type = sym.preciseRef(u.NoPrefix)
     def preciseRef(pre: Type): Type = u.typeRef(pre, sym, Nil)
     def safeOwner: Symbol = if (sym.owner eq sym) sym else sym.owner
-
-    def set(mask: TastyFlagSet)(implicit ctx: Context): sym.type = ctx.addFlags(sym, mask)
-    def reset(mask: TastyFlagSet)(implicit ctx: Context): sym.type = ctx.removeFlags(sym, mask)
-
-    def isOneOf(mask: TastyFlagSet): Boolean = sym.hasFlag(unsafeEncodeTastyFlagSet(mask))
-    def is(mask: TastyFlagSet): Boolean = sym.hasAllFlags(unsafeEncodeTastyFlagSet(mask))
-    def is(mask: TastyFlagSet, butNot: TastyFlagSet): Boolean =
-      if (!butNot)
-        sym.is(mask)
-      else
-        sym.is(mask) && sym.not(butNot)
-    def not(mask: TastyFlagSet): Boolean = sym.hasNoFlags(unsafeEncodeTastyFlagSet(mask))
   }
 
   /** if isConstructor, make sure it has one non-implicit parameter list */

--- a/src/compiler/scala/tools/nsc/tasty/bridge/SymbolOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/SymbolOps.scala
@@ -48,7 +48,7 @@ trait SymbolOps { self: TastyUniverse =>
   implicit final class SymbolDecorator(val sym: Symbol) {
 
     def isScala3Inline: Boolean = repr.originalFlagSet.is(Inline)
-    def isScala2Macro: Boolean = repr.originalFlagSet.is(FlagSets.Scala2MacroFlags)
+    def isScala2Macro: Boolean = repr.originalFlagSet.is(FlagSets.Scala2Macro)
 
     def isPureMixinCtor: Boolean = isMixinCtor && repr.originalFlagSet.is(Stable)
     def isMixinCtor: Boolean = u.nme.MIXIN_CONSTRUCTOR == sym.name && sym.owner.isTrait
@@ -56,7 +56,7 @@ trait SymbolOps { self: TastyUniverse =>
     def isTraitParamAccessor: Boolean = sym.owner.isTrait && repr.originalFlagSet.is(FieldAccessor|ParamSetter)
 
     def isParamGetter: Boolean =
-      sym.isMethod && sym.repr.originalFlagSet.is(FlagSets.FieldAccessorFlags)
+      sym.isMethod && sym.repr.originalFlagSet.is(FlagSets.FieldAccessor)
 
     /** A computed property that should only be called on a symbol which is known to have been initialised by the
      *  Tasty Unpickler and is not yet completed.
@@ -89,14 +89,14 @@ trait SymbolOps { self: TastyUniverse =>
     def set(mask: TastyFlagSet)(implicit ctx: Context): sym.type = ctx.addFlags(sym, mask)
     def reset(mask: TastyFlagSet)(implicit ctx: Context): sym.type = ctx.removeFlags(sym, mask)
 
-    def isOneOf(mask: TastyFlagSet): Boolean = sym.hasFlag(encodeFlagSet(mask))
-    def is(mask: TastyFlagSet): Boolean = sym.hasAllFlags(encodeFlagSet(mask))
+    def isOneOf(mask: TastyFlagSet): Boolean = sym.hasFlag(unsafeEncodeTastyFlagSet(mask))
+    def is(mask: TastyFlagSet): Boolean = sym.hasAllFlags(unsafeEncodeTastyFlagSet(mask))
     def is(mask: TastyFlagSet, butNot: TastyFlagSet): Boolean =
       if (!butNot)
         sym.is(mask)
       else
         sym.is(mask) && sym.not(butNot)
-    def not(mask: TastyFlagSet): Boolean = sym.hasNoFlags(encodeFlagSet(mask))
+    def not(mask: TastyFlagSet): Boolean = sym.hasNoFlags(unsafeEncodeTastyFlagSet(mask))
   }
 
   /** if isConstructor, make sure it has one non-implicit parameter list */

--- a/src/compiler/scala/tools/nsc/tasty/bridge/SymbolOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/SymbolOps.scala
@@ -56,7 +56,7 @@ trait SymbolOps { self: TastyUniverse =>
     def isTraitParamAccessor: Boolean = sym.owner.isTrait && repr.originalFlagSet.is(FieldAccessor|ParamSetter)
 
     def isParamGetter: Boolean =
-      sym.isMethod && sym.repr.originalFlagSet.is(FlagSets.FieldAccessor)
+      sym.isMethod && sym.repr.originalFlagSet.is(FlagSets.ParamGetter)
 
     /** A computed property that should only be called on a symbol which is known to have been initialised by the
      *  Tasty Unpickler and is not yet completed.
@@ -130,7 +130,11 @@ trait SymbolOps { self: TastyUniverse =>
           space.member(selector).orElse(lookInTypeCtor)
         }
       }
-      else space.member(encodeTermName(tname))
+      else {
+        val firstTry = space.member(encodeTermName(tname))
+        if (firstTry.isOverloaded) firstTry.filter(!_.isPrivateLocal)
+        else firstTry
+      }
     }
     if (isSymbol(member) && hasType(member)) member
     else errorMissing(space, tname)

--- a/src/compiler/scala/tools/nsc/tasty/bridge/TypeOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/TypeOps.scala
@@ -192,7 +192,7 @@ trait TypeOps { self: TastyUniverse =>
       if (args.exists(tpe => tpe.isInstanceOf[u.TypeBounds] | tpe.isInstanceOf[LambdaPolyType])) {
         val syms = mutable.ListBuffer.empty[Symbol]
         def bindWildcards(tpe: Type) = tpe match {
-          case tpe: u.TypeBounds   => ctx.newWildcardSym(tpe).tap(syms += _).pipe(_.ref)
+          case tpe: u.TypeBounds   => ctx.newWildcard(tpe).tap(syms += _).pipe(_.ref)
           case tpe: LambdaPolyType => tpe.toNested
           case tpe                 => tpe
         }
@@ -646,7 +646,7 @@ trait TypeOps { self: TastyUniverse =>
     override val typeParams: List[Symbol] = paramNames.lazyZip(paramInfos).map {
       case (name, bounds) =>
         val argInfo = normaliseIfBounds(bounds)
-        ctx.owner.newTypeParameter(name, u.NoPosition, FlagSets.Creation.HKTyParam).setInfo(argInfo)
+        ctx.owner.newTypeParameter(name, u.NoPosition, FlagSets.Creation.BoundedType).setInfo(argInfo)
     }
 
     val resType: Type = lambdaResultType(resultTypeOp())
@@ -674,7 +674,7 @@ trait TypeOps { self: TastyUniverse =>
 
     override val typeParams: List[Symbol] = paramNames.lazyZip(paramInfos).map {
       case (name, argInfo) =>
-        ctx.owner.newTypeParameter(name, u.NoPosition, FlagSets.Creation.TyParam).setInfo(argInfo)
+        ctx.owner.newTypeParameter(name, u.NoPosition, FlagSets.Creation.BoundedType).setInfo(argInfo)
     }
 
     val resType: Type = resultTypeOp() // potentially need to flatten? (probably not, happens in typer in dotty)

--- a/src/compiler/scala/tools/nsc/tasty/bridge/TypeOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/TypeOps.scala
@@ -619,7 +619,8 @@ trait TypeOps { self: TastyUniverse =>
     val paramInfos: List[Type] = paramInfosOp()
 
     override val params: List[Symbol] = paramNames.lazyZip(paramInfos).map {
-      case (name, argInfo) => ctx.owner.newValueParameter(name, u.NoPosition, encodeFlagSet(defaultFlags)).setInfo(argInfo)
+      case (name, argInfo) =>
+        ctx.owner.newValueParameter(name, u.NoPosition, newSymbolFlagSet(defaultFlags)).setInfo(argInfo)
     }
 
     val resType: Type = resultTypeOp()
@@ -647,7 +648,7 @@ trait TypeOps { self: TastyUniverse =>
     override val typeParams: List[Symbol] = paramNames.lazyZip(paramInfos).map {
       case (name, bounds) =>
         val argInfo = normaliseIfBounds(bounds)
-        ctx.owner.newTypeParameter(name, u.NoPosition, u.Flag.DEFERRED).setInfo(argInfo)
+        ctx.owner.newTypeParameter(name, u.NoPosition, FlagSets.Creation.HKTyParam).setInfo(argInfo)
     }
 
     val resType: Type = lambdaResultType(resultTypeOp())
@@ -674,7 +675,8 @@ trait TypeOps { self: TastyUniverse =>
     val paramInfos: List[Type] = paramInfosOp()
 
     override val typeParams: List[Symbol] = paramNames.lazyZip(paramInfos).map {
-      case (name, argInfo) => ctx.owner.newTypeParameter(name, u.NoPosition, u.Flag.DEFERRED).setInfo(argInfo)
+      case (name, argInfo) =>
+        ctx.owner.newTypeParameter(name, u.NoPosition, FlagSets.Creation.TyParam).setInfo(argInfo)
     }
 
     val resType: Type = resultTypeOp() // potentially need to flatten? (probably not, happens in typer in dotty)

--- a/src/compiler/scala/tools/nsc/tasty/bridge/TypeOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/TypeOps.scala
@@ -240,6 +240,9 @@ trait TypeOps { self: TastyUniverse =>
       bounds
   }
 
+  private[bridge] def sameErasure(sym: Symbol)(tpe: Type, ref: ErasedTypeRef)(implicit ctx: Context) =
+    NameErasure.sigName(tpe, sym) === ref
+
   /** This is a port from Dotty of transforming a Method type to an ErasedTypeRef
    */
   private[bridge] object NameErasure {
@@ -279,9 +282,11 @@ trait TypeOps { self: TastyUniverse =>
       else self
     }
 
-    def sigName(tp: Type, isJava: Boolean)(implicit ctx: Context): ErasedTypeRef = {
-      val normTp = translateFromRepeated(tp)(toArray = isJava)
-      erasedSigName(normTp.erasure)
+    def sigName(tp: Type, sym: Symbol)(implicit ctx: Context): ErasedTypeRef = {
+      val normTp = translateFromRepeated(tp)(toArray = sym.isJavaDefined)
+      erasedSigName(
+        u.erasure.erasure(sym)(normTp)
+      )
     }
 
     private def erasedSigName(erased: Type)(implicit ctx: Context): ErasedTypeRef = erased match {

--- a/src/compiler/scala/tools/nsc/tasty/bridge/TypeOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/TypeOps.scala
@@ -422,6 +422,7 @@ trait TypeOps { self: TastyUniverse =>
     override final def complete(sym: Symbol): Unit = {
       underlying.ensureCompleted()
       sym.info = underlying.tpe
+      underlying.attachments.all.foreach(sym.updateAttachment(_))
     }
   }
 

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -575,7 +575,7 @@ abstract class Erasure extends InfoTransform
       debuglog("generating bridge from %s (%s): %s%s to %s: %s%s".format(
         other, flagsToString(newFlags),
         otpe, other.locationString, member,
-        specialErasure(root)(member.tpe, root), member.locationString)
+        specialErasure(root)(member.tpe), member.locationString)
       )
 
       // the parameter symbols need to have the new owner
@@ -1120,7 +1120,7 @@ abstract class Erasure extends InfoTransform
                   gen.mkMethodCall(
                     qual1(),
                     fun.symbol,
-                    List(specialErasure(fun.symbol)(arg.tpe, fun.symbol)),
+                    List(specialErasure(fun.symbol)(arg.tpe)),
                     Nil
                   ),
                   isArrayTest(qual1())
@@ -1355,7 +1355,7 @@ abstract class Erasure extends InfoTransform
                 fields.dropFieldAnnotationsFromGetter(tree.symbol)
 
               try super.transform(tree1).clearType()
-              finally tpt setType specialErasure(tree1.symbol)(tree1.symbol.tpe, tree1.symbol).resultType
+              finally tpt setType specialErasure(tree1.symbol)(tree1.symbol.tpe).resultType
             case ApplyDynamic(qual, Literal(Constant(bootstrapMethodRef: Symbol)) :: _) =>
               tree
             case _: Apply if tree1 ne tree =>

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -575,7 +575,7 @@ abstract class Erasure extends InfoTransform
       debuglog("generating bridge from %s (%s): %s%s to %s: %s%s".format(
         other, flagsToString(newFlags),
         otpe, other.locationString, member,
-        specialErasure(root)(member.tpe), member.locationString)
+        specialErasure(root)(member.tpe, root), member.locationString)
       )
 
       // the parameter symbols need to have the new owner
@@ -1120,7 +1120,7 @@ abstract class Erasure extends InfoTransform
                   gen.mkMethodCall(
                     qual1(),
                     fun.symbol,
-                    List(specialErasure(fun.symbol)(arg.tpe)),
+                    List(specialErasure(fun.symbol)(arg.tpe, fun.symbol)),
                     Nil
                   ),
                   isArrayTest(qual1())
@@ -1355,7 +1355,7 @@ abstract class Erasure extends InfoTransform
                 fields.dropFieldAnnotationsFromGetter(tree.symbol)
 
               try super.transform(tree1).clearType()
-              finally tpt setType specialErasure(tree1.symbol)(tree1.symbol.tpe).resultType
+              finally tpt setType specialErasure(tree1.symbol)(tree1.symbol.tpe, tree1.symbol).resultType
             case ApplyDynamic(qual, Literal(Constant(bootstrapMethodRef: Symbol)) :: _) =>
               tree
             case _: Apply if tree1 ne tree =>

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1803,10 +1803,12 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               if (!ps.isEmpty && !superclazz.isSubClass(ps.head.typeSymbol))
                 pending += ParentSuperSubclassError(parent, superclazz, ps.head.typeSymbol, psym)
               if (!clazzIsTrait) {
+                def hasTraitParams(sym: Symbol) =
+                  sym.isScala3Defined && sym.isTrait && sym.hasAttachment[DottyParameterisedTrait]
                 // TODO perhaps there can be a flag to skip this when we know there can be no Scala 3 definitions
                 // or otherwise use an optimised representation for trait parameters
                 (parent.tpe :: ps).collectFirst {
-                  case p if p.typeSymbol.hasAttachment[DottyParameterisedTrait] =>
+                  case p if hasTraitParams(p.typeSymbol) =>
                     p.typeSymbol.attachments.get[DottyParameterisedTrait].foreach( attach =>
                       pending += ParentIsScala3TraitError(parent, p.typeSymbol, attach.params, psym)
                     )

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -232,7 +232,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     // (it erases in TypeTrees, but not in, e.g., the type a Function node)
     def phasedAppliedType(sym: Symbol, args: List[Type]) = {
       val tp = appliedType(sym, args)
-      if (phase.erasedTypes) erasure.specialScalaErasure(tp) else tp
+      if (phase.erasedTypes) erasure.specialScalaErasureFor(sym)(tp) else tp
     }
 
     def typedDocDef(docDef: DocDef, mode: Mode, pt: Type): Tree =

--- a/src/compiler/scala/tools/tasty/TastyFlags.scala
+++ b/src/compiler/scala/tools/tasty/TastyFlags.scala
@@ -60,8 +60,7 @@ object TastyFlags {
   final val Open                  = Enum.next
   final val ParamAlias            = Open.next
   final val Infix                 = ParamAlias.next
-
-  private[TastyFlags] final val maxFlag: Long = ParamAlias.shift
+  final val Invisible             = Infix.next
 
   def optFlag(cond: Boolean)(flag: TastyFlagSet): TastyFlagSet = if (cond) flag else EmptyTastyFlags
 
@@ -138,23 +137,9 @@ object TastyFlags {
         if (is(Open))          sb += "Open"
         if (is(ParamAlias))    sb += "ParamAlias"
         if (is(Infix))         sb += "Infix"
+        if (is(Invisible))     sb += "Invisible"
         sb.mkString(" | ")
       }
-    }
-  }
-
-  case class SingletonSets(val toLong: Long) extends AnyVal {
-    def map[A](f: TastyFlagSet => A): Iterable[A] = {
-      val buf = Iterable.newBuilder[A]
-      val orig = TastyFlagSet(toLong)
-      var flag = EmptyTastyFlags
-      while (flag.shift <= maxFlag) {
-        flag = flag.next
-        if (orig.is(flag)) {
-          buf += f(flag)
-        }
-      }
-      buf.result()
     }
   }
 

--- a/src/compiler/scala/tools/tasty/TastyFlags.scala
+++ b/src/compiler/scala/tools/tasty/TastyFlags.scala
@@ -47,8 +47,7 @@ object TastyFlags {
   final val Deferred              = Param.next
   final val Method                = Deferred.next
   final val Erased                = Method.next
-  final val Internal              = Erased.next
-  final val Inline                = Internal.next
+  final val Inline                = Erased.next
   final val InlineProxy           = Inline.next
   final val Opaque                = InlineProxy.next
   final val Extension             = Opaque.next
@@ -124,7 +123,6 @@ object TastyFlags {
         if (is(Deferred))      sb += "Deferred"
         if (is(Method))        sb += "Method"
         if (is(Erased))        sb += "Erased"
-        if (is(Internal))      sb += "Internal"
         if (is(Inline))        sb += "Inline"
         if (is(InlineProxy))   sb += "InlineProxy"
         if (is(Opaque))        sb += "Opaque"

--- a/src/compiler/scala/tools/tasty/TastyFormat.scala
+++ b/src/compiler/scala/tools/tasty/TastyFormat.scala
@@ -51,14 +51,31 @@ object TastyFormat {
    * is able to read final TASTy documents if the file's
    * `MinorVersion` is strictly less than the current value.
    */
-  final val ExperimentalVersion: Int = 3
+  final val ExperimentalVersion: Int = 0
 
   /**This method implements a binary relation (`<:<`) between two TASTy versions.
+   *
    * We label the lhs `file` and rhs `compiler`.
    * if `file <:< compiler` then the TASTy file is valid to be read.
    *
-   * TASTy versions have a partial order,
-   * for example `a <:< b` and `b <:< a` are both false if `a` and `b` have different major versions.
+   * A TASTy version, e.g. `v := 28.0-3` is composed of three fields:
+   *   - v.major == 28
+   *   - v.minor == 0
+   *   - v.experimental == 3
+   *
+   * TASTy versions have a partial order, for example,
+   * `a <:< b` and `b <:< a` are both false if
+   *   - `a` and `b` have different `major` fields.
+   *   - `a` and `b` have the same `major` & `minor` fields,
+   *     but different `experimental` fields, both non-zero.
+   *
+   * A TASTy version with a zero value for its `experimental` field
+   * is considered to be stable. Files with a stable TASTy version
+   * can be read by a compiler with an unstable TASTy version,
+   * (where the compiler's TASTy version has a higher `minor` field).
+   *
+   * A compiler with a stable TASTy version can never read a file
+   * with an unstable TASTy version.
    *
    * We follow the given algorithm:
    * ```

--- a/src/compiler/scala/tools/tasty/TastyFormat.scala
+++ b/src/compiler/scala/tools/tasty/TastyFormat.scala
@@ -187,7 +187,6 @@ object TastyFormat {
   final val TRUEconst = 4
   final val NULLconst = 5
   final val PRIVATE = 6
-  final val INTERNAL = 7
   final val PROTECTED = 8
   final val ABSTRACT = 9
   final val FINAL = 10
@@ -352,7 +351,6 @@ object TastyFormat {
 
   def isModifierTag(tag: Int): Boolean = tag match {
     case PRIVATE
-       | INTERNAL
        | PROTECTED
        | ABSTRACT
        | FINAL
@@ -416,7 +414,6 @@ object TastyFormat {
     case TRUEconst => "TRUEconst"
     case NULLconst => "NULLconst"
     case PRIVATE => "PRIVATE"
-    case INTERNAL => "INTERNAL"
     case PROTECTED => "PROTECTED"
     case ABSTRACT => "ABSTRACT"
     case FINAL => "FINAL"

--- a/src/compiler/scala/tools/tasty/TastyFormat.scala
+++ b/src/compiler/scala/tools/tasty/TastyFormat.scala
@@ -51,7 +51,7 @@ object TastyFormat {
    * is able to read final TASTy documents if the file's
    * `MinorVersion` is strictly less than the current value.
    */
-  final val ExperimentalVersion: Int = 1
+  final val ExperimentalVersion: Int = 3
 
   /**This method implements a binary relation (`<:<`) between two TASTy versions.
    * We label the lhs `file` and rhs `compiler`.
@@ -223,8 +223,9 @@ object TastyFormat {
   final val PARAMalias = 41
   final val TRANSPARENT = 42
   final val INFIX = 43
-  final val EMPTYCLAUSE = 44
-  final val SPLITCLAUSE = 45
+  final val INVISIBLE = 44
+  final val EMPTYCLAUSE = 45
+  final val SPLITCLAUSE = 46
 
   // Cat. 2:    tag Nat
 
@@ -387,6 +388,7 @@ object TastyFormat {
        | PARAMalias
        | EXPORTED
        | OPEN
+       | INVISIBLE
        | ANNOTATION
        | PRIVATEqualified
        | PROTECTEDqualified => true
@@ -449,6 +451,7 @@ object TastyFormat {
     case PARAMsetter => "PARAMsetter"
     case EXPORTED => "EXPORTED"
     case OPEN => "OPEN"
+    case INVISIBLE => "INVISIBLE"
     case PARAMalias => "PARAMalias"
     case EMPTYCLAUSE => "EMPTYCLAUSE"
     case SPLITCLAUSE => "SPLITCLAUSE"

--- a/src/compiler/scala/tools/tasty/TastyHeaderUnpickler.scala
+++ b/src/compiler/scala/tools/tasty/TastyHeaderUnpickler.scala
@@ -51,7 +51,7 @@ class TastyHeaderUnpickler(reader: TastyReader) {
         compilerMajor        = MajorVersion,
         compilerMinor        = MinorVersion,
         compilerExperimental = ExperimentalVersion
-      )
+      ) || scala3finalException(fileMajor, fileMinor, fileExperimental)
 
       check(validVersion, {
         val signature = signatureString(fileMajor, fileMinor, fileExperimental)
@@ -69,14 +69,26 @@ class TastyHeaderUnpickler(reader: TastyReader) {
     }
   }
 
-  def isAtEnd: Boolean = reader.isAtEnd
-
   private def check(cond: Boolean, msg: => String): Unit = {
     if (!cond) throw new UnpickleException(msg)
   }
 }
 
 object TastyHeaderUnpickler {
+
+  /** This escape hatch allows 28.0.3 compiler to read
+   *  28.0.0 TASTy files (aka produced by Scala 3.0.0 final)
+   *  @note this should be removed if we are able to test against
+   *        Scala 3.0.0 before releasing Scala 2.13.6
+   */
+  private def scala3finalException(
+      fileMajor: Int,
+      fileMinor: Int,
+      fileExperimental: Int): Boolean = (
+    MajorVersion == 28 && fileMajor == 28
+      && MinorVersion == 0 && fileMinor == 0
+      && ExperimentalVersion == 3 && fileExperimental == 0
+  )
 
   private def toolingAddendum = (
     if (ExperimentalVersion > 0)

--- a/src/compiler/scala/tools/tasty/TastyHeaderUnpickler.scala
+++ b/src/compiler/scala/tools/tasty/TastyHeaderUnpickler.scala
@@ -51,7 +51,7 @@ class TastyHeaderUnpickler(reader: TastyReader) {
         compilerMajor        = MajorVersion,
         compilerMinor        = MinorVersion,
         compilerExperimental = ExperimentalVersion
-      ) || scala3finalException(fileMajor, fileMinor, fileExperimental)
+      )
 
       check(validVersion, {
         val signature = signatureString(fileMajor, fileMinor, fileExperimental)
@@ -75,20 +75,6 @@ class TastyHeaderUnpickler(reader: TastyReader) {
 }
 
 object TastyHeaderUnpickler {
-
-  /** This escape hatch allows 28.0.3 compiler to read
-   *  28.0.0 TASTy files (aka produced by Scala 3.0.0 final)
-   *  @note this should be removed if we are able to test against
-   *        Scala 3.0.0 before releasing Scala 2.13.6
-   */
-  private def scala3finalException(
-      fileMajor: Int,
-      fileMinor: Int,
-      fileExperimental: Int): Boolean = (
-    MajorVersion == 28 && fileMajor == 28
-      && MinorVersion == 0 && fileMinor == 0
-      && ExperimentalVersion == 3 && fileExperimental == 0
-  )
 
   private def toolingAddendum = (
     if (ExperimentalVersion > 0)

--- a/src/reflect/scala/reflect/internal/Flags.scala
+++ b/src/reflect/scala/reflect/internal/Flags.scala
@@ -80,7 +80,7 @@ package internal
 // 57:          notOVERRIDE
 // 58:           notPRIVATE
 // 59:
-// 60:
+// 60:              SCALA3X
 // 61:
 // 62:
 // 63:
@@ -113,6 +113,7 @@ class ModifierFlags {
   final val LOCAL         = 1L << 19       // symbol is local to current class (i.e. private[this] or protected[this]
                                           // pre: PRIVATE or PROTECTED are also set
   final val JAVA          = 1L << 20       // symbol was defined by a Java class
+  final val SCALA3X       = 1L << 60       // class was defined in Scala 3
   final val STATIC        = 1L << 23       // static field, method or class
   final val CASEACCESSOR  = 1L << 24       // symbol is a case parameter (or its accessor, or a GADT skolem)
   final val TRAIT         = 1L << 25       // symbol is a trait
@@ -202,7 +203,7 @@ class Flags extends ModifierFlags {
   // The flags (1L << 59) to (1L << 63) are currently unused. If added to the InitialFlags mask,
   // they could be used as normal flags.
 
-  final val InitialFlags  = 0x0007FFFFFFFFFFFFL // normal flags, enabled from the first phase: 1L to (1L << 50)
+  final val InitialFlags  = 0x1007FFFFFFFFFFFFL // normal flags, enabled from the first phase: 1L to (1L << 50) + (1L << 60)
   final val LateFlags     = 0x00F8000000000000L // flags that override flags in (1L << 4) to (1L << 8): DEFERRED, FINAL, INTERFACE, METHOD, MODULE
   final val AntiFlags     = 0x0700000000000000L // flags that cancel flags in 1L to (1L << 2): PROTECTED, OVERRIDE, PRIVATE
   final val LateShift     = 47
@@ -320,7 +321,7 @@ class Flags extends ModifierFlags {
 
 
   /** These flags are not pickled */
-  final val FlagsNotPickled = IS_ERROR | OVERLOADED | LIFTED | TRANS_FLAG | LOCKED | TRIEDCOOKING
+  final val FlagsNotPickled = IS_ERROR | OVERLOADED | LIFTED | TRANS_FLAG | LOCKED | TRIEDCOOKING | SCALA3X
 
   // A precaution against future additions to FlagsNotPickled turning out
   // to be overloaded flags thus not-pickling more than intended.
@@ -477,8 +478,8 @@ class Flags extends ModifierFlags {
     case      `notPROTECTED` => "<notprotected>"                      // (1L << 56)
     case  0x200000000000000L => "<notoverride>"                       // (1L << 57)
     case        `notPRIVATE` => "<notprivate>"                        // (1L << 58)
-    case NEEDS_TREES         => "<needs_trees>"                       // (1L << 59)
-    case 0x1000000000000000L => ""                                    // (1L << 60)
+    case         NEEDS_TREES => "<needs_trees>"                       // (1L << 59)
+    case             SCALA3X => "<scala3>"                            // (1L << 60)
     case 0x2000000000000000L => ""                                    // (1L << 61)
     case 0x4000000000000000L => ""                                    // (1L << 62)
     case 0x8000000000000000L => ""                                    // (1L << 63)

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -122,6 +122,8 @@ trait StdAttachments {
 
   class DottyOpaqueTypeAlias(val tpe: Type)
 
+  case object DottyMethod extends PlainAttachment
+
   class QualTypeSymAttachment(val sym: Symbol)
 
   case object ConstructorNeedsFence extends PlainAttachment

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -122,7 +122,8 @@ trait StdAttachments {
 
   class DottyOpaqueTypeAlias(val tpe: Type)
 
-  case object DottyMethod extends PlainAttachment
+  case object DottyTerm extends PlainAttachment
+  case object DottyClass extends PlainAttachment
 
   class QualTypeSymAttachment(val sym: Symbol)
 

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -116,14 +116,11 @@ trait StdAttachments {
     */
   case object KnownDirectSubclassesCalled extends PlainAttachment
 
-  class DottyEnumSingleton(val name: String) extends PlainAttachment
+  case object DottyEnumSingleton extends PlainAttachment
 
   class DottyParameterisedTrait(val params: List[Symbol])
 
   class DottyOpaqueTypeAlias(val tpe: Type)
-
-  case object DottyTerm extends PlainAttachment
-  case object DottyClass extends PlainAttachment
 
   class QualTypeSymAttachment(val sym: Symbol)
 

--- a/src/reflect/scala/reflect/internal/SymbolPairs.scala
+++ b/src/reflect/scala/reflect/internal/SymbolPairs.scala
@@ -43,12 +43,12 @@ abstract class SymbolPairs {
     def rootType: Type      = self
 
     def lowType: Type       = self memberType low
-    def lowErased: Type     = erasure.specialErasure(base)(low.tpe, low)
+    def lowErased: Type     = erasure.specialErasure(low)(low.tpe)
     def lowClassBound: Type = classBoundAsSeen(low.tpe.typeSymbol)
 
     def highType: Type       = self memberType high
     def highInfo: Type       = self memberInfo high
-    def highErased: Type     = erasure.specialErasure(base)(high.tpe, high)
+    def highErased: Type     = erasure.specialErasure(high)(high.tpe)
     def highClassBound: Type = classBoundAsSeen(high.tpe.typeSymbol)
 
     def isErroneous = low.tpe.isErroneous || high.tpe.isErroneous

--- a/src/reflect/scala/reflect/internal/SymbolPairs.scala
+++ b/src/reflect/scala/reflect/internal/SymbolPairs.scala
@@ -43,12 +43,12 @@ abstract class SymbolPairs {
     def rootType: Type      = self
 
     def lowType: Type       = self memberType low
-    def lowErased: Type     = erasure.specialErasure(base)(low.tpe)
+    def lowErased: Type     = erasure.specialErasure(base)(low.tpe, low)
     def lowClassBound: Type = classBoundAsSeen(low.tpe.typeSymbol)
 
     def highType: Type       = self memberType high
     def highInfo: Type       = self memberInfo high
-    def highErased: Type     = erasure.specialErasure(base)(high.tpe)
+    def highErased: Type     = erasure.specialErasure(base)(high.tpe, high)
     def highClassBound: Type = classBoundAsSeen(high.tpe.typeSymbol)
 
     def isErroneous = low.tpe.isErroneous || high.tpe.isErroneous

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -263,8 +263,6 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     final val id = nextId() // identity displayed when -uniqid
     // assert(id != 11924, initName)
 
-    def debugTasty = s"Symbol($this, #$id, ${flagString})"
-
     private[this] var _validTo: Period = NoPeriod
 
     if (traceSymbolActivity)

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -972,6 +972,8 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
 
     final def isModuleVar = hasFlag(MODULEVAR)
 
+    final def isScala3Defined = hasFlag(SCALA3X)
+
     /**
      * Is this symbol static (i.e. with no outer instance)?
      * Q: When exactly is a sym marked as STATIC?

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -261,7 +261,9 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     rawatt = initPos
 
     final val id = nextId() // identity displayed when -uniqid
-    //assert(id != 3390, initName)
+    // assert(id != 11924, initName)
+
+    def debugTasty = s"Symbol($this, #$id, ${flagString})"
 
     private[this] var _validTo: Period = NoPeriod
 

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -261,7 +261,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     rawatt = initPos
 
     final val id = nextId() // identity displayed when -uniqid
-    // assert(id != 11924, initName)
+    //assert(id != 3390, initName)
 
     private[this] var _validTo: Period = NoPeriod
 

--- a/src/reflect/scala/reflect/internal/transform/Erasure.scala
+++ b/src/reflect/scala/reflect/internal/transform/Erasure.scala
@@ -148,7 +148,7 @@ trait Erasure {
         else if (sym eq UnitClass) BoxedUnitTpe
         else if (sym.isRefinementClass) apply(mergeParents(tp.parents))
         else if (sym.isDerivedValueClass) eraseDerivedValueClassRef(tref)
-        else if (isDottyEnumSingleton(sym)) apply(intersectionType(tp.parents)) // TODO [tasty]: dotty enum singletons are not modules.
+        else if (isDottyEnumSingleton(sym)) apply(mergeParents(tp.parents)) // TODO [tasty]: dotty enum singletons are not modules.
         else if (sym.isClass) eraseNormalClassRef(tref)
         else apply(transparentDealias(sym, pre, sym.owner)) // alias type or abstract type (including opaque type)
       case PolyType(tparams, restpe) =>

--- a/src/reflect/scala/reflect/internal/transform/Erasure.scala
+++ b/src/reflect/scala/reflect/internal/transform/Erasure.scala
@@ -530,6 +530,10 @@ trait Erasure {
     components.min((t, u) => compareErasedGlb(t, u))
   }
 
+  /** For a type alias, get its info as seen from
+   *  the current prefix and owner.
+   *  Sees through opaque type aliases.
+   */
   def transparentDealias(sym: Symbol, pre: Type, owner: Symbol) = {
     @inline def visible(tp: Type) = tp.asSeenFrom(pre, owner)
 

--- a/src/reflect/scala/reflect/internal/transform/Transforms.scala
+++ b/src/reflect/scala/reflect/internal/transform/Transforms.scala
@@ -51,7 +51,7 @@ trait Transforms { self: SymbolTable =>
 
   def transformedType(tpe: Type) = {
     val symbol = tpe.widen.typeSymbol
-    val erasureMap = if (symbol.hasAttachment[DottyTerm.type]) erasure.scala3Erasure else erasure.scalaErasure
+    val erasureMap = if (symbol.isScala3Defined) erasure.scala3Erasure else erasure.scalaErasure
     postErasure.elimErasedValueType(erasureMap(uncurry.uncurry(tpe)))
   }
 

--- a/src/reflect/scala/reflect/internal/transform/Transforms.scala
+++ b/src/reflect/scala/reflect/internal/transform/Transforms.scala
@@ -49,7 +49,10 @@ trait Transforms { self: SymbolTable =>
       erasure.transformInfo(sym,
         uncurry.transformInfo(sym, sym.info)))
 
-  def transformedType(tpe: Type) =
-    postErasure.elimErasedValueType(erasure.scalaErasure(uncurry.uncurry(tpe)))
+  def transformedType(tpe: Type) = {
+    val symbol = tpe.widen.typeSymbol
+    val erasureMap = if (symbol.hasAttachment[DottyTerm.type]) erasure.scala3Erasure else erasure.scalaErasure
+    postErasure.elimErasedValueType(erasureMap(uncurry.uncurry(tpe)))
+  }
 
 }

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -67,7 +67,8 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.UseInvokeSpecial
     this.TypeParamVarargsAttachment
     this.KnownDirectSubclassesCalled
-    this.DottyMethod
+    this.DottyTerm
+    this.DottyClass
     this.ConstructorNeedsFence
     this.MultiargInfixAttachment
     this.NullaryOverrideAdapted
@@ -527,5 +528,6 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     erasure.javaErasure
     erasure.verifiedJavaErasure
     erasure.boxingErasure
+    erasure.boxing3Erasure
   }
 }

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -67,8 +67,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.UseInvokeSpecial
     this.TypeParamVarargsAttachment
     this.KnownDirectSubclassesCalled
-    this.DottyTerm
-    this.DottyClass
+    this.DottyEnumSingleton
     this.ConstructorNeedsFence
     this.MultiargInfixAttachment
     this.NullaryOverrideAdapted

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -67,6 +67,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.UseInvokeSpecial
     this.TypeParamVarargsAttachment
     this.KnownDirectSubclassesCalled
+    this.DottyMethod
     this.ConstructorNeedsFence
     this.MultiargInfixAttachment
     this.NullaryOverrideAdapted
@@ -520,7 +521,9 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     uncurry.DesugaredParameterType
     erasure.GenericArray
     erasure.scalaErasure
+    erasure.scala3Erasure
     erasure.specialScalaErasure
+    erasure.specialScala3Erasure
     erasure.javaErasure
     erasure.verifiedJavaErasure
     erasure.boxingErasure

--- a/src/tastytest/dotty/tools/vulpix/ParallelTesting.scala
+++ b/src/tastytest/dotty/tools/vulpix/ParallelTesting.scala
@@ -1,0 +1,11 @@
+package dotty.tools.vulpix
+
+/** As of Scala 3.0.0-RC2, dotty compiler will enable the
+ *  usage of experimental features if the compiler is invoked
+ *  within a method on the class `dotty.tools.vulpix.ParallelTesting`
+ *
+ *  We use this to test experimental features on non-nightly releases.
+ */
+class ParallelTesting {
+  def unlockExperimentalFeatures[T](op: => T): T = op
+}

--- a/src/tastytest/scala/tools/tastytest/ClasspathOps.scala
+++ b/src/tastytest/scala/tools/tastytest/ClasspathOps.scala
@@ -1,0 +1,10 @@
+package scala.tools.tastytest
+
+import java.net.URL
+import java.nio.file.Paths
+
+object ClasspathOps {
+  implicit class ClassPathSyntax(private val ls: List[String]) extends AnyVal {
+    def asURLs: List[URL] = ls.map(Paths.get(_).toUri().toURL())
+  }
+}

--- a/src/tastytest/scala/tools/tastytest/Classpaths.scala
+++ b/src/tastytest/scala/tools/tastytest/Classpaths.scala
@@ -1,0 +1,17 @@
+package scala.tools.tastytest
+
+import scala.util.Properties
+import java.io.File.pathSeparatorChar
+
+object Classpaths {
+
+  private def classpathProp(name: String) =
+    Properties.propOrNone(name).map(_.split(pathSeparatorChar).filter(_.nonEmpty).toList).getOrElse(Nil)
+
+  def dottyCompiler: List[String] = classpathProp("tastytest.classpaths.dottyCompiler")
+
+  def scalaReflect: List[String] = classpathProp("tastytest.classpaths.scalaReflect")
+
+  def dottyLibrary: List[String] = classpathProp("tastytest.classpaths.dottyLibrary")
+
+}

--- a/src/tastytest/scala/tools/tastytest/Dotc.scala
+++ b/src/tastytest/scala/tools/tastytest/Dotc.scala
@@ -1,40 +1,73 @@
 package scala.tools.tastytest
 
-import scala.util.{ Try, Success }
+import scala.util.{Try, Success, Failure}
+import scala.util.control.NonFatal
 
-import java.lang.reflect.Modifier
+import scala.reflect.internal.util.ScalaClassLoader
+import scala.reflect.runtime.ReflectionUtils
+import java.lang.reflect.{Modifier, Method}
+
+import ClasspathOps._
 
 object Dotc extends Script.Command {
 
-  private[this] lazy val dotcProcess = processMethod("dotty.tools.dotc.Main")
+  final case class ClassLoader private (val parent: ScalaClassLoader)
 
-  def processMethod(mainClassName: String): Array[String] => Try[Boolean] = {
-    // TODO call it directly when we are bootstrapped
-    val mainClass = Class.forName(mainClassName)
-    val reporterClass = Class.forName("dotty.tools.dotc.reporting.Reporter")
+  def initClassloader(): Try[Dotc.ClassLoader] =
+    Try(Dotc.ClassLoader(ScalaClassLoader.fromURLs(Classpaths.dottyCompiler.asURLs)))
+
+  def loadClass(name: String)(implicit cl: Dotc.ClassLoader) =
+    Class.forName(name, true, cl.parent)
+
+  def invokeStatic(method: Method, args: Seq[Any])(implicit cl: Dotc.ClassLoader) = {
+    assert(Modifier.isStatic(method.getModifiers), s"$method is not static!")
+    invoke(method, null, args)
+  }
+
+  def invoke(method: Method, obj: AnyRef, args: Seq[Any])(implicit cl: Dotc.ClassLoader) = {
+    try cl.parent.asContext[AnyRef] {
+      method.invoke(obj, args.toArray:_*)
+    }
+    catch {
+      case NonFatal(ex) => throw ReflectionUtils.unwrapThrowable(ex)
+    }
+  }
+
+  private def dotcProcess(args: Seq[String])(implicit cl: Dotc.ClassLoader) = processMethod("dotty.tools.dotc.Main")(args)
+
+  def processMethod(mainClassName: String)(args: Seq[String])(implicit cl: Dotc.ClassLoader): Try[Boolean] = {
+    val mainClass = loadClass(mainClassName)
+    val reporterClass = loadClass("dotty.tools.dotc.reporting.Reporter")
     val Main_process = mainClass.getMethod("process", classOf[Array[String]])
-    assert(Modifier.isStatic(Main_process.getModifiers), s"$mainClassName.process is not static!")
     val Reporter_hasErrors = reporterClass.getMethod("hasErrors")
-    args => Try {
-      val reporter  = Main_process.invoke(null, args)
-      val hasErrors = Reporter_hasErrors.invoke(reporter).asInstanceOf[Boolean]
+    Try {
+      val reporter  = unlockExperimentalFeatures(invokeStatic(Main_process, Seq(args.toArray)))
+      val hasErrors = invoke(Reporter_hasErrors, reporter, Seq.empty).asInstanceOf[Boolean]
       !hasErrors
     }
   }
 
-  def dotc(out: String, classpath: String, additionalSettings: Seq[String], sources: String*): Try[Boolean] = {
+  def dotcVersion(implicit cl: Dotc.ClassLoader): String = {
+    val compilerPropertiesClass = loadClass("dotty.tools.dotc.config.Properties")
+    val Properties_simpleVersionString = compilerPropertiesClass.getMethod("simpleVersionString")
+    invokeStatic(Properties_simpleVersionString, Seq.empty).asInstanceOf[String]
+  }
+
+  def dotc(out: String, classpath: String, additionalSettings: Seq[String], sources: String*)(implicit cl: Dotc.ClassLoader): Try[Boolean] = {
     if (sources.isEmpty) {
       Success(true)
     }
     else {
-      val args = Array(
+      val libraryDeps = Classpaths.dottyLibrary ++ Classpaths.scalaReflect
+      val args = Seq(
         "-d", out,
-        "-classpath", classpath,
+        "-classpath", libraryDeps.mkString(classpath + Files.classpathSep, Files.classpathSep, ""),
         "-deprecation",
-        "-Yerased-terms",
         "-Xfatal-warnings",
-        "-usejavacp"
       ) ++ additionalSettings ++ sources
+      if (TastyTest.verbose) {
+        println(yellow(s"Invoking dotc (version $dotcVersion) with args: $args"))
+      }
       dotcProcess(args)
     }
   }
@@ -48,6 +81,12 @@ object Dotc extends Script.Command {
       return 1
     }
     val Seq(out, src) = args: @unchecked
+    implicit val scala3classloader: Dotc.ClassLoader = initClassloader() match {
+      case Success(cl) => cl
+      case Failure(err) =>
+        println(red(s"could not initialise Scala 3 classpath: $err"))
+        return 1
+    }
     val success = dotc(out, out, Nil, src).get
     if (success) 0 else 1
   }

--- a/src/tastytest/scala/tools/tastytest/Dotc.scala
+++ b/src/tastytest/scala/tools/tastytest/Dotc.scala
@@ -76,18 +76,18 @@ object Dotc extends Script.Command {
   val describe: String = s"$commandName <out: Directory> <src: File>"
 
   def process(args: String*): Int = {
-    if (args.length != 2) {
-      println(red(s"please provide two arguments in sub-command: $describe"))
+    if (args.length < 2) {
+      println(red(s"please provide at least two arguments in sub-command: $describe"))
       return 1
     }
-    val Seq(out, src) = args: @unchecked
+    val Seq(out, src, additional @ _*) = args: @unchecked
     implicit val scala3classloader: Dotc.ClassLoader = initClassloader() match {
       case Success(cl) => cl
       case Failure(err) =>
         println(red(s"could not initialise Scala 3 classpath: $err"))
         return 1
     }
-    val success = dotc(out, out, Nil, src).get
+    val success = dotc(out, out, additional, src).get
     if (success) 0 else 1
   }
 

--- a/src/tastytest/scala/tools/tastytest/DotcDecompiler.scala
+++ b/src/tastytest/scala/tools/tastytest/DotcDecompiler.scala
@@ -1,13 +1,14 @@
 package scala.tools.tastytest
 
-import scala.util.Try
+import scala.util.{Try, Success, Failure}
 
 object DotcDecompiler extends Script.Command {
 
-  private[this] lazy val dotcProcess = Dotc.processMethod("dotty.tools.dotc.decompiler.Main")
+  private def dotcProcess(args: Seq[String])(implicit cl: Dotc.ClassLoader) =
+    Dotc.processMethod("dotty.tools.dotc.decompiler.Main")(args)
 
-  def decompile(source: String, additionalSettings: Seq[String]): Try[Boolean] =
-    dotcProcess(("-usejavacp" +: additionalSettings :+ source).toArray)
+  def decompile(source: String, additionalSettings: Seq[String])(implicit cl: Dotc.ClassLoader): Try[Boolean] =
+    dotcProcess(("-usejavacp" +: additionalSettings :+ source))
 
   val commandName: String = "dotcd"
   val describe: String = s"$commandName <tasty: File> <args: String*>"
@@ -18,6 +19,12 @@ object DotcDecompiler extends Script.Command {
       return 1
     }
     val Seq(tasty, additionalSettings @ _*) = args: @unchecked
+    implicit val scala3classloader: Dotc.ClassLoader = Dotc.initClassloader() match {
+      case Success(cl) => cl
+      case Failure(err) =>
+        println(red(s"could not initialise Scala 3 classpath: $err"))
+        return 1
+    }
     val success = decompile(tasty, additionalSettings).get
     if (success) 0 else 1
   }

--- a/src/tastytest/scala/tools/tastytest/package.scala
+++ b/src/tastytest/scala/tools/tastytest/package.scala
@@ -1,10 +1,15 @@
 package scala.tools
 
+import dotty.tools.vulpix.ParallelTesting
+
 package object tastytest {
 
   import scala.util.Try
 
   import Files.{pathSep, classpathSep}
+
+  def unlockExperimentalFeatures[T](op: => T): T =
+    new ParallelTesting().unlockExperimentalFeatures(op)
 
   def printerrln(str: String): Unit = System.err.println(red(str))
   def printwarnln(str: String): Unit = System.err.println(yellow(str))

--- a/test/tasty/neg-move-macros/src-2/TestMacroCompat.check
+++ b/test/tasty/neg-move-macros/src-2/TestMacroCompat.check
@@ -1,4 +1,4 @@
-TestMacroCompat_fail.scala:7: error: can't find term required by object tastytest.MacroCompat: tastytest.`package`.Macros.posImpl; perhaps it is missing from the classpath.
+TestMacroCompat_fail.scala:7: error: can't find term required by object tastytest.MacroCompat: tastytest.package.Macros.posImpl; perhaps it is missing from the classpath.
     val result = MacroCompat.testCase("foo")(pos)
                                              ^
 1 error

--- a/test/tasty/neg/src-2/TestCompiletimeQuoteType.check
+++ b/test/tasty/neg/src-2/TestCompiletimeQuoteType.check
@@ -1,4 +1,4 @@
-TestCompiletimeQuoteType_fail.scala:4: error: Unsupported Scala 3 context function type in result: scala.quoted.Quotes ?=> scala.quoted.Type[T]; found in method of in object scala.quoted.Type.
+TestCompiletimeQuoteType_fail.scala:4: error: could not find implicit value for evidence parameter of type scala.quoted.Type[Int]
   def test = CompiletimeQuoteType.f[Int]
                                    ^
 1 error

--- a/test/tasty/neg/src-2/TestDelayedPrivate.check
+++ b/test/tasty/neg/src-2/TestDelayedPrivate.check
@@ -1,0 +1,4 @@
+TestDelayedPrivate_fail.scala:7: error: value Deeper is not a member of object tastytest.DelayedPrivate.Nested
+    DelayedPrivate.Nested.Deeper
+                          ^
+1 error

--- a/test/tasty/neg/src-2/TestDelayedPrivateInverse.check
+++ b/test/tasty/neg/src-2/TestDelayedPrivateInverse.check
@@ -1,0 +1,4 @@
+TestDelayedPrivateInverse_fail.scala:6: error: value Internal is not a member of object tastytest.DelayedPrivateInverse
+    val _ = DelayedPrivateInverse.Internal
+                                  ^
+1 error

--- a/test/tasty/neg/src-2/TestDelayedPrivateInverse_fail.scala
+++ b/test/tasty/neg/src-2/TestDelayedPrivateInverse_fail.scala
@@ -1,0 +1,8 @@
+package tastytest
+
+object TestDelayedPrivateInverse {
+  def test: DelayedPrivateInverse.Parent[Nothing] = ??? // force sealed children of parent
+  locally {
+    val _ = DelayedPrivateInverse.Internal
+  }
+}

--- a/test/tasty/neg/src-2/TestDelayedPrivate_fail.scala
+++ b/test/tasty/neg/src-2/TestDelayedPrivate_fail.scala
@@ -1,0 +1,9 @@
+package tastytest
+
+object TestDelayedPrivate {
+
+  locally {
+    val _ = Nil: List[DelayedPrivate.Root] // force Root to be seen first
+    DelayedPrivate.Nested.Deeper
+  }
+}

--- a/test/tasty/neg/src-2/TestInvisibleDefs.check
+++ b/test/tasty/neg/src-2/TestInvisibleDefs.check
@@ -1,0 +1,13 @@
+TestInvisibleDefs_fail.scala:5: error: type argIsHello is not a member of package tastytest
+  def foo: tastytest.argIsHello = ??? // has invisible flag so should not be seen
+                     ^
+TestInvisibleDefs_fail.scala:6: error: type argIsHello is not a member of package tastytest
+  def bar: tastytest.argIsHello = ??? // second try on same type
+                     ^
+TestInvisibleDefs_fail.scala:11: error: value getStatus is not a member of tastytest.InvisibleDefs.MyBean
+    mybean.getStatus() // error
+           ^
+TestInvisibleDefs_fail.scala:12: error: value setStatus is not a member of tastytest.InvisibleDefs.MyBean
+    mybean.setStatus("closed") // error
+           ^
+4 errors

--- a/test/tasty/neg/src-2/TestInvisibleDefs_fail.scala
+++ b/test/tasty/neg/src-2/TestInvisibleDefs_fail.scala
@@ -1,0 +1,15 @@
+package tastytest
+
+object TestInvisibleDefs {
+
+  def foo: tastytest.argIsHello = ??? // has invisible flag so should not be seen
+  def bar: tastytest.argIsHello = ??? // second try on same type
+
+  def testBean = {
+    val mybean = new InvisibleDefs.MyBean
+    mybean.status = "open"
+    mybean.getStatus() // error
+    mybean.setStatus("closed") // error
+  }
+
+}

--- a/test/tasty/neg/src-3/DelayedPrivate.scala
+++ b/test/tasty/neg/src-3/DelayedPrivate.scala
@@ -1,0 +1,15 @@
+package tastytest
+
+object DelayedPrivate {
+
+  sealed trait Root
+
+  object Nested {
+
+    private object Deeper {
+      final class Leaf extends Root
+    }
+
+  }
+
+}

--- a/test/tasty/neg/src-3/DelayedPrivateInverse.scala
+++ b/test/tasty/neg/src-3/DelayedPrivateInverse.scala
@@ -1,0 +1,8 @@
+package tastytest
+
+object DelayedPrivateInverse {
+  private object Internal {
+    final class Impl extends DelayedPrivateInverse.Parent[Nothing]
+  }
+  sealed trait Parent[T]
+}

--- a/test/tasty/neg/src-3/ErasedTypes.scala
+++ b/test/tasty/neg/src-3/ErasedTypes.scala
@@ -1,5 +1,7 @@
 package tastytest
 
+import language.experimental.erasedDefinitions
+
 object ErasedTypes {
 
   trait Foo {

--- a/test/tasty/neg/src-3/InvisibleDefs.scala
+++ b/test/tasty/neg/src-3/InvisibleDefs.scala
@@ -1,0 +1,16 @@
+package tastytest
+
+import scala.beans.BeanProperty
+
+object InvisibleDefs {
+
+  @main def argIsHello(arg: String): Unit = assert(arg == "Hello")
+
+  class MyBean {
+
+    @BeanProperty
+    var status = ""
+
+  }
+
+}

--- a/test/tasty/run/pre/tastytest/reflectshims/Context.scala
+++ b/test/tasty/run/pre/tastytest/reflectshims/Context.scala
@@ -1,0 +1,9 @@
+package tastytest.reflectshims
+
+trait Context {
+
+  type TreeShim = universe.TreeShim
+
+  val universe: Universe
+
+}

--- a/test/tasty/run/pre/tastytest/reflectshims/Universe.scala
+++ b/test/tasty/run/pre/tastytest/reflectshims/Universe.scala
@@ -1,0 +1,8 @@
+package tastytest.reflectshims
+
+abstract class Universe {
+  type TreeShim >: Null <: AnyRef with TreeShimApi
+  trait TreeShimApi extends Product { this: TreeShim => }
+
+  val EmptyTree: TreeShim
+}

--- a/test/tasty/run/pre/tastytest/reflectshims/impl/Context.scala
+++ b/test/tasty/run/pre/tastytest/reflectshims/impl/Context.scala
@@ -1,0 +1,17 @@
+package tastytest.reflectshims.impl
+
+import tastytest.reflectshims
+
+object Context extends reflectshims.Context {
+
+  object universe extends reflectshims.Universe {
+
+    abstract class TreeShimImpl extends TreeShimApi with Product
+
+    type TreeShim = TreeShimImpl
+
+    case object EmptyTree extends TreeShimImpl
+
+  }
+
+}

--- a/test/tasty/run/pre/tastytest/scala2Erasure/api.scala
+++ b/test/tasty/run/pre/tastytest/scala2Erasure/api.scala
@@ -28,6 +28,12 @@ object OpaqueHolder {
 }
 import OpaqueHolder._
 
+sealed abstract class Enumerated
+object Enumerated {
+  final val C1: Enumerated with A = new Enumerated with A {}
+  final val C2: Enumerated with B = new Enumerated with B {}
+}
+
 // The parameter type of `a_XX` should erase to A, `b_XX` to `B`, etc.
 // This is enforced by dottyApp/Main.scala
 class Z { self =>
@@ -246,5 +252,12 @@ class Z { self =>
   def intARRAYARRAY_130(x: Array[_ <: Array[Int]]): Unit = {}
   def objectARRAY_130(x: Array[_ <: Array[_ <: AnyVal]]): Unit = {}
   def stringARRAY_131(x: Array[String] with Array[Int]): Unit = {}
+
+  def enumerated_132(x: Enumerated.C1.type with Enumerated.C2.type): Unit = {}
+  def enumerated_133(x: Enumerated.C2.type with Enumerated.C1.type): Unit = {}
+  def enumerated_134(x: Enumerated.C1.type): Unit = {}
+  def enumeratedARRAY_135(x: Array[Enumerated.C1.type]): Unit = {}
+  def enumeratedARRAY_136(x: Array[Enumerated.C2.type with Enumerated.C1.type]): Unit = {}
+  def enumeratedARRAY_137(x: Array[Enumerated.C1.type with Enumerated.C2.type]): Unit = {}
 
 }

--- a/test/tasty/run/pre/tastytest/scala2Erasure/api.scala
+++ b/test/tasty/run/pre/tastytest/scala2Erasure/api.scala
@@ -1,0 +1,250 @@
+package tastytest
+
+// Keep synchronized with src-3/tastytest/dottyErasureApi/api.scala
+package scala2Erasure
+
+class foo extends scala.annotation.StaticAnnotation
+
+trait A
+trait B
+trait SubB extends B
+trait C
+trait Cov[+T]
+trait Univ extends Any
+
+class D
+
+class VC(val self: A) extends AnyVal
+class VC2(val self: A) extends AnyVal
+
+class Outer {
+  class E
+  trait F extends E
+}
+
+object OpaqueHolder {
+  type Q[T] = Cov[T]
+  type Y[T] = Cov[T]
+}
+import OpaqueHolder._
+
+// The parameter type of `a_XX` should erase to A, `b_XX` to `B`, etc.
+// This is enforced by dottyApp/Main.scala
+class Z { self =>
+  def a_01(a: A with B): Unit = {}
+  def b_02X(b: B with A): Unit = {}
+  def a_02(a: A with B with A): Unit = {}
+  def a_03(a: A with (B with A)): Unit = {}
+  def b_04(b: A with (B with A) @foo): Unit = {}
+  def b_04X(b: A with (B with C) @foo): Unit = {}
+  def b_05(b: A with (B with A) @foo with (C with B with A) @foo): Unit = {}
+
+  type T1 <: A with B
+  def a_06(a: T1): Unit = {}
+
+  type S <: B with T1
+  def a_07(a: S): Unit = {}
+
+  type T2 <: B with A
+  type U <: T2 with S
+  def b_08(b: U): Unit = {}
+
+  val singB: B = new B {}
+  def a_09(a: A with singB.type): Unit = {}
+  def b_10(b: singB.type with A): Unit = {}
+
+  type V >: SubB <: B
+  def b_11(b: V): Unit = {}
+  def b_12(b: V with SubB): Unit = {}
+
+  def d_13(d: D with A): Unit = {}
+  def d_14(d: A with D): Unit = {}
+
+  val singD: D = new D {}
+  def d_13x(d: singD.type with A): Unit = {}
+  def d_14x(d: A with singD.type): Unit = {}
+
+  type DEq = D
+  def d_15(d: A with DEq): Unit = {}
+  def d_16(d: A with (DEq @foo)): Unit = {}
+  def d_17(d: DEq with A): Unit = {}
+  def d_18(d: (DEq @foo) with A): Unit = {}
+
+  val singDEq: DEq @foo = new D {}
+  def d_15b(d: A with singDEq.type): Unit = {}
+  def d_16b(d: A with (singDEq.type @foo)): Unit = {}
+
+  type DSub <: D
+  def a_19(a: A with DSub): Unit = {}
+  def d_19x(d: DSub with A): Unit = {}
+  def z_20(z: DSub with Z): Unit = {}
+
+  type W1 <: A with Cov[Any]
+  type X1 <: Cov[Int] with W1
+  def a_21(a: X1): Unit = {}
+
+  type W2 <: A with Cov[Any]
+  type X2 <: Cov[Int] with W2
+  def a_22(a: X2): Unit = {}
+
+  def z_23(z: A with this.type): Unit = {}
+  def z_24(z: this.type with A): Unit = {}
+
+  def b_25(b: A with (B { type T })): Unit = {}
+  def a_26(a: (A { type T }) with ((B with A) { type T })): Unit = {}
+
+  def a_27(a: VC with B): Unit = {}
+  def a_28(a: B with VC): Unit = {}
+
+  val o1: Outer = new Outer
+  val o2: Outer = new Outer
+  def f_29(f: o1.E with o1.F): Unit = {}
+  def f_30(f: o1.F with o1.E): Unit = {}
+  def f_31(f: o1.E with o2.F): Unit = {}
+  def f_32(f: o2.F with o1.E): Unit = {}
+  def f_33(f: Outer#E with Outer#F): Unit = {}
+  def f_34(f: Outer#F with Outer#E): Unit = {}
+
+  val structural1: { type DSub <: D } = new { type DSub <: D }
+  def a_35(a: A with structural1.DSub): Unit = {}
+  def d_36(a: structural1.DSub with A): Unit = {}
+  def z_37(z: Z with structural1.DSub): Unit = {}
+  def z_38(z: structural1.DSub with Z): Unit = {}
+
+  val structural2: { type SubCB <: C with B } = new { type SubCB <: C with B }
+  def c_39(c: structural2.SubCB with B): Unit = {}
+  def c_40(c: B with structural2.SubCB): Unit = {}
+
+  val structural3a: { type SubB <: B; type SubCB <: C with SubB } = new { type SubB <: B; type SubCB <: C with SubB }
+  val structural3b: { type SubB <: B; type SubCB <: C with SubB } = new { type SubB <: B; type SubCB <: C with SubB }
+  def c_41(c: structural3a.SubB with structural3a.SubCB): Unit = {}
+  def c_42(c: structural3a.SubCB with structural3a.SubB): Unit = {}
+  def b_43(b: structural3a.SubB with structural3b.SubCB): Unit = {}
+  def c_44(c: structural3b.SubCB with structural3a.SubB): Unit = {}
+
+  type SubStructural <: C with structural3a.SubB
+  def c_45(x: structural3a.SubB with SubStructural): Unit = {}
+  def b_46(x: structural3b.SubB with SubStructural): Unit = {}
+
+  type Rec1 <: A with B
+  type Rec2 <: C with Rec1
+  def c_47(a: A with B with Rec2): Unit = {}
+  def a_48(a: (A with B) @foo with Rec2): Unit = {}
+
+  type F1 = A with B
+  type F2 = A with B
+  type Rec3 <: F1
+  type Rec4 <: C with Rec3
+  def c_49(a: F1 @foo with Rec4): Unit = {}
+  def c_50(a: F1 with Rec4): Unit = {}
+  def a_51(a: F2 @foo with Rec4): Unit = {}
+  def c_52(a: F2 with Rec4): Unit = {}
+
+  type AA = A
+  type F3 = AA with B
+  type Rec5 <: F3
+  type Rec6 <: C with Rec5
+  def a_53(a: F3 @foo with Rec6): Unit = {}
+  def c_54(a: F3 with Rec6): Unit = {}
+
+  val structural4a: { type M[X] <: A } = new { type M[X] <: A }
+  val structural4b: { type N <: B with structural4a.M[Int] } = new { type N <: B with structural4a.M[Int] }
+  def b_55(x: structural4a.M[Any] with structural4b.N): Unit = {}
+
+  type Bla = A { type M[X] <: A }
+  def b_56(x: Bla#M[Any] with ({ type N <: B with Bla#M[Int] })#N): Unit = {}
+  type AEq = A
+  type Bla2 = AEq { type M[X] <: A }
+  def a_57(x: Bla2#M[Any] with ({ type N <: B with Bla2#M[Int] })#N): Unit = {}
+
+  def int_58(x: Int with Singleton): Unit = {}
+  def int_59(x: Singleton with Int): Unit = {}
+  def int_60(x: Int with Any): Unit = {}
+  def int_61(x: Any with Int): Unit = {}
+  def int_62(x: Int with AnyVal): Unit = {}
+  def int_63(x: AnyVal with Int): Unit = {}
+
+  def intARRAY_64(x: Array[Int with Singleton]): Unit = {}
+  def object_65(x: Array[_ <: Int]): Unit = {}
+  def object_66(x: Array[_ <: Int with Singleton]): Unit = {}
+  def object_67(x: Array[_ <: Singleton with Int]): Unit = {}
+  def object_68(x: Array[_ <: Int with Any]): Unit = {}
+  def object_69(x: Array[_ <: Any with Int]): Unit = {}
+  def object_70(x: Array[_ <: Int with AnyVal]): Unit = {}
+  def object_71(x: Array[_ <: AnyVal with Int]): Unit = {}
+
+  def stringARRAY_72(x: Array[String with Singleton]): Unit = {}
+  def stringARRAY_73(x: Array[_ <: String]): Unit = {}
+  def stringARRAY_74(x: Array[_ <: String with Singleton]): Unit = {}
+  def stringARRAY_75(x: Array[_ <: Singleton with String]): Unit = {}
+  def stringARRAY_76(x: Array[_ <: String with Any]): Unit = {}
+  def stringARRAY_77(x: Array[_ <: Any with String]): Unit = {}
+  def stringARRAY_78(x: Array[_ <: String with AnyRef]): Unit = {}
+  def stringARRAY_79(x: Array[_ <: AnyRef with String]): Unit = {}
+
+  def object_80(x: Array[_ <: Singleton]): Unit = {}
+  def object_81(x: Array[_ <: AnyVal]): Unit = {}
+  def objectARRAY_82(x: Array[_ <: AnyRef]): Unit = {}
+  def object_83(x: Array[_ <: Any]): Unit = {}
+
+  def object_84(x: Array[_ <: Serializable]): Unit = {}
+  def object_85(x: Array[_ <: Univ]): Unit = {}
+  def aARRAY_86(x: Array[_ <: A]): Unit = {}
+  def aARRAY_87(x: Array[_ <: A with B]): Unit = {}
+
+  def objectARRAY_88(x: Array[Any]): Unit = {}
+  def objectARRAY_89(x: Array[AnyRef]): Unit = {}
+  def objectARRAY_90(x: Array[AnyVal]): Unit = {}
+
+  def stringARRAY_91(x: Array[_ <: ({ type Foo <: String with Singleton })#Foo]): Unit = {}
+  def stringARRAY_92(x: Array[({ type Foo <: String with Singleton })#Foo]): Unit = {}
+  def stringARRAY_93(x: Array[({ type Id[T] = T })#Id[String with Singleton]]): Unit = {}
+
+  def covARRAY_94(x: Array[Q[String]]): Unit = {} // cant define opaque type in scala 2, so it is ordinary type
+
+  def aARRAY_95(x: Array[(A with B { type L <: String }) with C]): Unit = {}
+  def aARRAY_96(x: Array[A { type L <: String }]): Unit = {}
+  def zARRAY_97(x: Array[self.type]): Unit = {}
+  def aARRAY_98(x: Array[(A { type L <: String }) with B]): Unit = {}
+  def stringARRAY_99[Arg <: String](x: Array[Arg]): Unit = {}
+  def aARRAY_100(x: Array[Bla2#M[Any] with ({ type N <: B with Bla2#M[Int] })#N]): Unit = {}
+  def zARRAY_101(x: Array[structural1.DSub with Z]): Unit = {}
+  def aARRAY_102(x: Array[F3 @foo with Rec6]): Unit = {}
+  def aARRAY_103(x: Array[A @foo]): Unit = {}
+  def dARRAY_104(x: Array[singD.type]): Unit = {}
+  def intARRAY_105(x: Array[3]): Unit = {}
+  def vcARRAY_106(x: Array[VC]): Unit = {}
+  def listARRAY_107(x: Array[List[_]]): Unit = {}
+  def intARRAY_108(x: Array[Int with String]): Unit = {}
+  def stringARRAY_109(x: Array[String with Int]): Unit = {}
+
+  def a_110(x: VC with VC2): Unit = {}
+  def a_111(x: VC2 with VC): Unit = {}
+  def aARRAY_112(x: Array[VC2 with VC]): Unit = {} // this should not erase to Array[A]???
+  def aARRAY_113(x: Array[VC with VC2]): Unit = {} // this should not erase to Array[A]???
+  def a_114(x: VC with D): Unit = {}
+  def d_115(x: D with VC): Unit = {}
+  def d_116(x: D with B with VC): Unit = {}
+  def d_117(x: B with D with VC): Unit = {}
+  def a_118(x: VC with B with D): Unit = {}
+  def a_119(x: VC with Int): Unit = {}
+  def int_120(x: Int with VC): Unit = {}
+
+  def object_121[T](x: Array[T]): Unit = {}
+  def object_122(x: Array[_ <: AnyVal with Singleton]): Unit = {}
+  def objectARRAY_123(x: Array[AnyVal with Singleton]): Unit = {}
+  def objectARRAY_124[T, U](x: Array[T with U]): Unit = {}
+  def objectARRAY_125(x: Array[({ type W <: String }) with ({ type X <: Int })]): Unit = {}
+  def covARRAY_126(x: Array[Q[B] with Y[SubB]]): Unit = {}
+  def covARRAY_127(x: Array[Q[B] with Y[SubB] { type X <: Cov[String] }]): Unit = {}
+
+  type SubAny <: Any
+  type SubAnyVal <: AnyVal
+
+  def objectARRAY_128(x: Array[SubAny with SubAnyVal]): Unit = {}
+  def intARRAYARRAY_129(x: Array[Array[Int]]): Unit = {}
+  def intARRAYARRAY_130(x: Array[_ <: Array[Int]]): Unit = {}
+  def objectARRAY_130(x: Array[_ <: Array[_ <: AnyVal]]): Unit = {}
+  def stringARRAY_131(x: Array[String] with Array[Int]): Unit = {}
+
+}

--- a/test/tasty/run/src-2/tastytest/TestErasure.scala
+++ b/test/tasty/run/src-2/tastytest/TestErasure.scala
@@ -1,0 +1,172 @@
+package tastytest
+
+import tastytest.{dottyErasure => dotc, scala2Erasure => nsc}
+
+object TestErasure extends Suite("TestErasure") {
+
+  val z = new dotc.Z
+
+  test("erasure of scala 3 from scala 2") {
+    z.a_01(anyObj)
+    z.a_02(anyObj)
+    z.a_02X(anyObj)
+    z.a_03(anyObj)
+    z.a_04(anyObj)
+    z.a_04X(anyObj)
+    z.a_05(anyObj)
+    z.a_06(anyObj)
+    z.a_07(anyObj)
+    z.a_08(anyObj)
+    z.a_09(anyObj)
+    z.a_10(anyObj)
+    z.b_11(anyObj)
+    z.subb_12(anyObj)
+    z.d_13(anyObj)
+    z.d_13x(anyObj)
+    z.d_14(anyObj)
+    z.d_14x(anyObj)
+    z.d_15(anyObj)
+    z.d_15b(anyObj)
+    z.d_16(anyObj)
+    z.d_16b(anyObj)
+    z.d_17(anyObj)
+    z.d_18(anyObj)
+    z.d_19(anyObj)
+    z.d_19x(anyObj)
+    z.d_20(anyObj)
+    z.a_21(anyObj)
+    z.a_22(anyObj)
+    z.z_23(anyObj)
+    z.z_24(anyObj)
+    z.a_25(anyObj)
+    z.a_26(anyObj)
+    z.a_27(anyObj) @@ ExpectCastOrNull
+    z.a_28(anyObj) @@ ExpectCastOrNull
+    z.e_29(anyObj)
+    z.e_30(anyObj)
+    z.e_31(anyObj)
+    z.e_32(anyObj)
+    z.e_33(anyObj)
+    z.e_34(anyObj)
+    z.d_35(anyObj)
+    z.d_36(anyObj)
+    z.d_37(anyObj)
+    z.d_38(anyObj)
+    z.b_39(anyObj)
+    z.b_40(anyObj)
+    z.b_41(anyObj)
+    z.b_42(anyObj)
+    z.b_43(anyObj)
+    z.b_44(anyObj)
+    z.b_45(anyObj)
+    z.b_46(anyObj)
+    z.a_47(anyObj)
+    z.a_48(anyObj)
+    z.a_49(anyObj)
+    z.a_50(anyObj)
+    z.a_51(anyObj)
+    z.a_52(anyObj)
+    z.a_53(anyObj)
+    z.a_54(anyObj)
+    z.a_55(anyObj)
+    z.a_56(anyObj)
+    z.a_57(anyObj)
+    z.int_58(1)
+    z.int_59(1)
+    z.int_60(1)
+    z.int_61(1)
+    z.int_62(1)
+    z.int_63(1)
+    z.intARRAY_64(anyObj)
+    z.intARRAY_65(anyObj)
+    z.intARRAY_66(anyObj)
+    z.intARRAY_67(anyObj)
+    z.intARRAY_68(anyObj)
+    z.intARRAY_69(anyObj)
+    z.intARRAY_70(anyObj)
+    z.intARRAY_71(anyObj)
+    // z.intARRAY_71a(anyObj) // illegal union type
+    // z.intARRAY_71b(anyObj) // illegal union type
+    z.stringARRAY_72(anyObj)
+    z.stringARRAY_73(anyObj)
+    z.stringARRAY_74(anyObj)
+    z.stringARRAY_75(anyObj)
+    z.stringARRAY_76(anyObj)
+    z.stringARRAY_77(anyObj)
+    z.stringARRAY_78(anyObj)
+    z.stringARRAY_79(anyObj)
+    // z.stringARRAY_79a(anyObj) // illegal union type
+    // z.stringARRAY_79b(anyObj) // illegal union type
+    z.object_80(anyObj)
+    z.object_81(anyObj)
+    z.objectARRAY_82(anyObj)
+    z.object_83(anyObj)
+    z.object_83a(anyObj)
+    // z.object_83b(anyObj) // illegal union type
+    // z.object_83c(anyObj) // illegal union type
+    // z.object_83d(anyObj) // illegal union type
+    // z.object_83e(anyObj) // illegal union type
+    z.serializableARRAY_84(anyObj)
+    z.univARRAY_85(anyObj)
+    z.aARRAY_86(anyObj)
+    z.aARRAY_87(anyObj)
+    z.objectARRAY_88(anyObj)
+    z.objectARRAY_89(anyObj)
+    z.objectARRAY_90(anyObj)
+    z.stringARRAY_91(anyObj)
+    z.stringARRAY_92(anyObj)
+    z.stringARRAY_93(anyObj)
+    z.covARRAY_94(anyObj)
+    z.aARRAY_95(anyObj)
+    z.aARRAY_96(anyObj)
+    z.zARRAY_97(anyObj)
+    z.aARRAY_98(anyObj)
+    z.stringARRAY_99(anyObj)
+    z.aARRAY_100(anyObj)
+    z.dARRAY_101(anyObj)
+    z.aARRAY_102(anyObj)
+    z.aARRAY_103(anyObj)
+    z.dARRAY_104(anyObj)
+    z.intARRAY_105(anyObj)
+    z.vcARRAY_106(anyObj)
+    z.listARRAY_107(anyObj)
+    z.intARRAY_108(anyObj)
+    z.intARRAY_109(anyObj)
+    z.a_110(anyObj) @@ ExpectCastOrNull
+    z.a_111(anyObj) @@ ExpectCastOrNull
+    z.vcARRAY_112(anyObj)
+    z.vcARRAY_113(anyObj)
+    z.a_114(anyObj) @@ ExpectCastOrNull
+    z.a_115(anyObj) @@ ExpectCastOrNull
+    z.a_116(anyObj) @@ ExpectCastOrNull
+    z.a_117(anyObj) @@ ExpectCastOrNull
+    z.a_118(anyObj) @@ ExpectCastOrNull
+    z.a_119(anyObj) @@ ExpectCastOrNull
+    z.a_120(anyObj) @@ ExpectCastOrNull
+    z.object_121(anyObj)
+    z.object_122(anyObj)
+    z.objectARRAY_123(anyObj)
+    z.object_124(anyObj)
+    z.objectARRAY_125(anyObj)
+    z.covARRAY_126(anyObj)
+    z.covARRAY_127(anyObj)
+    z.object_128(anyObj)
+    z.intARRAYARRAY_129(anyObj)
+    z.intARRAYARRAY_130(anyObj)
+    z.objectARRAY_130(anyObj)
+    z.intARRAY_131(anyObj)
+  }
+
+  test("erasure matches name") {
+    val methods = classOf[nsc.Z].getDeclaredMethods.toList ++ classOf[dotc.Z].getDeclaredMethods.toList
+    methods.foreach { m =>
+      m.getName match {
+        case s"${prefix}_${suffix}" =>
+          val paramClass = m.getParameterTypes()(0).getSimpleName.toLowerCase.replaceAll("""\[\]""", "ARRAY")
+          assert(prefix == paramClass, s"Method `$m` erased to `$paramClass` which does not match its prefix `$prefix`")
+        case _ =>
+      }
+    }
+  }
+
+}

--- a/test/tasty/run/src-2/tastytest/TestErasure.scala
+++ b/test/tasty/run/src-2/tastytest/TestErasure.scala
@@ -155,6 +155,12 @@ object TestErasure extends Suite("TestErasure") {
     z.intARRAYARRAY_130(anyObj)
     z.objectARRAY_130(anyObj)
     z.intARRAY_131(anyObj)
+    z.enumerated_132(anyObj)
+    z.enumerated_133(anyObj)
+    z.enumerated_134(anyObj)
+    z.enumeratedARRAY_135(anyObj)
+    z.enumeratedARRAY_136(anyObj)
+    z.enumeratedARRAY_137(anyObj)
   }
 
   test("erasure matches name") {

--- a/test/tasty/run/src-2/tastytest/TestIntersectionErasure.scala
+++ b/test/tasty/run/src-2/tastytest/TestIntersectionErasure.scala
@@ -1,12 +1,40 @@
 package tastytest
 
-import IntersectionErasure.{universe => u}
+import IntersectionErasure._
 
 object TestIntersectionErasure extends Suite("TestIntersectionErasure") {
 
-  test {
-    val sam: u.IntersectionSAM = x => x
-    assert(sam(u.EmptyTree) === (u.EmptyTree: u.TreeShimSAM))
+  def boxedId[T](t: T): T = t
+
+  val bWithA: B with A = new B with A {} // dotc erases to A, scalac to B
+
+  test("SAM bridges") {
+    val sam: IntersectionSAM = x => x
+    assert(sam(bWithA) === bWithA)
   }
+
+  test("VC param")(
+    assert(boxedId(new IntersectionVC(bWithA)).unwrapped == bWithA)
+  )
+
+  test("VC method unboxed")(
+    assert(boxedId(new IntersectionVC(bWithA)).matchesInternal(bWithA))
+  )
+
+  test("VC method boxed")(
+    assert(boxedId(new IntersectionVC(bWithA)).matches(new IntersectionVC(bWithA)))
+  )
+
+  test("VC parametric param")(
+    assert(boxedId(new IntersectionVCParametric(bWithA)).unwrapped == bWithA)
+  )
+
+  test("VC parametric method unboxed")(
+    assert(boxedId(new IntersectionVCParametric(bWithA)).matchesInternal(bWithA))
+  )
+
+  test("VC parametric method boxed")(
+    assert(boxedId(new IntersectionVCParametric(bWithA)).matches(new IntersectionVCParametric(bWithA)))
+  )
 
 }

--- a/test/tasty/run/src-2/tastytest/TestIntersectionErasure.scala
+++ b/test/tasty/run/src-2/tastytest/TestIntersectionErasure.scala
@@ -1,0 +1,12 @@
+package tastytest
+
+import IntersectionErasure.{universe => u}
+
+object TestIntersectionErasure extends Suite("TestIntersectionErasure") {
+
+  test {
+    val sam: u.IntersectionSAM = x => x
+    assert(sam(u.EmptyTree) === (u.EmptyTree: u.TreeShimSAM))
+  }
+
+}

--- a/test/tasty/run/src-2/tastytest/TestInvisibleDefs.scala
+++ b/test/tasty/run/src-2/tastytest/TestInvisibleDefs.scala
@@ -1,0 +1,15 @@
+package tastytest
+
+object TestInvisibleDefs extends Suite("TestInvisibleDefs") {
+
+  test("invoke '@main def argIsHello'") {
+    InvisibleDefs.argIsHello("Hello")
+  }
+
+  test("update bean.status") {
+    val mybean = new InvisibleDefs.MyBean
+    mybean.status = "open"
+    assert(mybean.status === "open")
+  }
+
+}

--- a/test/tasty/run/src-2/tastytest/TestOperatorToken.scala
+++ b/test/tasty/run/src-2/tastytest/TestOperatorToken.scala
@@ -1,0 +1,7 @@
+package tastytest
+
+object TestOperatorToken extends Suite("TestOperatorToken") {
+  test(assert(OperatorToken.<:< != null))
+  test(assert(OperatorToken.=:= != null))
+  test(assert(OperatorToken.<*> != null))
+}

--- a/test/tasty/run/src-2/tastytest/TestReflection.scala
+++ b/test/tasty/run/src-2/tastytest/TestReflection.scala
@@ -1,0 +1,18 @@
+package tastytest
+
+import tastytest.reflectshims.impl.Context
+import Context.universe.EmptyTree
+import Context.TreeShim
+
+object TestReflection extends Suite("TestReflection") {
+
+  test(assert(Reflection.reflectionInvokerIdentity(Context)(EmptyTree) === (EmptyTree: TreeShim)))
+  test(assert(new Reflection.Invoker(Context)(EmptyTree).tree === (EmptyTree: TreeShim)))
+
+  // TODO [tasty]: enable due to missing type ctx.TreeShim
+  // test {
+  //   val invoker = new Reflection.InvokerSAM(Context)
+  //   val id: invoker.TreeFn = x => x
+  //   assert(id(EmptyTree) === (EmptyTree: TreeShim))
+  // }
+}

--- a/test/tasty/run/src-2/tastytest/TestReflection.scala
+++ b/test/tasty/run/src-2/tastytest/TestReflection.scala
@@ -9,7 +9,7 @@ object TestReflection extends Suite("TestReflection") {
   test(assert(Reflection.reflectionInvokerIdentity(Context)(EmptyTree) === (EmptyTree: TreeShim)))
   test(assert(new Reflection.Invoker(Context)(EmptyTree).tree === (EmptyTree: TreeShim)))
 
-  // TODO [tasty]: enable due to missing type ctx.TreeShim
+  // bridge method not generated (AbstractMethodError) [same if Reflection.InvokerSAM is compiled by Scala 2]
   // test {
   //   val invoker = new Reflection.InvokerSAM(Context)
   //   val id: invoker.TreeFn = x => x

--- a/test/tasty/run/src-2/tastytest/TestSAMErasure.scala
+++ b/test/tasty/run/src-2/tastytest/TestSAMErasure.scala
@@ -1,0 +1,23 @@
+package tastytest
+
+import SAMErasure._
+
+object TestSAMErasure extends Suite("TestSAMErasure") {
+
+  def f = ((x: TreeShimSAM) => x): FunTreeShimSAM
+
+  def g = ((xs: Array[TreeShimSAM]) => xs): FunTreeShimSAM2
+
+  case object EmptyTree extends TreeShimSAMApi
+  val tree = EmptyTree.asInstanceOf[TreeShimSAM]
+
+  test {
+    assert(f(tree) == tree)
+  }
+
+  test {
+    val trees = Array(tree)
+    assert(g(trees) == trees)
+  }
+
+}

--- a/test/tasty/run/src-2/tastytest/TestSuperTypes.scala
+++ b/test/tasty/run/src-2/tastytest/TestSuperTypes.scala
@@ -11,11 +11,10 @@ object TestSuperTypes extends Suite("TestSuperTypes") {
     assert(("" match { case bar.A(x) => x: "Foo.foo" }) === "Foo.foo")
   }
 
-  // TODO [tasty]: what is happening here
-  // test("SUPERtype in type, version 2") {
-  //   val BarA = (new SuperTypes.Bar()).A
-  //   assert(("" match { case BarA(x) => x: "Foo.foo" }) === "Foo.foo")
-  // }
+  test("SUPERtype in type, version 2") {
+    val bar = new SuperTypes.Bar()
+    assert(("" match { case bar.A(x) => x : bar.foo.type }) === "Foo.foo")
+  }
 
   test("SUPER qualified in type tree") {
     assert((new SuperTypes.Baz().baz: "Foo.foo") === "Foo.foo")

--- a/test/tasty/run/src-3/tastytest/IntersectionErasure.scala
+++ b/test/tasty/run/src-3/tastytest/IntersectionErasure.scala
@@ -2,27 +2,22 @@ package tastytest
 
 object IntersectionErasure {
 
-  trait Universe {
+  trait A
+  trait B
 
-    type TreeShimSAM >: Null <: AnyRef with TreeShimSAMApi
-    trait TreeShimSAMApi extends Product { this: TreeShimSAM => }
-
-    val EmptyTree: TreeShimSAM
-
-    @FunctionalInterface
-    abstract class IntersectionSAM {
-      def apply(tree: TreeShimSAM): TreeShimSAM
-    }
-
+  @FunctionalInterface
+  abstract class IntersectionSAM {
+    def apply(arg: B with A): B with A
   }
 
-  object universe extends Universe {
-
-    abstract class TreeShimSAMImpl extends TreeShimSAMApi with Product
-    type TreeShimSAM = TreeShimSAMImpl
-    case object EmptyTree extends TreeShimSAMImpl
-
+  final class IntersectionVC(val unwrapped: B with A) extends AnyVal {
+    def matchesInternal(that: B with A): Boolean = that == unwrapped
+    def matches(that: IntersectionVC): Boolean = this == that
   }
 
+  final class IntersectionVCParametric[T <: B with A](val unwrapped: T) extends AnyVal {
+    def matchesInternal(that: T): Boolean = that == unwrapped
+    def matches(that: IntersectionVCParametric[T]): Boolean = this == that
+  }
 
 }

--- a/test/tasty/run/src-3/tastytest/IntersectionErasure.scala
+++ b/test/tasty/run/src-3/tastytest/IntersectionErasure.scala
@@ -1,0 +1,28 @@
+package tastytest
+
+object IntersectionErasure {
+
+  trait Universe {
+
+    type TreeShimSAM >: Null <: AnyRef with TreeShimSAMApi
+    trait TreeShimSAMApi extends Product { this: TreeShimSAM => }
+
+    val EmptyTree: TreeShimSAM
+
+    @FunctionalInterface
+    abstract class IntersectionSAM {
+      def apply(tree: TreeShimSAM): TreeShimSAM
+    }
+
+  }
+
+  object universe extends Universe {
+
+    abstract class TreeShimSAMImpl extends TreeShimSAMApi with Product
+    type TreeShimSAM = TreeShimSAMImpl
+    case object EmptyTree extends TreeShimSAMImpl
+
+  }
+
+
+}

--- a/test/tasty/run/src-3/tastytest/InvisibleDefs.scala
+++ b/test/tasty/run/src-3/tastytest/InvisibleDefs.scala
@@ -1,0 +1,16 @@
+package tastytest
+
+import scala.beans.BeanProperty
+
+object InvisibleDefs {
+
+  @main def argIsHello(arg: String): Unit = assert(arg == "Hello")
+
+  class MyBean {
+
+    @BeanProperty
+    var status = ""
+
+  }
+
+}

--- a/test/tasty/run/src-3/tastytest/OperatorToken.scala
+++ b/test/tasty/run/src-3/tastytest/OperatorToken.scala
@@ -1,0 +1,7 @@
+package tastytest
+
+enum OperatorToken {
+  case <:<
+  case =:=
+  case <*>
+}

--- a/test/tasty/run/src-3/tastytest/Reflection.scala
+++ b/test/tasty/run/src-3/tastytest/Reflection.scala
@@ -1,0 +1,23 @@
+package tastytest
+
+import tastytest.reflectshims
+
+object Reflection {
+
+  def reflectionInvokerIdentity(ctx: reflectshims.Context)(tree: ctx.TreeShim): ctx.TreeShim = tree
+
+  class Invoker[C <: reflectshims.Context with Singleton](val ctx: C)(root: ctx.TreeShim) {
+    def tree: ctx.TreeShim = root
+  }
+
+  // TODO [tasty]: enable due to missing type ctx.TreeShim
+  // class InvokerSAM[C <: reflectshims.Context with Singleton](val ctx: C) {
+
+  //   @FunctionalInterface
+  //   trait TreeFn {
+  //     def apply(tree: ctx.TreeShim): ctx.TreeShim
+  //   }
+
+  // }
+
+}

--- a/test/tasty/run/src-3/tastytest/Reflection.scala
+++ b/test/tasty/run/src-3/tastytest/Reflection.scala
@@ -10,14 +10,13 @@ object Reflection {
     def tree: ctx.TreeShim = root
   }
 
-  // TODO [tasty]: enable due to missing type ctx.TreeShim
-  // class InvokerSAM[C <: reflectshims.Context with Singleton](val ctx: C) {
+  class InvokerSAM[C <: reflectshims.Context with Singleton](val ctx: C) {
 
-  //   @FunctionalInterface
-  //   trait TreeFn {
-  //     def apply(tree: ctx.TreeShim): ctx.TreeShim
-  //   }
+    @FunctionalInterface
+    trait TreeFn {
+      def apply(tree: ctx.TreeShim): ctx.TreeShim
+    }
 
-  // }
+  }
 
 }

--- a/test/tasty/run/src-3/tastytest/SAMErasure.scala
+++ b/test/tasty/run/src-3/tastytest/SAMErasure.scala
@@ -1,0 +1,18 @@
+package tastytest
+
+object SAMErasure {
+
+  trait TreeShimSAMApi extends Product
+
+  type TreeShimSAM >: Null <: AnyRef with TreeShimSAMApi
+
+  implicit val TreeShimSAMTag: reflect.ClassTag[TreeShimSAM] =
+    reflect.classTag[TreeShimSAMApi].asInstanceOf[reflect.ClassTag[TreeShimSAM]]
+
+  @FunctionalInterface
+  trait FunTreeShimSAM { def apply(a: TreeShimSAM): TreeShimSAM }
+
+  @FunctionalInterface
+  trait FunTreeShimSAM2 { def apply(a: Array[TreeShimSAM]): Array[TreeShimSAM] }
+
+}

--- a/test/tasty/run/src-3/tastytest/SuperTypes.scala
+++ b/test/tasty/run/src-3/tastytest/SuperTypes.scala
@@ -3,7 +3,7 @@ package tastytest
 object SuperTypes {
 
   class Foo {
-    final val foo = "Foo.foo"
+    final val foo: "Foo.foo" = "Foo.foo"
   }
 
   class Bar extends Foo {

--- a/test/tasty/run/src-3/tastytest/dottyErasure/api.scala
+++ b/test/tasty/run/src-3/tastytest/dottyErasure/api.scala
@@ -1,0 +1,259 @@
+package tastytest
+
+// Keep synchronized with pre/tastytest/scala2ErasureApi/api.scala
+package dottyErasure
+
+class foo extends scala.annotation.StaticAnnotation
+
+trait A
+trait B
+trait SubB extends B
+trait C
+trait Cov[+T]
+trait Univ extends Any
+
+class D
+
+class VC(val self: A) extends AnyVal
+class VC2(val self: A) extends AnyVal
+
+class Outer {
+  class E
+  trait F extends E
+}
+
+object OpaqueHolder {
+  opaque type Q[T] <: Any = Cov[T]
+  opaque type Y[T] <: Any = Cov[T]
+}
+import OpaqueHolder._
+
+// The parameter type of `a_XX` should erase to A, `b_XX` to `B`, etc.
+// This is enforced by dottyApp/Main.scala
+class Z { self =>
+  def a_01(a: A with B): Unit = {}
+  def a_02X(b: B with A): Unit = {}
+  def a_02(a: A with B with A): Unit = {}
+  def a_03(a: A with (B with A)): Unit = {}
+  def a_04(b: A with (B with A) @foo): Unit = {}
+  def a_04X(b: A with (B with C) @foo): Unit = {}
+  def a_05(b: A with (B with A) @foo with (C with B with A) @foo): Unit = {}
+
+  type T1 <: A with B
+  def a_06(a: T1): Unit = {}
+
+  type S <: B with T1
+  def a_07(a: S): Unit = {}
+
+  type T2 <: B with A
+  type U <: T2 with S
+  def a_08(b: U): Unit = {}
+
+  val singB: B = new B {}
+  def a_09(a: A with singB.type): Unit = {}
+  def a_10(b: singB.type with A): Unit = {}
+
+  type V >: SubB <: B
+  def b_11(b: V): Unit = {}
+  def subb_12(b: V with SubB): Unit = {}
+
+  def d_13(d: D with A): Unit = {}
+  def d_14(d: A with D): Unit = {}
+
+  val singD: D = new D {}
+  def d_13x(d: singD.type with A): Unit = {}
+  def d_14x(d: A with singD.type): Unit = {}
+
+  type DEq = D
+  def d_15(d: A with DEq): Unit = {}
+  def d_16(d: A with (DEq @foo)): Unit = {}
+  def d_17(d: DEq with A): Unit = {}
+  def d_18(d: (DEq @foo) with A): Unit = {}
+
+  val singDEq: DEq @foo = new D {}
+  def d_15b(d: A with singDEq.type): Unit = {}
+  def d_16b(d: A with (singDEq.type @foo)): Unit = {}
+
+  type DSub <: D
+  def d_19(a: A with DSub): Unit = {}
+  def d_19x(d: DSub with A): Unit = {}
+  def d_20(z: DSub with Z): Unit = {}
+
+  type W1 <: A with Cov[Any]
+  type X1 <: Cov[Int] with W1
+  def a_21(a: X1): Unit = {}
+
+  type W2 <: A with Cov[Any]
+  type X2 <: Cov[Int] with W2
+  def a_22(a: X2): Unit = {}
+
+  def z_23(z: A with this.type): Unit = {}
+  def z_24(z: this.type with A): Unit = {}
+
+  def a_25(b: A with (B { type T })): Unit = {}
+  def a_26(a: (A { type T }) with ((B with A) { type T })): Unit = {}
+
+  def a_27(a: VC with B): Unit = {}
+  def a_28(a: B with VC): Unit = {}
+
+  val o1: Outer = new Outer
+  val o2: Outer = new Outer
+  def e_29(f: o1.E with o1.F): Unit = {}
+  def e_30(f: o1.F with o1.E): Unit = {}
+  def e_31(f: o1.E with o2.F): Unit = {}
+  def e_32(f: o2.F with o1.E): Unit = {}
+  def e_33(f: Outer#E with Outer#F): Unit = {}
+  def e_34(f: Outer#F with Outer#E): Unit = {}
+
+  val structural1: { type DSub <: D } = new { type DSub <: D }
+  def d_35(a: A with structural1.DSub): Unit = {}
+  def d_36(a: structural1.DSub with A): Unit = {}
+  def d_37(z: Z with structural1.DSub): Unit = {}
+  def d_38(z: structural1.DSub with Z): Unit = {}
+
+  val structural2: { type SubCB <: C with B } = new { type SubCB <: C with B }
+  def b_39(c: structural2.SubCB with B): Unit = {}
+  def b_40(c: B with structural2.SubCB): Unit = {}
+
+  val structural3a: { type SubB <: B; type SubCB <: C with SubB } = new { type SubB <: B; type SubCB <: C with SubB }
+  val structural3b: { type SubB <: B; type SubCB <: C with SubB } = new { type SubB <: B; type SubCB <: C with SubB }
+  def b_41(c: structural3a.SubB with structural3a.SubCB): Unit = {}
+  def b_42(c: structural3a.SubCB with structural3a.SubB): Unit = {}
+  def b_43(b: structural3a.SubB with structural3b.SubCB): Unit = {}
+  def b_44(c: structural3b.SubCB with structural3a.SubB): Unit = {}
+
+  type SubStructural <: C with structural3a.SubB
+  def b_45(x: structural3a.SubB with SubStructural): Unit = {}
+  def b_46(x: structural3b.SubB with SubStructural): Unit = {}
+
+  type Rec1 <: A with B
+  type Rec2 <: C with Rec1
+  def a_47(a: A with B with Rec2): Unit = {}
+  def a_48(a: (A with B) @foo with Rec2): Unit = {}
+
+  type F1 = A with B
+  type F2 = A with B
+  type Rec3 <: F1
+  type Rec4 <: C with Rec3
+  def a_49(a: F1 @foo with Rec4): Unit = {}
+  def a_50(a: F1 with Rec4): Unit = {}
+  def a_51(a: F2 @foo with Rec4): Unit = {}
+  def a_52(a: F2 with Rec4): Unit = {}
+
+  type AA = A
+  type F3 = AA with B
+  type Rec5 <: F3
+  type Rec6 <: C with Rec5
+  def a_53(a: F3 @foo with Rec6): Unit = {}
+  def a_54(a: F3 with Rec6): Unit = {}
+
+  val structural4a: { type M[X] <: A } = new { type M[X] <: A }
+  val structural4b: { type N <: B with structural4a.M[Int] } = new { type N <: B with structural4a.M[Int] }
+  def a_55(x: structural4a.M[Any] with structural4b.N): Unit = {}
+
+  type Bla = A { type M[X] <: A }
+  def a_56(x: Bla#M[Any] with ({ type N <: B with Bla#M[Int] })#N): Unit = {}
+  type AEq = A
+  type Bla2 = AEq { type M[X] <: A }
+  def a_57(x: Bla2#M[Any] with ({ type N <: B with Bla2#M[Int] })#N): Unit = {}
+
+  def int_58(x: Int with Singleton): Unit = {}
+  def int_59(x: Singleton with Int): Unit = {}
+  def int_60(x: Int with Any): Unit = {}
+  def int_61(x: Any with Int): Unit = {}
+  def int_62(x: Int with AnyVal): Unit = {}
+  def int_63(x: AnyVal with Int): Unit = {}
+
+  def intARRAY_64(x: Array[Int with Singleton]): Unit = {}
+  def intARRAY_65(x: Array[_ <: Int]): Unit = {}
+  def intARRAY_66(x: Array[_ <: Int with Singleton]): Unit = {}
+  def intARRAY_67(x: Array[_ <: Singleton with Int]): Unit = {}
+  def intARRAY_68(x: Array[_ <: Int with Any]): Unit = {}
+  def intARRAY_69(x: Array[_ <: Any with Int]): Unit = {}
+  def intARRAY_70(x: Array[_ <: Int with AnyVal]): Unit = {}
+  def intARRAY_71(x: Array[_ <: AnyVal with Int]): Unit = {}
+  def intARRAY_71a(x: Array[_ <: Int | Int]): Unit = {}
+  def intARRAY_71b(x: Array[_ <: 1 | 2]): Unit = {}
+
+  def stringARRAY_72(x: Array[String with Singleton]): Unit = {}
+  def stringARRAY_73(x: Array[_ <: String]): Unit = {}
+  def stringARRAY_74(x: Array[_ <: String with Singleton]): Unit = {}
+  def stringARRAY_75(x: Array[_ <: Singleton with String]): Unit = {}
+  def stringARRAY_76(x: Array[_ <: String with Any]): Unit = {}
+  def stringARRAY_77(x: Array[_ <: Any with String]): Unit = {}
+  def stringARRAY_78(x: Array[_ <: String with AnyRef]): Unit = {}
+  def stringARRAY_79(x: Array[_ <: AnyRef with String]): Unit = {}
+  def stringARRAY_79a(x: Array[_ <: String | String]): Unit = {}
+  def stringARRAY_79b(x: Array[_ <: "a" | "b"]): Unit = {}
+
+  def object_80(x: Array[_ <: Singleton]): Unit = {}
+  def object_81(x: Array[_ <: AnyVal]): Unit = {}
+  def objectARRAY_82(x: Array[_ <: AnyRef]): Unit = {}
+  def object_83(x: Array[_ <: Any]): Unit = {}
+  def object_83a(x: Array[_ <: Matchable]): Unit = {}
+  def object_83b(x: Array[_ <: Int | Double]): Unit = {}
+  def object_83c(x: Array[_ <: String | Int]): Unit = {}
+  def object_83d(x: Array[_ <: Int | Matchable]): Unit = {}
+  def object_83e(x: Array[_ <: AnyRef | AnyVal]): Unit = {}
+
+  def serializableARRAY_84(x: Array[_ <: Serializable]): Unit = {}
+  def univARRAY_85(x: Array[_ <: Univ]): Unit = {}
+  def aARRAY_86(x: Array[_ <: A]): Unit = {}
+  def aARRAY_87(x: Array[_ <: A with B]): Unit = {}
+
+  def objectARRAY_88(x: Array[Any]): Unit = {}
+  def objectARRAY_89(x: Array[AnyRef]): Unit = {}
+  def objectARRAY_90(x: Array[AnyVal]): Unit = {}
+
+  def stringARRAY_91(x: Array[_ <: ({ type Foo <: String with Singleton })#Foo]): Unit = {}
+  def stringARRAY_92(x: Array[({ type Foo <: String with Singleton })#Foo]): Unit = {}
+  def stringARRAY_93(x: Array[({ type Id[T] = T })#Id[String with Singleton]]): Unit = {}
+
+  def covARRAY_94(x: Array[Q[String]]): Unit = {}
+
+  def aARRAY_95(x: Array[(A with B { type L <: String }) with C]): Unit = {}
+  def aARRAY_96(x: Array[A { type L <: String }]): Unit = {}
+  def zARRAY_97(x: Array[self.type]): Unit = {}
+  def aARRAY_98(x: Array[(A { type L <: String }) with B]): Unit = {}
+  def stringARRAY_99[Arg <: String](x: Array[Arg]): Unit = {}
+  def aARRAY_100(x: Array[Bla2#M[Any] with ({ type N <: B with Bla2#M[Int] })#N]): Unit = {}
+  def dARRAY_101(x: Array[structural1.DSub with Z]): Unit = {}
+  def aARRAY_102(x: Array[F3 @foo with Rec6]): Unit = {}
+  def aARRAY_103(x: Array[A @foo]): Unit = {}
+  def dARRAY_104(x: Array[singD.type]): Unit = {}
+  def intARRAY_105(x: Array[3]): Unit = {}
+  def vcARRAY_106(x: Array[VC]): Unit = {}
+  def listARRAY_107(x: Array[List[_]]): Unit = {}
+  def intARRAY_108(x: Array[Int with String]): Unit = {}
+  def intARRAY_109(x: Array[String with Int]): Unit = {}
+
+  def a_110(x: VC with VC2): Unit = {}
+  def a_111(x: VC2 with VC): Unit = {}
+  def vcARRAY_112(x: Array[VC2 with VC]): Unit = {}
+  def vcARRAY_113(x: Array[VC with VC2]): Unit = {}
+  def a_114(x: VC with D): Unit = {}
+  def a_115(x: D with VC): Unit = {}
+  def a_116(x: D with B with VC): Unit = {}
+  def a_117(x: B with D with VC): Unit = {}
+  def a_118(x: VC with B with D): Unit = {}
+  def a_119(x: VC with Int): Unit = {}
+  def a_120(x: Int with VC): Unit = {}
+
+  def object_121[T](x: Array[T]): Unit = {}
+  def object_122(x: Array[_ <: AnyVal with Singleton]): Unit = {}
+  def objectARRAY_123(x: Array[AnyVal with Singleton]): Unit = {}
+  def object_124[T, U](x: Array[T with U]): Unit = {}
+  def objectARRAY_125(x: Array[({ type W <: String }) with ({ type X <: Int })]): Unit = {}
+  def covARRAY_126(x: Array[Q[B] with Y[SubB]]): Unit = {}
+  def covARRAY_127(x: Array[Q[B] with Y[SubB] { type X <: Cov[String] }]): Unit = {}
+
+  type SubAny <: Any
+  type SubAnyVal <: AnyVal
+
+  def object_128(x: Array[SubAny with SubAnyVal]): Unit = {}
+  def intARRAYARRAY_129(x: Array[Array[Int]]): Unit = {}
+  def intARRAYARRAY_130(x: Array[_ <: Array[Int]]): Unit = {}
+  def objectARRAY_130(x: Array[_ <: Array[_ <: AnyVal]]): Unit = {}
+  def intARRAY_131(x: Array[String] with Array[Int]): Unit = {}
+
+}

--- a/test/tasty/run/src-3/tastytest/dottyErasure/api.scala
+++ b/test/tasty/run/src-3/tastytest/dottyErasure/api.scala
@@ -28,6 +28,11 @@ object OpaqueHolder {
 }
 import OpaqueHolder._
 
+enum Enumerated {
+  case C1 extends Enumerated with A
+  case C2 extends Enumerated with B
+}
+
 // The parameter type of `a_XX` should erase to A, `b_XX` to `B`, etc.
 // This is enforced by dottyApp/Main.scala
 class Z { self =>
@@ -255,5 +260,12 @@ class Z { self =>
   def intARRAYARRAY_130(x: Array[_ <: Array[Int]]): Unit = {}
   def objectARRAY_130(x: Array[_ <: Array[_ <: AnyVal]]): Unit = {}
   def intARRAY_131(x: Array[String] with Array[Int]): Unit = {}
+
+  def enumerated_132(x: Enumerated.C1.type with Enumerated.C2.type): Unit = {}
+  def enumerated_133(x: Enumerated.C2.type with Enumerated.C1.type): Unit = {}
+  def enumerated_134(x: Enumerated.C1.type): Unit = {}
+  def enumeratedARRAY_135(x: Array[Enumerated.C1.type]): Unit = {}
+  def enumeratedARRAY_136(x: Array[Enumerated.C2.type with Enumerated.C1.type]): Unit = {}
+  def enumeratedARRAY_137(x: Array[Enumerated.C1.type with Enumerated.C2.type]): Unit = {}
 
 }

--- a/test/tasty/test/scala/tools/tastytest/TastyTestJUnit.scala
+++ b/test/tasty/test/scala/tools/tastytest/TastyTestJUnit.scala
@@ -67,7 +67,10 @@ class TastyTestJUnit {
   val propPkgName = "tastytest.packageName"
 
   def assertPropIsSet(prop: String): String = {
-    Properties.propOrNull(prop).ensuring(_ != null, s"-D$prop is not set")
+    Properties.propOrElse(prop, {
+      fail(s"-D$prop is not set")
+      "(unknown)"
+    })
   }
 }
 


### PR DESCRIPTION
Interesting points:
  - Addition of `SCALA3X` flag to `src/reflect/scala/reflect/internal/Flags.scala`
  - addition of scala 3 erasure modes (needed for new rules for erasure of intersection types and arrays in Scala 3)
  - sandbox classloader for invoking scala 3 compiler in tests.