### PR TITLE
Further adjust SubstMap to preserve source compatibility

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -1439,10 +1439,11 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
                               to: List[Symbol],
                               targetClass: Symbol,
                               addressFields: Boolean) extends TreeSymSubstituter(from, to) {
-    private def matcher(sym1: Symbol, sym2: Symbol) =
-      if (sym2.isTypeSkolem) sym2.deSkolemize eq sym1
-      else sym1 eq sym2
-    override val symSubst = SubstSymMap(from, to, matcher)
+    override val symSubst = new SubstSymMap(from, to) {
+      override def matches(sym1: Symbol, sym2: Symbol) =
+        if (sym2.isTypeSkolem) sym2.deSkolemize eq sym1
+        else sym1 eq sym2
+    }
 
     private def isAccessible(sym: Symbol): Boolean =
       if (currentOwner.isAnonymousFunction) {

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -3764,7 +3764,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     else {
       val syms1 = mapList(syms)(_.cloneSymbol)
       cloneSymbolsSubstSymMap.using { (msm: SubstSymMap) =>
-        msm.reload(syms, syms1)
+        msm.reset(syms, syms1)
         syms1.foreach(_.modifyInfo(msm))
       }
       syms1

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4059,7 +4059,7 @@ trait Types
         val resultThis = result.typeSymbol.thisType
         val substThisMap = new SubstThisMap(original.typeSymbol, resultThis)
         copyRefinedTypeSSM.using { (msm: SubstSymMap) =>
-          msm.reload(syms1, syms2)
+          msm.reset(syms1, syms2)
           syms2.foreach(_.modifyInfo(info => msm.apply(substThisMap.apply(info))))
         }
       }

--- a/test/junit/scala/reflect/internal/SubstMapTest.scala
+++ b/test/junit/scala/reflect/internal/SubstMapTest.scala
@@ -1,0 +1,13 @@
+package scala.reflect.internal
+
+import scala.tools.nsc.symtab.SymbolTableForUnitTesting
+
+class SubstMapTest {
+  object symbolTable extends SymbolTableForUnitTesting
+  import symbolTable._
+
+  // compile-test for https://github.com/scala/community-build/pull/1413
+  new SubstMap[String](Nil, Nil) {
+    protected def toType(fromtp: Type, tp: String) = fromtp
+  }
+}


### PR DESCRIPTION
it was recently sealed (by #9363), but in the community build we saw that Scalafix has their own subclass (in CompilerTypePrinter)