### PR TITLE
Accept supplementary Unicode characters in identifiers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -719,6 +719,7 @@ lazy val junit = project.in(file("test") / "junit")
       "-feature",
       "-Xlint:-valpattern,_",
       "-Wconf:msg=match may not be exhaustive:s", // if we missed a case, all that happens is the test fails
+      "-Wconf:cat=lint-nullary-unit&site=.*Test:s", // normal unit test style
       "-Ypatmat-exhaust-depth", "40", // despite not caring about patmat exhaustiveness, we still get warnings for this
     ),
     Compile / javacOptions ++= Seq("-Xlint"),

--- a/spec/01-lexical-syntax.md
+++ b/spec/01-lexical-syntax.md
@@ -6,13 +6,11 @@ chapter: 1
 
 # Lexical Syntax
 
-Scala programs are written using the Unicode Basic Multilingual Plane
-(_BMP_) character set; Unicode supplementary characters are not
-presently supported.  This chapter defines the two modes of Scala's
-lexical syntax, the Scala mode, and the _XML mode_. If not
-otherwise mentioned, the following descriptions of Scala tokens refer
-to _Scala mode_, and literal characters ‘c’ refer to the ASCII fragment
-`\u0000` – `\u007F`.
+Scala source code consists of Unicode text.
+
+The program text is tokenized as described in this chapter.
+See the last section for special support for XML literals,
+which are parsed in _XML mode_.
 
 To construct tokens, characters are distinguished according to the following
 classes (Unicode general category given in parentheses):
@@ -74,7 +72,7 @@ or `_`, and _constant identifiers_, which do not.
 For this purpose, lower case letters include not only a-z,
 but also all characters in Unicode category Ll (lowercase letter),
 as well as all letters that have contributory property
-Other_Lowercase, except characters in category Nl (letter numerals)
+Other_Lowercase, except characters in category Nl (letter numerals),
 which are never taken as lower case.
 
 The following are examples of variable identifiers:

--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -659,7 +659,7 @@ character. Characters are listed below in increasing order of
 precedence, with characters on the same line having the same precedence.
 
 ```scala
-(all letters)
+(all letters, as defined in [chapter 1](01-lexical-syntax.html), including `_` and `$`)
 |
 ^
 &
@@ -668,7 +668,7 @@ precedence, with characters on the same line having the same precedence.
 :
 + -
 * / %
-(all other special characters)
+(other operator characters, as defined in [chapter 1](01-lexical-syntax.html), including Unicode categories `Sm` and `So`)
 ```
 
 That is, operators starting with a letter have lowest precedence,

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -264,7 +264,7 @@ self =>
       if (syntaxErrors.isEmpty) firstTry
       else in.healBraces() match {
         case Nil      => showSyntaxErrors() ; firstTry
-        case patches  => (this withPatches patches).parse()
+        case patches  => withPatches(patches).parse()
       }
     }
   }

--- a/src/compiler/scala/tools/nsc/symtab/classfile/AbstractFileReader.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/AbstractFileReader.scala
@@ -27,9 +27,7 @@ import scala.tools.nsc.io.AbstractFile
  */
 final class AbstractFileReader(val buf: Array[Byte]) extends DataReader {
   @deprecated("Use other constructor", "2.13.0")
-  def this(file: AbstractFile) = {
-    this(file.toByteArray)
-  }
+  def this(file: AbstractFile) = this(file.toByteArray)
 
   /** the current input pointer
    */
@@ -67,9 +65,8 @@ final class AbstractFileReader(val buf: Array[Byte]) extends DataReader {
   def getByte(mybp: Int): Byte =
     buf(mybp)
 
-  def getBytes(mybp: Int, bytes: Array[Byte]): Unit = {
+  def getBytes(mybp: Int, bytes: Array[Byte]): Unit =
     System.arraycopy(buf, mybp, bytes, 0, bytes.length)
-  }
 
   /** extract a character at position bp from buf
    */
@@ -95,9 +92,8 @@ final class AbstractFileReader(val buf: Array[Byte]) extends DataReader {
    */
   def getDouble(mybp: Int): Double = longBitsToDouble(getLong(mybp))
 
-  def getUTF(mybp: Int, len: Int): String = {
+  def getUTF(mybp: Int, len: Int): String =
     new DataInputStream(new ByteArrayInputStream(buf, mybp, len)).readUTF
-  }
 
   /** skip next 'n' bytes
    */

--- a/src/partest/scala/tools/partest/DirectTest.scala
+++ b/src/partest/scala/tools/partest/DirectTest.scala
@@ -45,6 +45,7 @@ abstract class DirectTest {
   protected def pathOf(locations: String*) = locations.mkString(sys.props("path.separator"))
 
   // override to add additional settings besides -d testOutput.path
+  // default is -usejavacp
   def extraSettings: String = "-usejavacp"
   // a default Settings object using only extraSettings
   def settings: Settings = newSettings(CommandLineParser.tokenize(extraSettings))

--- a/src/partest/scala/tools/partest/package.scala
+++ b/src/partest/scala/tools/partest/package.scala
@@ -19,7 +19,6 @@ import scala.concurrent.duration.Duration
 import scala.io.Codec
 import scala.jdk.CollectionConverters._
 import scala.tools.nsc.util.Exceptional
-import scala.util.chaining._
 
 package object partest {
   type File         = java.io.File
@@ -180,17 +179,4 @@ package object partest {
   def isDebug                = sys.props.contains("partest.debug") || sys.env.contains("PARTEST_DEBUG")
   def debugSettings          = sys.props.getOrElse("partest.debug.settings", "")
   def log(msg: => Any): Unit = if (isDebug) Console.err.println(msg)
-
-  private val printable = raw"\p{Print}".r
-
-  def hexdump(s: String): Iterator[String] = {
-    var offset = 0
-    def hex(bytes: Array[Byte])   = bytes.map(b => f"$b%02x").mkString(" ")
-    def charFor(byte: Byte): Char = byte.toChar match { case c @ printable() => c ; case _ => '.' }
-    def ascii(bytes: Array[Byte]) = bytes.map(charFor).mkString
-    def format(bytes: Array[Byte]): String =
-      f"$offset%08x  ${hex(bytes.slice(0, 8))}%-24s ${hex(bytes.slice(8, 16))}%-24s |${ascii(bytes)}|"
-        .tap(_ => offset += bytes.length)
-    s.getBytes(codec.charSet).grouped(16).map(format)
-  }
 }

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -424,8 +424,17 @@ trait StdNames {
 
     /** Is name a variable name? */
     def isVariableName(name: Name): Boolean = {
+      import Character.{isHighSurrogate, isLowSurrogate, isLetter, isLowerCase, isValidCodePoint, toCodePoint}
       val first = name.startChar
-      (    ((first.isLower && first.isLetter) || first == '_')
+      def isLowerLetterSupplementary: Boolean =
+        first == '$' && {
+          val decoded = name.decoded
+          isHighSurrogate(decoded.charAt(0)) && decoded.length > 1 && isLowSurrogate(decoded.charAt(1)) && {
+            val codepoint = toCodePoint(decoded.charAt(0), decoded.charAt(1))
+            isValidCodePoint(codepoint) && isLetter(codepoint) && isLowerCase(codepoint)
+          }
+        }
+      (    ((first.isLower && first.isLetter) || first == '_' || isLowerLetterSupplementary)
         && (name != nme.false_)
         && (name != nme.true_)
         && (name != nme.null_)

--- a/test/files/neg/surrogates.check
+++ b/test/files/neg/surrogates.check
@@ -1,0 +1,4 @@
+surrogates.scala:3: error: illegal codepoint in Char constant: '\ud801\udc00'
+  def `too wide for Char` = '𐐀'
+                            ^
+1 error

--- a/test/files/neg/surrogates.scala
+++ b/test/files/neg/surrogates.scala
@@ -1,0 +1,4 @@
+
+class C {
+  def `too wide for Char` = '𐐀'
+}

--- a/test/files/pos/surrogates.scala
+++ b/test/files/pos/surrogates.scala
@@ -1,0 +1,28 @@
+
+// allow supplementary chars in identifiers
+
+class 𐐀 {
+  def 𐐀 = 42
+
+  // regression check: anything goes in strings
+  def x = "𐐀"
+  def y = s"$𐐀"
+  def w = s" 𐐀"
+}
+
+case class 𐐀𐐀(n: Int) {
+  def 𐐀𐐀 = n
+  def `𐐀𐐀1` = n + n
+}
+
+// uncontroversially, orphan surrogates may be introduced
+// via unicode escape.
+class Construction {
+  def hi = '\ud801'
+  def lo = '\udc00'
+  def endhi = "abc\ud801"
+  def startlo = "\udc00xyz"
+  def reversed = "xyz\udc00\ud801abc"
+}
+
+// was: error: illegal character '\ud801', '\udc00'

--- a/test/files/run/t12276.scala
+++ b/test/files/run/t12276.scala
@@ -1,6 +1,7 @@
 import scala.tools.nsc.Settings
 import scala.tools.nsc.interpreter.shell.{ILoop, ShellConfig}
-import scala.tools.partest.{hexdump, ReplTest}
+import scala.tools.partest.ReplTest
+import scala.tools.testkit.AssertUtil.hexdump
 
 object Test extends ReplTest {
   def code = s"""

--- a/test/files/run/t1406.scala
+++ b/test/files/run/t1406.scala
@@ -1,0 +1,32 @@
+
+import scala.tools.partest.DirectTest
+
+object Test extends DirectTest {
+  // for reference, UTF-8 of U0
+  //val data = Array(0xed, 0xa0, 0x81).map(_.asInstanceOf[Byte])
+  def U0 = "\ud801"
+  def U1 = "\udc00"
+  // \u10428 isLetter and isLowerCase
+  def U2 = "\ud801"
+  def U3 = "\udc28"
+  def code =
+    s"""class C {
+       |  def x = "$U0"
+       |  def y = "$U1"
+       |  def `$U0` = x
+       |  def `$U1` = y
+       |
+       |  def f(x: Any): Boolean = x match {
+       |    case ${U2}${U3}XYZ: String => true
+       |    case $U2$U3                => true
+       |  }
+       |  def g(x: Any) = x match {
+       |    case $U2$U3 @ _ => $U2$U3
+       |  }
+       |}""".stripMargin
+
+  def show(): Unit = {
+    assert(U0.length == 1)
+    assert(compile())
+  }
+}

--- a/test/files/run/t1406b.check
+++ b/test/files/run/t1406b.check
@@ -1,0 +1,6 @@
+newSource1.scala:4: error: illegal character '\ud801' missing low surrogate
+  def ? = x
+      ^
+newSource1.scala:5: error: illegal character '\udc00'
+  def ? = y
+      ^

--- a/test/files/run/t1406b.scala
+++ b/test/files/run/t1406b.scala
@@ -1,0 +1,22 @@
+
+import scala.tools.partest.DirectTest
+
+object Test extends DirectTest {
+  // for reference, UTF-8 of U0
+  //val data = Array(0xed, 0xa0, 0x81).map(_.asInstanceOf[Byte])
+  def U0 = "\ud801"
+  def U1 = "\udc00"
+  def code =
+    s"""class C {
+       |  def x = "$U0"
+       |  def y = "$U1"
+       |  def $U0 = x
+       |  def $U1 = y
+       |}""".stripMargin
+
+  def show(): Unit = {
+    assert(U0.length == 1)
+    assert(!compile())
+  }
+}
+

--- a/test/files/run/t9915/Test_2.scala
+++ b/test/files/run/t9915/Test_2.scala
@@ -1,12 +1,14 @@
 
+import scala.tools.testkit.AssertUtil.assertEqualStrings
+
 object Test extends App {
   val c = new C_1
-  assert(c.nulled == "X\u0000ABC")    // "X\000ABC"
-  assert(c.supped == "𐒈𐒝𐒑𐒛𐒐𐒘𐒕𐒖")
-
-  assert(C_1.NULLED == "X\u0000ABC")  // "X\000ABC"
-  assert(C_1.SUPPED == "𐒈𐒝𐒑𐒛𐒐𐒘𐒕𐒖")
-
-  assert(C_1.NULLED.size == "XYABC".size)
+  assert(C_1.NULLED.length == "XYABC".length)
   assert(C_1.SUPPED.codePointCount(0, C_1.SUPPED.length) == 8)
+
+  assertEqualStrings(c.nulled)("X\u0000ABC")    // "X\000ABC" in java source
+  assertEqualStrings(c.supped)("𐒈𐒝𐒑𐒛𐒐𐒘𐒕𐒖")
+
+  assertEqualStrings(C_1.NULLED)("X\u0000ABC")  // "X\000ABC" in java source
+  assertEqualStrings(C_1.SUPPED)("𐒈𐒝𐒑𐒛𐒐𐒘𐒕𐒖")
 }

--- a/test/junit/scala/tools/testkit/AssertUtilTest.scala
+++ b/test/junit/scala/tools/testkit/AssertUtilTest.scala
@@ -110,4 +110,10 @@ class AssertUtilTest {
     assertEquals(1, sut.errors.size)
     assertEquals(0, sut.errors.head._2.getSuppressed.length)
   }
+
+  /** TODO
+  @Test def `hexdump is supplementary-aware`: Unit = {
+    assertEquals("00000000  f0 90 90 80                                       |𐐀.|", hexdump("\ud801\udc00").next())
+  }
+  */
 }


### PR DESCRIPTION
Previously the lexer only accepted identifiers drawn from the basic multilingual plane. 

Fixes scala/bug#1406