### PR TITLE
2.13.x: Windows CI (GHA): add JDK 17 (alongside 8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ jobs:
     runs-on: windows-latest
     strategy:
       fail-fast: false
+      matrix:
+        include:
+          - java: 8
+          - java: 17-ea
     steps:
       - run: git config --global core.autocrlf false
       - name: Checkout
@@ -26,7 +30,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: adopt
-          java-version: 8
+          java-version: ${{matrix.java}}
 
       - name: Cache
         uses: actions/cache@v2

--- a/test/junit/scala/collection/immutable/StringLikeTest.scala
+++ b/test/junit/scala/collection/immutable/StringLikeTest.scala
@@ -64,10 +64,14 @@ class StringLikeTest {
     assertEquals("no trim toDouble", 2.0d, sOk.toDouble, 0.1d)
     assertEquals("no trim toFloat", 2.0f, sOk.toFloat, 0.1f)
 
-    assertThrows[java.lang.NumberFormatException](sNull.toInt, {s => s == "null"})
-    assertThrows[java.lang.NumberFormatException](sNull.toLong, {s => s == "null"})
-    assertThrows[java.lang.NumberFormatException](sNull.toShort, {s => s == "null"})
-    assertThrows[java.lang.NumberFormatException](sNull.toByte, {s => s == "null"})
+    // JDK 17 gives the nicer message
+    def isNullStringMessage(s: String) =
+      s == "null" || s == "Cannot parse null string"
+
+    assertThrows[java.lang.NumberFormatException](sNull.toInt, isNullStringMessage)
+    assertThrows[java.lang.NumberFormatException](sNull.toLong, isNullStringMessage)
+    assertThrows[java.lang.NumberFormatException](sNull.toShort, isNullStringMessage)
+    assertThrows[java.lang.NumberFormatException](sNull.toByte, isNullStringMessage)
 
     assertThrows[java.lang.NullPointerException](sNull.toDouble)
     assertThrows[java.lang.NullPointerException](sNull.toFloat)


### PR DESCRIPTION
Initially let's try 11, and if that goes well, let's see if we can make the leap to 17.