### PR TITLE
[backport] Underscore changes for `-Xsource:3`: parse `+_`/`-_` and prefix wildcard variables introduced by ?-syntax with `?`

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1077,7 +1077,14 @@ self =>
         simpleTypeRest(in.token match {
           case LPAREN   => atPos(start)(makeSafeTupleType(inParens(types()), start))
           case _        =>
-            if (isWildcardType)
+            if (currentRun.isScala3 && (in.name == raw.PLUS || in.name == raw.MINUS) && lookingAhead(in.token == USCORE)) {
+              val start = in.offset
+              val identName = in.name.encode.append("_").toTypeName
+              in.nextToken()
+              in.nextToken()
+              atPos(start)(Ident(identName))
+            }
+            else if (isWildcardType)
               wildcardType(in.skipToken())
             else
               path(thisOK = false, typeOK = true) match {

--- a/test/files/neg/variant-placeholders-future.check
+++ b/test/files/neg/variant-placeholders-future.check
@@ -1,0 +1,7 @@
+variant-placeholders-future.scala:4: error: `=', `>:', or `<:' expected
+  type -_ = Int // error -_ not allowed as a type def name without backticks
+        ^
+variant-placeholders-future.scala:5: error: `=', `>:', or `<:' expected
+  type +_ = Int // error +_ not allowed as a type def name without backticks
+        ^
+two errors found

--- a/test/files/neg/variant-placeholders-future.scala
+++ b/test/files/neg/variant-placeholders-future.scala
@@ -1,0 +1,6 @@
+// scalac: -Xsource:3
+//
+object Test {
+  type -_ = Int // error -_ not allowed as a type def name without backticks
+  type +_ = Int // error +_ not allowed as a type def name without backticks
+}

--- a/test/files/neg/variant-placeholders-nofuture.check
+++ b/test/files/neg/variant-placeholders-nofuture.check
@@ -1,0 +1,7 @@
+variant-placeholders-nofuture.scala:5: error: ';' expected but '_' found.
+  val fnMinusPlus1: -_ => +_ = (_: Int).toLong // error -_/+_ won't parse without -Xsource:3
+                     ^
+variant-placeholders-nofuture.scala:6: error: ')' expected but '_' found.
+  val fnMinusPlus2: (-_) => +_ = fnMinusPlus1  // error -_/+_ won't parse without -Xsource:3
+                      ^
+two errors found

--- a/test/files/neg/variant-placeholders-nofuture.scala
+++ b/test/files/neg/variant-placeholders-nofuture.scala
@@ -1,0 +1,8 @@
+object Test {
+  type `-_` = Int
+  type `+_` = Long
+
+  val fnMinusPlus1: -_ => +_ = (_: Int).toLong // error -_/+_ won't parse without -Xsource:3
+  val fnMinusPlus2: (-_) => +_ = fnMinusPlus1  // error -_/+_ won't parse without -Xsource:3
+  val fnMinusPlus3: -_ => (+_) = fnMinusPlus2  // error -_/+_ won't parse without -Xsource:3
+}

--- a/test/files/neg/wildcards-future.check
+++ b/test/files/neg/wildcards-future.check
@@ -1,0 +1,11 @@
+wildcards-future.scala:7: error: type mismatch;
+ found   : Map[_$1,_$2] where type _$2 >: Null, type _$1 <: AnyRef
+ required: Map[String,String]
+  underscores : Map[String, String] // error wildcard variables starting with `_`
+  ^
+wildcards-future.scala:9: error: type mismatch;
+ found   : Map[?$1,?$2] where type ?$2 >: Null, type ?$1 <: AnyRef
+ required: Map[String,String]
+  qmarks : Map[String, String] // error – wildcard variables should start with `?` to differentiate from the old syntax
+  ^
+two errors found

--- a/test/files/neg/wildcards-future.scala
+++ b/test/files/neg/wildcards-future.scala
@@ -1,0 +1,11 @@
+// scalac: -Xsource:3
+//
+object Test {
+  val underscores: Map[_ <: AnyRef, _ >: Null] = Map()
+  val qmarks: Map[? <: AnyRef, ? >: Null] = Map()
+
+  underscores : Map[String, String] // error wildcard variables starting with `_`
+
+  qmarks : Map[String, String] // error – wildcard variables should start with `?` to differentiate from the old syntax
+                               // (and have a mildly more readable error...)
+}

--- a/test/files/pos/variant-placeholders-future.scala
+++ b/test/files/pos/variant-placeholders-future.scala
@@ -1,0 +1,35 @@
+// scalac: -Xsource:3
+//
+object Test {
+  type `-_` = Int
+  type `+_` = Long
+
+  val fnMinusPlus1: -_ => +_ = (_: Int).toLong
+  val fnMinusPlus2: (-_) => +_ = fnMinusPlus1
+  val fnMinusPlus3: -_ => (+_) = fnMinusPlus2
+
+  val fnTupMinusPlus2: (=> -_, -_) => +_ = (a, b) => ((a: Int) + (b: Int)).toLong
+  def defMinusPlus2(byname: => -_, vararg: -_*): +_ = ((vararg.sum: Int) + (byname: -_)).toLong
+  val infixMinusPlus2: -_ Either +_ = Right[-_, +_](1L)
+
+  val optPlus: Option[+_] = Some[ + _ ](1L)  // spaces allowed
+  optPlus match {
+    case opt: Option[ + _ ] =>
+      val opt1: + _ = opt.get
+      val opt2: Long = opt1
+  }
+
+  val optMinus: Option[-_] = Some[ - _ ](1)  // spaces allowed
+  optMinus match {
+    case opt: Option[ - _ ] =>
+      val opt1: `-_` = opt.get
+      val optErr: - _ = opt.get
+      val opt2: Int = opt1
+  }
+
+  locally {
+    type `-_`[A] = A
+    type `+_`[A] = Option[A]
+    val optOpt: Option[ + _ [+_[-_[Int]]]] = Some(Some(Some(1)))
+  }
+}


### PR DESCRIPTION
This PR backports the following changes to Scala 2.12:

- https://github.com/scala/scala/pull/9605
- https://github.com/scala/scala/pull/9614
