### PR TITLE
fix scala/bug#12420: complete LambdaType param symbols lazily

### DIFF
--- a/src/compiler/scala/tools/nsc/tasty/bridge/FlagOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/FlagOps.scala
@@ -29,11 +29,20 @@ trait FlagOps { self: TastyUniverse =>
         | Enum | Infix | Open | ParamAlias | Invisible
     )
 
+    type FlagParser = TastyFlagSet => Context => TastyFlagSet
+
+    val addDeferred: FlagParser = flags => _ => flags | Deferred
+    val parseMethod: FlagParser = { mods0 => implicit ctx =>
+      var mods = EmptyTastyFlags
+      if (mods0.is(Erased)) erasedRefinementIsUnsupported[Unit]
+      if (mods0.isOneOf(Given | Implicit)) mods |= Implicit
+      mods
+    }
+
     object Creation {
       val ObjectDef: TastyFlagSet = Object | Lazy | Final | Stable
       val ObjectClassDef: TastyFlagSet = Object | Final
       val Default: u.FlagSet = newSymbolFlagSet(EmptyTastyFlags)
-      val BoundedType: u.FlagSet = newSymbolFlagSet(Deferred)
     }
     def withAccess(flags: TastyFlagSet, inheritedAccess: TastyFlagSet): TastyFlagSet =
       flags | (inheritedAccess & (Private | Local | Protected))

--- a/src/compiler/scala/tools/nsc/tasty/bridge/TastyCore.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/TastyCore.scala
@@ -34,6 +34,5 @@ abstract class TastyCore { self: TastyUniverse =>
   private val Identity = (x: Any) => x
 
   def id[T]: T => T = Identity.asInstanceOf[T => T]
-  def map[T, U](ts: List[T], f: T => U): List[U] = if (f `eq` Identity) ts.asInstanceOf[List[U]] else ts.map(f)
 
 }

--- a/test/files/run/tasty-lambdatype-strawman.check
+++ b/test/files/run/tasty-lambdatype-strawman.check
@@ -1,0 +1,3 @@
+PolyType([B => TypeBounds(NothingType, AppliedType(ParamRef(CC), [IntType])), CC => PolyType([_ => TypeBounds(NothingType, AnyType)], AnyType)], AppliedType(NamedRef(Bar), [ParamRef(B), ParamRef(CC)]))
+
+there was a cycle in creating Delta type constructor

--- a/test/files/run/tasty-lambdatype-strawman.scala
+++ b/test/files/run/tasty-lambdatype-strawman.scala
@@ -1,0 +1,168 @@
+import collection.immutable.ArraySeq
+
+object Test {
+
+  def main(args: Array[String]): Unit = {
+
+    val BarTypeConstructor = // [B <: CC[Int], CC[_]] => Bar[B, CC]
+      PolyType.from(
+        params = List(
+          "B" -> (hk => TypeBounds.upper(AppliedType(hk.ref(1), IntType :: Nil))),
+          "CC" -> (hk => PolyType.from(List("_" -> (_ => TypeBounds.upper(AnyType))), hk => AnyType))
+        ),
+        res = hk => AppliedType(NamedRef("Bar"), hk.ref(0) :: hk.ref(1) :: Nil)
+      )
+
+    println(BarTypeConstructor.debug)
+    println()
+
+    try {
+      val DeltaTypeConstructor = // [B <: CC[[I <: B] =>> Any], CC[_[_ <: B]]] =>> Delta[B, CC]
+        PolyType.from(
+          params = List(
+            "B" -> (hk =>
+              TypeBounds.upper(
+                AppliedType(
+                  tycon = hk.ref(1),
+                  args = PolyType.from(List("I" -> (_ => TypeBounds.upper(hk.ref(0)))), _ => AnyType) :: Nil
+                )
+              )
+            ),
+            "CC" -> (hk =>
+              PolyType.from(
+                params = List(
+                  "_" -> (_ =>
+                    PolyType.from(
+                      params = List(
+                        "_" -> (_ =>
+                          // force a cyclic completion - this type is illegal in Dotty
+                          // a completion would be needed here to check the bounds of `CC`
+                          TypeBounds.upper({val ref = hk.ref(0); ref.underlying; ref})
+                        )
+                      ),
+                      res = hk => AnyType
+                    )
+                  )
+                ),
+                res = hk => AnyType
+              )
+            )
+          ),
+          res = hk => AppliedType(NamedRef("Delta"), hk.ref(0) :: hk.ref(1) :: Nil)
+        )
+    } catch {
+      case err: AssertionError =>
+        assert(err.getMessage.contains("cyclic completion of SyncRef"))
+        println("there was a cycle in creating Delta type constructor")
+    }
+  }
+}
+
+final class SyncRef[A](private var compute: () => A) {
+  private var out: A = _
+  private var entered: Boolean = false
+
+  def apply(): A = {
+    if (entered) {
+      assert(out != null, "cyclic completion of SyncRef")
+    }
+    else {
+      entered = true
+      val result = compute()
+      compute = null
+      assert(result != null, "SyncRef is non-nullable")
+      out = result
+    }
+    out
+  }
+}
+
+sealed abstract class TypeOrCompleter {
+  def debug: String = this match {
+    case p: Product => s"${p.productPrefix}${
+      def iter(it: Iterator[Any], s: String = "(", e: String = ")"): String =
+        it.map {
+          case t: Type => t.debug
+          case t: Iterable[u] => iter(t.iterator, s = "[", e = "]")
+          case a => a.toString
+        }.mkString(s, ", ", e)
+      val it = p.productIterator
+      if (!it.hasNext) "" else iter(it)
+    }"
+    case _ => toString
+  }
+}
+
+abstract class Completer extends TypeOrCompleter {
+  def complete(sym: Symbol): Unit
+}
+
+abstract class Type extends TypeOrCompleter {
+  def underlying: Type = this
+}
+
+class Symbol(val name: String, private var myInfoOrCompleter: TypeOrCompleter) { self =>
+
+  def infoOrCompleter = myInfoOrCompleter
+
+  def info_=(tp: Type): Unit =
+    myInfoOrCompleter = tp
+
+  def info: Type = myInfoOrCompleter match {
+    case c: Completer =>
+      c.complete(self)
+      info
+    case t: Type => t
+  }
+
+  override def toString = s"$name => ${infoOrCompleter.debug}"
+
+}
+
+case class ParamRef(symbol: Symbol) extends Type {
+  override def underlying: Type = symbol.info
+  override def debug: String = s"ParamRef(${symbol.name})"
+}
+
+case class PolyType(params: List[Symbol], resultType: Type) extends Type
+case class AppliedType(tycon: Type, args: List[Type]) extends Type
+case class TypeBounds(lo: Type, hi: Type) extends Type
+object TypeBounds {
+  def upper(hi: Type) = TypeBounds(NothingType, hi)
+}
+case object IntType extends Type
+case object AnyType extends Type
+case object NothingType extends Type
+case class NamedRef(fullname: String) extends Type
+
+object PolyType {
+  def from(params: List[(String, HKTypeLambda => Type)], res: HKTypeLambda => Type): PolyType = {
+    val (names, infos0) = params.to(ArraySeq).unzip
+    val infos = (hk: HKTypeLambda) => () => infos0.map { case op => op(hk) }
+    new HKTypeLambda(names, infos, res).underlying
+  }
+}
+
+class HKTypeLambda(paramNames: ArraySeq[String], paramInfosOp: HKTypeLambda => () => ArraySeq[Type], resOp: HKTypeLambda => Type) { thisLambda =>
+
+  final val lambdaParams = {
+    val paramInfoDb = new SyncRef(paramInfosOp(thisLambda))
+    paramNames.zipWithIndex.map { case (name, idx) =>
+      new Symbol(name, new Completer {
+        def complete(sym: Symbol): Unit = {
+          sym.info = paramInfoDb()(idx)
+        }
+      })
+    }
+  }
+
+  final val resType = resOp(thisLambda)
+
+  def ref(idx: Int): ParamRef = new ParamRef(lambdaParams(idx))
+
+  def underlying: PolyType = {
+    lambdaParams.foreach(_.info)
+    new PolyType(lambdaParams.toList, resType)
+  }
+
+}

--- a/test/tasty/pos/src-2/dottyi3149/TestFooChildren.scala
+++ b/test/tasty/pos/src-2/dottyi3149/TestFooChildren.scala
@@ -6,7 +6,7 @@ import tastytest._
 object TestFooChildren {
   compiletimeHasNestedChildren[Foo](
     "dottyi3149.Foo.Bar",
-    // "dottyi3149.Foo.dottyi3149$Foo$$localSealedChildProxy", // workaround to represent "dottyi3149.Test.Bar$1",
+    "dottyi3149.Foo.dottyi3149$Foo$$localSealedChildProxy", // workaround to represent "dottyi3149.Test.Bar$1",k
     "dottyi3149.Test.O.Bar",
     "dottyi3149.Test.C.Bar"
   )

--- a/test/tasty/run/src-2/tastytest/TestIssue12420.scala
+++ b/test/tasty/run/src-2/tastytest/TestIssue12420.scala
@@ -1,0 +1,19 @@
+package tastytest
+
+import issue12420._
+import issue12420.{ShareLambda => sl}
+
+object TestIssue12420 extends Suite("TestIssue12420") {
+
+  def foo = new Foo
+  def eta = new Eta
+
+  test(assert(foo.bar.id.id == "Foo"))
+
+  test(foo.bar match { case User(UserId(id: String)) => assert(id == "Foo") })
+
+  test(assert(eta.inner == Boxxy.default))
+
+  test(assert(new sl.Foo[sl.Bar].foo(new sl.Bar[List]) == "Bar"))
+
+}

--- a/test/tasty/run/src-3/tastytest/issue12420/ShareLambda.scala
+++ b/test/tasty/run/src-3/tastytest/issue12420/ShareLambda.scala
@@ -1,0 +1,14 @@
+package tastytest.issue12420
+
+object ShareLambda {
+
+  class Foo[K[F[X] <: List[X]]] {
+    def foo[F[X] <: List[X]](x: K[F]): String = x.toString()
+  }
+
+  // `F[X] <: List[X]` is structurally shared in TASTy and defined in `Foo.K`
+  class Bar[F[X] <: List[X]] {
+    override def toString(): String = "Bar"
+  }
+
+}

--- a/test/tasty/run/src-3/tastytest/issue12420/absurd.scala
+++ b/test/tasty/run/src-3/tastytest/issue12420/absurd.scala
@@ -1,0 +1,10 @@
+package tastytest.issue12420
+
+class Boxxy[I <: Int, B <: Boxxy[I, B]]
+
+object Boxxy {
+  object default extends Boxxy[0, default.type]
+}
+
+class Qux[I <: Int, B <: Boxxy[I, B]](val inner: B)
+class Eta extends Qux(Boxxy.default)

--- a/test/tasty/run/src-3/tastytest/issue12420/hasId.scala
+++ b/test/tasty/run/src-3/tastytest/issue12420/hasId.scala
@@ -1,0 +1,15 @@
+package tastytest.issue12420
+
+trait HasId[+K] {
+  def id: K
+}
+
+trait Id[+T, K] {
+  def id: K
+}
+
+case class UserId(id: String) extends Id[User, String]
+case class User(id: UserId) extends HasId[UserId]
+
+class Bar[A <: HasId[Id[A, String]]](val bar: A)
+class Foo extends Bar(User(UserId("Foo")))


### PR DESCRIPTION
The bounds of a higher kinded type parameter can refer to the parameter itself - this previously caused a NullPointerException as the type parameters were not initialised yet when resolving their bounds. We resolve the cycle by initialising symbols for the bounds of type parameters before reading them,

Also now a lot of the lambda implementation is shared between the different kinds of lambda

fixes scala/bug#12420