### PR TITLE
Error on bad unapplySeq type

### DIFF
--- a/test/files/neg/t8127a.check
+++ b/test/files/neg/t8127a.check
@@ -1,4 +1,4 @@
-t8127a.scala:7: error: The result type of an unapplySeq method must contain a member `get` to be used as an extractor pattern, no such member exists in Seq[Any]
+t8127a.scala:7: error: Seq[Any] is not a valid result type of an unapplySeq method of an extractor.
     case H(v) =>
          ^
 1 error

--- a/test/files/neg/t8127a.scala
+++ b/test/files/neg/t8127a.scala
@@ -7,6 +7,9 @@ object Test {
     case H(v) =>
     case _ =>
   }
-  // now:  too many patterns for object H offering Boolean: expected 0, found 1
-  // was: result type Seq[_$2] of unapplySeq defined in method unapplySeq in object H does not conform to Option[_]
 }
+  // later: OK
+  // then: Seq[Any] is not a valid result type of an unapplySeq method of an extractor.
+  // and:  The result type of an unapplySeq method must contain a member `get` to be used as an extractor pattern, no such member exists in Seq[Any]
+  // now:  too many patterns for object H offering Boolean: expected 0, found 1
+  // was:  result type Seq[_$2] of unapplySeq defined in method unapplySeq in object H does not conform to Option[_]

--- a/test/files/neg/t9538.check
+++ b/test/files/neg/t9538.check
@@ -1,0 +1,13 @@
+t9538.scala:9: error: Option[String] is not a valid result type of an unapplySeq method of an extractor.
+  def f(x: Any) = x match { case X(y, z) => }
+                                 ^
+t9538.scala:10: error: Option[(Int, Int, Int)] is not a valid result type of an unapplySeq method of an extractor.
+  def g0(x: Any) = x match { case Y() => }
+                                  ^
+t9538.scala:11: error: Option[(Int, Int, Int)] is not a valid result type of an unapplySeq method of an extractor.
+  def g1(x: Any) = x match { case Y(y) => }
+                                  ^
+t9538.scala:12: error: Option[(Int, Int, Int)] is not a valid result type of an unapplySeq method of an extractor.
+  def g2(x: Any) = x match { case Y(y,z) => }
+                                  ^
+4 errors

--- a/test/files/neg/t9538.scala
+++ b/test/files/neg/t9538.scala
@@ -1,0 +1,13 @@
+
+
+
+object X { def unapplySeq(x: Any): Option[String] = { Some(x.toString.toUpperCase) }}
+
+object Y { def unapplySeq(v: Any) = Option((1, 2, 3)) }
+
+object Test extends App {
+  def f(x: Any) = x match { case X(y, z) => }
+  def g0(x: Any) = x match { case Y() => }
+  def g1(x: Any) = x match { case Y(y) => }
+  def g2(x: Any) = x match { case Y(y,z) => }
+}


### PR DESCRIPTION
In future, unapplySeq returning a Seq directly will be OK.
For now, avoid confusion.

Fixes https://github.com/scala/bug/issues/9538
Fixes https://github.com/scala/bug/issues/9869