### PR TITLE
Override checks between Java-defined members only for mixins

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -383,7 +383,7 @@ abstract class RefChecks extends Transform {
           def isOverrideAccessOK = member.isPublic || {      // member is public, definitely same or relaxed access
             (!other.isProtected || member.isProtected) &&    // if o is protected, so is m
             ((!isRootOrNone(ob) && ob.hasTransOwner(mb)) ||  // m relaxes o's access boundary
-             (other.isJavaDefined && (member.isJavaDefined || other.isProtected))) // overriding a protected java member, see #3946 #12349
+             (other.isJavaDefined && other.isProtected))     // overriding a protected java member, see #3946 #12349
           }
           if (!isOverrideAccessOK) {
             overrideAccessError()

--- a/test/files/neg/t12394.check
+++ b/test/files/neg/t12394.check
@@ -1,0 +1,11 @@
+Test.scala:2: error: cannot override final member:
+final def m(): Int (defined in class C)
+  with <defaultmethod> def m(): Int (defined in trait J)
+class S2 extends p.A.C with p.A.J
+      ^
+Test.scala:4: error: cannot override final member:
+final def m(): Int (defined in class C)
+  with <defaultmethod> def m(): Int (defined in trait J)
+class S3 extends p.A.C with K
+      ^
+2 errors

--- a/test/files/neg/t12394/A.java
+++ b/test/files/neg/t12394/A.java
@@ -1,0 +1,17 @@
+package p;
+
+public class A {
+  public static interface I {
+    default int m() { return 1; }
+  }
+
+  public static interface J extends I {
+    @Override default int m() { return 2; }
+  }
+
+  public static class C implements I {
+    @Override public final int m() { return 3; }
+  }
+
+  public static class D extends C implements J { }
+}

--- a/test/files/neg/t12394/Test.scala
+++ b/test/files/neg/t12394/Test.scala
@@ -1,0 +1,4 @@
+class S1 extends p.A.D
+class S2 extends p.A.C with p.A.J
+trait K extends p.A.J
+class S3 extends p.A.C with K


### PR DESCRIPTION
Override checking between Java-defined members can and should be
skipped: javac will do the checks anyway, and applying Scala's rules
can lead to false errors.

However, when mixing in a Java interface into a Scala class, default
methods in the interface have to be checked according to Scala's
rules, because Scala linearization applies in this case.

Fixes https://github.com/scala/bug/issues/12394