### PR TITLE
No ClassTag for matching abstract type tests

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Checkable.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Checkable.scala
@@ -297,6 +297,13 @@ trait Checkable {
       })
     )
 
+    def isRuntimeCheckable(P0: Type, X: Type = AnyTpe): Boolean = P0.widen match {
+      case TypeRef(_, NothingClass | NullClass | AnyValClass, _) => false
+      case RefinedType(_, decls) if !decls.isEmpty               => false
+      case RefinedType(parents, _)                               => parents.forall(isRuntimeCheckable(_, X))
+      case p                                                     => new CheckabilityChecker(X, p).result == RuntimeCheckable
+    }
+
     /** TODO: much better error positions.
       * Kind of stuck right now because they just pass us the one tree.
       * TODO: Eliminate inPattern, canRemedy, which have no place here.

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -1273,7 +1273,9 @@ trait Infer extends Checkable {
         return ErrorType
       }
 
-      checkCheckable(tree0, pattp, pt, inPattern = true, canRemedy)
+      // use the possibly abstract type `pt0` rather than `pt` so that `: T` given pt0=T is StaticallyTrue scala/bug#12406
+      checkCheckable(tree0, pattp, pt0, inPattern = true, canRemedy)
+
       if (pattp <:< pt) ()
       else {
         debuglog("free type params (1) = " + tpparams)

--- a/test/files/pos/t12406.scala
+++ b/test/files/pos/t12406.scala
@@ -1,0 +1,7 @@
+// scalac: -Werror
+object Scabug {
+  def foo[T : scala.reflect.ClassTag](bar: Either[String, T]): Boolean = bar match {
+    case Left(_) => false
+    case Right(_: T) => true
+  }
+}

--- a/test/files/pos/t12406b.scala
+++ b/test/files/pos/t12406b.scala
@@ -1,0 +1,7 @@
+// scalac: -Werror
+object Scabug {
+  def foo[T : scala.reflect.ClassTag](bar: Either[String, T]): Boolean = bar match {
+    case Left(_) => false
+    case Right(_) => true
+  }
+}

--- a/test/files/pos/t12406c.scala
+++ b/test/files/pos/t12406c.scala
@@ -1,0 +1,7 @@
+// scalac: -Werror
+object Scabug {
+  def foo[T](bar: Either[String, T]): Boolean = bar match {
+    case Left(_) => false
+    case Right(_: T) => true
+  }
+}


### PR DESCRIPTION
When the static type matches the type test, there's no need for a
ClassTag.  So it shouldn't emit an unchecked warning (checkCheckable).

Also, in that case, even if a ClassTag is available, there's no need to
use one (extractorForUncheckedType).

Compared to previously, two additional things will change: if the value
isn't of its static type (e.g. a cast was used) or it's _null_,
previously this would fail early with the case not matching.  Now,
instead, the case will match and (likely) it will fail as soon as the
value is used.

Fixes scala/bug#12406