### PR TITLE
Require less stack compiling 150 field case class (with a balanced AND)

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/TreeDSL.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeDSL.scala
@@ -140,7 +140,17 @@ trait TreeDSL {
     def NEW(tpt: Tree, args: Tree*): Tree   = New(tpt, List(args.toList))
 
     def NOT(tree: Tree)   = Select(tree, Boolean_not)
-    def AND(guards: Tree*) = if (guards.isEmpty) EmptyTree else guards reduceLeft gen.mkAnd
+    def AND(guards: Tree*) = {
+      def binaryTreeAnd(tests: Seq[Tree]): Tree = tests match{
+        case Seq() => EmptyTree
+        case Seq(single) => single
+        case multiple =>
+          val (before, after) = multiple.splitAt(tests.size / 2)
+          gen.mkAnd(binaryTreeAnd(before), binaryTreeAnd(after))
+      }
+
+      binaryTreeAnd(guards)
+    }
 
     def IF(tree: Tree)    = new IfStart(tree, EmptyTree)
     def TRY(tree: Tree)   = new TryStart(tree, Nil, EmptyTree)

--- a/test/files/run/idempotency-case-classes.check
+++ b/test/files/run/idempotency-case-classes.check
@@ -40,7 +40,7 @@ C(2,3)
   case _ => false
 }.&&({
       <synthetic> val C$1: C = x$1.asInstanceOf[C];
-      C.this.x.==(C$1.x).&&(C.this.y.==(C$1.y)).&&(C$1.canEqual(C.this))
+      C.this.x.==(C$1.x).&&(C.this.y.==(C$1.y).&&(C$1.canEqual(C.this)))
     }))
   };
   <synthetic> object C extends scala.runtime.AbstractFunction2[Int,Int,C] with java.io.Serializable {


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/12397 by turning the long change of `&&`s in the synthetic `def equals` method:

```scala
a && b && c && d && e && f && g && h 
```

Which currently parses into an unbalanced depth O(n) tree as follows:

```scala
(((((((a && b) && c) && d) && e) && f) && g) && h)
```

into a binary tree of depth O(log n):

```scala
(((a && b) && (c && d)) && ((e && f) && (g && h)))
```

Tested manually by pasting the following snippet into the `sbt scala` interpreter:

```scala
case class Big150(_0: Int, _1: Int, _2: Int, _3: Int, _4: Int, _5: Int, _6: Int, _7: Int,
                  _8: Int, _9: Int, _10: Int, _11: Int, _12: Int, _13: Int, _14: Int,
                  _15: Int, _16: Int, _17: Int, _18: Int, _19: Int, _20: Int, _21: Int,
                  _22: Int, _23: Int, _24: Int, _25: Int, _26: Int, _27: Int, _28: Int,
                  _29: Int, _30: Int, _31: Int, _32: Int, _33: Int, _34: Int, _35: Int,
                  _36: Int, _37: Int, _38: Int, _39: Int, _40: Int, _41: Int, _42: Int,
                  _43: Int, _44: Int, _45: Int, _46: Int, _47: Int, _48: Int, _49: Int,
                  _50: Int, _51: Int, _52: Int, _53: Int, _54: Int, _55: Int, _56: Int,
                  _57: Int, _58: Int, _59: Int, _60: Int, _61: Int, _62: Int, _63: Int,
                  _64: Int, _65: Int, _66: Int, _67: Int, _68: Int, _69: Int, _70: Int,
                  _71: Int, _72: Int, _73: Int, _74: Int, _75: Int, _76: Int, _77: Int,
                  _78: Int, _79: Int, _80: Int, _81: Int, _82: Int, _83: Int, _84: Int,
                  _85: Int, _86: Int, _87: Int, _88: Int, _89: Int, _90: Int, _91: Int,
                  _92: Int, _93: Int, _94: Int, _95: Int, _96: Int, _97: Int, _98: Int,
                  _99: Int, _100: Int, _101: Int, _102: Int, _103: Int, _104: Int,
                  _105: Int, _106: Int, _107: Int, _108: Int, _109: Int, _110: Int,
                  _111: Int, _112: Int, _113: Int, _114: Int, _115: Int, _116: Int,
                  _117: Int, _118: Int, _119: Int, _120: Int, _121: Int, _122: Int,
                  _123: Int, _124: Int, _125: Int, _126: Int, _127: Int, _128: Int,
                  _129: Int, _130: Int, _131: Int, _132: Int, _133: Int, _134: Int,
                  _135: Int, _136: Int, _137: Int, _138: Int, _139: Int, _140: Int,
                  _141: Int, _142: Int, _143: Int, _144: Int, _145: Int, _146: Int,
                  _147: Int, _148: Int, _149: Int)
```

This semi-reliably crashes the interpreter with a StackOverflow on 2.13.x, and works without issue on this PR.

I'm not sure where the tests should go, but let me know and I'll happily paste that snippet into your test suite (or you guys could do it on my behalf when merging!)

It's not clear to me if the other generated methods suffer the same unbalanced-AST issue, but glancing over the code it seems they don't: e.g. `.hashCode` has a long chain of `val` assignments of AST depth O(1), `.productElement` is one big pattern match of depth O(1), etc. The fact that this seems to fix the StackOverflow without it turning up somewhere else also supports the idea that `.equals` is the only generated method with this issue

Seems the problematic behavior was introduced 14 years ago in https://github.com/scala/scala/commit/8397c7b73c2930229eae509e089550b0c3020ce2#diff-205537ac4c08ea690ada72e398df0018dcaf2a7c4987c0d8d8df322314469578R162