### PR TITLE
Improve tab completion and code assist in REPL

### DIFF
--- a/src/reflect/scala/reflect/internal/Positions.scala
+++ b/src/reflect/scala/reflect/internal/Positions.scala
@@ -345,7 +345,8 @@ trait Positions extends api.Positions { self: SymbolTable =>
           if (t.pos includes pos) {
             if (isEligible(t)) last = t
             super.traverse(t)
-          } else t match {
+          }
+          t match {
             case mdef: MemberDef =>
               val annTrees = mdef.mods.annotations match {
                 case Nil if mdef.symbol != null =>

--- a/src/repl-frontend/scala/tools/nsc/interpreter/jline/Reader.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/jline/Reader.scala
@@ -169,7 +169,7 @@ object Reader {
         }
         true
       }
-      def show(text: String): Unit = {
+      def show(text: String): Unit = if (text != "") {
         reader.callWidget(LineReader.CLEAR)
         reader.getTerminal.writer.println()
         reader.getTerminal.writer.println(text)

--- a/src/repl-frontend/scala/tools/nsc/interpreter/jline/Reader.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/jline/Reader.scala
@@ -170,6 +170,7 @@ object Reader {
         true
       }
       def show(text: String): Unit = {
+        reader.callWidget(LineReader.CLEAR)
         reader.getTerminal.writer.println()
         reader.getTerminal.writer.println(text)
         reader.callWidget(LineReader.REDRAW_LINE)
@@ -354,6 +355,7 @@ class Completion(delegate: shell.Completion) extends shell.Completion with Compl
       case exacts =>
         val declStrings = exacts.map(_.declString()).filterNot(_ == "")
         if (declStrings.nonEmpty) {
+          lineReader.callWidget(LineReader.CLEAR)
           lineReader.getTerminal.writer.println()
           for (declString <- declStrings)
             lineReader.getTerminal.writer.println(declString)

--- a/src/repl-frontend/scala/tools/nsc/interpreter/jline/Reader.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/jline/Reader.scala
@@ -185,7 +185,7 @@ object Reader {
       // VIINS, VICMD, EMACS
       val keymap = if (config.viMode) VIINS else EMACS
       reader.getKeyMaps.put(MAIN, reader.getKeyMaps.get(keymap));
-      keyMap.bind(new Reference(ScalaShowType.Name), KeyMap.ctrl('T'))
+      keyMap.bind(new Reference(ScalaShowType.Name), KeyMap.alt(KeyMap.ctrl('t')))
     }
     def secure(p: java.nio.file.Path): Unit = {
       try scala.reflect.internal.util.OwnerOnlyChmod.chmodFileOrCreateEmpty(p)

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/Completion.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/Completion.scala
@@ -14,22 +14,23 @@ package scala.tools.nsc.interpreter
 package shell
 
 trait Completion {
-  def complete(buffer: String, cursor: Int): CompletionResult
+  final def complete(buffer: String, cursor: Int): CompletionResult = complete(buffer, cursor, filter = true)
+  def complete(buffer: String, cursor: Int, filter: Boolean): CompletionResult
 }
 object NoCompletion extends Completion {
-  def complete(buffer: String, cursor: Int) = NoCompletions
+  def complete(buffer: String, cursor: Int, filter: Boolean) = NoCompletions
 }
 
-case class CompletionResult(line: String, cursor: Int, candidates: List[CompletionCandidate]) {
+case class CompletionResult(line: String, cursor: Int, candidates: List[CompletionCandidate], typeAtCursor: String = "", typedTree: String = "") {
   final def orElse(other: => CompletionResult): CompletionResult =
     if (candidates.nonEmpty) this else other
 }
 object CompletionResult {
   val empty: CompletionResult = NoCompletions
 }
-object NoCompletions extends CompletionResult("", -1, Nil)
+object NoCompletions extends CompletionResult("", -1, Nil, "", "")
 
 case class MultiCompletion(underlying: Completion*) extends Completion {
-  override def complete(buffer: String, cursor: Int) =
-    underlying.foldLeft(CompletionResult.empty)((r, c) => r.orElse(c.complete(buffer, cursor)))
+  override def complete(buffer: String, cursor: Int, filter: Boolean) =
+    underlying.foldLeft(CompletionResult.empty)((r,c) => r.orElse(c.complete(buffer, cursor, filter)))
 }

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/LoopCommands.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/LoopCommands.scala
@@ -94,7 +94,7 @@ trait LoopCommands {
     echo("")
     echo("Useful default key bindings:")
     echo("  TAB           code completion")
-    echo("  CTRL-T        type at cursor, hit again to see the code with all types/implicits inferred.")
+    echo("  CTRL-ALT-T    show type at cursor, hit again to show code with types/implicits inferred.")
   }
   def ambiguousError(cmd: String): Result = {
     matchingCommands(cmd) match {

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/LoopCommands.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/LoopCommands.scala
@@ -94,7 +94,7 @@ trait LoopCommands {
     echo("")
     echo("Useful default key bindings:")
     echo("  TAB           code completion")
-    echo("  CTRL-SHIFT-T  type at cursor, hit again to see the code with all types/implicits inferred.")
+    echo("  CTRL-T        type at cursor, hit again to see the code with all types/implicits inferred.")
   }
   def ambiguousError(cmd: String): Result = {
     matchingCommands(cmd) match {

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/LoopCommands.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/LoopCommands.scala
@@ -14,7 +14,6 @@ package scala.tools.nsc.interpreter
 package shell
 
 import java.io.{PrintWriter => JPrintWriter}
-
 import scala.language.implicitConversions
 import scala.collection.mutable.ListBuffer
 import scala.tools.nsc.interpreter.ReplStrings.words
@@ -60,6 +59,7 @@ trait LoopCommands {
 
     // subclasses may provide completions
     def completion: Completion = NoCompletion
+    override def toString(): String = name
   }
   object LoopCommand {
     def nullary(name: String, help: String, f: () => Result): LoopCommand =
@@ -91,6 +91,10 @@ trait LoopCommands {
     echo("All commands can be abbreviated, e.g., :he instead of :help.")
 
     for (cmd <- commands) echo(formatStr.format(cmd.usageMsg, cmd.help))
+    echo("")
+    echo("Useful default key bindings:")
+    echo("  TAB           code completion")
+    echo("  CTRL-SHIFT-T  type at cursor, hit again to see the code with all types/implicits inferred.")
   }
   def ambiguousError(cmd: String): Result = {
     matchingCommands(cmd) match {
@@ -135,15 +139,15 @@ trait LoopCommands {
           case cmd :: Nil if !cursorAtName    => cmd.completion
           case cmd :: Nil if cmd.name == name => NoCompletion
           case cmd :: Nil =>
-            val completion = if (cmd.isInstanceOf[NullaryCmd] || cursor < line.length) cmd.name else cmd.name + " "
+            val completion = ":" + cmd.name
             new Completion {
-              def complete(buffer: String, cursor: Int) =
-                CompletionResult(buffer, cursor = 1, List(CompletionCandidate(completion)))
+              def complete(buffer: String, cursor: Int, filter: Boolean) =
+                CompletionResult(buffer, cursor = 1, List(CompletionCandidate(completion)), "", "")
             }
           case cmd :: rest =>
             new Completion {
-              def complete(buffer: String, cursor: Int) =
-                CompletionResult(buffer, cursor = 1, cmds.map(cmd => CompletionCandidate(cmd.name)))
+              def complete(buffer: String, cursor: Int, filter: Boolean) =
+                CompletionResult(buffer, cursor = 1, cmds.map(cmd => CompletionCandidate(":" + cmd.name)), "", "")
             }
         }
       case _ => NoCompletion

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/ReplCompletion.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/ReplCompletion.scala
@@ -19,7 +19,7 @@ import scala.util.control.NonFatal
  */
 class ReplCompletion(intp: Repl, val accumulator: Accumulator = new Accumulator) extends Completion {
 
-  def complete(buffer: String, cursor: Int): CompletionResult = {
+  def complete(buffer: String, cursor: Int, filter: Boolean): CompletionResult = {
     // special case for:
     //
     // scala> 1
@@ -30,13 +30,13 @@ class ReplCompletion(intp: Repl, val accumulator: Accumulator = new Accumulator)
 
     val bufferWithMultiLine = accumulator.toString + bufferWithVar
     val cursor1 = cursor + (bufferWithMultiLine.length - buffer.length)
-    codeCompletion(bufferWithMultiLine, cursor1)
+    codeCompletion(bufferWithMultiLine, cursor1, filter)
   }
 
   // A convenience for testing
   def complete(before: String, after: String = ""): CompletionResult = complete(before + after, before.length)
 
-  private def codeCompletion(buf: String, cursor: Int): CompletionResult = {
+  private def codeCompletion(buf: String, cursor: Int, filter: Boolean): CompletionResult = {
     require(cursor >= 0 && cursor <= buf.length)
 
     // secret handshakes
@@ -49,37 +49,24 @@ class ReplCompletion(intp: Repl, val accumulator: Accumulator = new Accumulator)
         case Right(result) => try {
           buf match {
             case slashPrint() if cursor == buf.length            =>
-              CompletionResult(buf, cursor, CompletionCandidate.fromStrings("" :: Naming.unmangle(result.print) :: Nil))
+              CompletionResult(buf, cursor, CompletionCandidate.fromStrings("" :: Naming.unmangle(result.print) :: Nil), "", "")
             case slashPrintRaw() if cursor == buf.length         =>
-              CompletionResult(buf, cursor, CompletionCandidate.fromStrings("" :: result.print :: Nil))
+              CompletionResult(buf, cursor, CompletionCandidate.fromStrings("" :: result.print :: Nil), "", "")
             case slashTypeAt(start, end) if cursor == buf.length =>
-              CompletionResult(buf, cursor, CompletionCandidate.fromStrings("" :: result.typeAt(start.toInt, end.toInt) :: Nil))
+              CompletionResult(buf, cursor, CompletionCandidate.fromStrings("" :: result.typeAt(start.toInt, end.toInt) :: Nil), "", "")
             case _                                               =>
               // under JLine 3, we no longer use the tabCount concept, so tabCount is always 1
               // which always gives us all completions
-              val (c, r)                         = result.completionCandidates(tabCount = 1)
-              // scala/bug#12238
-              // Currently, only when all methods are Deprecated should they be displayed `Deprecated` to users. Only handle result of PresentationCompilation#toCandidates.
-              // We don't handle result of PresentationCompilation#defStringCandidates, because we need to show the deprecated here.
-              if (r.nonEmpty && r.forall(!_.defString.startsWith("def"))) {
-                val groupByDef              = r.groupBy(_.defString)
-                val allOverrideIsUniversal  = groupByDef.filter(f => f._2.forall(_.isUniversal)).keySet
-                val allOverrideIsDeprecated = groupByDef.filter(f => f._2.forall(_.isDeprecated)).keySet
-                def isOverrideMethod(candidate: CompletionCandidate): Boolean = groupByDef(candidate.defString).size > 1
-                val rewriteDecr = r.map(candidate => {
-                  // If not all overloaded methods are deprecated, but they are overloaded methods, they (all) should be set to false.
-                  val isUniv = if (!allOverrideIsUniversal.contains(candidate.defString) && isOverrideMethod(candidate)) false else candidate.isUniversal
-                  val isDepr = if (!allOverrideIsDeprecated.contains(candidate.defString) && isOverrideMethod(candidate)) false else candidate.isDeprecated
-                  candidate.copy(isUniversal = isUniv, isDeprecated = isDepr)
-                })
-                CompletionResult(buf, c, rewriteDecr)
-              } else CompletionResult(buf, c, r)
+              val (c, r)                         = result.completionCandidates(filter, tabCount = 1)
+              val typeAtCursor = result.typeAt(cursor, cursor)
+              CompletionResult(buf, c, r, typeAtCursor, result.print)
           }
         } finally result.cleanup()
       }
     } catch {
       case NonFatal(e) =>
-        // e.printStackTrace()
+        if (intp.settings.debug)
+          e.printStackTrace()
         NoCompletions
     }
   }

--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -775,7 +775,8 @@ class IMain(val settings: Settings, parentClassLoaderOverride: Option[ClassLoade
   }
 
   /** One line of code submitted by the user for interpretation */
-  class Request(val line: String, origTrees: List[Tree], firstXmlPos: Position = NoPosition, generousImports: Boolean = false, synthetic: Boolean = false) extends ReplRequest {
+  class Request(val line: String, origTrees: List[Tree], firstXmlPos: Position = NoPosition,
+                generousImports: Boolean = false, synthetic: Boolean = false, storeResultInVal: Boolean = true) extends ReplRequest {
     def defines    = defHandlers flatMap (_.definedSymbols)
     def definesTermNames: List[String] = defines collect { case s: TermSymbol => s.decodedName.toString }
     def imports    = importedSymbols
@@ -801,6 +802,7 @@ class IMain(val settings: Settings, parentClassLoaderOverride: Option[ClassLoade
 
     // Wrap last tree in a valdef to give user a nice handle for it (`resN`)
     val trees: List[Tree] = origTrees match {
+      case xs if !storeResultInVal => xs
       case init :+ tree =>
         @tailrec def loop(scrut: Tree): Tree = scrut match {
           case _: Assign                => tree

--- a/src/repl/scala/tools/nsc/interpreter/Interface.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Interface.scala
@@ -323,21 +323,24 @@ trait PresentationCompilationResult {
   def candidates(tabCount: Int): (Int, List[String]) =
     completionCandidates(tabCount) match {
       case (cursor, cands) =>
-        (cursor, cands.map(_.defString))
+        (cursor, cands.map(_.name))
     }
 
-  def completionCandidates(tabCount: Int = -1): (Int, List[CompletionCandidate])
+  final def completionCandidates(tabCount: Int = -1): (Int, List[CompletionCandidate]) = completionCandidates(filter = true, tabCount)
+  def completionCandidates(filter: Boolean, tabCount: Int): (Int, List[CompletionCandidate])
 }
 
 case class CompletionCandidate(
-  defString: String,
+  name: String,
   arity: CompletionCandidate.Arity = CompletionCandidate.Nullary,
   isDeprecated: Boolean = false,
-  isUniversal: Boolean = false)
+  isUniversal: Boolean = false,
+  declString: () => String = () => "")
 object CompletionCandidate {
   sealed trait Arity
   case object Nullary extends Arity
   case object Nilary extends Arity
+  case object Infix extends Arity
   case object Other extends Arity
   // purely for convenience
   def fromStrings(defStrings: List[String]): List[CompletionCandidate] =

--- a/src/repl/scala/tools/nsc/interpreter/PresentationCompilation.scala
+++ b/src/repl/scala/tools/nsc/interpreter/PresentationCompilation.scala
@@ -60,7 +60,7 @@ trait PresentationCompilation { self: IMain =>
       }
       val importer = global.mkImporter(pc)
       //println(s"pc: [[$line1]], <<${trees.size}>>")
-      val request = new Request(line1, trees map (t => importer.importTree(t)), generousImports = true)
+      val request = new Request(line1, trees map (t => importer.importTree(t)), generousImports = true, storeResultInVal = false)
       val origUnit = request.mkUnit
       val unit = new pc.CompilationUnit(origUnit.source)
       unit.body = pc.mkImporter(global).importTree(origUnit.body)

--- a/src/repl/scala/tools/nsc/interpreter/PresentationCompilation.scala
+++ b/src/repl/scala/tools/nsc/interpreter/PresentationCompilation.scala
@@ -12,7 +12,9 @@
 
 package scala.tools.nsc.interpreter
 
-import scala.reflect.internal.util.{Position, RangePosition, StringOps}
+import scala.collection.mutable
+import scala.reflect.internal.util.{Position, RangePosition}
+import scala.tools.nsc.ast.parser.Tokens
 import scala.tools.nsc.backend.JavaPlatform
 import scala.tools.nsc.util.ClassPath
 import scala.tools.nsc.{Settings, interactive}
@@ -22,7 +24,7 @@ import scala.tools.nsc.interpreter.Results.{Error, Result}
 
 trait PresentationCompilation { self: IMain =>
 
-  private final val Cursor = IMain.DummyCursorFragment + " "
+  private final val Cursor = IMain.DummyCursorFragment
 
   /** Typecheck a line of REPL input, suitably wrapped with "interpreter wrapper" objects/classes, with the
     * presentation compiler. The result of this method gives access to the typechecked tree and to autocompletion
@@ -34,8 +36,28 @@ trait PresentationCompilation { self: IMain =>
     if (global == null) Left(Error)
     else {
       val pc = newPresentationCompiler()
-      val line1 = buf.patch(cursor, Cursor, 0)
-      val trees = pc.newUnitParser(line1).parseStats()
+      def cursorIsInKeyword(): Boolean = {
+        val scanner = pc.newUnitParser(buf).newScanner()
+        scanner.init()
+        while (scanner.token != Tokens.EOF) {
+          val token    = scanner.token
+          val o        = scanner.offset
+          scanner.nextToken()
+          if ((o to scanner.lastOffset).contains(cursor)) {
+            return (!Tokens.isIdentifier(token) && pc.syntaxAnalyzer.token2name.contains(token))
+          }
+        }
+        false
+      }
+      // Support completion of "def format = 42; for<TAB>" by replacing the keyword with foo_CURSOR_ before
+      // typechecking. Only do this when needed to be able ot correctly return the type of `foo.bar<CURSOR>`
+      // where `bar` is the complete name of a member.
+      val line1 = if (!cursorIsInKeyword()) buf else buf.patch(cursor, Cursor, 0)
+
+      val trees = pc.newUnitParser(line1).parseStats() match {
+        case Nil => List(pc.EmptyTree)
+        case xs => xs
+      }
       val importer = global.mkImporter(pc)
       //println(s"pc: [[$line1]], <<${trees.size}>>")
       val request = new Request(line1, trees map (t => importer.importTree(t)), generousImports = true)
@@ -89,8 +111,6 @@ trait PresentationCompilation { self: IMain =>
     interactiveGlobal
   }
 
-  private var lastCommonPrefixCompletion: Option[String] = None
-
   abstract class PresentationCompileResult(val compiler: interactive.Global, val inputRange: Position, val cursor: Int, val buf: String) extends PresentationCompilationResult {
     val unit: compiler.RichCompilationUnit // depmet broken for constructors, can't be ctor arg
 
@@ -120,15 +140,23 @@ trait PresentationCompilation { self: IMain =>
       }
     }
 
-    def typeString(tree: compiler.Tree): String =
-      compiler.exitingTyper(tree.tpe.toString)
+    def typeString(tree: compiler.Tree): String = {
+      tree.tpe match {
+        case null | compiler.NoType | compiler.ErrorType => ""
+        case tp => compiler.exitingTyper(tp.toString)
+      }
+    }
 
     def treeString(tree: compiler.Tree): String =
       compiler.showCode(tree)
 
     override def print = {
       val tree = treeAt(inputRange)
-      treeString(tree) + " // : " + tree.tpe.safeToString
+      val tpString = typeString(tree) match {
+        case "" => ""
+        case s => " // : "  + s
+      }
+      treeString(tree) + tpString
     }
 
 
@@ -138,7 +166,7 @@ trait PresentationCompilation { self: IMain =>
     val NoCandidates = (-1, Nil)
     type Candidates = (Int, List[CompletionCandidate])
 
-    override def completionCandidates(tabCount: Int): Candidates = {
+    override def completionCandidates(filter: Boolean, tabCount: Int): Candidates = {
       import compiler._
       import CompletionResult.NoResults
 
@@ -161,76 +189,56 @@ trait PresentationCompilation { self: IMain =>
         if (m.sym.paramss.isEmpty) CompletionCandidate.Nullary
         else if (m.sym.paramss.size == 1 && m.sym.paramss.head.isEmpty) CompletionCandidate.Nilary
         else CompletionCandidate.Other
-      def defStringCandidates(matching: List[Member], name: Name, isNew: Boolean): Candidates = {
+      def defStringCandidates(matching: List[Member], name: Name, isNew: Boolean) = {
+        val seen = new mutable.HashSet[Symbol]()
         val ccs = for {
           member <- matching
-          if member.symNameDropLocal == name
+          if seen.add(member.sym)
           sym <- if (member.sym.isClass && isNew) member.sym.info.decl(nme.CONSTRUCTOR).alternatives else member.sym.alternatives
           sugared = sym.sugaredSymbolOrSelf
         } yield {
-          val tp         = member.prefix memberType sym
-          val desc       = Seq(if (isMemberDeprecated(member)) "(deprecated)" else "", if (isMemberUniversal(member)) "(universal)" else "")
-          val methodOtherDesc = if (!desc.exists(_ != "")) "" else " " + desc.filter(_ != "").mkString(" ")
           CompletionCandidate(
-            defString = sugared.defStringSeenAs(tp) + methodOtherDesc,
+            name = member.symNameDropLocal.decoded,
             arity = memberArity(member),
             isDeprecated = isMemberDeprecated(member),
-            isUniversal = isMemberUniversal(member))
+            isUniversal = isMemberUniversal(member),
+            declString = () => {
+              if (sym.isPackageObjectOrClass) ""
+              else {
+                val tp              = member.prefix memberType sym
+                val desc            = Seq(if (isMemberDeprecated(member)) "(deprecated)" else "", if (isMemberUniversal(member)) "(universal)" else "")
+                val methodOtherDesc = if (!desc.exists(_ != "")) "" else " " + desc.filter(_ != "").mkString(" ")
+                sugared.defStringSeenAs(tp) + methodOtherDesc
+              }
+            })
         }
-        (cursor, CompletionCandidate("") :: ccs.distinct)
+        ccs
       }
-      def toCandidates(members: List[Member]): List[CompletionCandidate] =
-        members
-          .map(m => CompletionCandidate(m.symNameDropLocal.decoded, memberArity(m), isMemberDeprecated(m), isMemberUniversal(m)))
-          .sortBy(_.defString)
       val found = this.completionsAt(cursor) match {
         case NoResults => NoCandidates
         case r =>
           def shouldHide(m: Member): Boolean =
-            tabCount == 0 && (isMemberDeprecated(m) || isMemberUniversal(m))
-          val matching = r.matchingResults().filterNot(shouldHide)
-          val tabAfterCommonPrefixCompletion = lastCommonPrefixCompletion.contains(buf.substring(inputRange.start, cursor)) && matching.exists(_.symNameDropLocal == r.name)
-          val doubleTab = tabCount > 0 && matching.forall(_.symNameDropLocal == r.name)
-          if (tabAfterCommonPrefixCompletion || doubleTab) {
-            val pos1 = positionOf(cursor)
-            import compiler._
-            val locator = new Locator(pos1)
-            val tree = locator locateIn unit.body
-            var isNew = false
-            new TreeStackTraverser {
-              override def traverse(t: Tree): Unit = {
-                if (t eq tree) {
-                  isNew = path.dropWhile { case _: Select | _: Annotated => true; case _ => false}.headOption match {
-                    case Some(_: New) => true
-                    case _ => false
-                  }
-                } else super.traverse(t)
-              }
-            }.traverse(unit.body)
-            defStringCandidates(matching, r.name, isNew)
-          } else if (matching.isEmpty) {
-            // Lenient matching based on camel case and on eliding JavaBean "get" / "is" boilerplate
-            val camelMatches: List[Member] = r.matchingResults(CompletionResult.camelMatch(_)).filterNot(shouldHide)
-            val memberCompletions: List[CompletionCandidate] = toCandidates(camelMatches)
-            def allowCompletion = (
-              (memberCompletions.size == 1)
-                || CompletionResult.camelMatch(r.name)(r.name.newName(StringOps.longestCommonPrefix(memberCompletions.map(_.defString))))
-              )
-            if (memberCompletions.isEmpty) NoCandidates
-            else if (allowCompletion) (cursor - r.positionDelta, memberCompletions)
-            else (cursor, CompletionCandidate("") :: memberCompletions)
-          } else if (matching.nonEmpty && matching.forall(_.symNameDropLocal == r.name))
-            NoCandidates // don't offer completion if the only option has been fully typed already
-          else {
-            // regular completion
-            (cursor - r.positionDelta, toCandidates(matching))
-          }
+            filter && tabCount == 0 && (isMemberDeprecated(m) || isMemberUniversal(m))
+          val matching = r.matchingResults(nameMatcher = if (filter) {entered => candidate => candidate.startsWith(entered)} else _ => _ => true).filterNot(shouldHide)
+          val pos1 = positionOf(cursor)
+          import compiler._
+          val locator = new Locator(pos1)
+          val tree = locator locateIn unit.body
+          var isNew = false
+          new TreeStackTraverser {
+            override def traverse(t: Tree): Unit = {
+              if (t eq tree) {
+                isNew = path.dropWhile { case _: Select | _: Annotated => true; case _ => false}.headOption match {
+                  case Some(_: New) => true
+                  case _ => false
+                }
+              } else super.traverse(t)
+            }
+          }.traverse(unit.body)
+          val candidates = defStringCandidates(matching, r.name, isNew)
+          val pos = cursor - r.positionDelta
+          (pos, candidates.sortBy(_.name))
       }
-      lastCommonPrefixCompletion =
-        if (found != NoCandidates && buf.length >= found._1)
-          Some(buf.substring(inputRange.start, found._1) + StringOps.longestCommonPrefix(found._2.map(_.defString)))
-        else
-          None
       found
     }
 

--- a/test/files/run/repl-completions.check
+++ b/test/files/run/repl-completions.check
@@ -9,6 +9,7 @@ scala> :completions O.x
 [completions] O.x_y_z
 
 scala> :completions O.x_y_x
+[completions] O.x_y_x
 
 scala> :completions O.x_y_a
 
@@ -27,6 +28,6 @@ scala> :completions object O2 { val x = O.
 [completions] object O2 { val x = O.x_y_z
 
 scala> :completions :completion
-[completions] :completions 
+[completions] ::completions
 
 scala> :quit

--- a/versions.properties
+++ b/versions.properties
@@ -9,5 +9,5 @@ starr.version=2.13.6
 scala-asm.version=9.1.0-scala-1
 
 # jna.version must be updated together with jline-terminal-jna
-jline.version=3.19.0
+jline.version=3.20.0
 jna.version=5.3.1

--- a/versions.properties
+++ b/versions.properties
@@ -10,4 +10,4 @@ scala-asm.version=9.1.0-scala-1
 
 # jna.version must be updated together with jline-terminal-jna
 jline.version=3.20.0
-jna.version=5.3.1
+jna.version=5.8.0


### PR DESCRIPTION
Re-enable acronym-style completion, e.g. `getClass.gdm` offers `getDeclaredMethod[s]`.

Under JLine completion, move all filtering up in the UI layer. Reimplement #9510 (dealing with overloads that contain some deprecated alternatives) in the UI layer

Fix completion of keyword-starting-idents (e.g. `this.for<TAB>` offers `formatted`.

Register a widget on CTRL-ALT-T that prints the type of the expression at the cursor. A second invocation prints the desugared AST.

Enable Levenshtein based typo matching, but disable it for short strings which IMO tends to offer confusing results.

```
scala> scala.tools.nsc.util.EditDistance.levenshtien<TAB>

scala> scala.tools.nsc.util.EditDistance.levenshtein
```

Includes upgrade to JLine 3.20 (was 3.19)