### PR TITLE
Deprecate top-level wildcard type parameters

### DIFF
--- a/src/partest/scala/tools/partest/ScaladocModelTest.scala
+++ b/src/partest/scala/tools/partest/ScaladocModelTest.scala
@@ -72,7 +72,7 @@ abstract class ScaladocModelTest extends DirectTest {
 
     try {
       // 1 - compile with scaladoc and get the model out
-      val universe = model.getOrElse({sys.error("Scaladoc Model Test ERROR: No universe generated!")})
+      val universe = model.getOrElse { sys.error("Scaladoc Model Test ERROR: No universe generated!") }
       // 2 - check the model generated
       testModel(universe.rootPackage)
       println("Done.")

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -473,6 +473,7 @@ trait StdNames {
     def unexpandedName(name: Name): Name =
       name.lastIndexOf("$$") match {
         case 0 | -1 => name
+        case 1 if name.charAt(0) == '_' => if (name.isTermName) nme.WILDCARD else tpnme.WILDCARD
         case idx0   =>
           // Sketchville - We've found $$ but if it's part of $$$ or $$$$
           // or something we need to keep the bonus dollars, so e.g. foo$$$outer

--- a/src/reflect/scala/reflect/internal/TypeDebugging.scala
+++ b/src/reflect/scala/reflect/internal/TypeDebugging.scala
@@ -140,7 +140,7 @@ trait TypeDebugging {
     def debugString(tp: Type) = debug(tp)
   }
   def paramString(tp: Type)      = typeDebug.str params tp.params
-  def typeParamsString(tp: Type) = typeDebug.str brackets (tp.typeParams map (_.defString))
+  def typeParamsString(tp: Type) = typeDebug.str.brackets(tp.typeParams.map(_.defString))
   def debugString(tp: Type)      = typeDebug debugString tp
 }
 

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1559,18 +1559,16 @@ trait Types
     /** Bounds notation used in Scala syntax.
       * For example +This <: scala.collection.generic.Sorted[K,This].
       */
-    private[internal] def scalaNotation(typeString: Type => String): String = {
+    private[internal] def scalaNotation(typeString: Type => String): String =
       (if (emptyLowerBound) "" else " >: " + typeString(lo)) +
       (if (emptyUpperBound) "" else " <: " + typeString(hi))
-    }
     /** Bounds notation used in https://adriaanm.github.com/files/higher.pdf.
       * For example *(scala.collection.generic.Sorted[K,This]).
       */
-    private[internal] def starNotation(typeString: Type => String): String = {
+    private[internal] def starNotation(typeString: Type => String): String =
       if (emptyLowerBound && emptyUpperBound) ""
       else if (emptyLowerBound) s"(${typeString(hi)})"
       else s"(${typeString(lo)}, ${typeString(hi)})"
-    }
     override def kind = "TypeBoundsType"
     override def mapOver(map: TypeMap): Type = {
       val lo1 = map match {

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactoryTypeSupport.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactoryTypeSupport.scala
@@ -45,7 +45,7 @@ trait ModelFactoryTypeSupport {
           appendType0(tp)
         case tp :: tps =>
           appendType0(tp)
-          nameBuffer append sep
+          nameBuffer.append(sep)
           appendTypes0(tps, sep)
       }
 
@@ -202,15 +202,16 @@ trait ModelFactoryTypeSupport {
         /* Polymorphic types */
         case PolyType(tparams, result) =>
           assert(tparams.nonEmpty, "polymorphic type must have at least one type parameter")
-          def typeParamsToString(tps: List[Symbol]): String = if (tps.isEmpty) "" else
-            tps.map{tparam =>
-              tparam.varianceString + tparam.name + typeParamsToString(tparam.typeParams)
-            }.mkString("[", ", ", "]")
-          nameBuffer append typeParamsToString(tparams)
+          def typeParamsToString(tps: List[Symbol]): String =
+            if (tps.isEmpty) ""
+            else
+              tps.map { tparam =>
+                tparam.varianceString + tparam.unexpandedName + typeParamsToString(tparam.typeParams)
+              }.mkString("[", ", ", "]")
+          nameBuffer.append(typeParamsToString(tparams))
           appendType0(result)
 
         case et@ExistentialType(quantified, underlying) =>
-
           def appendInfoStringReduced(sym: Symbol, tp: Type): Unit = {
             if (sym.isType && !sym.isAliasType && !sym.isClass) {
                 tp match {

--- a/test/files/neg/t2462c.scala
+++ b/test/files/neg/t2462c.scala
@@ -1,4 +1,4 @@
-// scalac: -Xfatal-warnings
+// scalac: -Werror
 //
 
 import annotation._

--- a/test/files/neg/t5606.check
+++ b/test/files/neg/t5606.check
@@ -1,0 +1,16 @@
+t5606.scala:3: error: identifier expected but '_' found.
+case class CaseTest[_](someData: String)
+                    ^
+t5606.scala:5: error: using `?` as a type name requires backticks.
+case class CaseTest_?[?](someData: String)
+                      ^
+t5606.scala:8: error: identifier expected but '_' found.
+case class CaseTest2[_, _](someData: String)
+                     ^
+t5606.scala:11: error: identifier expected but '_' found.
+  def f[_](x: Int) = ???
+        ^
+t5606.scala:23: error: using `?` as a type name requires backticks.
+  def regress_?[F[?]]   = 2
+                  ^
+5 errors

--- a/test/files/neg/t5606.scala
+++ b/test/files/neg/t5606.scala
@@ -1,0 +1,26 @@
+// scalac: -Xsource:3
+// was: _ taken as ident of type param, but poor interactions below
+case class CaseTest[_](someData: String)
+
+case class CaseTest_?[?](someData: String)
+
+// was: _ already defined
+case class CaseTest2[_, _](someData: String)
+
+class C {
+  def f[_](x: Int) = ???
+}
+
+object Test extends App {
+  def f0 = new CaseTest("X")
+  def f1: CaseTest[Int] = new CaseTest[Int]("X")  // OK!
+  def f2: CaseTest[Int] = CaseTest[Int]("X")      // CaseTest[Any]
+  def f3 = new CaseTest[Int]("X").copy()          // CaseTest[Any]
+  def f4 = new CaseTest[Int]("X").copy[Int]()     // CaseTest[Any]
+
+  def regress0[F[_]]    = 0
+  def regress1[F[_, _]] = 1
+  def regress_?[F[?]]   = 2
+  //def regress0[F[_$$1]] = 0;
+  //def regress1[F[_$$2, _$$3]] = 1
+}

--- a/test/files/neg/t5606b.check
+++ b/test/files/neg/t5606b.check
@@ -1,0 +1,15 @@
+t5606b.scala:4: warning: Top-level wildcard is not allowed and will error under -Xsource:3
+case class CaseTest[_](someData: String)
+                    ^
+t5606b.scala:7: warning: Top-level wildcard is not allowed and will error under -Xsource:3
+case class CaseTest2[_, _](someData: String)
+                     ^
+t5606b.scala:7: warning: Top-level wildcard is not allowed and will error under -Xsource:3
+case class CaseTest2[_, _](someData: String)
+                        ^
+t5606b.scala:10: warning: Top-level wildcard is not allowed and will error under -Xsource:3
+  def f[_](x: Int) = ???
+        ^
+error: No warnings can be incurred under -Werror.
+4 warnings
+1 error

--- a/test/files/neg/t5606b.scala
+++ b/test/files/neg/t5606b.scala
@@ -1,3 +1,5 @@
+// scalac: -Xlint -Werror
+//
 // was: _ taken as ident of type param, now a fresh name
 case class CaseTest[_](someData: String)
 

--- a/test/files/neg/trailing-commas.check
+++ b/test/files/neg/trailing-commas.check
@@ -61,15 +61,9 @@ trait TypeArgs { def f: C[Int, String, ] }
 trailing-commas.scala:23: error: identifier expected but ']' found.
 trait TypeParamClause { type C[A, B, ] }
                                      ^
-trailing-commas.scala:23: error: ']' expected but '}' found.
-trait TypeParamClause { type C[A, B, ] }
-                                       ^
 trailing-commas.scala:24: error: identifier expected but ']' found.
 trait FunTypeParamClause { def f[A, B, ] }
                                        ^
-trailing-commas.scala:24: error: ']' expected but '}' found.
-trait FunTypeParamClause { def f[A, B, ] }
-                                         ^
 trailing-commas.scala:26: error: identifier expected but ')' found.
 trait SimpleType { def f: (Int, String, ) }
                                         ^
@@ -127,4 +121,4 @@ trait SimpleType2 { def f: (Int, ) }
 trailing-commas.scala:48: error: ')' expected but '}' found.
 trait SimpleType2 { def f: (Int, ) }
                                    ^
-43 errors
+41 errors


### PR DESCRIPTION
Deprecates using underscore (`_`) as a type parameter, except for "higher-order type parameters."

Under `-Xsource:3`, issue an error instead of merely warning.

```
class C[A]
class C[F[_]]
class C[_]       // no
```

Fixes scala/bug#5606