### PR TITLE
Delay package object decls entering to the package object phase

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
@@ -52,7 +52,7 @@ trait Analyzer extends AnyRef
   object packageObjects extends {
     val global: Analyzer.this.global.type = Analyzer.this.global
   } with SubComponent {
-    val deferredOpen = perRunCaches.newMap[Symbol, Symbol]()
+    val deferredOpen = perRunCaches.newSet[Symbol]()
     val phaseName = "packageobjects"
     val runsAfter = List[String]()
     val runsRightAfter= Some("namer")
@@ -77,10 +77,7 @@ trait Analyzer extends AnyRef
 
       def apply(unit: CompilationUnit): Unit = {
         openPackageObjectsTraverser(unit.body)
-        deferredOpen.foreach {
-          case (dest, container) =>
-            openPackageModule(container, dest)
-        }
+        deferredOpen.foreach(openPackageModule(_))
       }
     }
   }

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -467,17 +467,6 @@ trait Namers extends MethodSynthesis {
 
       val existingModule = context.scope lookupModule tree.name
       if (existingModule.isModule && !existingModule.hasPackageFlag && inCurrentScope(existingModule) && (currentRun.canRedefine(existingModule) || existingModule.isSynthetic)) {
-        // This code accounts for the way the package objects found in the classpath are opened up
-        // early by the completer of the package itself. If the `packageobjects` phase then finds
-        // the same package object in sources, we have to clean the slate and remove package object
-        // members from the package class.
-        //
-        // TODO scala/bug#4695 Pursue the approach in https://github.com/scala/scala/pull/2789 that avoids
-        //      opening up the package object on the classpath at all if one exists in source.
-        if (existingModule.isPackageObject) {
-          val packageScope = existingModule.enclosingPackageClass.rawInfo.decls
-          packageScope.foreach(mem => if (mem.owner != existingModule.enclosingPackageClass) packageScope unlink mem)
-        }
         updatePosFlags(existingModule, tree.pos, moduleFlags)
         setPrivateWithin(tree, existingModule)
         existingModule.moduleClass andAlso (setPrivateWithin(tree, _))

--- a/src/compiler/scala/tools/reflect/ReflectGlobal.scala
+++ b/src/compiler/scala/tools/reflect/ReflectGlobal.scala
@@ -66,5 +66,7 @@ class ReflectGlobal(currentSettings: Settings, reporter: Reporter, override val 
   override implicit val MirrorTag: ClassTag[Mirror] = ClassTag[Mirror](classOf[Mirror])
   override type RuntimeClass = java.lang.Class[_]
   override implicit val RuntimeClassTag: ClassTag[RuntimeClass] = ClassTag[RuntimeClass](classOf[RuntimeClass])
+
+  override def openPackageModule(pkgClass: Symbol, force: Boolean): Unit = super.openPackageModule(pkgClass, true)
 }
 

--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -1355,6 +1355,13 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
     }
   }
 
+  override def isPastPackageObjects = {
+    (if (currentTyperRun == null) NoCompilationUnit else currentTyperRun.currentUnit) match {
+      case unit: RichCompilationUnit => unit.isParsed
+      case _                         => super.isPastPackageObjects
+    }
+  }
+
   def newTyperRun(): Unit = {
     currentTyperRun = new TyperRun
   }

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -339,6 +339,9 @@ abstract class SymbolTable extends macros.Universe
     }
   }
 
+  def deferredOpenPackageModule(container: Symbol, dest: Symbol): Unit = {
+    openPackageModule(container, dest)
+  }
   def openPackageModule(container: Symbol, dest: Symbol): Unit = {
     // unlink existing symbols in the package
     for (member <- container.info.decls.iterator) {
@@ -396,7 +399,7 @@ abstract class SymbolTable extends macros.Universe
       case _ => false
     }
     if (pkgModule.isModule && !fromSource) {
-      openPackageModule(pkgModule, pkgClass)
+      deferredOpenPackageModule(pkgModule, pkgClass)
     }
   }
 

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -339,9 +339,6 @@ abstract class SymbolTable extends macros.Universe
     }
   }
 
-  def deferredOpenPackageModule(container: Symbol, dest: Symbol): Unit = {
-    openPackageModule(container, dest)
-  }
   def openPackageModule(container: Symbol, dest: Symbol): Unit = {
     // unlink existing symbols in the package
     for (member <- container.info.decls.iterator) {
@@ -391,7 +388,7 @@ abstract class SymbolTable extends macros.Universe
   }
 
   /** if there's a `package` member object in `pkgClass`, enter its members into it. */
-  def openPackageModule(pkgClass: Symbol): Unit = {
+  def openPackageModule(pkgClass: Symbol, force: Boolean = false): Unit = {
 
     val pkgModule = pkgClass.packageObject
     def fromSource = pkgModule.rawInfo match {
@@ -399,7 +396,7 @@ abstract class SymbolTable extends macros.Universe
       case _ => false
     }
     if (pkgModule.isModule && !fromSource) {
-      deferredOpenPackageModule(pkgModule, pkgClass)
+      openPackageModule(pkgModule, pkgClass)
     }
   }
 

--- a/test/files/run/package-object-stale-decl.scala
+++ b/test/files/run/package-object-stale-decl.scala
@@ -1,0 +1,40 @@
+import scala.reflect.io.Path
+import scala.tools.partest._
+import java.io.File
+
+object Test extends StoreReporterDirectTest {
+  class V1 {
+    def pkg = "package object b extends B"
+    def B   = "package b; class B { def stale = 42 }"
+    def A   = "package b; class A { stale }"
+  }
+  class V2 extends V1 {
+    override def B   = "package b; class B { }"
+  }
+
+  override def extraSettings = s"-cp ${sys.props("partest.lib")}${File.pathSeparator}$testOutput"
+
+  def show(): Unit = {
+    val v1 = new V1
+    val v2 = new V2
+    compiles(v1.A, v1.B, v1.pkg)()
+    delete(testOutput / "b" / "A.class")
+    compiles(v2.B, v2.A)(Some("not found: value stale"))
+  }
+
+  def compiles(codes: String*)(expectedError: Option[String] = None) = {
+    val global = newCompiler()
+    withRun(global)(_ compileSources newSources(codes: _*))
+    val reporterOutput = storeReporter.infos.map(x => x.pos.showError(x.msg)).mkString("\n")
+    expectedError match {
+      case None =>
+        assert(!global.reporter.hasErrors, reporterOutput)
+      case Some(text) =>
+        assert(global.reporter.hasErrors, "expected compile failure, got success")
+        assert(reporterOutput.contains(text), reporterOutput)
+    }
+  }
+
+  def delete(paths: Path*) = paths.foreach(p => assert(p.delete(), s"$p didn't delete"))
+  def code = ""
+}

--- a/test/files/run/package-object-toolbox.scala
+++ b/test/files/run/package-object-toolbox.scala
@@ -1,0 +1,40 @@
+import java.io.File
+import java.net.URLClassLoader
+
+import scala.reflect.io.Path
+import scala.reflect.runtime.{ universe => ru }
+import scala.tools.partest._
+import scala.tools.reflect.ToolBox
+
+import org.junit.Assert._
+
+object Test extends StoreReporterDirectTest {
+  val cp = List(sys.props("partest.lib"), testOutput.path)
+  override def extraSettings = s"-cp ${cp.mkString(File.pathSeparator)}"
+
+  def show(): Unit = {
+    compiles("package object pkg { def foo = 1 }")
+    val loader = new URLClassLoader(cp.map(new File(_).toURI.toURL).toArray)
+    val mirror = ru.runtimeMirror(loader)
+
+    val toolbox = mirror.mkToolBox()
+    val result1 = toolbox.eval(toolbox.parse("pkg.foo"))
+    assertEquals(1, result1)
+
+    val obj  = toolbox.eval(toolbox.parse("pkg.`package`"))
+    val pkg  = mirror.staticPackage("pkg")
+    val sym  = pkg.info.decl(ru.TermName("foo")).asMethod
+    val meth = mirror.reflect(obj).reflectMethod(sym)
+    val res2 = meth.apply()
+    assertEquals(1, res2)
+  }
+
+  def compiles(codes: String*) = {
+    val global = newCompiler()
+    withRun(global)(_ compileSources newSources(codes: _*))
+    assert(!global.reporter.hasErrors, storeReporter.infos.mkString("\n"))
+  }
+
+  def delete(paths: Path*) = paths.foreach(p => assert(p.delete(), s"$p didn't delete"))
+  def code = ""
+}

--- a/test/files/run/package-object-with-inner-class-in-ancestor-simpler-still.scala
+++ b/test/files/run/package-object-with-inner-class-in-ancestor-simpler-still.scala
@@ -1,0 +1,25 @@
+import scala.reflect.io.Path
+import scala.tools.partest._
+import java.io.File
+
+object Test extends StoreReporterDirectTest {
+  def A   = "package b; class A"
+  def pkg = "package object b extends A"
+
+  override def extraSettings = s"-cp ${sys.props("partest.lib")}${File.pathSeparator}$testOutput"
+
+  def show(): Unit = {
+    compiles(A, pkg)
+    delete(testOutput / "b" / "A.class")
+    compiles(A)
+  }
+
+  def compiles(codes: String*) = {
+    val global = newCompiler()
+    withRun(global)(_ compileSources newSources(codes: _*))
+    assert(!global.reporter.hasErrors, storeReporter.infos.mkString("\n"))
+  }
+
+  def delete(paths: Path*) = paths.foreach(p => assert(p.delete(), s"$p didn't delete"))
+  def code = ""
+}

--- a/test/files/run/package-object-with-inner-class-in-ancestor-simpler.scala
+++ b/test/files/run/package-object-with-inner-class-in-ancestor-simpler.scala
@@ -1,0 +1,26 @@
+import scala.reflect.io.Path
+import scala.tools.partest._
+import java.io.File
+
+object Test extends StoreReporterDirectTest {
+  def A   = "package b; class A"
+  def pkg = "package object b extends A"
+  def M   = "package b; class M"
+
+  override def extraSettings = s"-cp ${sys.props("partest.lib")}${File.pathSeparator}$testOutput"
+
+  def show(): Unit = {
+    compiles(A, pkg, M)
+    delete(testOutput / "b" / "A.class")
+    compiles(M, A)
+  }
+
+  def compiles(codes: String*) = {
+    val global = newCompiler()
+    withRun(global)(_ compileSources newSources(codes: _*))
+    assert(!global.reporter.hasErrors, storeReporter.infos.mkString("\n"))
+  }
+
+  def delete(paths: Path*) = paths.foreach(p => assert(p.delete(), s"$p didn't delete"))
+  def code = ""
+}

--- a/test/files/run/package-object-with-inner-class-in-ancestor.scala
+++ b/test/files/run/package-object-with-inner-class-in-ancestor.scala
@@ -1,0 +1,33 @@
+import scala.reflect.io.Path
+import scala.tools.partest._
+import java.io.File
+
+object Test extends StoreReporterDirectTest {
+  class V1 {
+    def O   = "package b; object O { def o = \"\" }"
+    def A   = "package b; class A { class C { O.o } }"
+    def pkg = "package object b extends A"
+  }
+  class V2 extends V1 {
+    override def O = "package b; object O { def o = 42 }"
+  }
+
+  override def extraSettings = s"-cp ${sys.props("partest.lib")}${File.pathSeparator}$testOutput"
+
+  def show(): Unit = {
+    val v1 = new V1
+    compiles(v1.O, v1.A, v1.pkg)
+    delete(testOutput / "b" / "A.class", testOutput / "b" / "A$C.class")
+    val v2 = new V2
+    compiles(v2.O, v2.A)
+  }
+
+  def compiles(codes: String*) = {
+    val global = newCompiler()
+    withRun(global)(_ compileSources newSources(codes: _*))
+    assert(!global.reporter.hasErrors, storeReporter.infos.mkString("\n"))
+  }
+
+  def delete(paths: Path*) = paths.foreach(p => assert(p.delete(), s"$p didn't delete"))
+  def code = ""
+}

--- a/test/junit/scala/tools/nsc/DeterminismTest.scala
+++ b/test/junit/scala/tools/nsc/DeterminismTest.scala
@@ -330,6 +330,14 @@ class DeterminismTest {
     test(List(code))
   }
 
+  @Test def testPackageObjectUserLand(): Unit = {
+    def code = List[SourceFile](
+      source("package.scala", "package userland; object `package` { type Throwy = java.lang.Throwable }"),
+      source("th.scala", "package userland; class th[T <: Throwy](cause: T = null)")
+      )
+    test(code :: Nil)
+  }
+
   def source(name: String, code: String): SourceFile = new BatchSourceFile(name, code)
 }
 


### PR DESCRIPTION
Existing code in the compiler avoids loading package.class when a source file contains a new definition for the package object. The source definition would be used instead in the `packageObjects` phase. 

This PR takes it a step further and defers forcing the info of _all_ package.class until the `packageObjects` phase. This avoids spurious `symbol not found` errors when in a particular incremental compilation scenarion, when: a) super-class of the package object (defined within the same package) is provided as a source file and B) the package object is _not_ supplied as a source file.

This change is intended to obviate the workaround in Zinc that supplies `package.scala` to the compiler more often than should be strictly necessary.

As a bonus, this addresses an issue with compiler determinism:

Fixes scala/bug#12092

Relates to #3389

Fixes scala/bug#5954 (properly this time, workaround removed and tests still pass)
Fixes scala/bug#4695


