### PR TITLE
Fix Stream.iterator memory leak

### DIFF
--- a/src/library/scala/collection/LinearSeq.scala
+++ b/src/library/scala/collection/LinearSeq.scala
@@ -276,7 +276,12 @@ private[collection] final class LinearSeqIterator[A](coll: LinearSeqOps[A, Linea
   // A call-by-need cell
   private[this] final class LazyCell(st: => LinearSeqOps[A, LinearSeq, LinearSeq[A]]) { lazy val v = st }
 
-  private[this] var these: LazyCell = new LazyCell(coll)
+  private[this] var these: LazyCell = {
+    // Reassign reference to avoid creating a private class field and holding a reference to the head.
+    // LazyCell would otherwise close over `coll`.
+    val initialHead = coll
+    new LazyCell(initialHead)
+  }
 
   def hasNext: Boolean = these.v.nonEmpty
 

--- a/test/files/run/stream-gc.check
+++ b/test/files/run/stream-gc.check
@@ -1,1 +1,1 @@
-warning: 5 deprecations (since 2.13.0); re-run with -deprecation for details
+warning: 6 deprecations (since 2.13.0); re-run with -deprecation for details

--- a/test/files/run/stream-gc.scala
+++ b/test/files/run/stream-gc.scala
@@ -8,4 +8,5 @@ object Test extends App {
   Stream.tabulate(100)(_ => new Array[AnyRef](10000)).collectFirst { case x if false => x }
   Stream.tabulate(100)(_ => new Array[AnyRef](10000)).collectFirst { case x if false => x }
   Stream.tabulate(100)(_ => new Array[AnyRef](10000)).collectFirst { case x if false => x }
+  Stream.tabulate(100)(_ => new Array[AnyRef](10000)).iterator.foreach(_ => ())
 }


### PR DESCRIPTION
`Stream.iterator` kept a reference to the head of the stream which prevented any part of the Stream from getting garbage collected. I suspect this was the underlying cause of similar fixes like #8367. Scala 2.11 is unaffected.

This change prevents `LinearSeqIterator` from creating a private field and closing over the head of the `Stream` as a `coll` class field.

Before:
```
javap -p build/quick/classes/library/scala/collection/LinearSeqIterator.class
Compiled from "LinearSeq.scala"
public final class scala.collection.LinearSeqIterator<A> extends scala.collection.AbstractIterator<A> {
  private final scala.collection.LinearSeqOps<A, scala.collection.LinearSeq, scala.collection.LinearSeq<A>> coll;
  private scala.collection.LinearSeqIterator<A>.LazyCell these;
  public boolean hasNext();
  public A next();
...
}
```

After:
```
javap -p build/quick/classes/library/scala/collection/LinearSeqIterator.class
Compiled from "LinearSeq.scala"
public final class scala.collection.LinearSeqIterator<A> extends scala.collection.AbstractIterator<A> {
  private scala.collection.LinearSeqIterator<A>.LazyCell these;
  public boolean hasNext();
  public A next();
...
}
```

I didn't find any open issues on scala/bug for this.