### PR TITLE
More details to forward reference error messages

### DIFF
--- a/test/files/neg/forward.check
+++ b/test/files/neg/forward.check
@@ -1,10 +1,13 @@
-forward.scala:6: error: forward reference extends over definition of value x
+forward.scala:8: error: forward reference to value x defined on line 9 extends over definition of value x
     def f: Int = x;
                  ^
-forward.scala:10: error: forward reference extends over definition of value x
+forward.scala:12: error: forward reference to method g defined on line 14 extends over definition of value x
     def f: Int = g;
                  ^
-forward.scala:15: error: forward reference extends over definition of variable x
+forward.scala:17: error: forward reference to method g defined on line 19 extends over definition of variable x
     def f: Int = g;
                  ^
-3 errors
+forward.scala:29: error: forward reference to value ec defined on line 32 extends over definition of value z
+      a <- fInt
+        ^
+4 errors

--- a/test/files/neg/forward.scala
+++ b/test/files/neg/forward.scala
@@ -1,3 +1,5 @@
+import scala.concurrent._
+
 object Test {
   def f: Int = x;
   val x: Int = f;
@@ -20,5 +22,14 @@ object Test {
     def f: Int = g;
     Console.println("foo");
     def g: Int = f;
+  }
+  {
+    val fInt = Future.successful(1)
+    val z = for {
+      a <- fInt
+    } yield a
+
+    implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
+    z
   }
 }

--- a/test/files/neg/t2910.check
+++ b/test/files/neg/t2910.check
@@ -1,16 +1,16 @@
-t2910.scala:3: error: forward reference extends over definition of value ret
+t2910.scala:3: error: forward reference to value MyMatch defined on line 4 extends over definition of value ret
     val ret = l.collect({ case MyMatch(id) => id })
                                ^
-t2910.scala:9: error: forward reference extends over definition of value z
+t2910.scala:9: error: forward reference to lazy value s defined on line 11 extends over definition of value z
     println(s.length)
             ^
-t2910.scala:16: error: forward reference extends over definition of value z
+t2910.scala:16: error: forward reference to lazy value x defined on line 18 extends over definition of value z
       x
       ^
-t2910.scala:30: error: forward reference extends over definition of value x
+t2910.scala:30: error: forward reference to value x defined on line 31 extends over definition of value x
     lazy val f: Int = x
                       ^
-t2910.scala:35: error: forward reference extends over definition of variable x
+t2910.scala:35: error: forward reference to lazy value g defined on line 37 extends over definition of variable x
     lazy val f: Int = g
                       ^
 5 errors

--- a/test/files/neg/t4098.check
+++ b/test/files/neg/t4098.check
@@ -1,13 +1,13 @@
-t4098.scala:3: error: forward reference not allowed from self constructor invocation
+t4098.scala:3: error: forward reference to method b defined on line 4 not allowed from self constructor invocation
     this(b)
          ^
-t4098.scala:8: error: forward reference not allowed from self constructor invocation
+t4098.scala:8: error: forward reference to lazy value b defined on line 9 not allowed from self constructor invocation
     this(b)
          ^
-t4098.scala:13: error: forward reference not allowed from self constructor invocation
+t4098.scala:13: error: forward reference to value b defined on line 14 not allowed from self constructor invocation
     this(b)
          ^
-t4098.scala:18: error: forward reference not allowed from self constructor invocation
+t4098.scala:18: error: forward reference to method b defined on line 20 not allowed from self constructor invocation
     this(b)
          ^
 4 errors

--- a/test/files/neg/t4419.check
+++ b/test/files/neg/t4419.check
@@ -1,4 +1,4 @@
-t4419.scala:2: error: forward reference extends over definition of value b
+t4419.scala:2: error: forward reference to value a defined on line 2 extends over definition of value b
   { val b = a; val a = 1 ; println(a) }
             ^
 1 error

--- a/test/files/neg/t5390.check
+++ b/test/files/neg/t5390.check
@@ -1,4 +1,4 @@
-t5390.scala:7: error: forward reference extends over definition of value b
+t5390.scala:7: error: forward reference to value a defined on line 8 extends over definition of value b
     val b = a.B("")
             ^
 1 error

--- a/test/files/neg/t5390b.check
+++ b/test/files/neg/t5390b.check
@@ -1,4 +1,4 @@
-t5390b.scala:7: error: forward reference extends over definition of value b
+t5390b.scala:7: error: forward reference to value a defined on line 8 extends over definition of value b
     val b = a.B("")
             ^
 1 error

--- a/test/files/neg/t5390c.check
+++ b/test/files/neg/t5390c.check
@@ -1,4 +1,4 @@
-t5390c.scala:7: error: forward reference extends over definition of value b
+t5390c.scala:7: error: forward reference to value a defined on line 8 extends over definition of value b
     val b = new a.B("")
                 ^
 1 error

--- a/test/files/neg/t5390d.check
+++ b/test/files/neg/t5390d.check
@@ -1,4 +1,4 @@
-t5390d.scala:7: error: forward reference extends over definition of value b
+t5390d.scala:7: error: forward reference to value a defined on line 8 extends over definition of value b
     val b = a.B.toString
             ^
 1 error


### PR DESCRIPTION
Include the referenced symbol and the line where it's defined.

Closes scala/bug#12382