### PR TITLE
Suggest toOption.get for right.get

### DIFF
--- a/src/library/scala/util/Either.scala
+++ b/src/library/scala/util/Either.scala
@@ -690,7 +690,7 @@ object Either {
      *
      * @throws java.util.NoSuchElementException if the projection is `Left`.
      */
-    @deprecated("Use `Either.getOrElse` instead", "2.13.0")
+    @deprecated("Use `Either.toOption.get` instead", "2.13.0")
     def get: B = e match {
       case Right(b) => b
       case _        => throw new NoSuchElementException("Either.right.get on Left")


### PR DESCRIPTION
Yes, Option.get is bad and you should feel bad. But the deprecation warning should not give you such lessons, but just point to the replacement at hand.