### PR TITLE
Normalize partests for classpath and stderr

### DIFF
--- a/src/partest/scala/tools/partest/DirectTest.scala
+++ b/src/partest/scala/tools/partest/DirectTest.scala
@@ -42,8 +42,10 @@ abstract class DirectTest {
   def testPath   = SFile(sys.props("partest.test-path"))
   def testOutput = Directory(sys.props("partest.output"))
 
+  protected def pathOf(locations: String*) = locations.mkString(sys.props("path.separator"))
+
   // override to add additional settings besides -d testOutput.path
-  def extraSettings: String = ""
+  def extraSettings: String = "-usejavacp"
   // a default Settings object using only extraSettings
   def settings: Settings = newSettings(CommandLineParser.tokenize(extraSettings))
   // settings factory using given args and also debug settings

--- a/test/files/run/analyzerPlugins.scala
+++ b/test/files/run/analyzerPlugins.scala
@@ -3,8 +3,6 @@ import scala.tools.nsc._
 
 object Test extends DirectTest {
 
-  override def extraSettings: String = "-usejavacp"
-
   def code = """
     class testAnn extends annotation.TypeConstraint
 

--- a/test/files/run/annotatedRetyping.scala
+++ b/test/files/run/annotatedRetyping.scala
@@ -2,8 +2,6 @@ import scala.tools.partest._
 
 object Test extends DirectTest {
 
-  override def extraSettings: String = "-usejavacp"
-
   def code = """
     class testAnn extends annotation.Annotation
 

--- a/test/files/run/delambdafy_t6028.scala
+++ b/test/files/run/delambdafy_t6028.scala
@@ -12,8 +12,5 @@ object Test extends DirectTest {
                         |}
                         |""".stripMargin.trim
 
-  override def show(): Unit =
-    Console.withErr(System.out) {
-      compile()
-    }
+  override def show(): Unit = compile()
 }

--- a/test/files/run/delambdafy_t6555.scala
+++ b/test/files/run/delambdafy_t6555.scala
@@ -6,8 +6,5 @@ object Test extends DirectTest {
 
   override def code = "class Foo { val f = (param: String) => param } "
 
-  override def show(): Unit =
-    Console.withErr(System.out) {
-      compile()
-    }
+  override def show(): Unit = compile()
 }

--- a/test/files/run/delambdafy_uncurry_byname_inline.scala
+++ b/test/files/run/delambdafy_uncurry_byname_inline.scala
@@ -11,8 +11,5 @@ object Test extends DirectTest {
                         |}
                         |""".stripMargin.trim
 
-  override def show(): Unit =
-    Console.withErr(System.out) {
-      compile()
-    }
+  override def show(): Unit = compile()
 }

--- a/test/files/run/delambdafy_uncurry_byname_method.scala
+++ b/test/files/run/delambdafy_uncurry_byname_method.scala
@@ -11,8 +11,5 @@ object Test extends DirectTest {
                         |}
                         |""".stripMargin.trim
 
-  override def show(): Unit =
-    Console.withErr(System.out) {
-      compile()
-    }
+  override def show(): Unit = compile()
 }

--- a/test/files/run/delambdafy_uncurry_inline.scala
+++ b/test/files/run/delambdafy_uncurry_inline.scala
@@ -11,9 +11,5 @@ object Test extends DirectTest {
                         |}
                         |""".stripMargin.trim
 
-  override def show(): Unit = {
-    Console.withErr(System.out) {
-      compile()
-    }
-  }
+  override def show(): Unit = compile()
 }

--- a/test/files/run/delambdafy_uncurry_method.scala
+++ b/test/files/run/delambdafy_uncurry_method.scala
@@ -11,9 +11,5 @@ object Test extends DirectTest {
                         |}
                         |""".stripMargin.trim
 
-  override def show(): Unit = {
-    Console.withErr(System.out) {
-      compile()
-    }
-  }
+  override def show(): Unit = compile()
 }

--- a/test/files/run/dynamic-applyDynamic.scala
+++ b/test/files/run/dynamic-applyDynamic.scala
@@ -13,11 +13,7 @@ object Test extends DirectTest {
     }
   """.trim
 
-  override def show(): Unit = {
-    Console.withErr(System.out) {
-      compile()
-    }
-  }
+  override def show(): Unit = compile()
 }
 
 import language.dynamics

--- a/test/files/run/dynamic-applyDynamicNamed.scala
+++ b/test/files/run/dynamic-applyDynamicNamed.scala
@@ -13,11 +13,7 @@ object Test extends DirectTest {
     }
   """.trim
 
-  override def show(): Unit = {
-    Console.withErr(System.out) {
-      compile()
-    }
-  }
+  override def show(): Unit = compile()
 }
 
 import language.dynamics

--- a/test/files/run/dynamic-selectDynamic.scala
+++ b/test/files/run/dynamic-selectDynamic.scala
@@ -12,11 +12,7 @@ object Test extends DirectTest {
     }
   """.trim
 
-  override def show(): Unit = {
-    Console.withErr(System.out) {
-      compile()
-    }
-  }
+  override def show(): Unit = compile()
 }
 
 import language.dynamics

--- a/test/files/run/dynamic-updateDynamic.scala
+++ b/test/files/run/dynamic-updateDynamic.scala
@@ -13,11 +13,7 @@ object Test extends DirectTest {
     }
   """.trim
 
-  override def show(): Unit = {
-    Console.withErr(System.out) {
-      compile()
-    }
-  }
+  override def show(): Unit = compile()
 }
 
 import language.dynamics

--- a/test/files/run/existential-rangepos.scala
+++ b/test/files/run/existential-rangepos.scala
@@ -9,5 +9,5 @@ abstract class A[T] {
   val bar: Set[_ <: T]
 }""".trim
 
-  override def show(): Unit = Console.withErr(System.out)(compile())
+  override def show(): Unit = compile()
 }

--- a/test/files/run/icode-reader-dead-code.scala
+++ b/test/files/run/icode-reader-dead-code.scala
@@ -30,13 +30,13 @@ object Test extends DirectTest {
         |}
       """.stripMargin
 
-    compileString(newCompiler("-usejavacp", "-cp", testOutput.path))(aCode)
+    compileString(newCompiler("-cp", testOutput.path))(aCode)
 
     addDeadCode()
 
     // If inlining fails, the compiler will issue an inliner warning that is not present in the
     // check file
-    compileString(newCompiler("-usejavacp", "-cp", testOutput.path, "-opt:l:inline", "-opt-inline-from:**"))(bCode)
+    compileString(newCompiler("-cp", testOutput.path, "-opt:l:inline", "-opt-inline-from:**"))(bCode)
   }
 
   def readClass(file: String) = {

--- a/test/files/run/large_class.scala
+++ b/test/files/run/large_class.scala
@@ -2,7 +2,6 @@ import scala.tools.partest._
 
 // a cold run of partest takes about 15s for this test on my laptop
 object Test extends DirectTest {
-  override def extraSettings: String = "-usejavacp"
 
   def s(n: Int) = "\""+n+"\""
 
@@ -18,9 +17,5 @@ object Test extends DirectTest {
                                                     s(n+60000)+")") mkString ";"}
       |}""".stripMargin.trim
 
-  override def show(): Unit = {
-    Console.withErr(System.out) {
-      compile()
-    }
-  }
+  override def show(): Unit = compile()
 }

--- a/test/files/run/large_code.scala
+++ b/test/files/run/large_code.scala
@@ -2,7 +2,6 @@ import scala.tools.partest._
 
 // a cold run of partest takes about 15s for this test on my laptop
 object Test extends DirectTest {
-  override def extraSettings: String = "-usejavacp"
 
   // test that we hit the code size limit and error out gracefully
   // 5958 is the magic number (2^16/11 -- each `a(1,2,3,4,5,6)` is 11 bytes of bytecode)
@@ -15,9 +14,5 @@ object Test extends DirectTest {
       |  }
       |}""".stripMargin.trim
 
-  override def show(): Unit = {
-    Console.withErr(System.out) {
-      compile()
-    }
-  }
+  override def show(): Unit = compile()
 }

--- a/test/files/run/literals-parsing.scala
+++ b/test/files/run/literals-parsing.scala
@@ -19,7 +19,5 @@ object Test extends DirectTest {
     }
   """.trim
 
-  override def show(): Unit = Console.withErr(System.out) {
-    compile()
-  }
+  override def show(): Unit = compile()
 }

--- a/test/files/run/macroPlugins-namerHooks.scala
+++ b/test/files/run/macroPlugins-namerHooks.scala
@@ -2,7 +2,6 @@ import scala.tools.partest._
 import scala.tools.nsc._
 
 object Test extends DirectTest {
-  override def extraSettings: String = "-usejavacp"
 
   def code = """
     case class C(x: Int, y: Int)

--- a/test/files/run/maxerrs.scala
+++ b/test/files/run/maxerrs.scala
@@ -14,8 +14,6 @@ object Test extends DirectTest {
     }
   """.trim
 
-  override def extraSettings = "-usejavacp"
-
   // a reporter that ignores all limits
   lazy val store = new UnfilteredStoreReporter
 

--- a/test/files/run/patmat-no-inline-isEmpty.scala
+++ b/test/files/run/patmat-no-inline-isEmpty.scala
@@ -24,8 +24,8 @@ object Test extends DirectTest {
       |}
     """.stripMargin
 
-  def show(): Unit = Console.withErr(System.out) {
-    compileString(newCompiler("-usejavacp"))(depCode)
-    compileString(newCompiler("-usejavacp", "-cp", testOutput.path, "-Vprint:patmat"))(code)
+  def show(): Unit = {
+    compileString(newCompiler())(depCode)
+    compileString(newCompiler("-cp", testOutput.path, "-Vprint:patmat"))(code)
   }
 }

--- a/test/files/run/patmat-no-inline-unapply.scala
+++ b/test/files/run/patmat-no-inline-unapply.scala
@@ -16,8 +16,8 @@ object Test extends DirectTest {
       |}
     """.stripMargin
 
-  def show(): Unit = Console.withErr(System.out) {
-    compileString(newCompiler("-usejavacp"))(depCode)
-    compileString(newCompiler("-usejavacp", "-cp", testOutput.path, "-Vprint:patmat"))(code)
+  def show(): Unit = {
+    compileString(newCompiler())(depCode)
+    compileString(newCompiler("-cp", testOutput.path, "-Vprint:patmat"))(code)
   }
 }

--- a/test/files/run/patmat-origtp-switch.scala
+++ b/test/files/run/patmat-origtp-switch.scala
@@ -12,9 +12,5 @@ object Test extends DirectTest {
   }
   """
 
-  override def show(): Unit = {
-    Console.withErr(System.out) {
-      compile()
-    }
-  }
+  override def show(): Unit = compile()
 }

--- a/test/files/run/patmat-seq.scala
+++ b/test/files/run/patmat-seq.scala
@@ -51,9 +51,5 @@ object Test extends DirectTest {
       |}
     """.stripMargin
 
-  override def show(): Unit = {
-    Console.withErr(System.out) {
-      compile()
-    }
-  }
+  override def show(): Unit = compile()
 }

--- a/test/files/run/sbt-icode-interface.scala
+++ b/test/files/run/sbt-icode-interface.scala
@@ -9,7 +9,7 @@ object Test extends DirectTest {
   """.trim
 
   def show(): Unit = {
-    val global = newCompiler("-usejavacp")
+    val global = newCompiler()
     import global._
     val r = new Run
     r.compileSources(newSourceFile(code) :: Nil)

--- a/test/files/run/sd187.scala
+++ b/test/files/run/sd187.scala
@@ -32,10 +32,5 @@ object Test extends DirectTest {
     |}
     |""".stripMargin
 
-
-  override def show(): Unit = {
-    Console.withErr(System.out) {
-      compile()
-    }
-  }
+  override def show(): Unit = compile()
 }

--- a/test/files/run/sd275.scala
+++ b/test/files/run/sd275.scala
@@ -24,7 +24,7 @@ package p1 {
   """
 
   override def extraSettings = {
-    val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
+    val classpath = pathOf(sys.props("partest.lib"), testOutput.path)
     s"-cp $classpath"
   }
 

--- a/test/files/run/string-switch-pos.scala
+++ b/test/files/run/string-switch-pos.scala
@@ -15,5 +15,5 @@ object Test extends DirectTest {
       |}
     """.stripMargin.trim
 
-  override def show(): Unit = Console.withErr(Console.out) { super.compile() }
+  override def show(): Unit = compile()
 }

--- a/test/files/run/t10203.scala
+++ b/test/files/run/t10203.scala
@@ -14,11 +14,7 @@ object Test extends DirectTest {
     }
   """.trim
 
-  override def show(): Unit = {
-    Console.withErr(System.out) {
-      compile()
-    }
-  }
+  override def show(): Unit = compile()
 }
 
 import language.dynamics

--- a/test/files/run/t10344.scala
+++ b/test/files/run/t10344.scala
@@ -13,9 +13,5 @@ object t10344 {
 }
   """
 
-  override def show(): Unit = {
-    Console.withErr(System.out) {
-      compile()
-    }
-  }
+  override def show(): Unit = compile()
 }

--- a/test/files/run/t10751.scala
+++ b/test/files/run/t10751.scala
@@ -23,11 +23,7 @@ object Test extends DirectTest {
     }
   """.trim
 
-  override def show(): Unit = {
-    Console.withErr(System.out) {
-      compile()
-    }
-  }
+  override def show(): Unit = compile()
 }
 
 class C {

--- a/test/files/run/t11385.scala
+++ b/test/files/run/t11385.scala
@@ -12,7 +12,7 @@ object Test extends DirectTest {
   def show() = assert {
     val tmp = createTempDirectory("t11385")
     val pkg = createDirectories(tmp.resolve("acme").resolve("C").resolve("sub"))
-    compile("-usejavacp", "-classpath", tmp.toString)
+    compile("-classpath", tmp.toString)
   }
 }
 

--- a/test/files/run/t11731.scala
+++ b/test/files/run/t11731.scala
@@ -35,7 +35,7 @@ object Test extends DirectTest {
   private def fakeSbt = new sbt.FakeSbt
 
   override def show() = {
-    val global = newCompiler("-usejavacp", "-feature")
+    val global = newCompiler("-feature")
 
     def checkMsg(): Unit =
       assert(global.reporter.asInstanceOf[StoreReporter].infos.head.msg.contains("postfix operator"))

--- a/test/files/run/t12405.scala
+++ b/test/files/run/t12405.scala
@@ -24,7 +24,5 @@ object Test extends DirectTest {
       |}
       |""".stripMargin
 
-  override def show(): Unit = Console.withErr(System.out) {
-    compile()
-  }
+  override def show(): Unit = compile()
 }

--- a/test/files/run/t4841-no-plugin.scala
+++ b/test/files/run/t4841-no-plugin.scala
@@ -7,8 +7,6 @@ import java.io.File
 object Test extends DirectTest {
   override def code = "class Code"
 
-  override def extraSettings = s"-usejavacp"
-
   override def show() = {
     val tmp = new File(testOutput.jfile, "plugins.partest").getAbsolutePath
     compile("-Xdev", s"-Xplugin:$tmp", "-Xpluginsdir", tmp)

--- a/test/files/run/t5463.scala
+++ b/test/files/run/t5463.scala
@@ -12,7 +12,7 @@ object Test extends DirectTest {
 
     val classpath = List(sys.props("partest.lib"), jarpath, testOutput.path) mkString sys.props("path.separator")
     try {
-      compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(code)
+      compileString(newCompiler("-cp", classpath))(code)
       throw new Error("Compilation should have failed");
     } catch {
       case ex: FatalError => // this is expected

--- a/test/files/run/t5545.scala
+++ b/test/files/run/t5545.scala
@@ -3,9 +3,9 @@ import java.io._
 
 object Test extends DirectTest {
 
-  override def extraSettings: String = "-usejavacp -d " + testOutput.path + " -cp " + testOutput.path
+  override def extraSettings: String = s"-usejavacp -cp ${testOutput.path}"
 
-  override def code = """
+  override def code = s"""
     // scala/bug#5545
     trait F[@specialized(Int) T1, R] {
       def f(v1: T1): R
@@ -14,12 +14,8 @@ object Test extends DirectTest {
   """.trim
 
   override def show(): Unit = {
-    // redirect err to out, for logging
-    val prevErr = System.err
-    System.setErr(System.out)
     compile()
     // the bug manifests at the second compilation, when the bytecode is already there
     compile()
-    System.setErr(prevErr)
   }
 }

--- a/test/files/run/t5603.scala
+++ b/test/files/run/t5603.scala
@@ -7,7 +7,7 @@ import scala.tools.nsc.reporters.ConsoleReporter
 
 object Test extends DirectTest {
 
-  override def extraSettings: String = "-usejavacp -Vprint:parser -Ystop-after:parser -d " + testOutput.path
+  override def extraSettings: String = "-usejavacp -Vprint:parser -Ystop-after:parser"
 
   override def code = """
     trait Greeting {
@@ -24,13 +24,7 @@ object Test extends DirectTest {
     object Test extends App {}
   """.trim
 
-  override def show(): Unit = {
-    // redirect err to out, for logging
-    val prevErr = System.err
-    System.setErr(System.out)
-    compile()
-    System.setErr(prevErr)
-  }
+  override def show(): Unit = compile()
 
   override def newCompiler(args: String*): Global = {
 

--- a/test/files/run/t5717.scala
+++ b/test/files/run/t5717.scala
@@ -2,12 +2,10 @@ import scala.tools.partest._
 import java.io.File
 
 object Test extends StoreReporterDirectTest {
-  def code = ???
+  def code = "package a { class B }"
 
-  def compileCode(code: String) = {
-    val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
-    compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(code)
-  }
+  override def extraSettings: String = s"-cp ${pathOf(sys.props("partest.lib"), testOutput.path)}"
+
   // TODO
   // Don't assume output is on physical disk
   // Let the compiler tell us output dir
@@ -16,7 +14,7 @@ object Test extends StoreReporterDirectTest {
   def show(): Unit = {
     // Don't crash when we find a file 'a' where package 'a' should go.
     scala.reflect.io.File(testOutput.path + "/a").writeAll("a")
-    compileCode("package a { class B }")
+    compile()
     val List(i) = filteredInfos
     // for some reason, nio doesn't throw the same exception on windows and linux/mac
     import File.separator

--- a/test/files/run/t5905-features.scala
+++ b/test/files/run/t5905-features.scala
@@ -7,8 +7,6 @@ import tools.partest.DirectTest
 object Test extends DirectTest {
   override def code = "class Code { def f = (1 to 10) size }" // exercise a feature to sanity-check coverage of -language options
 
-  override def extraSettings = s"-usejavacp -d ${testOutput.path}"
-
   override def show() = {
     val global = newCompiler("-Ystop-after:typer")
     compileString(global)("")   // warm me up, scotty

--- a/test/files/run/t5905b-features.scala
+++ b/test/files/run/t5905b-features.scala
@@ -5,8 +5,6 @@ import tools.partest.DirectTest
 object Test extends DirectTest {
   override def code = "class Code"
 
-  override def extraSettings = s"-usejavacp -d ${testOutput.path}"
-
   override def show() = {
     //compile("-language", "--")  // no error
     compile(s"-language:noob")

--- a/test/files/run/t5938.scala
+++ b/test/files/run/t5938.scala
@@ -3,7 +3,7 @@ import scala.tools.partest.DirectTest
 object Test extends DirectTest {
 
   override def extraSettings: String =
-    s"-usejavacp -d ${testOutput.path} -cp ${testOutput.path} -d ${testOutput.path}"
+    s"-usejavacp -cp ${testOutput.path}"
 
   override def code = """
 object O extends C {
@@ -15,11 +15,9 @@ object O extends C {
 
   override def show(): Unit = {
     val global = newCompiler()
-    Console.withErr(System.out) {
-      compileString(global)(code)
-      compileString(global)(code)
-      loadClass // was "duplicate name and signature in class X"
-    }
+    compileString(global)(code)
+    compileString(global)(code)
+    loadClass // was "duplicate name and signature in class X"
   }
 
   def loadClass: Class[_] = {

--- a/test/files/run/t5940.scala
+++ b/test/files/run/t5940.scala
@@ -17,8 +17,8 @@ object Test extends DirectTest {
     }
   """
   def compileMacros() = {
-    val classpath = List(sys.props("partest.lib"), sys.props("partest.reflect")) mkString sys.props("path.separator")
-    compileString(newCompiler("-language:experimental.macros", "-cp", classpath, "-d", testOutput.path))(macros_1)
+    val classpath = pathOf(sys.props("partest.lib"), sys.props("partest.reflect"))
+    compileString(newCompiler("-language:experimental.macros", "-cp", classpath))(macros_1)
   }
 
   def test_2 = """
@@ -27,7 +27,7 @@ object Test extends DirectTest {
     }
   """
   def compileTest() = {
-    val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
+    val classpath = pathOf(sys.props("partest.lib"), testOutput.path)
     compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(test_2)
   }
 

--- a/test/files/run/t6028.scala
+++ b/test/files/run/t6028.scala
@@ -13,9 +13,5 @@ object Test extends DirectTest {
                         |}
                         |""".stripMargin.trim
 
-  override def show(): Unit = {
-    Console.withErr(System.out) {
-      compile()
-    }
-  }
+  override def show(): Unit = compile()
 }

--- a/test/files/run/t6288.scala
+++ b/test/files/run/t6288.scala
@@ -40,11 +40,7 @@ object Test extends DirectTest {
       |}
       |""".stripMargin.trim
 
-  override def show(): Unit = {
+  override def show(): Unit = compile()
     // Now: [84][84]Case3.unapply([84]x1);
     // Was: [84][84]Case3.unapply([64]x1);
-    Console.withErr(System.out) {
-      compile()
-    }
-  }
 }

--- a/test/files/run/t6440.scala
+++ b/test/files/run/t6440.scala
@@ -5,8 +5,8 @@ object Test extends StoreReporterDirectTest {
   def code = ???
 
   def compileCode(code: String) = {
-    val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
-    compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(code)
+    val classpath = pathOf(sys.props("partest.lib"), testOutput.path)
+    compileString(newCompiler("-cp", classpath))(code)
   }
 
   def library1 = """

--- a/test/files/run/t6440b.scala
+++ b/test/files/run/t6440b.scala
@@ -5,8 +5,8 @@ object Test extends StoreReporterDirectTest {
   def code = ???
 
   def compileCode(code: String) = {
-    val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
-    compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(code)
+    val classpath = pathOf(sys.props("partest.lib"), testOutput.path)
+    compileString(newCompiler("-cp", classpath))(code)
   }
 
   def library1 = """

--- a/test/files/run/t6502.scala
+++ b/test/files/run/t6502.scala
@@ -6,7 +6,7 @@ object Test extends StoreReporterDirectTest {
   def code = ???
 
   private def compileCode(code: String, jarFileName: String) = {
-    val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
+    val classpath = pathOf(sys.props("partest.lib"), testOutput.path)
     compileString(newCompiler("-cp", classpath, "-d", s"${testOutput.path}/$jarFileName"))(code)
   }
   private def runAdded(codeToRun: String): String = {
@@ -15,7 +15,6 @@ object Test extends StoreReporterDirectTest {
     assert(added.nonEmpty, lines)
     output.mkString("\n")
   }
-
 
   def app1 = """
     package test

--- a/test/files/run/t6555.scala
+++ b/test/files/run/t6555.scala
@@ -7,9 +7,5 @@ object Test extends DirectTest {
 
   override def code = "class Foo { val f = (param: Int) => param } "
 
-  override def show(): Unit = {
-    Console.withErr(System.out) {
-      compile()
-    }
-  }
+  override def show(): Unit = compile()
 }

--- a/test/files/run/t7271.scala
+++ b/test/files/run/t7271.scala
@@ -16,13 +16,7 @@ object Test extends DirectTest {
     }
   """.trim
 
-  override def show(): Unit = {
-    // redirect err to out, for logging
-    val prevErr = System.err
-    System.setErr(System.out)
-    compile()
-    System.setErr(prevErr)
-  }
+  override def show(): Unit = compile()
 
   override def newCompiler(args: String*): Global = {
 

--- a/test/files/run/t7876.scala
+++ b/test/files/run/t7876.scala
@@ -2,7 +2,6 @@ import scala.tools.partest._
 
 // Type constructors for FunctionN and TupleN should not be considered as function type / tuple types.
 object Test extends DirectTest {
-  override def extraSettings: String = "-usejavacp"
 
   def code = ""
 

--- a/test/files/run/t8433.scala
+++ b/test/files/run/t8433.scala
@@ -42,5 +42,5 @@ object Test extends DirectTest {
     ScalaClassLoader(getClass.getClassLoader).run("Main", Nil)
   }
 
-  override def extraSettings = s"-usejavacp -d ${testOutput.path} -cp ${testOutput.path}"
+  override def extraSettings = s"-usejavacp -cp ${testOutput.path}"
 }

--- a/test/files/run/t8502.scala
+++ b/test/files/run/t8502.scala
@@ -5,8 +5,8 @@ object Test extends StoreReporterDirectTest {
   def code = ???
 
   def compileCode(code: String) = {
-    val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
-    compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(code)
+    val classpath = pathOf(sys.props("partest.lib"), testOutput.path)
+    compileString(newCompiler("-cp", classpath))(code)
   }
 
   def show(): Unit = {

--- a/test/files/run/t8502b.scala
+++ b/test/files/run/t8502b.scala
@@ -10,8 +10,8 @@ object Test extends StoreReporterDirectTest {
   def code = ???
 
   def compileCode(code: String) = {
-    val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
-    compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(code)
+    val classpath = pathOf(sys.props("partest.lib"), testOutput.path)
+    compileString(newCompiler("-cp", classpath))(code)
   }
 
   def show(): Unit = {

--- a/test/files/run/t8907.scala
+++ b/test/files/run/t8907.scala
@@ -5,7 +5,7 @@ object Test extends StoreReporterDirectTest {
   def code = ???
 
   def compileCode(code: String) = {
-    val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
+    val classpath = pathOf(sys.props("partest.lib"), testOutput.path)
     compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(code)
   }
 

--- a/test/files/run/t9097.scala
+++ b/test/files/run/t9097.scala
@@ -9,7 +9,7 @@ object Test extends StoreReporterDirectTest {
     "-Ydelambdafy:method",
     "-Vprint:delambdafy",
     s"-d ${testOutput.path}"
-  ) mkString " "
+  ).mkString(" ")
 
   override def code = """package o
                         |package a {

--- a/test/files/run/t9437b.scala
+++ b/test/files/run/t9437b.scala
@@ -12,7 +12,7 @@ import Opcodes._
 // that uses the class with named arguments.
 // Any failure will be dumped to std out.
 object Test extends DirectTest {
-  override def extraSettings: String = "-usejavacp -d " + testOutput.path + " -cp " + testOutput.path
+  override def extraSettings: String = s"-usejavacp -cp ${testOutput.path}"
 
   def generateCode(): Unit = {
     val className =  "Foo"
@@ -78,15 +78,8 @@ class Driver {
 """
 
   override def show(): Unit = {
-    // redirect err to out, for logging
-    val prevErr = System.err
-    System.setErr(System.out)
-    try {
-      generateCode()
-      compile()
-      Class.forName("Driver").getDeclaredConstructor().newInstance()
-    }
-    finally
-      System.setErr(prevErr)
+    generateCode()
+    compile()
+    Class.forName("Driver").getDeclaredConstructor().newInstance()
   }
 }

--- a/test/files/run/typetags_without_scala_reflect_manifest_lookup.scala
+++ b/test/files/run/typetags_without_scala_reflect_manifest_lookup.scala
@@ -2,7 +2,7 @@ import scala.tools.partest._
 import scala.tools.nsc.Settings
 
 object Test extends DirectTest {
-  override def extraSettings = "-cp " + sys.props("partest.lib") + " -d \"" + testOutput.path + "\""
+  override def extraSettings = "-cp " + sys.props("partest.lib")
 
   def code = """
     object Test extends App {

--- a/test/files/run/typetags_without_scala_reflect_typetag_lookup.scala
+++ b/test/files/run/typetags_without_scala_reflect_typetag_lookup.scala
@@ -3,6 +3,9 @@ import scala.tools.partest._
 object Test extends StoreReporterDirectTest {
   def code = ???
 
+  // differs for two compilations
+  override def extraSettings: String = ""
+
   def library = """
     import scala.reflect.runtime.universe._
 
@@ -11,8 +14,8 @@ object Test extends StoreReporterDirectTest {
     }
   """
   def compileLibrary() = {
-    val classpath = List(sys.props("partest.lib"), sys.props("partest.reflect")) mkString sys.props("path.separator")
-    compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(library)
+    val classpath = pathOf(sys.props("partest.lib"), sys.props("partest.reflect"))
+    compileString(newCompiler("-cp", classpath))(library)
   }
 
   def app = """
@@ -27,15 +30,15 @@ object Test extends StoreReporterDirectTest {
     }
   """
   def compileApp() = {
-    val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
-    compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(app)
+    val classpath = pathOf(sys.props("partest.lib"), testOutput.path)
+    compileString(newCompiler("-cp", classpath))(app)
   }
 
   def show(): Unit = {
     compileLibrary();
     println(filteredInfos.mkString("\n"))
     storeReporter.infos.clear()
-    compileApp();
+    compileApp()
     // we should get "missing or invalid dependency detected" errors, because we're trying to use an implicit that can't be unpickled
     // but we don't know the number of these errors and their order, so I just ignore them all
     println(filteredInfos.filterNot(_.msg.contains("is missing from the classpath")).mkString("\n"))

--- a/test/files/run/typetags_without_scala_reflect_typetag_manifest_interop.scala
+++ b/test/files/run/typetags_without_scala_reflect_typetag_manifest_interop.scala
@@ -4,6 +4,9 @@ import scala.tools.nsc.Settings
 object Test extends StoreReporterDirectTest {
   def code = ???
 
+  // differs for two compilations
+  override def extraSettings: String = ""
+
   def library = """
     import scala.reflect.runtime.universe._
 
@@ -13,8 +16,8 @@ object Test extends StoreReporterDirectTest {
     }
   """
   def compileLibrary() = {
-    val classpath = List(sys.props("partest.lib"), sys.props("partest.reflect")) mkString sys.props("path.separator")
-    compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(library)
+    val classpath = pathOf(sys.props("partest.lib"), sys.props("partest.reflect"))
+    compileString(newCompiler("-cp", classpath))(library)
   }
 
   def app = """
@@ -29,19 +32,17 @@ object Test extends StoreReporterDirectTest {
     }
   """
   def compileApp() = {
-    val classpath = List(sys.props("partest.lib"), testOutput.path) mkString sys.props("path.separator")
-    val global = newCompiler("-cp", classpath, "-d", testOutput.path)
-    compileString(newCompiler("-cp", classpath, "-d", testOutput.path))(app)
-    //global.reporter.ERROR.foreach(println)
+    val classpath = pathOf(sys.props("partest.lib"), testOutput.path)
+    compileString(newCompiler("-cp", classpath))(app)
   }
 
   def show(): Unit = {
     compileLibrary();
     println(filteredInfos.mkString("\n"))
     storeReporter.infos.clear()
-    compileApp();
+    compileApp()
     // we should get "missing or invalid dependency detected" errors, because we're trying to use an implicit that can't be unpickled
     // but we don't know the number of these errors and their order, so I just ignore them all
-    println(filteredInfos.filterNot (_.msg.contains("is missing from the classpath")).mkString("\n"))
+    println(filteredInfos.filterNot(_.msg.contains("is missing from the classpath")).mkString("\n"))
   }
 }

--- a/test/scaladoc/run/t5527.scala
+++ b/test/scaladoc/run/t5527.scala
@@ -137,11 +137,8 @@ object Test extends DirectTest {
     }
   """.trim
 
-  // redirect err to out, for logging
-  override def show(): Unit = StreamCapture.savingSystem {
-    System.setErr(System.out)
-    compile()
-  }
+  override def show(): Unit = compile()
+
   // doc.Settings
   override def newSettings(args: List[String]) = new doc.Settings(_ => ()).tap(_.processArguments(args, true))
   // ScaladocGlobal yielded by DocFactory#compiler, requires doc.Settings


### PR DESCRIPTION
DirectTest supplies `-usejavacp` in `extraSettings`;
there are two reflect tests that turn it off.

`-d` is supplied with settings, so it is not necessary
to specify it.

Capturing stderr to the log file was added in 2013,
so remove old cruft.