### PR TITLE
Avoid possible NPE after cancelled compilation

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GenBCode.scala
@@ -105,8 +105,8 @@ abstract class GenBCode extends SubComponent {
     }
 
     private def close(): Unit = {
-      postProcessor.classfileWriter.close()
-      generatedClassHandler.close()
+      Option(postProcessor.classfileWriter).foreach(_.close())
+      Option(generatedClassHandler).foreach(_.close())
     }
   }
 }


### PR DESCRIPTION
I noticed this when cancelling the compile:
```
[warn] Canceling execution...
[error] ## Exception when compiling 707 sources to /Users/jz/code/scala/build/quick/classes/library
[error] java.lang.NullPointerException
[error] scala.tools.nsc.backend.jvm.GenBCode$BCodePhase.close(GenBCode.scala:108)
[error] scala.tools.nsc.backend.jvm.GenBCode$BCodePhase.$anonfun$run$1(GenBCode.scala:84)
[error] scala.tools.nsc.backend.jvm.GenBCode$BCodePhase.run(GenBCode.scala:78)
[error] scala.tools.nsc.Global$Run.compileUnitsInternal(Global.scala:1514)
[error] scala.tools.nsc.Global$Run.compileUnits(Global.scala:1498)
[error] scala.tools.nsc.Global$Run.compileSources(Global.scala:1491)
[error] scala.tools.nsc.Global$Run.compile(Global.scala:1620)
[error] xsbt.CachedCompiler0.run(CompilerInterface.scala:153)
[error] xsbt.CachedCompiler0.run(CompilerInterface.scala:125)
[error] xsbt.CompilerInterface.run(CompilerInterface.scala:39)
[error] sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
```
