### PR TITLE
Adapted multiarg infix is just a tuple

### DIFF
--- a/test/files/neg/t8035-removed.check
+++ b/test/files/neg/t8035-removed.check
@@ -13,4 +13,11 @@ t8035-removed.scala:11: error: adaptation of an empty argument list by inserting
   given arguments: <none>
   sdf.format()
             ^
+t8035-removed.scala:14: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
+        signature: List.::[B >: A](elem: B): List[B]
+  given arguments: 42, 27
+ after adaptation: List.::((42, 27): (Int, Int))
+  Nil.::(42, 27)      // yeswarn
+        ^
+1 warning
 3 errors

--- a/test/files/neg/t8035-removed.scala
+++ b/test/files/neg/t8035-removed.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:3.0
+// scalac: -Xsource:3.0 -Xlint -Werror
 //
 object Foo {
   List(1,2,3).toSet()
@@ -9,4 +9,7 @@ object Foo {
   import java.text.SimpleDateFormat
   val sdf = new SimpleDateFormat("yyyyMMdd-HH0000")
   sdf.format()
+
+  (42, 27) :: Nil     // nowarn
+  Nil.::(42, 27)      // yeswarn
 }


### PR DESCRIPTION
Don't warn about this common idiom.
```
(42, 27) :: Nil     // nowarn
```
It will warn after tweaking how right-associative applications are type-checked.

Currently, parser pulls the arg into a temp val, so there is no adaptation.

After the tweak, the rewrite happens after typecheck of desugared application, so there is normal adaptation.