### PR TITLE
Remove redundant null check when matching value classes with extractor

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
@@ -124,6 +124,7 @@ trait MatchTranslation {
             // (the prefix of the argument passed to the unapply must equal the prefix of the type of the binder)
             val typeTest = TypeTestTreeMaker(binder, binder, paramType, paramType)(pos, extractorArgTypeTest = true)
             val binderKnownNonNull = typeTest impliesBinderNonNull binder
+            assert(binderKnownNonNull, s"$binder")
             // skip null test if it's implied
             if (binderKnownNonNull) {
               val unappBinder = typeTest.nextBinder

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
@@ -123,17 +123,9 @@ trait MatchTranslation {
             // TODO: the outer check is mandated by the spec for case classes, but we do it for user-defined unapplies as well [SPEC]
             // (the prefix of the argument passed to the unapply must equal the prefix of the type of the binder)
             val typeTest = TypeTestTreeMaker(binder, binder, paramType, paramType)(pos, extractorArgTypeTest = true)
-            val binderKnownNonNull = typeTest impliesBinderNonNull binder
-            assert(binderKnownNonNull, s"$binder")
-            // skip null test if it's implied
-            if (binderKnownNonNull) {
-              val unappBinder = typeTest.nextBinder
-              (typeTest :: treeMakers(unappBinder, pos), unappBinder)
-            } else {
-              val nonNullTest = NonNullTestTreeMaker(typeTest.nextBinder, paramType, pos)
-              val unappBinder = nonNullTest.nextBinder
-              (typeTest :: nonNullTest :: treeMakers(unappBinder, pos), unappBinder)
-            }
+            // binder is known non-null because the type test would not succeed on `null`
+            val unappBinder = typeTest.nextBinder
+            (typeTest :: treeMakers(unappBinder, pos), unappBinder)
           }
         }
 

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
@@ -454,17 +454,6 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
         def and(a: Result, b: Result): Result                         = false // we don't and type tests, so the conjunction must include at least one false
         def tru                                                       = true
       }
-
-      def nonNullImpliedByTestChecker(binder: Symbol) = new TypeTestCondStrategy {
-        type Result = Boolean
-
-        def typeTest(testedBinder: Symbol, expectedTp: Type): Result  = testedBinder eq binder
-        def nonNullTest(testedBinder: Symbol): Result                 = testedBinder eq binder
-        def equalsTest(pat: Tree, testedBinder: Symbol): Result       = false // could in principle analyse pat and see if it's statically known to be non-null
-        def eqTest(pat: Tree, testedBinder: Symbol): Result           = false // could in principle analyse pat and see if it's statically known to be non-null
-        def and(a: Result, b: Result): Result                         = a || b
-        def tru                                                       = false
-      }
     }
 
     /** implements the run-time aspects of (§8.2) (typedPattern has already done the necessary type transformations)
@@ -560,8 +549,6 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
 
       // is this purely a type test, e.g. no outer check, no equality tests (used in switch emission)
       def isPureTypeTest = renderCondition(pureTypeTestChecker)
-
-      def impliesBinderNonNull(binder: Symbol) = renderCondition(nonNullImpliedByTestChecker(binder))
 
       override def toString = "TT"+((expectedTp, testedBinder.name, nextBinderTp))
     }

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
@@ -214,11 +214,11 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
       val nullCheck = REF(prevBinder) OBJ_NE NULL
       lazy val localSubstitution = Substitution(Nil, Nil)
 
-      def isExpectedPrimitiveType = isPrimitiveValueType(expectedTp)
+      def skipNullTest = isPrimitiveValueType(expectedTp) || expectedTp.typeSymbol.isDerivedValueClass
 
       def chainBefore(next: Tree)(casegen: Casegen): Tree =
         atPos(pos) {
-          if (isExpectedPrimitiveType) next
+          if (skipNullTest) next
           else casegen.ifThenElseZero(nullCheck, next)
         }
 

--- a/test/files/run/t12405.check
+++ b/test/files/run/t12405.check
@@ -1,0 +1,96 @@
+[[syntax trees at end of                    patmat]] // newSource1.scala
+package <empty> {
+  final class C[A] extends scala.AnyVal {
+    <paramaccessor> private[this] val x: A = _;
+    <stable> <accessor> <paramaccessor> def x: A = C.this.x;
+    def <init>(x: A): C[A] = {
+      C.super.<init>();
+      ()
+    };
+    def isEmpty: Boolean = C.isEmpty$extension[A](C.this);
+    def get: A = C.get$extension[A](C.this);
+    override <synthetic> def hashCode(): Int = C.hashCode$extension[A](C.this)();
+    override <synthetic> def equals(x$1: Any): Boolean = C.equals$extension[A](C.this)(x$1)
+  };
+  object C extends scala.AnyRef {
+    def <init>(): C.type = {
+      C.super.<init>();
+      ()
+    };
+    def unapply[T](c: C[T]): C[T] = c;
+    final def isEmpty$extension[A]($this: C[A]): Boolean = scala.Predef.???;
+    final def get$extension[A]($this: C[A]): A = scala.Predef.???;
+    final <synthetic> def hashCode$extension[A]($this: C[A])(): Int = $this.x.hashCode();
+    final <synthetic> def equals$extension[A]($this: C[A])(x$1: Any): Boolean = {
+  case <synthetic> val x1: Any = x$1;
+  case5(){
+    if (x1.isInstanceOf[C[A]])
+      matchEnd4(true)
+    else
+      case6()
+  };
+  case6(){
+    matchEnd4(false)
+  };
+  matchEnd4(x: Boolean){
+    x
+  }
+}.&&({
+      <synthetic> val C$1: C[A] = x$1.asInstanceOf[C[A]];
+      $this.x.==(C$1.x)
+    })
+  };
+  class Test extends scala.AnyRef {
+    def <init>(): Test = {
+      Test.super.<init>();
+      ()
+    };
+    def m1(a: Any): Any = {
+      case <synthetic> val x1: Any = a;
+      case6(){
+        if (x1.isInstanceOf[C[T]])
+          {
+            <synthetic> val x2: C[T] = (x1.asInstanceOf[C[T]]: C[T]);
+            {
+              <synthetic> val o8: C[T] = C.unapply[T](x2);
+              if (o8.isEmpty.unary_!)
+                {
+                  val x: T = o8.get;
+                  matchEnd5(x)
+                }
+              else
+                case7()
+            }
+          }
+        else
+          case7()
+      };
+      case7(){
+        matchEnd5(null)
+      };
+      matchEnd5(x: Any){
+        x
+      }
+    };
+    def m2(c: C[String]): String = {
+      case <synthetic> val x1: C[String] = c;
+      case5(){
+        <synthetic> val o7: C[String] = C.unapply[String](x1);
+        if (o7.isEmpty.unary_!)
+          {
+            val x: String = o7.get;
+            matchEnd4(x)
+          }
+        else
+          case6()
+      };
+      case6(){
+        matchEnd4("")
+      };
+      matchEnd4(x: String){
+        x
+      }
+    }
+  }
+}
+

--- a/test/files/run/t12405.scala
+++ b/test/files/run/t12405.scala
@@ -1,0 +1,30 @@
+import scala.tools.partest._
+
+object Test extends DirectTest {
+  override def extraSettings: String = "-usejavacp -Vprint:patmat -Ystop-after:patmat"
+
+  override val code =
+    """final class C[A](val x: A) extends AnyVal {
+      |  def isEmpty: Boolean = ???
+      |  def get: A = ???
+      |}
+      |object C {
+      |  def unapply[T](c: C[T]): C[T] = c
+      |}
+      |class Test {
+      |  def m1(a: Any) = a match {
+      |    case C(x) => x
+      |    case _ => null
+      |  }
+      |
+      |  def m2(c: C[String]) = c match {
+      |    case C(x) => x
+      |    case _ => ""
+      |  }
+      |}
+      |""".stripMargin
+
+  override def show(): Unit = Console.withErr(System.out) {
+    compile()
+  }
+}


### PR DESCRIPTION
Follow-up for https://github.com/scala/scala/pull/6485

Fixes https://github.com/scala/bug/issues/12405