### PR TITLE
Fixed definition of opchar

### DIFF
--- a/spec/13-syntax-summary.md
+++ b/spec/13-syntax-summary.md
@@ -21,7 +21,7 @@ digit            ::=  ‘0’ | … | ‘9’
 paren            ::=  ‘(’ | ‘)’ | ‘[’ | ‘]’ | ‘{’ | ‘}’
 delim            ::=  ‘`’ | ‘'’ | ‘"’ | ‘.’ | ‘;’ | ‘,’
 opchar           ::=  // printableChar not matched by (whiteSpace | upper | lower |
-                      // letter | digit | paren | delim | Unicode_Sm | Unicode_So)
+                      // letter | digit | paren | delim)
 printableChar    ::=  // all characters in [\u0020, \u007F] inclusive
 UnicodeEscape    ::=  ‘\’ ‘u’ {‘u’} hexDigit hexDigit hexDigit hexDigit
 hexDigit         ::=  ‘0’ | … | ‘9’ | ‘A’ | … | ‘F’ | ‘a’ | … | ‘f’


### PR DESCRIPTION
The characters to be excluded by Unicode category are specified
as the definition of opchar, but it is not appropriate for the
following reasons.

 - The printableChar definition covers the range \u0020 to \u007F,
   and Unicode_So does not contain any characters in that range
 - Unicode_Sm contains five characters, +<=>| ~, symbols that should
   be the target of opchar, and these should not be excluded from
   opchar.
   In addition, all characters other than those five are after \u0080
   and are not eligible for printableChar.

https://github.com/scala/bug/issues/12260