### PR TITLE
Speed up BSP import of project into IDE by skipping JMH source gen

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -673,6 +673,7 @@ lazy val bench = project.in(file("test") / "benchmarks")
       else "org.scala-lang" % "scala-compiler" % benchmarkScalaVersion :: Nil
     },
     scalacOptions ++= Seq("-feature", "-opt:l:inline", "-opt-inline-from:scala/**", "-opt-warnings"),
+    Jmh / bspEnabled := false // Skips JMH source generators during IDE import to avoid needing to compile scala-library during the import
   ).settings(inConfig(JmhPlugin.JmhKeys.Jmh)(scalabuild.JitWatchFilePlugin.jitwatchSettings))
 
 


### PR DESCRIPTION
JMH has source generators that wrap the user-written benchmarks in
synthetic code that wraps it will timing loops.

By default, BSP import runs all source generators. This is useful
for things like protobuf bindings, where the user wants to code
against the generated APIs.

But the JMH generated code isn't useful to see in the IDE and
by skipping it we can import the project without needing to
trigger compilation of scala-library / bench.

Part of scala/scala-dev#778