### PR TITLE
Avoid entering synthetic trees during specialization

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -1401,7 +1401,16 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
       }
     }
 
-    protected override def newBodyDuplicator(context: Context): SpecializeBodyDuplicator = new SpecializeBodyDuplicator(context)
+    private class SpecializeNamer(context: Context) extends Namer(context) {
+      // Avoid entering synthetic trees during specialization because the duplicated trees already contain them.
+      override def enterSyntheticSym(tree: Tree): Symbol = tree.symbol
+    }
+
+    protected override def newBodyDuplicator(context: Context): SpecializeBodyDuplicator =
+      new SpecializeBodyDuplicator(context)
+
+    override def newNamer(context: Context): Namer =
+      new SpecializeNamer(context)
   }
 
   /** Introduced to fix scala/bug#7343: Phase ordering problem between Duplicators and Specialization.

--- a/test/files/neg/t9014.check
+++ b/test/files/neg/t9014.check
@@ -1,0 +1,4 @@
+t9014.scala:4: error: Inner is already defined as case class Inner
+    case class Inner(default: T)
+               ^
+1 error

--- a/test/files/neg/t9014.scala
+++ b/test/files/neg/t9014.scala
@@ -1,0 +1,7 @@
+object Test {
+  def spec[@specialized(Byte, Short, Int, Long) T : Integral](t: T) = {
+    // still broken - specialize can't deal with the synthetic companion object
+    case class Inner(default: T)
+    t
+  }
+}

--- a/test/files/pos/t9014.scala
+++ b/test/files/pos/t9014.scala
@@ -1,0 +1,6 @@
+object Test {
+  def spec[@specialized(Byte, Short, Int, Long) T : Integral](t: T) = {
+    def inner(default: T = t): T = t
+    inner()
+  }
+}


### PR DESCRIPTION
because the duplicated trees already contain them.
When we try to retype both the existing synthetic trees
and the newly entered ones it breaks (e.g. for default getters).

Fixes scala/bug#9014