### PR TITLE
Never inline varargs after named arg rewrite

### DIFF
--- a/test/files/pos/t11964.scala
+++ b/test/files/pos/t11964.scala
@@ -1,0 +1,19 @@
+// scalac: -Werror -Xlint
+
+object Hmm {
+  def zxc(b: Int*)(implicit x: Int = 3) = "" + b + x
+  def res = zxc(4)
+}
+
+object Test {
+  def foo(a: Any, b: Any = null, c: Any = null)(cs: String*) = ???
+  def res = foo("", c = "")("X")
+}
+
+object OP {
+  def f(a: Int, b: String*) = "first"
+  def res = f(b = "sl19", a = 28)  // looks like the issue is only with single arg supplied to varargs.
+  def or  = f(b = ("x"::"y"::Nil):_*, a = 42)  // 2.13 syntax only
+  //def and = f(b = ("x"::"y"::Nil):_*)   // broken under 2.13, which disallows default + varargs
+  def and = List(elems = ("x"::"y"::Nil):_*)
+}

--- a/test/files/run/names-defaults.check
+++ b/test/files/run/names-defaults.check
@@ -13,9 +13,6 @@ names-defaults.scala:371: warning: the parameter name x is deprecated: use s ins
 names-defaults.scala:35: warning: local var var2 in value <local Test> is never used
     var var2 = 0
         ^
-names-defaults.scala:108: warning: local val x$34 in value <local Test> is never used
-  println(t7.f(b = "sl19", a = 28)) // first
-                   ^
 names-defaults.scala:279: warning: local val u in method foo is never used
   class A2489 { def foo(): Unit = { def bar(a: Int = 1) = a; bar(); val u = 0 } }
                                                                         ^
@@ -25,12 +22,6 @@ names-defaults.scala:280: warning: local val v in method foo is never used
 names-defaults.scala:280: warning: local val u in method foo is never used
   class A2489x2 { def foo(): Unit = { val v = 10; def bar(a: Int = 1, b: Int = 2) = a; bar(); val u = 0 } }
                                                                                                   ^
-names-defaults.scala:380: warning: local val x$104 in value <local Test> is never used
-  println(t3697.a(3)())
-                  ^
-names-defaults.scala:385: warning: local val x$112 in value <local Test> is never used
-  println(t3697.b(b = 1, a = 2, c = 3))
-                                    ^
 names-defaults.scala:269: warning: multiline expressions might require enclosing parentheses; a value can be silently discarded when Unit is expected
     spawn(b = { val ttt = 1; ttt }, a = 0)
                              ^


### PR DESCRIPTION
If a temp val has been created to hold varargs,
always use it. A single constant arg would induce
inlining and creation of a fresh varargs, ignoring
the unused temp val.

Fixes scala/bug#11964