### PR TITLE
Teach backend to emit `iinc` instructions

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeIdiomatic.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeIdiomatic.scala
@@ -392,6 +392,7 @@ abstract class BCodeIdiomatic {
 
     final def load( idx: Int, tk: BType): Unit = { emitVarInsn(Opcodes.ILOAD,  idx, tk) } // can-multi-thread
     final def store(idx: Int, tk: BType): Unit = { emitVarInsn(Opcodes.ISTORE, idx, tk) } // can-multi-thread
+    final def iinc( idx: Int, increment: Int): Unit = jmethod.visitIincInsn(idx, increment) // can-multi-thread
 
     final def aload( tk: BType): Unit = { emitTypeBased(JCodeMethodN.aloadOpcodes,  tk) } // can-multi-thread
     final def astore(tk: BType): Unit = { emitTypeBased(JCodeMethodN.astoreOpcodes, tk) } // can-multi-thread

--- a/test/files/jvm/iinc.check
+++ b/test/files/jvm/iinc.check
@@ -1,0 +1,18 @@
+def increment
+  iinc 1
+  iinc 54
+  iinc 127
+  iinc -1
+  iinc -54
+  iinc -128
+end increment
+def wideIncrement
+  iinc 128
+  iinc 8765
+  iinc 32767
+  iinc -129
+  iinc -8765
+  iinc -32768
+end wideIncrement
+def tooBigForIinc
+end tooBigForIinc

--- a/test/files/jvm/iinc/Increment_1.scala
+++ b/test/files/jvm/iinc/Increment_1.scala
@@ -1,0 +1,37 @@
+class Increment {
+
+  // `iinc`
+  def increment(x: Int): Int = {
+    var i = x
+    i += 1
+    i += 54
+    i += 127
+    i -= 1
+    i -= 54
+    i -= 128
+    i
+  }
+
+  // `wide iinc`
+  def wideIncrement(x: Int): Int = {
+    var i = x
+    i += 128
+    i += 8765
+    i += 32767
+    i -= 129
+    i -= 8765
+    i -= 32768
+    i
+  }
+
+  def tooBigForIinc(x: Int): Int = {
+    var i = x
+    i += 32768
+    i += 56789
+    i += 2147483647
+    i -= 32769
+    i -= 56789
+    i -= 2147483647
+    i
+  }
+}

--- a/test/files/jvm/iinc/test.scala
+++ b/test/files/jvm/iinc/test.scala
@@ -1,0 +1,17 @@
+import scala.tools.partest.BytecodeTest
+
+import scala.tools.asm.tree.IincInsnNode
+
+object Test extends BytecodeTest {
+  def show: Unit = {
+    val classNode = loadClassNode("Increment")
+    for (name <- List("increment", "wideIncrement", "tooBigForIinc")) {
+      println(s"def $name")
+      getMethod(classNode, name).instructions.toArray().collect {
+        case insn: IincInsnNode => println(s"  iinc ${insn.incr}")
+      }
+      println(s"end $name")
+    }
+  }
+}
+

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
@@ -1865,14 +1865,14 @@ class InlinerTest extends BytecodeTesting {
       ALOAD, ARRAYLENGTH, ISTORE, ICONST_0, ISTORE, // get length, init loop counter
       -1 /*8*/, ILOAD, ILOAD, IF_ICMPGE /*25*/,     // check loop condition
       ALOAD, ILOAD, IALOAD, ISTORE, ALOAD, ILOAD, "consume", // load element, store into local, call body
-      ILOAD, ICONST_1, IADD, ISTORE, GOTO /*8*/,    // increase loop counter, jump
-      -1 /*25*/, RETURN))
+      IINC, GOTO /*7*/,    // increase loop counter, jump
+      -1 /*26*/, RETURN))
 
     assertSameSummary(getMethod(c, "t2"), List(
       ALOAD, ARRAYLENGTH, ISTORE, ICONST_0, ISTORE,
       -1 /*8*/, ILOAD, ILOAD, IF_ICMPGE /*24*/,
       ALOAD, ILOAD, AALOAD, "trim", POP,
-      ILOAD, ICONST_1, IADD, ISTORE, GOTO /*8*/,
+      IINC, GOTO /*8*/,
       -1 /*24*/, RETURN)
     )
   }
@@ -1891,14 +1891,14 @@ class InlinerTest extends BytecodeTesting {
       -1 /*14*/, ILOAD, ILOAD, IF_ICMPGE /*39*/, // loop condition
       ALOAD, ILOAD, IALOAD, ICONST_1, IADD, ISTORE, // compute element
       ALOAD, ILOAD, ILOAD, IASTORE, // store element
-      ILOAD, ICONST_1, IADD, ISTORE, GOTO /*14*/, // increase counter, jump
-      -1 /*39*/, ALOAD, ARETURN)
+      IINC, GOTO /*22*/, // increase counter, jump
+      -1 /*44*/, ALOAD, ARETURN)
     )
     assertSameSummary(getMethod(c, "t2"), List(
       ALOAD, ARRAYLENGTH, ISTORE, ILOAD, ANEWARRAY, ASTORE, ILOAD, ICONST_0, IF_ICMPLE /*38*/, ICONST_0, ISTORE, // init new array, loop counter
       -1 /*15*/, ILOAD, ILOAD, IF_ICMPGE /*38*/, // loop condition
       ALOAD, ILOAD, AALOAD, "trim", ASTORE, ALOAD, ACONST_NULL, ASTORE, ASTORE, ALOAD, ILOAD, ALOAD, AASTORE, ACONST_NULL, ASTORE, // compute and store element
-      ILOAD, ICONST_1, IADD, ISTORE, GOTO /*15*/, // increase counter, jump
+      IINC, GOTO /*15*/, // increase counter, jump
       -1 /*38*/, ALOAD, ARETURN)
     )
   }


### PR DESCRIPTION
The backend is now able to turn `x += 42` into an `iinc 42`
instruction. The optimization only applies to `+=` and `-=`, provided
the the net increment fits inside a signed 16-bit value (the ASM library
handles choosing `iinc` or `wide iinc` as is appropriate).

Fixes scala/bug#7452