### PR TITLE
Fix typo in Logic.scala

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
@@ -395,7 +395,7 @@ trait Logic extends Debugging {
     // according to subtyping, e.g., V = ConstantType(1) and V = Int are valid assignments
     // we rewrite V = C to a fresh boolean symbol, and model what we know about the variable's domain
     // in a prelude (the equality axioms)
-    //   1. a variable with a closed domain (of a sealed type) must be assigned one of the instantiatable types in its domain
+    //   1. a variable with a closed domain (of a sealed type) must be assigned one of the instantiable types in its domain
     //   2. for each variable V in props, and each constant C it is compared to,
     //      compute which assignments imply each other (as in the example above: V = 1 implies V = Int)
     //      and which assignments are mutually exclusive (V = String implies -(V = Int))


### PR DESCRIPTION
instantiatable -> instantiable