### PR TITLE
Deprecate calling a type `?` without backticks

### DIFF
--- a/test/files/neg/qmark-deprecated.check
+++ b/test/files/neg/qmark-deprecated.check
@@ -1,0 +1,42 @@
+qmark-deprecated.scala:4: warning: using `?` as a type name will require backticks in the future.
+class Foo[?] // error
+          ^
+qmark-deprecated.scala:6: warning: using `?` as a type name will require backticks in the future.
+class Bar[M[?] <: List[?]] // errors
+            ^
+qmark-deprecated.scala:6: warning: `?` in a type will be interpreted as a wildcard in the future, wrap it in backticks to keep the current meaning.
+class Bar[M[?] <: List[?]] // errors
+                       ^
+qmark-deprecated.scala:10: warning: using `?` as a type name will require backticks in the future.
+  class ? { val x = 1 } // error
+        ^
+qmark-deprecated.scala:16: warning: using `?` as a type name will require backticks in the future.
+  trait ? // error
+        ^
+qmark-deprecated.scala:22: warning: using `?` as a type name will require backticks in the future.
+  type ? = Int // error
+       ^
+qmark-deprecated.scala:27: warning: `?` in a type will be interpreted as a wildcard in the future, wrap it in backticks to keep the current meaning.
+  val x: Array[?] = new Array[?](0) // errors
+               ^
+qmark-deprecated.scala:27: warning: `?` in a type will be interpreted as a wildcard in the future, wrap it in backticks to keep the current meaning.
+  val x: Array[?] = new Array[?](0) // errors
+                              ^
+qmark-deprecated.scala:30: warning: `?` in a type will be interpreted as a wildcard in the future, wrap it in backticks to keep the current meaning.
+  def foo1[T <: Array[?]](x: T): Array[?] = x // errors
+                      ^
+qmark-deprecated.scala:30: warning: `?` in a type will be interpreted as a wildcard in the future, wrap it in backticks to keep the current meaning.
+  def foo1[T <: Array[?]](x: T): Array[?] = x // errors
+                                       ^
+qmark-deprecated.scala:33: warning: using `?` as a type name will require backticks in the future.
+  def bar1[?] = {} // error
+           ^
+qmark-deprecated.scala:35: warning: using `?` as a type name will require backticks in the future.
+  def bar3[M[?]] = {} // error
+             ^
+qmark-deprecated.scala:38: warning: using `?` as a type name will require backticks in the future.
+  type A[?] = Int // error
+         ^
+error: No warnings can be incurred under -Werror.
+13 warnings
+1 error

--- a/test/files/neg/qmark-deprecated.scala
+++ b/test/files/neg/qmark-deprecated.scala
@@ -1,0 +1,40 @@
+// scalac: -deprecation -Xfatal-warnings
+//
+
+class Foo[?] // error
+class Foo2[`?`] // ok
+class Bar[M[?] <: List[?]] // errors
+class Bar2[M[`?`] <: List[`?`]] // ok
+
+object G {
+  class ? { val x = 1 } // error
+}
+object G2 {
+  class `?` { val x = 1 } // ok
+}
+object H {
+  trait ? // error
+}
+object H2 {
+  trait `?` // ok
+}
+object I {
+  type ? = Int // error
+}
+object I2 {
+  type `?` = Int // ok
+
+  val x: Array[?] = new Array[?](0) // errors
+  val y: Array[`?`] = new Array[`?`](0) // ok
+
+  def foo1[T <: Array[?]](x: T): Array[?] = x // errors
+  def foo2[T <: Array[`?`]](x: T): Array[`?`] = x // ok
+
+  def bar1[?] = {} // error
+  def bar2[`?`] = {} // ok
+  def bar3[M[?]] = {} // error
+  def bar4[M[`?`]] = {} // error
+
+  type A[?] = Int // error
+  type B[`?`] = Int // ok
+}


### PR DESCRIPTION
https://github.com/scala/scala/pull/9560 introduced a new meaning for
`?` under `-Xsource:3`, but to smooth out the migration it'd be nice if
we could also enable this meaning by default. Before doing so, let's
deprecate any current usage of `?` as a type that isn't wrapped in
backticks.