### PR TITLE
Fix intermittent auth failure to artifactory from Jenkins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,12 +54,13 @@ val fatalWarnings = settingKey[Boolean]("whether or not warnings should be fatal
 // enable fatal warnings automatically on CI
 Global / fatalWarnings := insideCI.value
 
+Global / credentials ++= {
+  val file = Path.userHome / ".credentials"
+  if (file.exists && !file.isDirectory) List(Credentials(file))
+  else Nil
+}
+
 lazy val publishSettings : Seq[Setting[_]] = Seq(
-  credentials ++= {
-    val file = Path.userHome / ".credentials"
-    if (file.exists && !file.isDirectory) List(Credentials(file))
-    else Nil
-  },
   // Add a "default" Ivy configuration because sbt expects the Scala distribution to have one:
   ivyConfigurations += Configuration.of("Default", "default", "Default", true, Vector(Configurations.Runtime), true),
   publishMavenStyle := true

--- a/project/ScriptCommands.scala
+++ b/project/ScriptCommands.scala
@@ -107,7 +107,13 @@ object ScriptCommands {
       Global / baseVersionSuffix := "SPLIT",
       Global / resolvers += "scala-pr" at url,
       Global / publishTo := Some("sonatype-releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2"),
-      Global / credentials += Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", env("SONA_USER"), env("SONA_PASS"))
+      Global / credentials ++= {
+        val user = env("SONA_USER")
+        val pass = env("SONA_PASS")
+        if (user != "" && pass != "")
+         List(Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", user, pass))
+        else Nil
+      }
       // pgpSigningKey and pgpPassphrase are set externally by travis / the bootstrap script, as the sbt-pgp plugin is not enabled by default
     ) ++ enableOptimizer
   }
@@ -168,7 +174,12 @@ object ScriptCommands {
 
     Seq(
       Global / publishTo := Some("scala-pr-publish" at url2),
-      Global / credentials += Credentials("Artifactory Realm", "scala-ci.typesafe.com", "scala-ci", env("PRIVATE_REPO_PASS"))
+      Global / credentials ++= {
+        val pass = env("PRIVATE_REPO_PASS")
+        if (pass != "")
+          List(Credentials("Artifactory Realm", "scala-ci.typesafe.com", "scala-ci", pass))
+        else Nil
+      }
     )
   }
 


### PR DESCRIPTION
In 41e376a, the build was updated to support publishing from
Travis CI.

However, on Jenkins, the old means of supplying the publish
credentials to pr-validation snapshots was retained, it has
a ~/.credentials file. So we provided two credentials for the
same host/realm to SBT, and on Jenkins the DirectCredentials
contains an empty password.

Which one of these would SBT pick?

```
sbt 'setupPublishCore https://scala-ci.typesafe.com/artifactory/scala-pr-validation-snapshots/' 'show credentials'
[info] compiler / credentials
[info] 	List(DirectCredentials("Artifactory Realm", "scala-ci.typesafe.com", "scala-ci", ****), FileCredentials("/Users/jz/.credentials"))
[info] scalap / credentials
[info] 	List(DirectCredentials("Artifactory Realm", "scala-ci.typesafe.com", "scala-ci", ****), FileCredentials("/Users/jz/.credentials"))
...    <10 more like this>
[info] credentials
[info] 	List(DirectCredentials("Artifactory Realm", "scala-ci.typesafe.com", "scala-ci", ****))
```

The `ivySbt` task in SBT registers the credentials in order in a global map
in Ivy (`CredentialStore`). So on Jenkins, the invalid `DirectCredentials`
would be overwritten in the map by he `FileCredentials`.

But the fact that this is global state in Ivy appears to be a source of cross
talk between the configured credentials for different modules in the build.
Even though the publish task is serialized through the ivy lock, this lock
does not enclose the previous execution of the `ivySbt` which sets up the
credentials in `CredentialStore`.

In our build, notice that the root project does _not_ have the
`FileCredentials` set. So if the `ivySBT` task for this project runs last,
the global map will have the incorrect `DirectCredentials`.

The fix in our build is easy, avoid configuring the `DirectCredentials` if the
environment variables are absent. We can also standardize on using
`Global/credentials := `.

The principled fix in SBT would be to thread the credentials down to the HTTP
client without using global state. It could also emit a warning if conflicting
credentials are configured for a given host/realm.