### PR TITLE
[backport] Fix intermittent auth failure to artifactory from Jenkins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,6 +56,12 @@ val diffUtilsDep      = "com.googlecode.java-diff-utils" % "diffutils"       % "
   * real publishing should be done with sbt's standard `publish` task. */
 lazy val publishDists = taskKey[Unit]("Publish to ./dists/maven-sbt.")
 
+credentials in Global ++= {
+  val file = Path.userHome / ".credentials"
+  if (file.exists && !file.isDirectory) List(Credentials(file))
+  else Nil
+}
+
 lazy val publishSettings : Seq[Setting[_]] = Seq(
   publishDists := {
     val artifacts = (packagedArtifacts in publish).value

--- a/project/ScriptCommands.scala
+++ b/project/ScriptCommands.scala
@@ -106,7 +106,13 @@ object ScriptCommands {
       baseVersionSuffix in Global := "SPLIT",
       resolvers in Global += "scala-pr" at url,
       publishTo in Global := Some("sonatype-releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2"),
-      credentials in Global += Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", env("SONA_USER"), env("SONA_PASS"))
+      credentials in Global ++= {
+        val user = env("SONA_USER")
+        val pass = env("SONA_PASS")
+        if (user != "" && pass != "")
+          List(Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", user, pass))
+        else Nil
+      }
       // pgpSigningKey and pgpPassphrase are set externally by travis / the bootstrap script, as the sbt-pgp plugin is not enabled by default
     ) ++ enableOptimizer
   }
@@ -159,7 +165,12 @@ object ScriptCommands {
 
     Seq(
       publishTo in Global := Some("scala-pr-publish" at url2),
-      credentials in Global += Credentials("Artifactory Realm", "scala-ci.typesafe.com", "scala-ci", env("PRIVATE_REPO_PASS"))
+      credentials in Global ++= {
+        val pass = env("PRIVATE_REPO_PASS")
+        if (pass != "")
+          List(Credentials("Artifactory Realm", "scala-ci.typesafe.com", "scala-ci", env("PRIVATE_REPO_PASS")))
+        else Nil
+      }
     )
   }
 


### PR DESCRIPTION
In 41e376a, the build was updated to support publishing from
Travis CI.

However, on Jenkins, the old means of supplying the publish
credentials to pr-validation snapshots was retained, it has
a ~/.credentials file. So we provided two credentials for the
same host/realm to SBT, and on Jenkins the DirectCredentials
contains an empty password.

Which one of these would SBT pick?

```
sbt 'setupPublishCore https://scala-ci.typesafe.com/artifactory/scala-pr-validation-snapshots/' 'show credentials'
[info] compiler / credentials
[info] 	List(DirectCredentials("Artifactory Realm", "scala-ci.typesafe.com", "scala-ci", ****), FileCredentials("/Users/jz/.credentials"))
[info] scalap / credentials
...    <10 more like this>
[info] credentials
[info] 	List(DirectCredentials("Artifactory Realm", "scala-ci.typesafe.com", "scala-ci", ****))
```

The `ivySbt` task in SBT registers the credentials in order in a global map
in Ivy (`CredentialStore`). So on Jenkins, the invalid `DirectCredentials`
would be overwritten in the map by he `FileCredentials`.

But the fact that this is global state in Ivy appears to be a source of cross
talk between the configured credentials for different modules in the build.
Even though the publish task is serialized through the ivy lock, this lock
does not enclose the previous execution of the `ivySbt` which sets up the
credentials in `CredentialStore`.

In our build, notice that the root project does _not_ have the
`FileCredentials` set. So if the `ivySBT` task for this project runs last,
the global map will have the incorrect `DirectCredentials`.

The fix in our build is easy, avoid configuring the `DirectCredentials` if the
environment variables are absent. We can also standardize on using
`Global/credentials := `.

The principled fix in SBT would be to thread the credentials down to the HTTP
client without using global state. It could also emit a warning if conflicting
credentials are configured for a given host/realm.

(cherry picked from commit a8ec10d02c81f3eeb8f6787ba2c041bfec5d6221)