### PR TITLE
Fixed Syntax Summary

### DIFF
--- a/spec/13-syntax-summary.md
+++ b/spec/13-syntax-summary.md
@@ -14,15 +14,18 @@ The lexical syntax of Scala is given by the following grammar in EBNF form:
 
 ```ebnf
 whiteSpace       ::=  ‘\u0020’ | ‘\u0009’ | ‘\u000D’ | ‘\u000A’
-upper            ::=  ‘A’ | … | ‘Z’ | ‘$’ // and any character in Unicode category Lu, Lt or Nl, and any character in Lo and Ml that don't have contributory property Other_Lowercase
-lower            ::=  ‘a’ | … | ‘z’ | ‘_’ // and any character in Unicode category Ll, and and any character in Lo or Ml that has contributory property Other_Lowercase
+upper            ::=  ‘A’ | … | ‘Z’ | ‘$’ and any character in Unicode category Lu, Lt or Nl,
+                      and any character in Lo and Ml that don't have contributory property Other_Lowercase
+lower            ::=  ‘a’ | … | ‘z’ | ‘_’ and any character in Unicode category Ll,
+                      and any character in Lo or Ml that has contributory property Other_Lowercase
 letter           ::=  upper | lower
 digit            ::=  ‘0’ | … | ‘9’
 paren            ::=  ‘(’ | ‘)’ | ‘[’ | ‘]’ | ‘{’ | ‘}’
 delim            ::=  ‘`’ | ‘'’ | ‘"’ | ‘.’ | ‘;’ | ‘,’
-opchar           ::=  // printableChar not matched by (whiteSpace | upper | lower |
-                      // letter | digit | paren | delim | Unicode_Sm | Unicode_So)
-printableChar    ::=  // all characters in [\u0020, \u007F] inclusive
+opchar           ::=  ‘!’ | ‘#’ | ‘%’ | ‘&’ | ‘*’ | ‘+’ | ‘-’ | ‘/’ | ‘:’ |
+                      ‘<’ | ‘=’ | ‘>’ | ‘?’ | ‘@’ | ‘\’ | ‘^’ | ‘|’ | ‘~’ |
+                      and any character in Unicode categories Sm, So
+printableChar    ::=  all characters in [\u0020, \u007E] inclusive
 UnicodeEscape    ::=  ‘\’ ‘u’ {‘u’} hexDigit hexDigit hexDigit hexDigit
 hexDigit         ::=  ‘0’ | … | ‘9’ | ‘A’ | … | ‘F’ | ‘a’ | … | ‘f’
 charEscapeSeq    ::=  ‘\’ (‘b’ | ‘t’ | ‘n’ | ‘f’ | ‘r’ | ‘"’ | ‘'’ | ‘\’)


### PR DESCRIPTION
Reflect the following modifications to match
the behavior of the actual code.

 - Unicode_Sm and Unicode_So included in opchar
 - Enumerates the characters available in opchar
 - Removed \u007F from printableChar

 Also removed unnecessary comment outs.

https://github.com/scala/bug/issues/12260