### PR TITLE
Handle Singleton types in patmat's outer prefix align testing

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
@@ -394,6 +394,7 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
                     false
                   case TypeRef(pre, sym, args) =>
                     val testedBinderClass = testedBinder.info.upperBound.typeSymbol
+                    // alternatively..... = testedBinder.info.baseClasses.find(_.isClass).getOrElse(NoSymbol)
                     val testedBinderType = testedBinder.info.baseType(testedBinderClass)
 
                     val testedPrefixIsExpectedTypePrefix = pre =:= testedBinderType.prefix
@@ -402,7 +403,7 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
                         case ThisType(thissym) =>
                           ThisType(thissym.cloneSymbol(thissym.owner))
                         case _ =>
-                          val preSym = pre.termSymbol
+                          val preSym = pre.termSymbol.orElse(pre.typeSymbol)
                           val freshPreSym = preSym.cloneSymbol(preSym.owner).setInfo(preSym.info)
                           singleType(pre.prefix, freshPreSym)
                       }

--- a/test/files/pos/t12392.scala
+++ b/test/files/pos/t12392.scala
@@ -1,0 +1,14 @@
+import scala.reflect.api.Universe
+
+object Test {
+  type SingletonUniverse = Universe with Singleton
+  def deepIntersectionTypeMembers[U <: SingletonUniverse](targetType: U#Type): List[U#Type] = {
+    def go(tpe: U#Type): List[U#Type] = {
+      tpe match {
+        case r: U#RefinedTypeApi => r.parents.flatMap(t => deepIntersectionTypeMembers[U]((t.dealias): U#Type))
+        case _ => List(tpe)
+      }
+    }
+    go(targetType).distinct
+  }
+}


### PR DESCRIPTION
Singleton abstract types are isStable, but they don't have a term
symbol.  But, at least in the given test case, they do have a type
symbol (the type parameter symbol) so we can construct a fresh singleton
type using that type symbol and use that to determine that no outer test
is needed for the prefix.  That hinges on the assumption that the
machinery around Singleton is successfully enforcing that it all ends up
deriving from a single value and two types are never from different
prefixes.

Alternatively we can just use `pre.typeSymbol == NoSymbol` as a guard
and always emit an outer test on the prefix.  That undermines that
Singleton abstract types are stable, but I can't tell in the context of
outer tests whether that's the right or the wrong choice...

Fixes https://github.com/scala/bug/issues/12392