### PR TITLE
 Avoid IllegalArgumentException in JDK17+ for lambda deser.

### DIFF
--- a/src/library/scala/runtime/LambdaDeserializer.scala
+++ b/src/library/scala/runtime/LambdaDeserializer.scala
@@ -101,8 +101,7 @@ object LambdaDeserializer {
         /* instantiatedMethodType = */ instantiated,
         /* flags                  = */ flags.asInstanceOf[AnyRef],
         /* markerInterfaceCount   = */ 1.asInstanceOf[AnyRef],
-        /* markerInterfaces[0]    = */ markerInterface,
-        /* bridgeCount            = */ 0.asInstanceOf[AnyRef]
+        /* markerInterfaces[0]    = */ markerInterface
       )
     }
 


### PR DESCRIPTION
Fixes scala/bug#12419