### PR TITLE
When checking bounds fails, return original undetermined parameters

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -1076,7 +1076,7 @@ trait Infer extends Checkable {
      */
     def inferMethodInstance(fn: Tree, undetParams: List[Symbol],
                             args: List[Tree], pt0: Type): List[Symbol] = fn.tpe match {
-      case mt @ MethodType(params0, _) =>
+      case mt @ MethodType(_, _) =>
         try {
           val pt      = if (pt0.typeSymbol == UnitClass) WildcardType else pt0
           val formals = formalTypes(mt.paramTypes, args.length)
@@ -1094,17 +1094,17 @@ trait Infer extends Checkable {
             adjusted.undetParams match {
               case Nil  => Nil
               case xs   =>
-                // #3890
+                // scala/bug#3890
                 val xs1 = treeSubst.typeMap mapOver xs
                 if (xs ne xs1)
                   new TreeSymSubstTraverser(xs, xs1) traverseTrees fn :: args
                 enhanceBounds(adjusted.okParams, adjusted.okArgs, xs1)
                 xs1
             }
-          } else Nil
-        }
-        catch ifNoInstance { msg =>
-          NoMethodInstanceError(fn, args, msg); List()
+          } else undetParams
+        } catch ifNoInstance { msg =>
+          NoMethodInstanceError(fn, args, msg)
+          undetParams
         }
       case x => throw new MatchError(x)
     }

--- a/test/files/neg/leibniz-liskov.check
+++ b/test/files/neg/leibniz-liskov.check
@@ -55,8 +55,8 @@ leibniz-liskov.scala:21: error: type mismatch;
  required: F[U]
   def convert1[T, U](l: List[T])(ev: T =:= U): List[U] = ev.substituteContra(l)
                                                                              ^
-leibniz-liskov.scala:21: error: type mismatch;
- found   : F[T]
+leibniz-liskov.scala:21: error: polymorphic expression cannot be instantiated to expected type;
+ found   : [F[_]]F[T]
  required: List[U]
   def convert1[T, U](l: List[T])(ev: T =:= U): List[U] = ev.substituteContra(l)
                                                                             ^
@@ -72,8 +72,8 @@ leibniz-liskov.scala:22: error: type mismatch;
  required: F[T]
   def convert2[T, U](l: List[U])(ev: T =:= U): List[T] = ev.substituteCo(l)
                                                                          ^
-leibniz-liskov.scala:22: error: type mismatch;
- found   : F[U]
+leibniz-liskov.scala:22: error: polymorphic expression cannot be instantiated to expected type;
+ found   : [F[_]]F[U]
  required: List[T]
   def convert2[T, U](l: List[U])(ev: T =:= U): List[T] = ev.substituteCo(l)
                                                                         ^
@@ -111,8 +111,8 @@ leibniz-liskov.scala:35: error: type mismatch;
  required: F[U]
   def convertConsume2[U, T](c: Consumes[T])(ev: U <:< T): Consumes[U] = ev.substituteCo(c)
                                                                                         ^
-leibniz-liskov.scala:35: error: type mismatch;
- found   : F[T]
+leibniz-liskov.scala:35: error: polymorphic expression cannot be instantiated to expected type;
+ found   : [F[+_]]F[T]
  required: LeibnizLiskov.this.Consumes[U]
     (which expands to)  U => Unit
   def convertConsume2[U, T](c: Consumes[T])(ev: U <:< T): Consumes[U] = ev.substituteCo(c)

--- a/test/files/neg/t12413.check
+++ b/test/files/neg/t12413.check
@@ -1,0 +1,16 @@
+t12413.scala:13: error: inferred type arguments [AnyRef] do not conform to method close's type parameter bounds [Phantom >: AnyRef <: Open]
+  println(door.close.toString())
+               ^
+t12413.scala:14: error: inferred type arguments [AnyRef] do not conform to method close's type parameter bounds [Phantom >: AnyRef <: Open]
+  println(door.close == 0)
+               ^
+t12413.scala:15: error: inferred type arguments [AnyRef] do not conform to method open's type parameter bounds [Phantom >: AnyRef <: Open]
+  println(door.open().toString)
+               ^
+t12413.scala:16: error: inferred type arguments [AnyRef] do not conform to method open's type parameter bounds [Phantom >: AnyRef <: Open]
+  println(door.open().toString())
+               ^
+t12413.scala:17: error: inferred type arguments [AnyRef] do not conform to method open's type parameter bounds [Phantom >: AnyRef <: Open]
+  println(door.open() == 0)
+               ^
+5 errors

--- a/test/files/neg/t12413.scala
+++ b/test/files/neg/t12413.scala
@@ -1,0 +1,18 @@
+class Open
+
+class Door[State] {
+  def close[Phantom >: State <: Open]: Int = 0
+  def open[Phantom >: State <: Open](): Int = 0
+}
+
+class Test {
+  val door = new Door[AnyRef]
+  // the error here happens later (at refchecks)
+  println(door.close.toString)
+  // the errors below happen when typing implicit conversions
+  println(door.close.toString())
+  println(door.close == 0)
+  println(door.open().toString)
+  println(door.open().toString())
+  println(door.open() == 0)
+}

--- a/test/files/neg/t7509.check
+++ b/test/files/neg/t7509.check
@@ -6,7 +6,4 @@ t7509.scala:3: error: type mismatch;
  required: R
   crash(42)
         ^
-t7509.scala:3: error: could not find implicit value for parameter ev: R
-  crash(42)
-       ^
-3 errors
+2 errors

--- a/test/files/neg/t8463.check
+++ b/test/files/neg/t8463.check
@@ -19,9 +19,4 @@ t8463.scala:5: error: type mismatch;
  required: T[Long]
   insertCell(Foo(5))
                  ^
-t8463.scala:5: error: type mismatch;
- found   : Test.Foo[T]
- required: Test.Foo[Test.Cell]
-  insertCell(Foo(5))
-                ^
-4 errors
+3 errors


### PR DESCRIPTION
`inferMethodInstance` assumes that it doesn't matter what is returned
when `checkBounds` fails because it issues errors.
However that is not the case when typechecking in silent mode,
e.g. in `tryTypedApply` which can recover with implicit conversions.
When typechecking the inserted conversions we should see
the yet undetermined type parameters and try to infer them again.

Fixes scala/bug#12413