### PR TITLE
Optimise immutable.Queue.last in case `in` is nonEmpty

### DIFF
--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -97,6 +97,11 @@ sealed class Queue[+A] protected(protected val in: List[A], protected val out: L
     else if (in.nonEmpty) new Queue(Nil, in.reverse.tail)
     else throw new NoSuchElementException("tail on empty queue")
 
+  override def last: A =
+    if (in.nonEmpty) in.head
+    else if (out.nonEmpty) out.last
+    else throw new NoSuchElementException("last on empty queue")
+
   /* This is made to avoid inefficient implementation of iterator. */
   override def forall(p: A => Boolean): Boolean =
     in.forall(p) && out.forall(p)


### PR DESCRIPTION
Currently `immutable.Queue.last/init` are always O(n). It is possible to execute them in O(1) whenever `in` is `nonEmpty`.