### PR TITLE
Add detail to HashMap's lookup error message

### DIFF
--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -628,11 +628,11 @@ private final class BitmapIndexedMapNode[K, +V](
 
     if ((dataMap & bitpos) != 0) {
       val index = indexFrom(dataMap, mask, bitpos)
-      if (key == getKey(index)) getValue(index) else throw new NoSuchElementException("key not found: " + key)
+      if (key == getKey(index)) getValue(index) else throw new NoSuchElementException(s"key not found: $key")
     } else if ((nodeMap & bitpos) != 0) {
       getNode(indexFrom(nodeMap, mask, bitpos)).apply(key, originalHash, keyHash, shift + BitPartitionSize)
     } else {
-      throw new NoSuchElementException("key not found: " + key)
+      throw new NoSuchElementException(s"key not found: $key")
     }
   }
 

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -628,11 +628,11 @@ private final class BitmapIndexedMapNode[K, +V](
 
     if ((dataMap & bitpos) != 0) {
       val index = indexFrom(dataMap, mask, bitpos)
-      if (key == getKey(index)) getValue(index) else throw new NoSuchElementException
+      if (key == getKey(index)) getValue(index) else throw new NoSuchElementException("key not found: " + key)
     } else if ((nodeMap & bitpos) != 0) {
       getNode(indexFrom(nodeMap, mask, bitpos)).apply(key, originalHash, keyHash, shift + BitPartitionSize)
     } else {
-      throw new NoSuchElementException
+      throw new NoSuchElementException("key not found: " + key)
     }
   }
 

--- a/test/junit/scala/collection/immutable/HashMapTest.scala
+++ b/test/junit/scala/collection/immutable/HashMapTest.scala
@@ -8,6 +8,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import scala.tools.testkit.AllocationTest
+import scala.tools.testkit.AssertUtil.assertThrows
 
 @RunWith(classOf[JUnit4])
 class HashMapTest extends AllocationTest{
@@ -342,13 +343,7 @@ class HashMapTest extends AllocationTest{
 
   @Test
   def noSuchElement(): Unit = {
-    val m = HashMap[Int, Int](1 -> 1)
-    try {
-      m(2)
-    } catch {
-      case e: NoSuchElementException =>
-        assertEquals("key not found: 2", e.getMessage())
-      case e: Throwable => throw e
-    }
+    assertThrows[NoSuchElementException](HashMap(1->1)(2), _ == "key not found: 2")
+    assertThrows[NoSuchElementException](HashMap.empty(3), _ == "key not found: 3")
   }
 }

--- a/test/junit/scala/collection/immutable/HashMapTest.scala
+++ b/test/junit/scala/collection/immutable/HashMapTest.scala
@@ -339,4 +339,16 @@ class HashMapTest extends AllocationTest{
     check(cs => TreeMap(cs: _*)) // exercise special case for HashMap/HasForEachEntry
     check(cs => HashMap(cs: _*).withDefault(_ => ???)) // default cases
   }
+
+  @Test
+  def noSuchElement(): Unit = {
+    val m = HashMap[Int, Int](1 -> 1)
+    try {
+      m(2)
+    } catch {
+      case e: NoSuchElementException =>
+        assertEquals("key not found: 2", e.getMessage())
+      case e: Throwable => throw e
+    }
+  }
 }


### PR DESCRIPTION
Fixes scala/bug#12391

Scala 2.13 throws NoSuchElementException without any messages.
It's expected to throw "key not found: x"
This fixes it.