### PR TITLE
MINOR: upgrade junit5 in test:junit module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,6 +37,8 @@ import scala.build._, VersionUtil._
 // Non-Scala dependencies:
 val junitDep          = "junit"                          % "junit"                            % "4.13.2"
 val junitInterfaceDep = "com.novocode"                   % "junit-interface"                  % "0.11"                            % Test
+val jupiterDep        = "org.junit.jupiter"              % "junit-jupiter"                    % "5.7.1"                           % Test
+val jupiterApiDep     = "org.junit.jupiter"              % "junit-jupiter-api"                % "5.7.1"                           % Test
 val scalacheckDep     = "org.scalacheck"                %% "scalacheck"                       % "1.15.4"                          % Test
 val jolDep            = "org.openjdk.jol"                % "jol-core"                         % "0.13"
 val asmDep            = "org.scala-lang.modules"         % "scala-asm"                        % versionProps("scala-asm.version")
@@ -727,7 +729,7 @@ lazy val junit = project.in(file("test") / "junit")
       "-Ypatmat-exhaust-depth", "40", // despite not caring about patmat exhaustiveness, we still get warnings for this
     ),
     Compile / javacOptions ++= Seq("-Xlint"),
-    libraryDependencies ++= Seq(junitInterfaceDep, jolDep, diffUtilsDep),
+    libraryDependencies ++= Seq(jupiterApiDep, jupiterDep, junitInterfaceDep, jolDep, diffUtilsDep),
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v", "-s"),
     Compile / unmanagedSourceDirectories := Nil,
     Test / unmanagedSourceDirectories := List(baseDirectory.value)

--- a/test/junit/scala/ArrayTest.scala
+++ b/test/junit/scala/ArrayTest.scala
@@ -1,7 +1,7 @@
 package scala
 
-import org.junit.Assert.{ assertArrayEquals, assertFalse, assertTrue }
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.{ assertArrayEquals, assertFalse, assertTrue }
+import org.junit.jupiter.api.Test
 
 import scala.runtime.BoxedUnit
 
@@ -41,10 +41,10 @@ class ArrayTest {
     val ys = Array(Vector(1, 2, 3))
     def anyxs = xs.asInstanceOf[Array[AnyRef]]
     def anyys = ys.asInstanceOf[Array[AnyRef]]
-    assertTrue("Arrays of List and Vector should compare equal", Array.equals(anyxs, anyys))
+    assertTrue(Array.equals(anyxs, anyys), "Arrays of List and Vector should compare equal")
     assertTrue(xs.sameElements(ys))     // for fun
     //assertTrue(Array.equals(xs, ys))  // would be nice
-    assertTrue("Arrays of String", Array.equals(Array[AnyRef]("hello, world"), Array[AnyRef]("hello, world")))
-    assertFalse("Arrays of String", Array.equals(Array[AnyRef]("hello, world"), Array[AnyRef]("goodbye, cruel world")))
+    assertTrue(Array.equals(Array[AnyRef]("hello, world"), Array[AnyRef]("hello, world")), "Arrays of String")
+    assertFalse(Array.equals(Array[AnyRef]("hello, world"), Array[AnyRef]("goodbye, cruel world")), "Arrays of String")
   }
 }

--- a/test/junit/scala/CollectTest.scala
+++ b/test/junit/scala/CollectTest.scala
@@ -1,7 +1,7 @@
 package scala
 
-import org.junit.Assert._
-import org.junit.{Ignore, Test}
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.{Disabled, Test}
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -52,15 +52,18 @@ class CollectTest {
   def testStreamCollectFirst(): Unit =
     testing(Seq(1), Some(1))(Stream.continually(1) collectFirst { case x if f(x) && x < 2 => x})
 
-  @Ignore @Test
+  @Disabled
+  @Test
   def testIteratorCollect(): Unit =
     testing(???)((Iterator(1, 2) collect { case x if f(x) && x < 2 => x}).toList)
 
-  @Ignore @Test
+  @Test
+  @Disabled
   def testListViewCollect(): Unit =
     testing(???)((Iterator(1, 2) collect { case x if f(x) && x < 2 => x}).toList)
 
-  @Ignore @Test
+  @Test
+  @Disabled
   def testFutureCollect(): Unit = {
     // This would do the trick in Future.collect, but I haven't added this yet as there is a tradeoff
     // with extra allocations to consider.

--- a/test/junit/scala/EnumerationTest.scala
+++ b/test/junit/scala/EnumerationTest.scala
@@ -1,11 +1,8 @@
 package scala.collection
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class EnumerationTest {
 
   @Test def t10906(): Unit = {

--- a/test/junit/scala/ExtractorTest.scala
+++ b/test/junit/scala/ExtractorTest.scala
@@ -1,7 +1,7 @@
 package scala
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.RunTesting
 
@@ -23,10 +23,11 @@ class ExtractorTest extends RunTesting {
     }
   }
 
-  @Test(expected = classOf[MatchError]) def testOptionalFunctionExtractorMatchError(): Unit = {
-    2 match {
+  @Test
+  def testOptionalFunctionExtractorMatchError(): Unit = {
+    assertThrows(classOf[MatchError], () => 2 match {
       case of.unlift(m) =>
-    }
+    })
   }
 
   @Test def testOptionalFunctionExtractorSeq(): Unit = {
@@ -37,10 +38,11 @@ class ExtractorTest extends RunTesting {
     }
   }
 
-  @Test(expected = classOf[MatchError]) def testOptionalFunctionExtractorSeqMatchError(): Unit = {
-    Seq(1, 2) match {
+  @Test
+  def testOptionalFunctionExtractorSeqMatchError(): Unit = {
+    assertThrows(classOf[MatchError], () => Seq(1, 2) match {
       case of.unlift.elementWise(m0, m1) =>
-    }
+    })
   }
 
   val pf: PartialFunction[Int, String] = {
@@ -55,10 +57,11 @@ class ExtractorTest extends RunTesting {
     }
   }
 
-  @Test(expected = classOf[MatchError]) def testPartialFunctionExtractorMatchError(): Unit = {
-    2 match {
+  @Test
+  def testPartialFunctionExtractorMatchError(): Unit = {
+    assertThrows(classOf[MatchError], () => 2 match {
       case pf(m) =>
-    }
+    })
   }
 
   @Test def testPartialFunctionExtractorSeq(): Unit = {
@@ -69,10 +72,11 @@ class ExtractorTest extends RunTesting {
     }
   }
 
-  @Test(expected = classOf[MatchError]) def testPartialFunctionExtractorSeqMatchError(): Unit = {
-    Seq(1, 2) match {
+  @Test
+  def testPartialFunctionExtractorSeqMatchError(): Unit = {
+    assertThrows(classOf[MatchError], () => Seq(1, 2) match {
       case pf.elementWise(m0, m1) =>
-    }
+    })
   }
 
 }

--- a/test/junit/scala/MatchErrorSerializationTest.scala
+++ b/test/junit/scala/MatchErrorSerializationTest.scala
@@ -1,13 +1,10 @@
 package scala
 
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Test
 
 /**
   * Created by estsauver on 6/15/17.
   */
-@RunWith(classOf[JUnit4])
 class MatchErrorSerializationTest {
 
   @Test

--- a/test/junit/scala/OptionJavaTest.java
+++ b/test/junit/scala/OptionJavaTest.java
@@ -17,8 +17,15 @@ import java.util.List;
 
 import scala.jdk.javaapi.CollectionConverters;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OptionJavaTest {
 
@@ -54,9 +61,9 @@ public class OptionJavaTest {
         assertFalse(noneIntegerOpt.nonEmpty());
     }
 
-    @Test(expected = java.util.NoSuchElementException.class)
+    @Test
     public void testGetNoneIntegerFailure() {
-        noneIntegerOpt.get();
+        assertThrows(java.util.NoSuchElementException.class, () ->noneIntegerOpt.get());
     }
 
     @Test
@@ -77,9 +84,9 @@ public class OptionJavaTest {
         assertFalse(noneStringOpt.nonEmpty());
     }
 
-    @Test(expected = java.util.NoSuchElementException.class)
+    @Test
     public void testGetNoneStringFailure() {
-        noneStringOpt.get();
+        assertThrows(java.util.NoSuchElementException.class, () ->noneStringOpt.get());
     }
 
     @Test

--- a/test/junit/scala/OptionTest.scala
+++ b/test/junit/scala/OptionTest.scala
@@ -1,7 +1,7 @@
 package scala
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.RunTesting
 
@@ -22,8 +22,8 @@ class OptionTest extends RunTesting {
   import runner._
   import scala.tools.reflect.{ ToolBoxError => E }
 
-  @Test(expected = classOf[E]) def testSomeZipList(): Unit = run("""Some("foo") zip List("bar", "baz")""")
-  @Test(expected = classOf[E]) def testSomeZipNil(): Unit = run("""Some("foo") zip Nil""")
-  @Test(expected = classOf[E]) def testNoneZipList(): Unit = run("""None zip List("bar")""")
-  @Test(expected = classOf[E]) def testNoneZipNil(): Unit = run("""None zip Nil""")
+  @Test() def testSomeZipList(): Unit = assertThrows(classOf[E], run("""Some("foo") zip List("bar", "baz")"""))
+  @Test() def testSomeZipNil(): Unit = assertThrows(classOf[E], run("""Some("foo") zip Nil"""))
+  @Test() def testNoneZipList(): Unit = assertThrows(classOf[E], run("""None zip List("bar")"""))
+  @Test() def testNoneZipNil(): Unit = assertThrows(classOf[E], run("""None zip Nil"""))
 }

--- a/test/junit/scala/PartialFunctionCompositionTest.scala
+++ b/test/junit/scala/PartialFunctionCompositionTest.scala
@@ -1,11 +1,8 @@
 package scala
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class PartialFunctionCompositionTest {
   val fallbackFun = (_: String) => "fallback"
   val passAll: PartialFunction[String, String] = { case any => any }

--- a/test/junit/scala/PartialFunctionSerializationTest.scala
+++ b/test/junit/scala/PartialFunctionSerializationTest.scala
@@ -1,10 +1,7 @@
 package scala
 
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class PartialFunctionSerializationTest {
   val pf1: PartialFunction[Int, Int] = { case n if n > 0 => 1 }
   val pf2: PartialFunction[Int, Int] = { case n if n <= 0 => 2 }

--- a/test/junit/scala/PredefTest.scala
+++ b/test/junit/scala/PredefTest.scala
@@ -1,7 +1,7 @@
 package scala
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 
 class PredefTest {

--- a/test/junit/scala/SerializationStabilityTest.scala
+++ b/test/junit/scala/SerializationStabilityTest.scala
@@ -3,7 +3,7 @@ package scala
 import scala.annotation.nowarn
 import scala.reflect.io.File
 import java.util.Base64
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 package collection {
   object accessWrappers { val Wrappers = convert.JavaCollectionWrappers }

--- a/test/junit/scala/StringTest.scala
+++ b/test/junit/scala/StringTest.scala
@@ -4,7 +4,7 @@ import scala.tools.reflect.ToolBoxError
 import scala.tools.testkit.AssertUtil._
 import scala.tools.testkit.RunTesting
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class StringTest extends RunTesting {
   @Test def testNoSelf(): Unit   = assertThrows[ToolBoxError](runner.run(""" "A".self """))

--- a/test/junit/scala/collection/ArrayOpsTest.scala
+++ b/test/junit/scala/collection/ArrayOpsTest.scala
@@ -1,11 +1,8 @@
 package scala.collection
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class ArrayOpsTest {
 
   @Test

--- a/test/junit/scala/collection/BuildFromTest.scala
+++ b/test/junit/scala/collection/BuildFromTest.scala
@@ -1,6 +1,6 @@
 package scala.collection
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import scala.annotation.unused
 import scala.collection.mutable.Builder

--- a/test/junit/scala/collection/CatTest.scala
+++ b/test/junit/scala/collection/CatTest.scala
@@ -1,11 +1,9 @@
 package scala.collection
 
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Test
+
 import scala.collection.immutable.{List, Vector}
 
-@RunWith(classOf[JUnit4])
 /* Test for scala/bug#8014 and ++ in general  */
 class CatTest {
   val noVec = Vector.empty[Int]

--- a/test/junit/scala/collection/CollectionConversionsTest.scala
+++ b/test/junit/scala/collection/CollectionConversionsTest.scala
@@ -1,7 +1,7 @@
 package scala.collection
 
-import org.junit.Test
-import org.junit.Assert._
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions._
 
 import scala.collection.mutable.Buffer
 import scala.reflect.ClassTag

--- a/test/junit/scala/collection/EqualityTest.scala
+++ b/test/junit/scala/collection/EqualityTest.scala
@@ -1,12 +1,10 @@
 package scala.collection
 
-import org.junit.{Assert, Test}
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.{Assertions, Test}
+
 import scala.collection.immutable.{LazyList, List, Range}
 import scala.collection.mutable.ArrayBuffer
 
-@RunWith(classOf[JUnit4])
 class EqualityTest {
 
   @Test
@@ -15,15 +13,15 @@ class EqualityTest {
     val lazyList: Iterable[Int] = LazyList(1, 2, 3)
     val buffer = ArrayBuffer(1, 2, 3)
     val range = Range.inclusive(1, 3)
-    Assert.assertTrue(list == lazyList)
-    Assert.assertTrue(list.## == lazyList.##)
-    Assert.assertTrue(list == (buffer: Iterable[Int]))
-    Assert.assertTrue(list.## == buffer.##)
-    Assert.assertTrue(list == (range: Iterable[Int]))
-    Assert.assertTrue(list.## == range.##)
+    Assertions.assertTrue(list == lazyList)
+    Assertions.assertTrue(list.## == lazyList.##)
+    Assertions.assertTrue(list == (buffer: Iterable[Int]))
+    Assertions.assertTrue(list.## == buffer.##)
+    Assertions.assertTrue(list == (range: Iterable[Int]))
+    Assertions.assertTrue(list.## == range.##)
     buffer += 4
-    Assert.assertTrue(list != (buffer: Iterable[Int]))
-    Assert.assertTrue(list.## != buffer.##)
+    Assertions.assertTrue(list != (buffer: Iterable[Int]))
+    Assertions.assertTrue(list.## != buffer.##)
   }
 
   @Test
@@ -31,12 +29,12 @@ class EqualityTest {
     val xs = List(1, 2, 3)
     var n = 0
     val xsView = xs.view.map { x => n += 1; x }
-    Assert.assertTrue(xs != xsView)
-    Assert.assertTrue(xsView != xs)
-    Assert.assertTrue(xs.## != xsView.##)
-    Assert.assertEquals(0, n) // The view hasn’t been evaluated
-    Assert.assertTrue(xs sameElements xsView) // sameElements does evaluate the view elements
-    Assert.assertEquals(3, n)
+    Assertions.assertTrue(xs != xsView)
+    Assertions.assertTrue(xsView != xs)
+    Assertions.assertTrue(xs.## != xsView.##)
+    Assertions.assertEquals(0, n) // The view hasn’t been evaluated
+    Assertions.assertTrue(xs sameElements xsView) // sameElements does evaluate the view elements
+    Assertions.assertEquals(3, n)
   }
 
 }

--- a/test/junit/scala/collection/FactoriesTest.scala
+++ b/test/junit/scala/collection/FactoriesTest.scala
@@ -1,10 +1,9 @@
 package scala.collection
 
-import org.junit.Assert.{assertEquals, assertSame, assertTrue}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertSame, assertTrue}
+import org.junit.jupiter.api.{Assertions, Test}
 
 import scala.collection.mutable.ArrayBuffer
-import org.junit.{Assert, Test}
-
 import scala.collection.{immutable => im}
 
 class FactoriesTest {
@@ -16,7 +15,7 @@ class FactoriesTest {
     def cloneCollection[A, C](xs: Iterable[A])(implicit bf: BuildFrom[xs.type, A, C]): C =
       bf.fromSpecific(xs)(xs)
 
-    Assert.assertEquals("ArrayBuffer", cloneCollection(seq).collectionClassName)
+    Assertions.assertEquals("ArrayBuffer", cloneCollection(seq).collectionClassName)
   }
 
   @Test def factoryIgnoresSourceCollectionFactory(): Unit = {
@@ -24,7 +23,7 @@ class FactoriesTest {
     def cloneElements[A, C](xs: Iterable[A])(cb: Factory[A, C]): C =
       cb.fromSpecific(xs)
 
-    Assert.assertEquals("List", cloneElements(seq)(Seq).collectionClassName)
+    Assertions.assertEquals("List", cloneElements(seq)(Seq).collectionClassName)
   }
 
   def apply(factory: IterableFactory[Iterable]): Unit = {
@@ -111,9 +110,10 @@ class FactoriesTest {
       input <- inputs
     } {
       assertSame(
-        s"IterableFactory ($factory)'s method `from` should return the same reference when passed $input",
         input,
-        factory.from(input))
+        factory.from(input),
+        s"IterableFactory ($factory)'s method `from` should return the same reference when passed $input"
+      )
     }
   def sortedFactoryFromIterableOnceReturnsSameReference[CC[X] <: IterableOnce[X] , A](
     factories: SortedIterableFactory[CC]*
@@ -125,9 +125,10 @@ class FactoriesTest {
       input <- inputs
     } {
       assertSame(
-        s"SortedIterableFactory ($factory)'s method `from` should return the same reference when passed $input",
         input,
-        factory.from(input))
+        factory.from(input),
+        s"SortedIterableFactory ($factory)'s method `from` should return the same reference when passed $input"
+      )
     }
   def mapFactoryFromIterableOnceReturnsSameReference[CC[X, Y] <: Map[X, Y] , K, V](
    factories: MapFactory[CC]*
@@ -139,9 +140,9 @@ class FactoriesTest {
       input <- inputs
     } {
       assertSame(
-        s"MapFactory ($factory)'s method `from` should return the same reference when passed $input",
         input,
-        factory.from(input))
+        factory.from(input),
+        s"MapFactory ($factory)'s method `from` should return the same reference when passed $input")
     }
   def sortedMapFactoryFromIterableOnceReturnsSameReference[CC[X, Y] <: Map[X, Y] , K, V](
     factories: SortedMapFactory[CC]*
@@ -153,9 +154,10 @@ class FactoriesTest {
       input <- inputs
     } {
       assertSame(
-        s"SortedMapFactory ($factory)'s method `from` should return the same reference when passed $input",
         input,
-        factory.from(input))
+        factory.from(input),
+        s"SortedMapFactory ($factory)'s method `from` should return the same reference when passed $input"
+      )
     }
 
 

--- a/test/junit/scala/collection/GenericTest.scala
+++ b/test/junit/scala/collection/GenericTest.scala
@@ -4,7 +4,7 @@ import mutable.Builder
 
 import scala.util.Try
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 trait Parse[A] {
   def parse(s: String): Option[A]

--- a/test/junit/scala/collection/IndexedSeqOptimizedTest.scala
+++ b/test/junit/scala/collection/IndexedSeqOptimizedTest.scala
@@ -1,11 +1,8 @@
 package scala.collection
 
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class IndexedSeqOptimizedTest {
 
   @Test

--- a/test/junit/scala/collection/IndexedSeqTest.scala
+++ b/test/junit/scala/collection/IndexedSeqTest.scala
@@ -1,9 +1,7 @@
 package scala.collection
 
-import org.junit.Test
-import org.junit.Assert._
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions._
 
 /**
   * base class for testing common methods on a various implementations
@@ -11,7 +9,6 @@ import org.junit.runners.JUnit4
   * @tparam T the collection type
   * @tparam E the element type
   */
-@RunWith(classOf[JUnit4])
 abstract class IndexedTest[T, E] {
 
   protected def size = 10
@@ -35,7 +32,7 @@ abstract class IndexedTest[T, E] {
   @Test def checkIndexedAccess(): Unit = {
     val test = underTest(size)
     for (i <- 0 until size) {
-      assertEquals(s" at index $i", expectedValueAtIndex(i), get(test, i))
+      assertEquals(expectedValueAtIndex(i), get(test, i), s" at index $i")
     }
   }
 
@@ -61,12 +58,12 @@ abstract class IndexedTest[T, E] {
     val txtAndState = s"$txt canBeSame $canBeSame isMutableContent $isMutableContent isTakeAllSame $isTakeAllSame offset $offset len $len length(test) ${length(test)}"
     val isValidSame = canBeSame && !isMutableContent && offset == 0 && len == size
     if (isValidSame && isTakeAllSame)
-      assertSame(txtAndState, orig, test)
+      assertSame(orig, test, txtAndState)
     else
-      assertNotSame(txtAndState, orig, test)
-    assertSame(txtAndState, len, length(test))
+      assertNotSame(orig, test, txtAndState)
+    assertSame(len, length(test), txtAndState)
     for (i <- 0 until len) {
-      assertEquals(s" $txtAndState $i $offset $len", expectedValueAtIndex(i + offset), get(test, i))
+      assertEquals(expectedValueAtIndex(i + offset), get(test, i), s" $txtAndState $i $offset $len")
     }
   }
 
@@ -116,8 +113,8 @@ abstract class IndexedTest[T, E] {
     for (start <- 0 until size) {
       val empty1 = slice(orig, start, start)
       val empty2 = slice(orig, start, start)
-      assertEquals(s"start $start", 0, length(empty1))
-      if (isEmptyConstant) assertSame(s"start $start", empty1, empty2)
+      assertEquals(0, length(empty1), s"start $start")
+      if (isEmptyConstant) assertSame(empty1, empty2, s"start $start")
     }
   }
 
@@ -160,8 +157,8 @@ abstract class IndexedTest[T, E] {
     val e = take(orig, 0)
     for (len <- List(-1, -10, -99, Int.MinValue)) {
       val empty = take(orig, len)
-      assertEquals(s"len $len", 0, length(empty))
-      if (isEmptyConstant) assertSame(s"len $len", e, empty)
+      assertEquals(0, length(empty), s"len $len")
+      if (isEmptyConstant) assertSame(e, empty, s"len $len")
     }
   }
 
@@ -175,7 +172,7 @@ abstract class IndexedTest[T, E] {
     assertNotNull(e)
     for (len <- List(size + 1, size + 10, Int.MaxValue)) {
       val all = take(orig, len)
-      assertEquals(s"len $len", size, length(all))
+      assertEquals(size, length(all), s"len $len")
       expectSameContent("", true, orig, all, 0, size)
     }
   }
@@ -405,7 +402,7 @@ package IndexedTestImpl {
     override def isTakeAllSame = true
 
     override def doAssertEquals(txt: String, expected: T, actual: T): Unit = {
-      assertEquals(txt, expected, actual)
+      assertEquals(expected, actual, txt)
     }
 
     def createEmpty(size: Int) : T
@@ -437,7 +434,7 @@ package IndexedTestImpl {
     override def isTakeAllSame = true
 
     override def doAssertEquals(txt: String, expected: T, actual: T): Unit = {
-      assertEquals(txt, expected, actual)
+      assertEquals(expected, actual, txt)
     }
 
   }
@@ -460,7 +457,7 @@ package IndexedTestImpl {
     override def isTakeAllSame = false
 
     override def doAssertEquals(txt: String, expected: StringOps, actual: StringOps): Unit = {
-      assertEquals(txt, expected, actual)
+      assertEquals(expected, actual, txt)
     }
 
   }

--- a/test/junit/scala/collection/IndexedSeqViewTest.scala
+++ b/test/junit/scala/collection/IndexedSeqViewTest.scala
@@ -1,11 +1,8 @@
 package scala.collection
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class IndexedSeqViewTest {
   @Test
   def _toString(): Unit = {

--- a/test/junit/scala/collection/IterableTest.scala
+++ b/test/junit/scala/collection/IterableTest.scala
@@ -1,6 +1,7 @@
 package scala.collection
 
-import org.junit.{Assert, Test}, Assert.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Test
 
 import scala.collection.immutable.{ArraySeq, List, Range, Vector}
 import scala.tools.testkit.AssertUtil._
@@ -281,8 +282,8 @@ class IterableTest {
   @deprecated("Uses deprecated hasDefiniteSize, extends HashMap", since="2.13.0")
   @Test
   def hasDefiniteSize(): Unit = {
+    import scala.collection.{immutable => i, mutable => m}
     import scala.{collection => c}
-    import scala.collection.{mutable => m, immutable => i}
     assertEquals(true, Some(1).hasDefiniteSize)
     assertEquals(true, None.hasDefiniteSize)
     assertEquals(true, Option(1).hasDefiniteSize)

--- a/test/junit/scala/collection/IterableViewLikeTest.scala
+++ b/test/junit/scala/collection/IterableViewLikeTest.scala
@@ -1,7 +1,7 @@
 package scala.collection
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 class IterableViewLikeTest {
 

--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -1,15 +1,12 @@
 package scala.collection
 
-import org.junit.Assert.{ assertThrows => _, _ }
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.{ assertThrows => _, _ }
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.AssertUtil._
 
 import Seq.empty
 
-@RunWith(classOf[JUnit4])
 class IteratorTest {
 
   private def from0 = Iterator.from(0)
@@ -19,7 +16,7 @@ class IteratorTest {
     val it = new Iterator[Int] { var i = 0 ; def hasNext = { counter = i; true } ; def next() = { i += 1; i } }
     val slidingIt = it sliding 2
     slidingIt.next()
-    assertEquals("Counter should be one, that means we didn't look further than needed", 1, counter)
+    assertEquals(1, counter, "Counter should be one, that means we didn't look further than needed")
   }
 
   @Test def groupedIteratorIsLazyWhenPadded(): Unit = {
@@ -27,7 +24,7 @@ class IteratorTest {
     def it = new Iterator[Int] { var i = 0 ; def hasNext = { counter = i; true } ; def next() = { i += 1; i } }
     val slidingIt = it sliding 2 withPadding -1
     slidingIt.next()
-    assertEquals("Counter should be one, that means we didn't look further than needed", 1, counter)
+    assertEquals(1, counter, "Counter should be one, that means we didn't look further than needed")
   }
 
   @Test def dropDoesNotGrowStack(): Unit = {
@@ -817,7 +814,7 @@ class IteratorTest {
     val it3 = it2 ++ Array(4).iterator
     assertEquals(2, it3.next())
     assertEquals(3, it3.next())
-    assertTrue("concatted tail of it3 should be next", it3.hasNext)
+    assertTrue(it3.hasNext, "concatted tail of it3 should be next")
   }
 
 }

--- a/test/junit/scala/collection/LazyZipOpsTest.scala
+++ b/test/junit/scala/collection/LazyZipOpsTest.scala
@@ -2,15 +2,12 @@ package scala.collection
 
 import org.hamcrest.CoreMatchers._
 import org.hamcrest.MatcherAssert._
-import org.junit.Assert.{assertThat => _, _}
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.{assertArrayEquals, assertEquals, assertFalse, assertTrue}
+import org.junit.jupiter.api.Test
 
 import scala.AdaptedArrowAssocWorkaround.Tx
 import scala.collection.immutable._
 
-@RunWith(classOf[JUnit4])
 class LazyZipOpsTest {
 
   private val ws = List(1, 2, 3)

--- a/test/junit/scala/collection/LinearSeqOptimizedTest.scala
+++ b/test/junit/scala/collection/LinearSeqOptimizedTest.scala
@@ -1,11 +1,8 @@
 package scala.collection
 
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class LinearSeqOptimizedTest {
 
   @Test def `t9936 indexWhere`(): Unit = {

--- a/test/junit/scala/collection/LinearSeqTest.scala
+++ b/test/junit/scala/collection/LinearSeqTest.scala
@@ -1,10 +1,7 @@
 package scala.collection
 
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class LinearSeqTest {
   // Tests regression on issue 11262
   @Test def extensionIteratorTest(): Unit = {

--- a/test/junit/scala/collection/MapTest.scala
+++ b/test/junit/scala/collection/MapTest.scala
@@ -1,7 +1,7 @@
 package scala.collection
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 class MapTest {
   @deprecated("Tests deprecated API", since="2.13")

--- a/test/junit/scala/collection/MapViewTest.scala
+++ b/test/junit/scala/collection/MapViewTest.scala
@@ -1,7 +1,7 @@
 package scala.collection
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 class MapViewTest {
   @Test

--- a/test/junit/scala/collection/MinByMaxByTest.scala
+++ b/test/junit/scala/collection/MinByMaxByTest.scala
@@ -1,7 +1,7 @@
 package scala.collection
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.annotation.unused
 import scala.tools.testkit.AssertUtil.assertThrows
@@ -23,9 +23,9 @@ class MinByMaxByTest {
   def testCorrectness() = {
     def f(x: Int) = -1 * x
     val max = list.maxBy(f)
-    assertTrue("f(list.maxBy(f)) should ≥ f(x) where x is any element of list.", list.forall(f(_) <= f(max)))
+    assertTrue(list.forall(f(_) <= f(max)), "f(list.maxBy(f)) should ≥ f(x) where x is any element of list.")
     val min = list.minBy(f)
-    assertTrue("f(list.minBy(f)) should ≤ f(x) where x is any element of list.", list.forall(f(_) >= f(min)))
+    assertTrue(list.forall(f(_) >= f(min)), "f(list.minBy(f)) should ≤ f(x) where x is any element of list.")
   }
 
   // Ensure that it always returns the first match if more than one element have the same largest/smallest f(x).

--- a/test/junit/scala/collection/NewBuilderTest.scala
+++ b/test/junit/scala/collection/NewBuilderTest.scala
@@ -3,8 +3,8 @@ package scala.collection
 import scala.{collection => sc}, sc.{mutable => scm, immutable => sci}
 import scala.reflect.ClassTag
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 /* Tests various maps by making sure they all agree on the same answers. */
 class NewBuilderTest {
@@ -15,7 +15,7 @@ class NewBuilderTest {
     def test[T: ClassTag](mapped: Any): Unit = {
       val expected = reflect.classTag[T].runtimeClass
       val isInstance = reflect.classTag[T].runtimeClass.isInstance(mapped)
-      assertTrue(s"$mapped (of class ${mapped.getClass} is not a in instance of ${expected}", isInstance)
+      assertTrue(isInstance, s"$mapped (of class ${mapped.getClass} is not a in instance of ${expected}")
     }
 
     test[sc.GenTraversable[_]   ]((sc.GenTraversable(1):    sc.GenTraversable[Int]).map(x => x))

--- a/test/junit/scala/collection/ReusableBuildersTest.scala
+++ b/test/junit/scala/collection/ReusableBuildersTest.scala
@@ -1,11 +1,8 @@
 package scala.collection
 
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /* Tests various maps by making sure they all agree on the same answers. */
-@RunWith(classOf[JUnit4])
 class ReusableBuildersTest {
   // GrowingBuilders are NOT reusable but can clear themselves
   @Test

--- a/test/junit/scala/collection/SearchingTest.scala
+++ b/test/junit/scala/collection/SearchingTest.scala
@@ -1,12 +1,9 @@
 package scala.collection
 
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 import scala.collection.Searching._
 
-@RunWith(classOf[JUnit4])
 class SearchingTest {
 
   @Test

--- a/test/junit/scala/collection/SeqTest.scala
+++ b/test/junit/scala/collection/SeqTest.scala
@@ -1,7 +1,7 @@
 package scala.collection
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.{AllocationTest, CompileTime}
 

--- a/test/junit/scala/collection/SeqTests.scala
+++ b/test/junit/scala/collection/SeqTests.scala
@@ -1,6 +1,6 @@
 package scala.collection.immutable
 
-import org.junit.Assert
+import org.junit.jupiter.api.Assertions
 
 object SeqTests {
   def checkSearch[A](seq: Seq[A], needle: A, ord: Ordering[A]): Unit = {
@@ -15,13 +15,13 @@ object SeqTests {
       sorted.search(needle, from, to)(ord) match {
         case Found(foundIndex: Int) => {
           val found = sorted(foundIndex)
-          Assert.assertTrue(s"found value $found not equivalent to searched value $needle in List(0-1000) between indices $from and $to", ord.equiv(found, needle))
+          Assertions.assertTrue(ord.equiv(found, needle), s"found value $found not equivalent to searched value $needle in List(0-1000) between indices $from and $to")
         }
         case InsertionPoint(insertionPoint: Int) =>
           for ((e, i) <- sorted.zipWithIndex) {
             if(i >= from && i < to) {
-              if(i < insertionPoint) Assert.assertFalse(s"a value before the insertion point was greater than $needle", ord.gt(e, needle))
-              else Assert.assertFalse(s"a values past the insertion point was smaller than $needle", ord.lt(e, needle))
+              if(i < insertionPoint) Assertions.assertFalse(ord.gt(e, needle), s"a value before the insertion point was greater than $needle")
+              else Assertions.assertFalse(ord.lt(e, needle), s"a values past the insertion point was smaller than $needle")
             }
             //else we don't want to make any statements for values out of that range
           }

--- a/test/junit/scala/collection/SeqViewTest.scala
+++ b/test/junit/scala/collection/SeqViewTest.scala
@@ -1,11 +1,8 @@
 package scala.collection
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class SeqViewTest {
   @Test
   def _toString(): Unit = {

--- a/test/junit/scala/collection/SetMapConsistencyTest.scala
+++ b/test/junit/scala/collection/SetMapConsistencyTest.scala
@@ -1,6 +1,6 @@
 package scala.collection
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import scala.collection.{mutable => cm, immutable => ci}
 import scala.jdk.CollectionConverters._
 

--- a/test/junit/scala/collection/SetMapRulesTest.scala
+++ b/test/junit/scala/collection/SetMapRulesTest.scala
@@ -12,10 +12,8 @@
 
 package scala.collection
 
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Test
-import org.junit.Assert._
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions._
 
 import scala.annotation.unused
 import scala.collection.{mutable, immutable, concurrent}
@@ -35,7 +33,6 @@ import scala.jdk.CollectionConverters._
   * 1 is indirectly tested by using the `Value` instances as keys in all tests. 3 cannot be tested directly. The other
   * rules have explicit tests.
   */
-@RunWith(classOf[JUnit4])
 class SetMapRulesTest {
 
   class Value private (val id: Int, extra: Int) {
@@ -68,7 +65,7 @@ class SetMapRulesTest {
   private def checkUnique[T <: mutable.Iterable[_]](gen: () => T, op: String)(f: T => T): Unit = {
     val v1 = gen()
     val v2 = f(v1)
-    assertNotSame(s"$op should be a different object", v1, v2)
+    assertNotSame(v1, v2, s"$op should be a different object")
   }
 
   private def checkPreservesKeyIdentities[T <: collection.Map[Value, Value]](gen: () => T, op: String)(f: T => T): Unit = {
@@ -76,7 +73,7 @@ class SetMapRulesTest {
     val keys1 = v1.keysIterator.map(_.toTuple).toSet
     val v2 = f(v1)
     val keys2 = v2.keysIterator.map(_.toTuple).toSet
-    assertTrue(s"$op should preserve key identities (all of $keys1 should be in $keys2)", keys1.forall(k => keys2.contains(k)))
+    assertTrue(keys1.forall(k => keys2.contains(k)), s"$op should preserve key identities (all of $keys1 should be in $keys2)")
   }
 
   private def checkPreservesIdentities[T <: collection.Iterable[Value]](gen: () => T, op: String)(f: T => T): Unit = {
@@ -84,7 +81,7 @@ class SetMapRulesTest {
     val keys1 = v1.iterator.map(_.toTuple).toSet
     val v2 = f(v1)
     val keys2 = v2.iterator.map(_.toTuple).toSet
-    assertTrue(s"$op should preserve key identities (all of $keys1 should be in $keys2)", keys1.forall(k => keys2.contains(k)))
+    assertTrue(keys1.forall(k => keys2.contains(k)), s"$op should preserve key identities (all of $keys1 should be in $keys2)")
   }
 
   private def checkDiscardsKeyIdentities[T <: collection.Map[Value, Value]](gen: () => T, op: String)(f: T => T): Unit = {
@@ -92,7 +89,7 @@ class SetMapRulesTest {
     val keys1 = v1.keysIterator.map(_.toTuple).toSet
     val v2 = f(v1)
     val keys2 = v2.keysIterator.map(_.toTuple).toSet
-    assertTrue(s"$op should discard key identities (none of $keys1 should be in $keys2)", keys1.forall(k => !keys2.contains(k)))
+    assertTrue(keys1.forall(k => !keys2.contains(k)), s"$op should discard key identities (none of $keys1 should be in $keys2)")
   }
 
   private def checkDiscardsIdentities[T <: collection.Iterable[Value]](gen: () => T, op: String)(f: T => T): Unit = {
@@ -100,7 +97,7 @@ class SetMapRulesTest {
     val keys1 = v1.iterator.map(_.toTuple).toSet
     val v2 = f(v1)
     val keys2 = v2.iterator.map(_.toTuple).toSet
-    assertTrue(s"$op should discard key identities (none of $keys1 should be in $keys2)", keys1.forall(k => !keys2.contains(k)))
+    assertTrue(keys1.forall(k => !keys2.contains(k)), s"$op should discard key identities (none of $keys1 should be in $keys2)")
   }
 
   private def checkAllValuesUpdated[T <: collection.Map[Value, Value]](gen: () => T, op: String)(f: T => T): Unit = {
@@ -108,7 +105,7 @@ class SetMapRulesTest {
     val values1 = v1.valuesIterator.map(_.toTuple).toSet
     val v2 = f(v1)
     val values2 = v2.valuesIterator.map(_.toTuple).toSet
-    assertTrue(s"$op should update values (none of $values1 should be in $values2)", values1.forall(k => !values2.contains(k)))
+    assertTrue(values1.forall(k => !values2.contains(k)), s"$op should update values (none of $values1 should be in $values2)")
   }
 
   private def checkNoSharedValues[T <: immutable.Map[Value, Value]](gen: () => T, op: String)(f: T => T): Unit = {
@@ -117,7 +114,7 @@ class SetMapRulesTest {
     val v2 = f(v1)
     val entries1b = v1.iterator.map { case (k, v) => (k.toTuple, v.toTuple) }.toSet
     @unused val entries2 = v2.iterator.map { case (k, v) => (k.toTuple, v.toTuple) }.toSet
-    assertEquals(s"$op should preserve original values ($entries1a should be equal to $entries1b)", entries1a, entries1b)
+    assertEquals(entries1a, entries1b, s"$op should preserve original values ($entries1a should be equal to $entries1b)")
   }
 
   private def checkMap(gen: () => collection.Map[Value, Value]): Unit = {

--- a/test/junit/scala/collection/SortedSetMapEqualsTest.scala
+++ b/test/junit/scala/collection/SortedSetMapEqualsTest.scala
@@ -1,7 +1,7 @@
 package scala.collection
 
-import org.junit.{Assert, Test}
-import Assert.{assertEquals, assertNotEquals}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertNotEquals}
+import org.junit.jupiter.api.Test
 
 class SortedSetMapEqualsTest {
   @Test

--- a/test/junit/scala/collection/SortedSetTest.scala
+++ b/test/junit/scala/collection/SortedSetTest.scala
@@ -1,11 +1,8 @@
 package scala.collection
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class SortedSetTest {
   import SortedSetTest._
 

--- a/test/junit/scala/collection/StrictOptimizedSeqTest.scala
+++ b/test/junit/scala/collection/StrictOptimizedSeqTest.scala
@@ -1,12 +1,10 @@
 package scala.collection
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
 import scala.collection.immutable.Vector
 
-@RunWith(classOf[JUnit4])
 class StrictOptimizedSeqTest {
 
   @Test

--- a/test/junit/scala/collection/StringOpsTest.scala
+++ b/test/junit/scala/collection/StringOpsTest.scala
@@ -1,13 +1,10 @@
 package scala.collection
 
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
 import scala.tools.testkit.AssertUtil.assertThrows
 
 
-@RunWith(classOf[JUnit4])
 class StringOpsTest {
   // Test for scala/bug#10951
   @Test def mkstring(): Unit = {

--- a/test/junit/scala/collection/StringParsersTest.scala
+++ b/test/junit/scala/collection/StringParsersTest.scala
@@ -1,44 +1,40 @@
 package scala.collection
 
-import org.junit.Test
-import org.junit.Assert.{ assertThrows => _, _ }
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.{assertThrows => _, _}
+import org.junit.jupiter.api.Test
+
 import scala.tools.testkit.AssertUtil._
 import scala.util.Try
 
-@RunWith(classOf[JUnit4])
 class StringParsersTest {
 
   def doubleOK(str: String): Unit = assertTrue(
-    s"str.toDouble <> str.toDoubleOption for $str",
     (str.toDoubleOption, Try(str.toDouble).toOption) match {
       case (Some(d1), Some(d2)) => d1.isNaN && d2.isNaN || d1 == d2
       case (o1, o2) => o1 == o2
-    })
+    }, s"str.toDouble <> str.toDoubleOption for $str")
 
   def floatOK(str: String): Unit = assertTrue(
-    s"str.toFloat <> str.toFloatOption for $str",
     (str.toFloatOption, Try(str.toFloat).toOption) match {
       case (Some(f1), Some(f2)) if f1.isNaN && f2.isNaN => true
       case (o1, o2) => o1 == o2
-    })
+    }, s"str.toFloat <> str.toFloatOption for $str")
 
   def byteOK(str: String): Unit = assertTrue(
-    s"str.toByte <> str.toByteOption for $str",
-    str.toByteOption == Try(str.toByte).toOption)
+    str.toByteOption == Try(str.toByte).toOption,
+    s"str.toByte <> str.toByteOption for $str")
 
   def shortOK(str: String): Unit = assertTrue(
-    s"str.toShort <> str.toShortOption for $str",
-    str.toShortOption == Try(str.toShort).toOption)
+    str.toShortOption == Try(str.toShort).toOption,
+    s"str.toShort <> str.toShortOption for $str")
 
   def intOK(str: String): Unit = assertTrue(
-    s"str.toInt <> str.toIntOption for $str",
-    str.toIntOption == Try(str.toInt).toOption)
+    str.toIntOption == Try(str.toInt).toOption,
+    s"str.toInt <> str.toIntOption for $str")
 
   def longOK(str: String): Unit = assertTrue(
-    s"str.toLong <> str.toLongOption for $str",
-    str.toLongOption == Try(str.toLong).toOption)
+    str.toLongOption == Try(str.toLong).toOption,
+    s"str.toLong <> str.toLongOption for $str")
 
   val forAllExamples = List("", "+", "-", "0", "-0", "+0", "1", "-1", "+1")
 

--- a/test/junit/scala/collection/TraversableLikeTest.scala
+++ b/test/junit/scala/collection/TraversableLikeTest.scala
@@ -1,7 +1,7 @@
 package scala.collection
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 class TraversableLikeTest {
   @Test

--- a/test/junit/scala/collection/TraversableOnceTest.scala
+++ b/test/junit/scala/collection/TraversableOnceTest.scala
@@ -1,7 +1,7 @@
 package scala.collection
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 import scala.util.Random
 
 /* Test for scala/bug#7614 */

--- a/test/junit/scala/collection/UnsortedTest.scala
+++ b/test/junit/scala/collection/UnsortedTest.scala
@@ -1,13 +1,10 @@
 package scala.collection
 
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Test
 
 import scala.{collection => c}
 import scala.collection.{immutable => i, mutable => m}
 
-@RunWith(classOf[JUnit4])
 class UnsortedTest {
   @Test
   def usortedIsSpecific(): Unit = {

--- a/test/junit/scala/collection/ViewTest.scala
+++ b/test/junit/scala/collection/ViewTest.scala
@@ -1,8 +1,8 @@
 package scala.collection
 
 import scala.collection.immutable.List
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 

--- a/test/junit/scala/collection/WithFilterTest.scala
+++ b/test/junit/scala/collection/WithFilterTest.scala
@@ -3,7 +3,7 @@ package scala.collection
 import immutable.{TreeMap, TreeSet}
 import scala.annotation.unused
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class WithFilterTest {
 

--- a/test/junit/scala/collection/concurrent/TrieMapTest.scala
+++ b/test/junit/scala/collection/concurrent/TrieMapTest.scala
@@ -1,7 +1,7 @@
 package scala.collection.concurrent
 
-import org.junit.Test
-import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
 
 import scala.util.hashing.Hashing
 import scala.tools.testkit.AssertUtil.assertThrows

--- a/test/junit/scala/collection/convert/BinaryTreeStepperTest.scala
+++ b/test/junit/scala/collection/convert/BinaryTreeStepperTest.scala
@@ -12,12 +12,9 @@
 
 package scala.collection.convert
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class BinaryTreeStepperTest {
   @Test
   def testStepper(): Unit = {

--- a/test/junit/scala/collection/convert/JCollectionWrapperTest.scala
+++ b/test/junit/scala/collection/convert/JCollectionWrapperTest.scala
@@ -2,8 +2,8 @@ package scala.collection.convert
 
 import java.{util => ju}
 
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 import scala.collection.Iterable
 import scala.collection.JavaConverters._
 

--- a/test/junit/scala/collection/convert/JIterableWrapperTest.scala
+++ b/test/junit/scala/collection/convert/JIterableWrapperTest.scala
@@ -2,8 +2,8 @@ package scala.collection.convert
 
 import java.{lang => jl, util => ju}
 
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 import scala.collection.Iterable
 import scala.collection.JavaConverters._
 

--- a/test/junit/scala/collection/convert/JListWrapperTest.scala
+++ b/test/junit/scala/collection/convert/JListWrapperTest.scala
@@ -2,8 +2,8 @@ package scala.collection.convert
 
 import java.{util => ju}
 
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 import scala.collection.JavaConverters._
 import scala.collection.immutable.List
 import scala.collection.mutable.Buffer

--- a/test/junit/scala/collection/convert/JSetWrapperTest.scala
+++ b/test/junit/scala/collection/convert/JSetWrapperTest.scala
@@ -2,8 +2,8 @@ package scala.collection.convert
 
 import java.{util => ju}
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 import scala.collection.JavaConverters._
 import scala.collection.Set
 

--- a/test/junit/scala/collection/convert/MapWrapperTest.scala
+++ b/test/junit/scala/collection/convert/MapWrapperTest.scala
@@ -2,14 +2,11 @@ package scala.collection.convert
 
 import java.util
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.jdk.CollectionConverters._
 
-@RunWith(classOf[JUnit4])
 class MapWrapperTest {
 
   /* Test for scala/bug#7883 */

--- a/test/junit/scala/collection/convert/NullSafetyToJavaTest.scala
+++ b/test/junit/scala/collection/convert/NullSafetyToJavaTest.scala
@@ -2,8 +2,8 @@ package scala.collection.convert
 
 import java.{lang => jl}
 
-import org.junit.Test
-import org.junit.Assert.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertNull
 
 import scala.collection.{concurrent, mutable}
 import scala.jdk.CollectionConverters._

--- a/test/junit/scala/collection/convert/NullSafetyToScalaTest.scala
+++ b/test/junit/scala/collection/convert/NullSafetyToScalaTest.scala
@@ -3,8 +3,8 @@ package scala.collection.convert
 import java.util.{concurrent => juc}
 import java.{lang => jl, util => ju}
 
-import org.junit.Test
-import org.junit.Assert.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertNull
 
 import scala.jdk.CollectionConverters._
 

--- a/test/junit/scala/collection/convert/WrapperSerializationTest.scala
+++ b/test/junit/scala/collection/convert/WrapperSerializationTest.scala
@@ -1,7 +1,7 @@
 package scala.collection.convert
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.jdk.CollectionConverters._
 

--- a/test/junit/scala/collection/generic/DecoratorsTest.scala
+++ b/test/junit/scala/collection/generic/DecoratorsTest.scala
@@ -1,6 +1,6 @@
 package scala.collection.generic
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import scala.AdaptedArrowAssocWorkaround.Tx
 import scala.annotation.unused

--- a/test/junit/scala/collection/immutable/ArraySeqTest.scala
+++ b/test/junit/scala/collection/immutable/ArraySeqTest.scala
@@ -1,14 +1,11 @@
 package scala.collection.immutable
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.annotation.nowarn
 import scala.reflect.ClassTag
 
-@RunWith(classOf[JUnit4])
 class ArraySeqTest {
   @Test
   def slice(): Unit = {

--- a/test/junit/scala/collection/immutable/ChampMapSmokeTest.scala
+++ b/test/junit/scala/collection/immutable/ChampMapSmokeTest.scala
@@ -1,7 +1,7 @@
 package scala.collection.immutable
 
-import org.junit.Assert.{assertEquals, assertFalse, assertSame, assertTrue}
-import org.junit.{Assert, Test}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertSame, assertTrue}
+import org.junit.jupiter.api.{Assertions, Test}
 
 object ChampMapSmokeTest {
 
@@ -214,10 +214,10 @@ class ChampMapSmokeTest {
     val s1, s2 = new String("s") // equals, but distinct references,
     val key = "k"
     var map = emptyMap[Any, Any].updated(key, s1).updated(key, s2)
-    Assert.assertSame(s2, map.apply(key))
+    Assertions.assertSame(s2, map.apply(key))
     class collision() { override def hashCode = key.hashCode}
     for (i <- (0 to 1024)) map = map.updated(new collision(), "")
-    Assert.assertSame(s1, map.updated(key, s1).apply(key))
+    Assertions.assertSame(s1, map.updated(key, s1).apply(key))
   }
 
   @Test def replacedValueIdentical(): Unit = {

--- a/test/junit/scala/collection/immutable/ChampSetSmokeTest.scala
+++ b/test/junit/scala/collection/immutable/ChampSetSmokeTest.scala
@@ -2,8 +2,8 @@ package scala.collection.immutable
 
 import java.{util => ju}
 
-import org.junit.Assert.{assertEquals, assertTrue}
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Test
 
 import scala.collection.immutable.ChampMapSmokeTest.mkTuple
 

--- a/test/junit/scala/collection/immutable/HashMapTest.scala
+++ b/test/junit/scala/collection/immutable/HashMapTest.scala
@@ -1,16 +1,12 @@
 package scala.collection.immutable
 
 import java.util.Collections
-
-import org.junit.Assert._
-import org.junit.{Ignore, Test}
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.{Disabled, Test}
 
 import scala.tools.testkit.AllocationTest
 import scala.tools.testkit.AssertUtil.assertThrows
 
-@RunWith(classOf[JUnit4])
 class HashMapTest extends AllocationTest{
 
   @Test
@@ -237,7 +233,7 @@ class HashMapTest extends AllocationTest{
   }
 
   @Test
-  @Ignore // TODO Port {HashMap, HashSet}.concat allocation reduction
+  @Disabled // TODO Port {HashMap, HashSet}.concat allocation reduction
   def addSharedAllocations2(): Unit = {
     val nonEmpty1 = HashMap("a" -> 1,
       "b" -> 2,
@@ -259,7 +255,7 @@ class HashMapTest extends AllocationTest{
   }
 
   @Test
-  @Ignore // TODO Port {HashMap, HashSet}.concat allocation reduction
+  @Disabled // TODO Port {HashMap, HashSet}.concat allocation reduction
   def addCollidingAllocations(): Unit = {
     val nonEmpty1 = HashMap("a" -> 1,
       "b" -> 2,

--- a/test/junit/scala/collection/immutable/HashSetTest.scala
+++ b/test/junit/scala/collection/immutable/HashSetTest.scala
@@ -1,14 +1,11 @@
 package scala.collection.immutable
 
-import org.junit.Assert.{ assertThrows => _, _ }
-import org.junit.{Ignore, Test}
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.{assertThrows => _, _}
+import org.junit.jupiter.api.{Disabled, Test}
 
 import scala.tools.testkit.AllocationTest
 import scala.tools.testkit.AssertUtil._
 
-@RunWith(classOf[JUnit4])
 class HashSetTest extends AllocationTest {
 
   @Test
@@ -95,7 +92,7 @@ class HashSetTest extends AllocationTest {
     })
   }
   @Test
-  @Ignore // TODO Port {HashMap, HashSet}.concat allocation reduction
+  @Disabled // TODO Port {HashMap, HashSet}.concat allocation reduction
   def nonAllocatingUnionEqual(): Unit = {
     val base1 = generate()
     val base2 = generate()
@@ -105,7 +102,7 @@ class HashSetTest extends AllocationTest {
   }
 
   @Test
-  @Ignore // TODO Port {HashMap, HashSet}.concat allocation reduction
+  @Disabled // TODO Port {HashMap, HashSet}.concat allocation reduction
   def nonAllocatingPlusPlusEqual(): Unit = {
     val base1 = generate()
     val base2 = generate()
@@ -149,7 +146,7 @@ class HashSetTest extends AllocationTest {
     })
   }
   @Test
-  @Ignore // TODO Port {HashMap, HashSet}.concat allocation reduction
+  @Disabled // TODO Port {HashMap, HashSet}.concat allocation reduction
   def nonAllocatingUnionSubsetShared(): Unit = {
     val base1 = generate()
     val base2 = base1 - base1.head
@@ -159,7 +156,7 @@ class HashSetTest extends AllocationTest {
   }
 
   @Test
-  @Ignore // TODO Port {HashMap, HashSet}.concat allocation reduction
+  @Disabled // TODO Port {HashMap, HashSet}.concat allocation reduction
   def nonAllocatingPlusPlusSubsetShared(): Unit = {
     val base1 = generate()
     val base2 = base1 - base1.head
@@ -167,8 +164,9 @@ class HashSetTest extends AllocationTest {
       base1 ++ base2
     })
   }
+
   @Test
-  @Ignore // TODO Port {HashMap, HashSet}.concat allocation reduction
+  @Disabled // TODO Port {HashMap, HashSet}.concat allocation reduction
   def nonAllocatingUnionSubsetUnshared(): Unit = {
     val base1 = generate()
     val base2 = generate() - base1.head
@@ -178,7 +176,7 @@ class HashSetTest extends AllocationTest {
   }
 
   @Test
-  @Ignore // TODO Port {HashMap, HashSet}.concat allocation reduction
+  @Disabled // TODO Port {HashMap, HashSet}.concat allocation reduction
   def nonAllocatingPlusPlusSubsetUnshared(): Unit = {
     val base1 = generate()
     val base2 = generate() - base1.head
@@ -186,8 +184,9 @@ class HashSetTest extends AllocationTest {
       base1 ++ base2
     })
   }
+
   @Test
-  @Ignore // TODO Port {HashMap, HashSet}.concat allocation reduction
+  @Disabled // TODO Port {HashMap, HashSet}.concat allocation reduction
   def nonAllocatingUnionSupersetShared(): Unit = {
     val base1 = generate()
     val base2 = base1 + "Mike"
@@ -197,7 +196,7 @@ class HashSetTest extends AllocationTest {
   }
 
   @Test
-  @Ignore // TODO Port {HashMap, HashSet}.concat allocation reduction
+  @Disabled // TODO Port {HashMap, HashSet}.concat allocation reduction
   def nonAllocatingPlusPlusSupersetShared(): Unit = {
     val base1 = generate()
     val base2 = base1 + "Mike"
@@ -205,8 +204,9 @@ class HashSetTest extends AllocationTest {
       base1 ++ base2
     })
   }
+
   @Test
-  @Ignore // TODO Port {HashMap, HashSet}.concat allocation reduction
+  @Disabled // TODO Port {HashMap, HashSet}.concat allocation reduction
   def nonAllocatingUnionSupersetUnshared(): Unit = {
     val base1 = generate()
     val base2 = generate() + "Mike"
@@ -216,7 +216,7 @@ class HashSetTest extends AllocationTest {
   }
 
   @Test
-  @Ignore // TODO Port {HashMap, HashSet}.concat allocation reduction
+  @Disabled // TODO Port {HashMap, HashSet}.concat allocation reduction
   def nonAllocatingPlusPlusSupersetUnshared(): Unit = {
     val base1 = generate()
     val base2 = generate() + "Mike"
@@ -237,7 +237,7 @@ class HashSetTest extends AllocationTest {
 
     override def toString: String = s"$hashCode-$other"
   }
-  @Ignore // TODO Port {HashMap, HashSet}.concat allocation reduction
+  @Disabled // TODO Port {HashMap, HashSet}.concat allocation reduction
   @Test def collidingAdd(): Unit = {
     val initial = generateWithCollisions(1, 1000)
     assertEquals(1000, initial.size)

--- a/test/junit/scala/collection/immutable/IntMapTest.scala
+++ b/test/junit/scala/collection/immutable/IntMapTest.scala
@@ -12,14 +12,11 @@
 
 package scala.collection.immutable
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.ReflectUtil
 
-@RunWith(classOf[JUnit4])
 class IntMapTest {
   @Test
   def `isEmpty O(1)`(): Unit = {

--- a/test/junit/scala/collection/immutable/LazyListGCTest.scala
+++ b/test/junit/scala/collection/immutable/LazyListGCTest.scala
@@ -1,15 +1,12 @@
 package scala.collection.immutable
 
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Test
-import org.junit.Assert._
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions._
 
 import scala.ref.WeakReference
 import scala.util.Try
 
 // TODO: fill this out with all relevant LazyList methods
-@RunWith(classOf[JUnit4])
 class LazyListGCTest {
   /** Test helper to verify that the given LazyList operation allows
     * GC of the head during processing of the tail.

--- a/test/junit/scala/collection/immutable/LazyListLazinessTest.scala
+++ b/test/junit/scala/collection/immutable/LazyListLazinessTest.scala
@@ -1,7 +1,7 @@
 package scala.collection.immutable
 
-import org.junit.Test
-import org.junit.Assert._
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions._
 
 import scala.collection.{IterableOnce, Iterator, SeqFactory}
 

--- a/test/junit/scala/collection/immutable/LazyListTest.scala
+++ b/test/junit/scala/collection/immutable/LazyListTest.scala
@@ -1,17 +1,14 @@
 package scala.collection
 package immutable
 
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Test
-import org.junit.Assert._
+import org.junit.jupiter.api.{Test, Timeout}
+import org.junit.jupiter.api.Assertions._
 
 import scala.annotation.unused
 import scala.collection.mutable.{Builder, ListBuffer}
 import scala.tools.testkit.AssertUtil
 import scala.util.Try
 
-@RunWith(classOf[JUnit4])
 class LazyListTest {
 
   @Test
@@ -192,7 +189,8 @@ class LazyListTest {
 
   val cycle1: LazyList[Int] = 1 #:: 2 #:: cycle1
   val cycle2: LazyList[Int] = 1 #:: 2 #:: 3 #:: cycle2
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10)
   def testSameElements(): Unit = {
     assert(LazyList().sameElements(LazyList()))
     assert(!LazyList().sameElements(LazyList(1)))

--- a/test/junit/scala/collection/immutable/ListMapTest.scala
+++ b/test/junit/scala/collection/immutable/ListMapTest.scala
@@ -1,14 +1,11 @@
 package scala.collection.immutable
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.runtime.AbstractFunction2
 import scala.tools.testkit.AllocationTest
 
-@RunWith(classOf[JUnit4])
 class ListMapTest extends AllocationTest {
 
   @Test

--- a/test/junit/scala/collection/immutable/ListSetTest.scala
+++ b/test/junit/scala/collection/immutable/ListSetTest.scala
@@ -1,11 +1,8 @@
 package scala.collection.immutable
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class ListSetTest {
 
   @Test

--- a/test/junit/scala/collection/immutable/ListTest.scala
+++ b/test/junit/scala/collection/immutable/ListTest.scala
@@ -1,15 +1,12 @@
 package scala.collection.immutable
 
-import org.junit.Assert._
-import org.junit.{Assert, Test}
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.{Assertions, Test}
 
 import scala.ref.WeakReference
 import scala.tools.testkit.{AllocationTest, CompileTime}
 import scala.collection.Sizes
 
-@RunWith(classOf[JUnit4])
 class ListTest extends AllocationTest{
   /**
    * Test that empty iterator does not hold reference
@@ -35,7 +32,7 @@ class ListTest extends AllocationTest{
 
     // check something is result to protect from JIT optimizations
     for ((i, _) <- emptyIterators) {
-      Assert.assertTrue(i.isEmpty)
+      Assertions.assertTrue(i.isEmpty)
     }
 
     // await gc up to ~5 seconds
@@ -47,23 +44,23 @@ class ListTest extends AllocationTest{
     }
 
     // real assertion
-    Assert.assertTrue(emptyIterators.exists(_._2.get.isEmpty))
+    Assertions.assertTrue(emptyIterators.exists(_._2.get.isEmpty))
   }
 
   @Test
   def updated(): Unit = {
     val xs = 1 :: 2 :: Nil
-    Assert.assertEquals(0 :: 2 :: Nil, xs.updated(index = 0, elem = 0))
-    Assert.assertEquals(1 :: 0 :: Nil, xs.updated(index = 1, elem = 0))
+    Assertions.assertEquals(0 :: 2 :: Nil, xs.updated(index = 0, elem = 0))
+    Assertions.assertEquals(1 :: 0 :: Nil, xs.updated(index = 1, elem = 0))
     try {
       xs.updated(index = -1, 0)
-      Assert.fail("No exception thrown")
+      Assertions.fail("No exception thrown")
     } catch {
       case e: IndexOutOfBoundsException => ()
     }
     try {
       xs.updated(index = 2, 0)
-      Assert.fail("No exception thrown")
+      Assertions.fail("No exception thrown")
     } catch {
       case e: IndexOutOfBoundsException => ()
     }

--- a/test/junit/scala/collection/immutable/LongMapTest.scala
+++ b/test/junit/scala/collection/immutable/LongMapTest.scala
@@ -12,14 +12,11 @@
 
 package scala.collection.immutable
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.ReflectUtil.{getFieldAccessible => f}
 
-@RunWith(classOf[JUnit4])
 class LongMapTest {
 
   @Test

--- a/test/junit/scala/collection/immutable/MapHashcodeTest.scala
+++ b/test/junit/scala/collection/immutable/MapHashcodeTest.scala
@@ -1,7 +1,7 @@
 package scala.collection.immutable
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.AllocationTest
 import scala.util.hashing.MurmurHash3
@@ -230,8 +230,8 @@ class MapHashcodeTest extends AllocationTest {
   }
 
   private def assertConsistent(m: Map[_, _]): Unit = {
-    assertEquals(m.getClass.toString, MurmurHash3.mapHash(m), m.hashCode())
-    assertEquals(m.getClass.toString, MurmurHash3.unorderedHash(m, MurmurHash3.mapSeed), m.hashCode())
+    assertEquals(MurmurHash3.mapHash(m), m.hashCode(), m.getClass.toString)
+    assertEquals(MurmurHash3.unorderedHash(m, MurmurHash3.mapSeed), m.hashCode(), m.getClass.toString)
   }
 
   @Test

--- a/test/junit/scala/collection/immutable/MapTest.scala
+++ b/test/junit/scala/collection/immutable/MapTest.scala
@@ -1,7 +1,7 @@
 package scala.collection.immutable
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 class MapTest {
 
@@ -112,30 +112,30 @@ class MapTest {
       for (form <- List(addList, addMap, addArray, addSortSame, addSortReverse, addTreeSame, addTreeReverse)) {
         val info = s"form[${form.getClass.getSimpleName}]=$form, size=$size, start=$start"
 
-        assertEquals(info, expected, (treeMap ++ form).toList)
-        assertEquals(info, expected, (sortMap ++ form).toList)
+        assertEquals(expected, (treeMap ++ form).toList, info)
+        assertEquals(expected, (sortMap ++ form).toList, info)
 
-        assertEquals(info, expected, (treeMap ++ form.iterator).toList)
-        assertEquals(info, expected, (sortMap ++ form.iterator).toList)
+        assertEquals(expected, (treeMap ++ form.iterator).toList)
+        assertEquals(expected, (sortMap ++ form.iterator).toList)
 
-        assertEquals(info, expected, (form.foldLeft(treeMap) {
+        assertEquals(expected, (form.foldLeft(treeMap) {
           _ + _
-        }).toList)
-        assertEquals(info, expected, (form.foldLeft(sortMap) {
+        }).toList, info)
+        assertEquals(expected, (form.foldLeft(sortMap) {
           _ + _
-        }).toList)
+        }).toList, info)
 
         for (form2 <- List(addList, addMap, addArray, addSortSame, addSortReverse, addTreeSame, addTreeReverse)) {
           val info2 = s"form2[${form2.getClass.getSimpleName}]=$form2, $info"
 
-          assertEquals(info2, expected, (emptySB ++= form ++= form2).result().toList)
-          assertEquals(info2, expected, (emptyTB ++= form ++= form2).result().toList)
+          assertEquals(expected, (emptySB ++= form ++= form2).result().toList, info2)
+          assertEquals(expected, (emptyTB ++= form ++= form2).result().toList, info2)
 
-          assertEquals(info2, expected, ((form.foldLeft(emptySB)(_ += _)) ++= form2).result().toList)
-          assertEquals(info2, expected, ((form.foldLeft(emptyTB)(_ += _)) ++= form2).result().toList)
+          assertEquals(expected, ((form.foldLeft(emptySB)(_ += _)) ++= form2).result().toList, info2)
+          assertEquals(expected, ((form.foldLeft(emptyTB)(_ += _)) ++= form2).result().toList, info2)
 
-          assertEquals(info2, expected, (form2.foldLeft(form.foldLeft(emptySB)(_ += _))(_ += _)).result().toList)
-          assertEquals(info2, expected, (form2.foldLeft(form.foldLeft(emptySB)(_ += _))(_ += _)).result().toList)
+          assertEquals(expected, (form2.foldLeft(form.foldLeft(emptySB)(_ += _))(_ += _)).result().toList, info2)
+          assertEquals(expected, (form2.foldLeft(form.foldLeft(emptySB)(_ += _))(_ += _)).result().toList, info2)
 
         }
       }

--- a/test/junit/scala/collection/immutable/NumericRangeTest.scala
+++ b/test/junit/scala/collection/immutable/NumericRangeTest.scala
@@ -1,13 +1,10 @@
 package scala.collection.immutable
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.AssertUtil.assertThrows
 
-@RunWith(classOf[JUnit4])
 class NumericRangeTest {
 
   @Test

--- a/test/junit/scala/collection/immutable/QueueTest.scala
+++ b/test/junit/scala/collection/immutable/QueueTest.scala
@@ -1,11 +1,8 @@
 package scala.collection.immutable
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 /* Tests for collection.immutable.Queue  */
 class QueueTest {
 

--- a/test/junit/scala/collection/immutable/RangeConsistencyTest.scala
+++ b/test/junit/scala/collection/immutable/RangeConsistencyTest.scala
@@ -1,13 +1,10 @@
 package scala.collection.immutable
 
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import scala.math._
 import scala.util._
 
 /* Tests various ranges by making sure they all agree on the same answers. */
-@RunWith(classOf[JUnit4])
 class RangeConsistencyTest {
   def r2nr[T: Integral](
     r: Range, puff: T, stride: T, check: (T,T) => Boolean, bi: T => BigInt

--- a/test/junit/scala/collection/immutable/RangeTest.scala
+++ b/test/junit/scala/collection/immutable/RangeTest.scala
@@ -1,13 +1,11 @@
 package scala.collection.immutable
 
-import org.junit.{Assert, Test}
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertSame, assertTrue}
+import org.junit.jupiter.api.Test
+
 import scala.tools.testkit.AssertUtil
 
-@RunWith(classOf[JUnit4])
 class RangeTest {
-  import Assert.{ assertThrows => _, _ }
   import AssertUtil._
 
   @Test
@@ -70,9 +68,9 @@ class RangeTest {
     assertEquals(10, it.next())
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def largeRangeMap(): Unit = {
-    Int.MinValue to Int.MaxValue map identity
+    assertThrows[IllegalArgumentException](Int.MinValue to Int.MaxValue map identity)
   }
 
   @Test

--- a/test/junit/scala/collection/immutable/SeqTest.scala
+++ b/test/junit/scala/collection/immutable/SeqTest.scala
@@ -1,13 +1,10 @@
 package scala.collection.immutable
 
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import scala.collection.Sizes
 import scala.tools.testkit.{AllocationTest, CompileTime}
 
-@RunWith(classOf[JUnit4])
 class SeqTest extends AllocationTest {
 
   @Test def emptyNonAllocating(): Unit = {

--- a/test/junit/scala/collection/immutable/SerializationTest.scala
+++ b/test/junit/scala/collection/immutable/SerializationTest.scala
@@ -1,11 +1,8 @@
 package scala.collection.immutable
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class SerializationTest {
 
   @Test
@@ -133,7 +130,7 @@ class SerializationTest {
     val after = serializeDeserialize(original)
     assertEquals(original, after)
     if(expectedClass ne null)
-      assertTrue("Deserialized class "+after.getClass.getName+" is not assignable to "+expectedClass.getName, expectedClass.isInstance(after))
+      assertTrue(expectedClass.isInstance(after), "Deserialized class "+after.getClass.getName+" is not assignable to "+expectedClass.getName)
   }
 
   private def serializeDeserialize[T <: AnyRef](obj: T): T = {

--- a/test/junit/scala/collection/immutable/SetTest.scala
+++ b/test/junit/scala/collection/immutable/SetTest.scala
@@ -3,8 +3,8 @@ package scala.collection.immutable
 // "Disabled string conversions so as not to get confused!"
 import scala.Predef.{any2stringadd => _, _}
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 class SetTest {
   @Test

--- a/test/junit/scala/collection/immutable/SmallMapTest.scala
+++ b/test/junit/scala/collection/immutable/SmallMapTest.scala
@@ -1,6 +1,6 @@
 package scala.collection.immutable
 
-import org.junit.Assert._
+import org.junit.jupiter.api.Assertions._
 import org.junit._
 
 import scala.tools.testkit.AllocationTest

--- a/test/junit/scala/collection/immutable/SortedMapTest.scala
+++ b/test/junit/scala/collection/immutable/SortedMapTest.scala
@@ -1,12 +1,9 @@
 package scala.collection.immutable
 
-import org.junit.Assert.{assertEquals, assertNotEquals}
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.{assertEquals, assertNotEquals}
+import org.junit.jupiter.api.Test
 import scala.tools.testkit.AllocationTest
 
-@RunWith(classOf[JUnit4])
 class SortedMapTest extends AllocationTest {
   @Test
   def testWithDefaultValueReturnsSortedMapWithDefaultValue(): Unit = {

--- a/test/junit/scala/collection/immutable/SortedSetTest.scala
+++ b/test/junit/scala/collection/immutable/SortedSetTest.scala
@@ -1,6 +1,6 @@
 package scala.collection.immutable
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.AllocationTest
 

--- a/test/junit/scala/collection/immutable/StreamTest.scala
+++ b/test/junit/scala/collection/immutable/StreamTest.scala
@@ -1,15 +1,12 @@
 package scala.collection.immutable
 
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Test
-import org.junit.Assert._
+import org.junit.jupiter.api.{Test, Timeout}
+import org.junit.jupiter.api.Assertions._
 
 import scala.annotation.unused
 import scala.ref.WeakReference
 import scala.util.Try
 
-@RunWith(classOf[JUnit4])
 @deprecated("Tests deprecated Stream", since="2.13")
 class StreamTest {
 
@@ -147,7 +144,8 @@ class StreamTest {
 
   val cycle1: Stream[Int] = 1 #:: 2 #:: cycle1
   val cycle2: Stream[Int] = 1 #:: 2 #:: 3 #:: cycle2
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10)
   def testSameElements(): Unit = {
     assert(Stream().sameElements(Stream()))
     assert(!Stream().sameElements(Stream(1)))

--- a/test/junit/scala/collection/immutable/StringLikeTest.scala
+++ b/test/junit/scala/collection/immutable/StringLikeTest.scala
@@ -1,15 +1,12 @@
 package scala.collection.immutable
 
-import org.junit.Assert.{ assertThrows => _, _ }
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.{ assertThrows => _, _ }
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.AssertUtil._
 import scala.util.Random
 
 /* Test for scala/bug#8988 */
-@RunWith(classOf[JUnit4])
 class StringLikeTest {
   @Test
   def testStringSplitWithChar(): Unit = {
@@ -53,16 +50,16 @@ class StringLikeTest {
     assertThrows[java.lang.NumberFormatException](sOne.toLong)
     assertThrows[java.lang.NumberFormatException](sOne.toShort)
     assertThrows[java.lang.NumberFormatException](sOne.toByte)
-    assertEquals("trim toDouble", 1.0d, sOne.toDouble, 0.1d)
-    assertEquals("trim toDouble", 1.0d, sOne.toDouble, 0.1d)
-    assertEquals("trim toFloat", 1.0f, sOne.toFloat, 0.1f)
+    assertEquals(1.0d, sOne.toDouble, 0.1d, "trim toDouble")
+    assertEquals(1.0d, sOne.toDouble, 0.1d, "trim toDouble")
+    assertEquals(1.0f, sOne.toFloat, 0.1f, "trim toFloat")
 
-    assertEquals("no trim toInt", 2, sOk.toInt)
-    assertEquals("no trim toLong", 2L, sOk.toLong)
-    assertEquals("no trim toShort",  2.toShort, sOk.toShort)
-    assertEquals("no trim toByte", 2.toByte, sOk.toByte)
-    assertEquals("no trim toDouble", 2.0d, sOk.toDouble, 0.1d)
-    assertEquals("no trim toFloat", 2.0f, sOk.toFloat, 0.1f)
+    assertEquals(2, sOk.toInt, "no trim toInt")
+    assertEquals(2L, sOk.toLong, "no trim toLong")
+    assertEquals(2.toShort, sOk.toShort, "no trim toShort")
+    assertEquals(2.toByte, sOk.toByte, "no trim toByte")
+    assertEquals(2.0d, sOk.toDouble, 0.1d, "no trim toDouble")
+    assertEquals(2.0f, sOk.toFloat, 0.1f, "no trim toFloat")
 
     // JDK 17 gives the nicer message
     def isNullStringMessage(s: String) =

--- a/test/junit/scala/collection/immutable/TreeMapTest.scala
+++ b/test/junit/scala/collection/immutable/TreeMapTest.scala
@@ -2,14 +2,11 @@ package scala.collection.immutable
 
 import java.util.Collections
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.AllocationTest
 
-@RunWith(classOf[JUnit4])
 class TreeMapTest extends AllocationTest {
 
   @Test
@@ -124,7 +121,7 @@ class TreeMapTest extends AllocationTest {
 
     compareCount = 0
     assertEquals(exp, act)
-    assertTrue(compareCount.toString, compareCount < 30)
+    assertTrue(compareCount < 30, compareCount.toString)
 
     onlyAllocates(408)(assertEquals(exp, act))
   }
@@ -200,8 +197,8 @@ class TreeMapTest extends AllocationTest {
     val all = List[(Map[K, V], String)]((tree1_1,"tree1_1"), (tree1_2, "tree1_2"), (tree2_1, "tree2_1"), (tree2_2, "tree2_2"), (treeHash, "treeHash"))
     for ((lhs, lText ) <- all;
          (rhs, rText) <-all) {
-      assertEquals(s"$lText $rText", lhs, rhs)
-      assertEquals(s"$rText $lText", rhs, lhs)
+      assertEquals(lhs, rhs, s"$lText $rText")
+      assertEquals(rhs, lhs, s"$rText $lText")
     }
   }
 
@@ -259,7 +256,7 @@ class TreeMapTest extends AllocationTest {
     val src: Map[Int, String] = TreeMap(Range(0, 100, 2).map((_, "")) :_*)
     for (i <- Range(-1, 101, 2)) {
       src - i
-      assertSame(i.toString, src, nonAllocating(src - i, text = i.toString))
+      assertSame(src, nonAllocating(src - i, text = i.toString), i.toString)
     }
   }
 }

--- a/test/junit/scala/collection/immutable/TreeSeqMapTest.scala
+++ b/test/junit/scala/collection/immutable/TreeSeqMapTest.scala
@@ -2,12 +2,9 @@ package scala
 package collection
 package immutable
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class TreeSeqMapTest {
   @Test
   def t7445(): Unit = {
@@ -142,9 +139,9 @@ class TreeSeqMapTest {
       val v = toBinaryString(i)
       val o3 = o1.include(i, v)
       val o4 = o1.append(i, v)
-      assertEquals(s"$i", o3, o4)
+      assertEquals(o3, o4, s"$i")
       val o5 = o2.appendInPlace(i, v)
-      assertEquals(s"$i", o3, o5)
+      assertEquals(o3, o5, s"$i")
     }
   }
   @Test
@@ -153,25 +150,25 @@ class TreeSeqMapTest {
       val e1 = TreeSeqMap.empty[Int, Int]
       val e2 = e1 + (3 -> 1) + (2 -> 2) + (1 -> 3) + (3 -> 4)
       val e3 = e2.tail
-      assertEquals(s"default empty keeps insertion order", List(2 -> 2, 1 -> 3), e3.toList)
+      assertEquals(List(2 -> 2, 1 -> 3), e3.toList, "default empty keeps insertion order")
     }
     {
       val e1 = TreeSeqMap.empty[Int, Int](TreeSeqMap.OrderBy.Modification)
       val e2 = e1 + (3 -> 1) + (2 -> 2) + (1 -> 3) + (3 -> 4)
       val e3 = e2.tail
-      assertEquals(s"modification empty keeps modification order", List(1 -> 3, 3 -> 4), e3.toList)
+      assertEquals(List(1 -> 3, 3 -> 4), e3.toList, "modification empty keeps modification order")
     }
     {
       val e1 = TreeSeqMap(3 -> 1).empty
       val e2 = e1 + (3 -> 1) + (2 -> 2) + (1 -> 3) + (3 -> 4)
       val e3 = e2.tail
-      assertEquals(s"default empty from instance keeps insertion order", List(2 -> 2, 1 -> 3), e3.toList)
+      assertEquals(List(2 -> 2, 1 -> 3), e3.toList, "default empty from instance keeps insertion order")
     }
     {
       val e1 = TreeSeqMap(3 -> 1).orderingBy(TreeSeqMap.OrderBy.Modification).empty
       val e2 = e1 + (3 -> 1) + (2 -> 2) + (1 -> 3) + (3 -> 4)
       val e3 = e2.tail
-      assertEquals(s"modification empty from instance keeps modification order", List(1 -> 3, 3 -> 4), e3.toList)
+      assertEquals(List(1 -> 3, 3 -> 4), e3.toList, "modification empty from instance keeps modification order")
     }
   }
 }

--- a/test/junit/scala/collection/immutable/TreeSetTest.scala
+++ b/test/junit/scala/collection/immutable/TreeSetTest.scala
@@ -3,14 +3,11 @@ package scala.collection.immutable
 import java.util
 import java.util.Collections
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.AllocationTest
 
-@RunWith(classOf[JUnit4])
 class TreeSetTest extends AllocationTest {
 
   @Test
@@ -172,7 +169,7 @@ class TreeSetTest extends AllocationTest {
 
     compareCount = 0
     assertEquals(exp, act)
-    assertTrue(compareCount.toString, compareCount < 30)
+    assertTrue(compareCount < 30, compareCount.toString)
     //we cant combine this with th above assertion as onlyAllocates run lots of time to determne the allocation
     onlyAllocates(408)(assertEquals(exp, act))
   }
@@ -253,8 +250,8 @@ class TreeSetTest extends AllocationTest {
     val all = List[(Set[K], String)]((tree1_1, "tree1_1"), (tree1_2, "tree1_2"), (tree2_1, "tree2_1"), (tree2_2, "tree2_2"), (treeHash, "treeHash"))
     for ((lhs, lText) <- all;
          (rhs, rText) <- all) {
-      assertEquals(s"$lText $rText", lhs, rhs)
-      assertEquals(s"$rText $lText", rhs, lhs)
+      assertEquals(lhs, rhs, s"$lText $rText")
+      assertEquals(rhs, lhs, s"$rText $lText")
     }
   }
 

--- a/test/junit/scala/collection/immutable/VectorMapTest.scala
+++ b/test/junit/scala/collection/immutable/VectorMapTest.scala
@@ -1,11 +1,8 @@
 package scala.collection.immutable
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class VectorMapTest {
 
   @Test

--- a/test/junit/scala/collection/immutable/VectorTest.scala
+++ b/test/junit/scala/collection/immutable/VectorTest.scala
@@ -1,15 +1,12 @@
 package scala.collection.immutable
 
-import org.junit.Assert._
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.annotation.unused
 import scala.collection.mutable.{ListBuffer, StringBuilder}
 import scala.reflect.{ClassTag, classTag}
 
-@RunWith(classOf[JUnit4])
 class VectorTest {
   import VectorUtils.validateDebug
 
@@ -42,8 +39,8 @@ class VectorTest {
       validateDebug(prefix)
       validateDebug(suffix)
       validateDebug(prefix ++: suffix)
-      assertEquals((prefix, suffix).toString, els, prefix ++: suffix)
-      assertEquals((prefix, suffix).toString, els, prefix :++ suffix)
+      assertEquals(els, prefix ++: suffix, (prefix, suffix).toString)
+      assertEquals(els, prefix :++ suffix, (prefix, suffix).toString)
       assertEquals(els, prefix.toList ++: suffix)
       assertEquals(els, prefix.toList :++ suffix)
     }
@@ -197,7 +194,7 @@ class VectorTest {
       j <- -100 to 4000 by 6
     } {
       val v2 = v.take(i)
-      assertArrayEquals(s"<${v2.length}>.take($j)", v2.toArray.take(j), v2.iterator.take(j).toArray)
+      assertArrayEquals(v2.toArray.take(j), v2.iterator.take(j).toArray, s"<${v2.length}>.take($j)")
     }
   }
 
@@ -209,7 +206,7 @@ class VectorTest {
       j <- -100 to 4000 by 60
     } {
       val v2 = v.take(i)
-      assertArrayEquals(s"<${v2.length}>.drop($j)", v2.toArray.drop(j), v2.iterator.drop(j).toArray)
+      assertArrayEquals(v2.toArray.drop(j), v2.iterator.drop(j).toArray, s"<${v2.length}>.drop($j)")
     }
   }
 
@@ -222,7 +219,7 @@ class VectorTest {
       k <- -100 to 4000 by 60
     } {
       val v2 = v.take(i)
-      assertArrayEquals(s"<${v2.length}>.slice($j, $k)", v2.toArray.slice(j, k), v2.iterator.slice(j, k).toArray)
+      assertArrayEquals(v2.toArray.slice(j, k), v2.iterator.slice(j, k).toArray, s"<${v2.length}>.slice($j, $k)")
     }
   }
 

--- a/test/junit/scala/collection/immutable/WrappedStringTest.scala
+++ b/test/junit/scala/collection/immutable/WrappedStringTest.scala
@@ -1,11 +1,8 @@
 package scala.collection.immutable
 
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Test
-import org.junit.Assert._
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions._
 
-@RunWith(classOf[JUnit4])
 class WrappedStringTest {
 
   @Test // scala/bug#11518

--- a/test/junit/scala/collection/mutable/AnyRefMapTest.scala
+++ b/test/junit/scala/collection/mutable/AnyRefMapTest.scala
@@ -1,12 +1,9 @@
 package scala.collection.mutable
 
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Test
-import org.junit.Assert._
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions._
 
 /* Test for scala/bug#10540 */
-@RunWith(classOf[JUnit4])
 class AnyRefMapTest {
 
   @Test def testAnyRefMapCopy(): Unit = {

--- a/test/junit/scala/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBufferTest.scala
@@ -1,7 +1,7 @@
 package scala.collection.mutable
 
-import org.junit.Test
-import org.junit.Assert.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 
 import scala.annotation.nowarn
 import scala.tools.testkit.AssertUtil.{assertThrows, fail}

--- a/test/junit/scala/collection/mutable/ArrayDequeTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayDequeTest.scala
@@ -1,8 +1,8 @@
 package scala.collection.mutable
 
 import scala.collection.immutable.List
-import org.junit.Test
-import org.junit.Assert._
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions._
 
 import scala.annotation.nowarn
 import scala.collection.SeqFactory

--- a/test/junit/scala/collection/mutable/ArraySeqTest.scala
+++ b/test/junit/scala/collection/mutable/ArraySeqTest.scala
@@ -1,13 +1,10 @@
 package scala.collection.mutable
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.collection.immutable.Seq
 
-@RunWith(classOf[JUnit4])
 class ArraySeqTest {
   @Test
   def t11187(): Unit = {

--- a/test/junit/scala/collection/mutable/ArraySortingTest.scala
+++ b/test/junit/scala/collection/mutable/ArraySortingTest.scala
@@ -1,12 +1,9 @@
 package scala.collection.mutable
 
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Test
-import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
 
 /* Tests various maps by making sure they all agree on the same answers. */
-@RunWith(classOf[JUnit4])
 class ArraySortingTest {
   
   class CantSortMe(val i: Int) {

--- a/test/junit/scala/collection/mutable/BitSetTest.scala
+++ b/test/junit/scala/collection/mutable/BitSetTest.scala
@@ -1,13 +1,10 @@
 package scala.collection.mutable
 
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Assert.{ assertThrows => _, _ }
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.{ assertThrows => _, _ }
 
 import scala.tools.testkit.AssertUtil._
 
-@RunWith(classOf[JUnit4])
 class BitSetTest {
   // Test for scala/bug#8910
   @Test def capacityExpansionTest(): Unit = {

--- a/test/junit/scala/collection/mutable/CollisionProofHashMapTest.scala
+++ b/test/junit/scala/collection/mutable/CollisionProofHashMapTest.scala
@@ -1,12 +1,9 @@
 package scala.collection
 package mutable
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class CollisionProofHashMapTest {
 
   @Test

--- a/test/junit/scala/collection/mutable/HashMapTest.scala
+++ b/test/junit/scala/collection/mutable/HashMapTest.scala
@@ -1,12 +1,9 @@
 package scala.collection
 package mutable
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class HashMapTest {
 
   @Test
@@ -260,6 +257,6 @@ class HashMapTest {
     val m = mutable.HashMap(
       0 -> 1, 1 -> 1, 2 -> 1, 3 -> 1, 4 -> 1, 5 -> 1, 6 -> 1, 7 -> 1, 8 -> 1, 9 -> 1, 241 -> 1)
       .mapValuesInPlace((_, _) => -1)
-    assertTrue(m.toString, m.forall(_._2 == -1))
+    assertTrue(m.forall(_._2 == -1), m.toString)
   }
 }

--- a/test/junit/scala/collection/mutable/HashSetTest.scala
+++ b/test/junit/scala/collection/mutable/HashSetTest.scala
@@ -1,7 +1,7 @@
 package scala.collection.mutable
 
-import org.junit.Test
-import org.junit.Assert._
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions._
 
 class HashSetTest {
   // based on run/hashset.scala partest

--- a/test/junit/scala/collection/mutable/LinkedHashMapTest.scala
+++ b/test/junit/scala/collection/mutable/LinkedHashMapTest.scala
@@ -1,14 +1,11 @@
 package scala.collection.mutable
 
-import org.junit.Assert._
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.{ Assert, Test }
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.collection.mutable
 
 /* Test for scala/bug#9095 */
-@RunWith(classOf[JUnit4])
 class LinkedHashMapTest {
   class TestClass extends mutable.LinkedHashMap[String, Int] {
     def lastItemRef = lastEntry
@@ -19,9 +16,9 @@ class LinkedHashMapTest {
     val lhm = new TestClass
     Seq("a" -> 8, "b" -> 9).foreach(kv => lhm.put(kv._1, kv._2))
     
-    Assert.assertNotNull(lhm.lastItemRef)
+    assertNotNull(lhm.lastItemRef)
     lhm.clear()
-    Assert.assertNull(lhm.lastItemRef)
+    assertNull(lhm.lastItemRef)
   }
 
   @Test

--- a/test/junit/scala/collection/mutable/LinkedHashSetTest.scala
+++ b/test/junit/scala/collection/mutable/LinkedHashSetTest.scala
@@ -1,13 +1,10 @@
 package scala.collection.mutable
 
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.{ Assert, Test }
+import org.junit.jupiter.api.{Assertions, Test}
 
 import scala.collection.mutable
 
 /* Test for scala/bug#9095 */
-@RunWith(classOf[JUnit4])
 class LinkedHashSetTest {
   class TestClass extends mutable.LinkedHashSet[String] {
     def lastItemRef = lastEntry
@@ -17,9 +14,9 @@ class LinkedHashSetTest {
   def testClear(): Unit = {
     val lhs = new TestClass
     Seq("a", "b").foreach(k => lhs.add(k))
-    
-    Assert.assertNotNull(lhs.lastItemRef)
+
+    Assertions.assertNotNull(lhs.lastItemRef)
     lhs.clear()
-    Assert.assertNull(lhs.lastItemRef)
+    Assertions.assertNull(lhs.lastItemRef)
   }
 }

--- a/test/junit/scala/collection/mutable/ListBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ListBufferTest.scala
@@ -1,10 +1,9 @@
 package scala.collection.mutable
 
-import org.junit.Assert.{assertEquals, assertTrue}
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows, assertTrue}
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.AssertUtil.assertSameElements
-
 import scala.annotation.nowarn
 
 class ListBufferTest {
@@ -106,14 +105,14 @@ class ListBufferTest {
     assertEquals(ListBuffer(0, 1), b3)
   }
 
-  @Test(expected = classOf[IndexOutOfBoundsException])
+  @Test
   def removeWithNegativeIndex(): Unit = {
-    ListBuffer(0, 1, 2).remove(-1)
+    assertThrows(classOf[IndexOutOfBoundsException], () => ListBuffer(0, 1, 2).remove(-1))
   }
 
-  @Test(expected = classOf[IndexOutOfBoundsException])
+  @Test
   def removeWithTooLargeIndex(): Unit = {
-    ListBuffer(0).remove(1)
+    assertThrows(classOf[IndexOutOfBoundsException], () => ListBuffer(0).remove(1))
   }
 
   @Test
@@ -133,24 +132,24 @@ class ListBufferTest {
     testRemoveMany(idx = 2, count = 1, expectation = ListBuffer(0, 1))
   }
 
-  @Test(expected = classOf[IndexOutOfBoundsException])
+  @Test
   def removeManyWithNegativeIndex(): Unit = {
-    ListBuffer(0, 1, 2).remove(idx = -1, count = 1)
+    assertThrows(classOf[IndexOutOfBoundsException], () => ListBuffer(0, 1, 2).remove(idx = -1, count = 1))
   }
 
-  @Test(expected = classOf[IndexOutOfBoundsException])
+  @Test
   def removeManyWithTooLargeIndex(): Unit = {
-    ListBuffer(0).remove(idx = 1, count = 1)
+    assertThrows(classOf[IndexOutOfBoundsException], () => ListBuffer(0).remove(idx = 1, count = 1))
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def removeManyWithNegativeCount(): Unit = {
-    ListBuffer(0).remove(idx = 0, count = -1)
+    assertThrows(classOf[IllegalArgumentException], () => ListBuffer(0).remove(idx = 0, count = -1))
   }
 
-  @Test(expected = classOf[IndexOutOfBoundsException])
+  @Test
   def removeManyWithTooLargeCount(): Unit = {
-    ListBuffer(0).remove(idx = 0, count = 100)
+    assertThrows(classOf[IndexOutOfBoundsException], () => ListBuffer(0).remove(idx = 0, count = 100))
   }
 
   @nowarn("cat=deprecation")

--- a/test/junit/scala/collection/mutable/MutationTrackerTest.scala
+++ b/test/junit/scala/collection/mutable/MutationTrackerTest.scala
@@ -14,7 +14,7 @@ package scala.collection.mutable
 
 import java.util.ConcurrentModificationException
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.AssertUtil.assertThrows
 

--- a/test/junit/scala/collection/mutable/MutationTrackingTest.scala
+++ b/test/junit/scala/collection/mutable/MutationTrackingTest.scala
@@ -15,7 +15,7 @@ package mutable
 
 import java.util.ConcurrentModificationException
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import scala.annotation.nowarn
 import scala.tools.testkit.AssertUtil.assertThrows

--- a/test/junit/scala/collection/mutable/OpenHashMapTest.scala
+++ b/test/junit/scala/collection/mutable/OpenHashMapTest.scala
@@ -1,7 +1,7 @@
 package scala.collection.mutable
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 import org.openjdk.jol.info.GraphWalker
 
 /** Tests for [[OpenHashMap]]. */
@@ -57,22 +57,22 @@ class OpenHashMapTest {
 
     val m = OpenHashMap.empty[MyClass, Int]
     val obj = new MyClass
-    assertEquals("Found a key instance in the map before adding one!?", 0, countInstances(m))
+    assertEquals(0, countInstances(m), "Found a key instance in the map before adding one!?")
     m.put(obj, 0)
-    assertEquals("There should be only one key instance in the map.", 1, countInstances(m))
+    assertEquals(1, countInstances(m), "There should be only one key instance in the map.")
     m.put(obj, 1)
-    assertEquals("There should still be only one key instance in the map.", 1, countInstances(m))
+    assertEquals(1, countInstances(m), "There should still be only one key instance in the map.")
     m.remove(obj)
-    assertEquals("There should be no key instance in the map.", 0, countInstances(m))
+    assertEquals(0, countInstances(m), "There should be no key instance in the map.")
 
     val obj2 = new MyClass
-    assertEquals("The hash codes of the test objects need to match.", obj.##, obj2.##)
+    assertEquals(obj.##, obj2.##, "The hash codes of the test objects need to match.")
     m.put(obj, 0)
     m.put(obj2, 0)
-    assertEquals("There should be two key instances in the map.", 2, countInstances(m))
+    assertEquals(2, countInstances(m), "There should be two key instances in the map.")
     m.remove(obj)
-    assertEquals("There should be one key instance in the map.", 1, countInstances(m))
+    assertEquals(1, countInstances(m), "There should be one key instance in the map.")
     m.remove(obj2)
-    assertEquals("There should be no key instance in the map.", 0, countInstances(m))
+    assertEquals(0, countInstances(m), "There should be no key instance in the map.")
   }
 }

--- a/test/junit/scala/collection/mutable/PriorityQueueTest.scala
+++ b/test/junit/scala/collection/mutable/PriorityQueueTest.scala
@@ -1,15 +1,12 @@
 package scala.collection.mutable
 
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import scala.collection.mutable
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
 
 import scala.tools.testkit.AssertUtil.assertThrows
 
-@RunWith(classOf[JUnit4])
 /* Test for scala/bug#7568  */
 class PriorityQueueTest {
   val priorityQueue = new mutable.PriorityQueue[Int]()

--- a/test/junit/scala/collection/mutable/QueueTest.scala
+++ b/test/junit/scala/collection/mutable/QueueTest.scala
@@ -1,12 +1,9 @@
 package scala.collection.mutable
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 import scala.collection.mutable
 
-@RunWith(classOf[JUnit4])
 class QueueTest {
 
   @Test

--- a/test/junit/scala/collection/mutable/SerializationTest.scala
+++ b/test/junit/scala/collection/mutable/SerializationTest.scala
@@ -1,12 +1,9 @@
 package scala.collection.mutable
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 import scala.collection.mutable
 
-@RunWith(classOf[JUnit4])
 class SerializationTest {
 
   @Test
@@ -102,7 +99,7 @@ class SerializationTest {
   private def assertEqualsAfterDeserialization[A](original: mutable.Iterable[A], expectedClass: Class[_]): Unit = {
     val after = serializeDeserialize(original)
     assertEquals(original, after)
-    assertTrue("Deserialized class "+after.getClass.getName+" is not assignable to "+expectedClass.getName, expectedClass.isInstance(after))
+    assertTrue(expectedClass.isInstance(after), "Deserialized class "+after.getClass.getName+" is not assignable to "+expectedClass.getName)
   }
 
   private def serializeDeserialize[T <: AnyRef](obj: T): T = {

--- a/test/junit/scala/collection/mutable/SetTest.scala
+++ b/test/junit/scala/collection/mutable/SetTest.scala
@@ -1,7 +1,7 @@
 package scala.collection.mutable
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 class SetTest {
 

--- a/test/junit/scala/collection/mutable/SortedMapTest.scala
+++ b/test/junit/scala/collection/mutable/SortedMapTest.scala
@@ -1,8 +1,8 @@
 package scala.collection
 package mutable
 
-import org.junit.Assert.{assertEquals, assertNotEquals}
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.{assertEquals, assertNotEquals}
+import org.junit.jupiter.api.Test
 
 class SortedMapTest {
   @Test

--- a/test/junit/scala/collection/mutable/StackTest.scala
+++ b/test/junit/scala/collection/mutable/StackTest.scala
@@ -1,11 +1,8 @@
 package scala.collection.mutable
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class StackTest {
 
   @Test

--- a/test/junit/scala/collection/mutable/StringBuilderTest.scala
+++ b/test/junit/scala/collection/mutable/StringBuilderTest.scala
@@ -1,7 +1,7 @@
 package scala.collection.mutable
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 class StringBuilderTest {
   @Test

--- a/test/junit/scala/collection/mutable/TreeMapTest.scala
+++ b/test/junit/scala/collection/mutable/TreeMapTest.scala
@@ -1,13 +1,10 @@
 package scala.collection.mutable
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 import scala.collection.mutable
 
-@RunWith(classOf[JUnit4])
 class TreeMapTest {
 
   @Test

--- a/test/junit/scala/collection/mutable/TreeSetTest.scala
+++ b/test/junit/scala/collection/mutable/TreeSetTest.scala
@@ -1,15 +1,12 @@
 package scala.collection.mutable
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 import scala.collection.immutable.{ List,  Vector}
 import scala.collection.mutable
 
 
-@RunWith(classOf[JUnit4])
 class TreeSetTest {
 
   @Test

--- a/test/junit/scala/collection/mutable/UnrolledBufferTest.scala
+++ b/test/junit/scala/collection/mutable/UnrolledBufferTest.scala
@@ -1,10 +1,7 @@
 package scala.collection.mutable
 
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class UnrolledBufferTestTest {
   @Test
   def test_SI9254_original(): Unit = {

--- a/test/junit/scala/collection/mutable/VectorTest.scala
+++ b/test/junit/scala/collection/mutable/VectorTest.scala
@@ -1,6 +1,6 @@
 package scala.collection.mutable
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /* Test for scala/bug#8014 and ++ in general  */
 class VectorTest {

--- a/test/junit/scala/concurrent/FutureTest.scala
+++ b/test/junit/scala/concurrent/FutureTest.scala
@@ -1,8 +1,8 @@
 
 package scala.concurrent
 
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.AssertUtil._
 import scala.util.Try
@@ -57,7 +57,7 @@ class FutureTest {
     // normally we have no guarantee that firstCompletedOf completed, so we assert that this assumption held
     assertNotReachable(result, unfulfilled) {
       quick.complete(Try(result))
-      assertTrue("First must complete", first.isCompleted)
+      assertTrue(first.isCompleted, "First must complete")
     }
     /* The test has this structure under the hood:
     val p = Promise[String]

--- a/test/junit/scala/concurrent/duration/SerializationTest.scala
+++ b/test/junit/scala/concurrent/duration/SerializationTest.scala
@@ -1,11 +1,8 @@
 package scala.concurrent.duration
 
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 
-@RunWith(classOf[JUnit4])
 class SerializationTest {
   @Test
   def test_SI9197(): Unit = {

--- a/test/junit/scala/concurrent/duration/SpecialDurationsTest.scala
+++ b/test/junit/scala/concurrent/duration/SpecialDurationsTest.scala
@@ -1,10 +1,7 @@
 package scala.concurrent.duration
 
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class SpecialDurationsTest {
   @Test
   def test_11178(): Unit = {

--- a/test/junit/scala/concurrent/impl/DefaultPromiseTest.scala
+++ b/test/junit/scala/concurrent/impl/DefaultPromiseTest.scala
@@ -2,8 +2,8 @@ package scala.concurrent.impl
 
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.CountDownLatch
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext
 import scala.concurrent.impl.Promise.DefaultPromise
@@ -87,7 +87,7 @@ class DefaultPromiseTest {
 
       expected match {
         case NoEffect =>
-          assertTrue(s"Shouldn't throw exception: $result", result.isSuccess)
+          assertTrue(result.isSuccess, s"Shouldn't throw exception: $result")
           assertEquals(Map.empty[(Try[Result], HandlerId), Int], fireCounts)
         case HandlersFired(firingResult, handlers) =>
           assert(result.isSuccess)

--- a/test/junit/scala/io/SourceTest.scala
+++ b/test/junit/scala/io/SourceTest.scala
@@ -1,8 +1,8 @@
 
 package scala.io
 
-import org.junit.Test
-import org.junit.Assert._
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions._
 
 import java.io.{Console => _, _}
 
@@ -28,13 +28,14 @@ class SourceTest {
       case "The Scala compiler and reflection APIs." =>
       case "This is the documentation for the Scala standard library." =>
       case l =>
-        assertTrue(s"$l\n${ls.mkString("\n")}", false)
+        assertTrue(false, s"$l\n${ls.mkString("\n")}")
     }
   }
-  @Test(expected = classOf[java.io.FileNotFoundException])
+  @Test
   def loadFromMissingResource(): Unit = {
-    Source.fromResource("missing.txt")
+    assertThrows(classOf[java.io.FileNotFoundException], () => Source.fromResource("missing.txt"))
   }
+
   @Test def canCustomizeReporting() = {
     class CapitalReporting(is: InputStream) extends BufferedSource(is) {
       override def report(pos: Int, msg: String, out: PrintStream): Unit = {

--- a/test/junit/scala/jdk/AccumulatorTest.scala
+++ b/test/junit/scala/jdk/AccumulatorTest.scala
@@ -12,12 +12,9 @@
 
 package scala.jdk
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class AccumulatorTest {
   @Test
   def map(): Unit = {

--- a/test/junit/scala/jdk/DurationConvertersTest.scala
+++ b/test/junit/scala/jdk/DurationConvertersTest.scala
@@ -14,8 +14,8 @@ package scala.jdk
 
 import java.time.{Duration => JavaDuration}
 
-import org.junit.Assert.{assertEquals, assertTrue}
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Test
 
 import scala.AdaptedArrowAssocWorkaround.Tx
 import scala.concurrent.duration._
@@ -36,8 +36,8 @@ class DurationConvertersTest {
       Long.MaxValue       -> Tx(9223372036L, 854775807)
     ).foreach { case (n, (expSecs, expNanos)) =>
       val result = n.nanos.toJava
-      assertEquals(s"toJava($n nanos) -> $expSecs s)", expSecs, result.getSeconds)
-      assertEquals(s"toJava($n nanos) -> $expNanos n)", expNanos, result.getNano)
+      assertEquals(expSecs, result.getSeconds, s"toJava($n nanos) -> $expSecs s)")
+      assertEquals(expNanos, result.getNano, s"toJava($n nanos) -> $expNanos n)")
     }
   }
 
@@ -51,8 +51,8 @@ class DurationConvertersTest {
       9223372036854L  -> Tx(9223372036L, 854000000)
     ).foreach { case (n, (expSecs, expNanos)) =>
       val result = n.millis.toJava
-      assertEquals(s"toJava($n millis) -> $expSecs s)", expSecs, result.getSeconds)
-      assertEquals(s"toJava($n millis) -> $expNanos n)", expNanos, result.getNano)
+      assertEquals(expSecs, result.getSeconds, s"toJava($n millis) -> $expSecs s)")
+      assertEquals(expNanos, result.getNano, s"toJava($n millis) -> $expNanos n)")
     }
   }
 
@@ -66,8 +66,8 @@ class DurationConvertersTest {
       9223372036854775L  -> Tx(9223372036L, 854775000)
     ).foreach { case (n, (expSecs, expNanos)) =>
       val result = n.micros.toJava
-      assertEquals(s"toJava($n micros) -> $expSecs s)", expSecs, result.getSeconds)
-      assertEquals(s"toJava($n micros) -> $expNanos n)", expNanos, result.getNano)
+      assertEquals(expSecs, result.getSeconds, s"toJava($n micros) -> $expSecs s)")
+      assertEquals(expNanos, result.getNano, s"toJava($n micros) -> $expNanos n)")
     }
   }
 
@@ -107,7 +107,7 @@ class DurationConvertersTest {
   def unsupportedJavaDurationThrows(): Unit = {
     Seq(JavaDuration.ofSeconds(-9223372037L), JavaDuration.ofSeconds(9223372037L)).foreach { d =>
       val res = Try { conv.toScala(d) }
-      assertTrue(s"Expected exception for $d but got success", res.isFailure)
+      assertTrue(res.isFailure, s"Expected exception for $d but got success")
     }
   }
 }

--- a/test/junit/scala/jdk/FunctionConvertersTest.scala
+++ b/test/junit/scala/jdk/FunctionConvertersTest.scala
@@ -14,8 +14,8 @@ package scala.jdk
 
 import java.io.NotSerializableException
 
-import org.junit.Assert.{ assertThrows => _, _ }
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.{ assertThrows => _, _ }
+import org.junit.jupiter.api.Test
 
 import scala.annotation.unused
 import scala.jdk.FunctionConverters._

--- a/test/junit/scala/jdk/FutureConvertersTest.java
+++ b/test/junit/scala/jdk/FutureConvertersTest.java
@@ -12,7 +12,7 @@
 
 package scala.jdk;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import scala.concurrent.Future;
 import scala.concurrent.Promise;
 
@@ -20,7 +20,7 @@ import java.util.concurrent.*;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static scala.jdk.javaapi.FutureConverters.asJava;
 import static scala.jdk.javaapi.FutureConverters.asScala;
 
@@ -31,9 +31,9 @@ public class FutureConvertersTest {
     public void testToScalaSuccess() {
         final CompletableFuture<String> cs = new CompletableFuture<>();
         final Future<String> f = asScala(cs);
-        assertFalse("f must not yet be completed", f.isCompleted());
+        assertFalse(f.isCompleted(), "f must not yet be completed");
         cs.complete("Hello");
-        assertTrue("f must be completed by now", f.isCompleted());
+        assertTrue(f.isCompleted(), "f must be completed by now");
         assertEquals("Hello", f.value().get().get());
     }
 
@@ -41,10 +41,10 @@ public class FutureConvertersTest {
     public void testToScalaFailure() {
         final CompletableFuture<String> cs = new CompletableFuture<>();
         final Future<String> f = asScala(cs);
-        assertFalse("f must not yet be completed", f.isCompleted());
+        assertFalse(f.isCompleted(), "f must not yet be completed");
         final Exception ex = new RuntimeException("Hello");
         cs.completeExceptionally(ex);
-        assertTrue("f must be completed by now", f.isCompleted());
+        assertTrue(f.isCompleted(), "f must be completed by now");
         assertEquals(ex, f.value().get().failed().get());
     }
 
@@ -54,9 +54,9 @@ public class FutureConvertersTest {
         final Promise<String> p = promise();
         final CompletionStage<String> cs = asJava(p.future());
         final CompletableFuture<String> cp = (CompletableFuture<String>) cs;
-        assertFalse("cs must not yet be completed", cp.isDone());
+        assertFalse(cp.isDone(), "cs must not yet be completed");
         p.success("Hello");
-        assertTrue("cs must be completed by now", cp.isDone());
+        assertTrue(cp.isDone(), "cs must be completed by now");
         assertEquals("Hello", cp.get());
     }
 
@@ -66,20 +66,20 @@ public class FutureConvertersTest {
         final Promise<String> p = promise();
         final CompletionStage<String> cs = asJava(p.future());
         final CompletableFuture<String> cp = (CompletableFuture<String>) cs;
-        assertFalse("cs must not yet be completed", cp.isDone());
+        assertFalse(cp.isDone(), "cs must not yet be completed");
         final Exception ex = new RuntimeException("Hello");
         p.failure(ex);
-        assertTrue("cs must be completed by now", cp.isDone());
-        assertEquals("exceptionally equals", ex.toString(), cp.exceptionally(x -> x.toString()).get());
+        assertTrue(cp.isDone(), "cs must be completed by now");
+        assertEquals(ex.toString(), cp.exceptionally(x -> x.toString()).get(), "exceptionally equals");
         Throwable thr = null;
         try {
             cp.get();
         } catch (Throwable t) {
             thr = t;
         }
-        assertNotNull("get() must throw", thr);
-        assertEquals("thrown exception must be wrapped", ExecutionException.class, thr.getClass());
-        assertEquals("wrapper must contain the right exception", ex, thr.getCause());
+        assertNotNull(thr, "get() must throw");
+        assertEquals(ExecutionException.class, thr.getClass(), "thrown exception must be wrapped");
+        assertEquals(ex, thr.getCause(), "wrapper must contain the right exception");
     }
 
     @Test
@@ -90,7 +90,7 @@ public class FutureConvertersTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final CompletionStage<String> second = cs.thenApply(x -> {
             try {
-                assertTrue("latch must succeed", latch.await(1, SECONDS));
+                assertTrue(latch.await(1, SECONDS), "latch must succeed");
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
@@ -109,14 +109,14 @@ public class FutureConvertersTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final CompletionStage<Void> second = cs.thenAccept(x -> {
             try {
-                assertTrue("latch must succeed", latch.await(1, SECONDS));
+                assertTrue(latch.await(1, SECONDS), "latch must succeed");
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
         });
         p.success("Hello");
         latch.countDown();
-        assertNull("result must be Void", second.toCompletableFuture().get());
+        assertNull(second.toCompletableFuture().get(), "result must be Void");
     }
 
     @Test
@@ -127,14 +127,14 @@ public class FutureConvertersTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final CompletionStage<Void> second = cs.thenRun(() -> {
             try {
-                assertTrue("latch must succeed", latch.await(1, SECONDS));
+                assertTrue(latch.await(1, SECONDS), "latch must succeed");
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
         });
         p.success("Hello");
         latch.countDown();
-        assertNull("result must be Void", second.toCompletableFuture().get());
+        assertNull(second.toCompletableFuture().get(), "result must be Void");
     }
 
     @Test
@@ -146,7 +146,7 @@ public class FutureConvertersTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final CompletionStage<Integer> second = cs.thenCombine(other, (x, y) -> {
             try {
-                assertTrue("latch must succeed", latch.await(1, SECONDS));
+                assertTrue(latch.await(1, SECONDS), "latch must succeed");
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
@@ -166,14 +166,14 @@ public class FutureConvertersTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final CompletionStage<Void> second = cs.thenAcceptBoth(other, (x, y) -> {
             try {
-                assertTrue("latch must succeed", latch.await(1, SECONDS));
+                assertTrue(latch.await(1, SECONDS), "latch must succeed");
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
         });
         p.success("Hello");
         latch.countDown();
-        assertNull("result must be Void", second.toCompletableFuture().get());
+        assertNull(second.toCompletableFuture().get(), "result must be Void");
     }
 
     @Test
@@ -185,14 +185,14 @@ public class FutureConvertersTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final CompletionStage<Void> second = cs.runAfterBoth(other, () -> {
             try {
-                assertTrue("latch must succeed", latch.await(1, SECONDS));
+                assertTrue(latch.await(1, SECONDS), "latch must succeed");
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
         });
         p.success("Hello");
         latch.countDown();
-        assertNull("result must be Void", second.toCompletableFuture().get());
+        assertNull(second.toCompletableFuture().get(), "result must be Void");
     }
 
     @Test
@@ -204,7 +204,7 @@ public class FutureConvertersTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final CompletionStage<Integer> second = cs.applyToEither(other, x -> {
             try {
-                assertTrue("latch must succeed", latch.await(1, SECONDS));
+                assertTrue(latch.await(1, SECONDS), "latch must succeed");
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
@@ -224,14 +224,14 @@ public class FutureConvertersTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final CompletionStage<Void> second = cs.acceptEither(other, x -> {
             try {
-                assertTrue("latch must succeed", latch.await(1, SECONDS));
+                assertTrue(latch.await(1, SECONDS), "latch must succeed");
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
         });
         p.success("Hello");
         latch.countDown();
-        assertNull("result must be Void", second.toCompletableFuture().get());
+        assertNull(second.toCompletableFuture().get(), "result must be Void");
     }
 
     @Test
@@ -243,14 +243,14 @@ public class FutureConvertersTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final CompletionStage<Void> second = cs.runAfterEither(other, () -> {
             try {
-                assertTrue("latch must succeed", latch.await(1, SECONDS));
+                assertTrue(latch.await(1, SECONDS), "latch must succeed");
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
         });
         p.success("Hello");
         latch.countDown();
-        assertNull("result must be Void", second.toCompletableFuture().get());
+        assertNull(second.toCompletableFuture().get(), "result must be Void");
     }
 
     @Test
@@ -261,7 +261,7 @@ public class FutureConvertersTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final CompletionStage<String> second = cs.thenCompose(x -> {
             try {
-                assertTrue("latch must succeed", latch.await(1, SECONDS));
+                assertTrue(latch.await(1, SECONDS), "latch must succeed");
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
@@ -280,7 +280,7 @@ public class FutureConvertersTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final CompletionStage<String> second = cs.whenComplete((v, e) -> {
             try {
-                assertTrue("latch must succeed", latch.await(1, SECONDS));
+                assertTrue(latch.await(1, SECONDS), "latch must succeed");
             } catch (Exception ex) {
                 throw new RuntimeException(ex);
             }
@@ -298,7 +298,7 @@ public class FutureConvertersTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final CompletionStage<Integer> second = cs.handle((v, e) -> {
             try {
-                assertTrue("latch must succeed", latch.await(1, SECONDS));
+                assertTrue(latch.await(1, SECONDS), "latch must succeed");
             } catch (Exception ex) {
                 throw new RuntimeException(ex);
             }
@@ -317,7 +317,7 @@ public class FutureConvertersTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final CompletionStage<String> second = cs.exceptionally(e -> {
             try {
-                assertTrue("latch must succeed", latch.await(1, SECONDS));
+                assertTrue(latch.await(1, SECONDS), "latch must succeed");
             } catch (Exception ex) {
                 throw new RuntimeException(ex);
             }

--- a/test/junit/scala/jdk/OptionConvertersTest.scala
+++ b/test/junit/scala/jdk/OptionConvertersTest.scala
@@ -14,14 +14,11 @@ package scala.jdk
 
 import java.util._
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 import scala.jdk.OptionConverters._
 
-@RunWith(classOf[JUnit4])
 class OptionConvertersTest {
   @Test
   def scalaToEverything(): Unit = {

--- a/test/junit/scala/jdk/StepperConversionTest.scala
+++ b/test/junit/scala/jdk/StepperConversionTest.scala
@@ -12,8 +12,8 @@
 
 package scala.jdk
 
-import org.junit.Test
-import org.junit.Assert.{assertFalse, assertTrue}
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.{assertFalse, assertTrue}
 
 import scala.collection.{AnyStepper, DoubleStepper, IntStepper, LongStepper, Stepper, concurrent => cc, immutable => ci, mutable => cm}
 import scala.{collection => co}
@@ -32,7 +32,7 @@ class StepperConversionTest {
     def check[X](x: X): Boolean
     def msg[X](x: X): String
     def assert(x: Any): Unit =
-      if(!check(x)) assertTrue(msg(x), false)
+      if(!check(x)) assertTrue(false, msg(x))
   }
   object SpecCheck {
     def apply(f: Any => Boolean, err: Any => String = _ => "SpecCheck failed") = new SpecCheck {

--- a/test/junit/scala/jdk/StepperTest.scala
+++ b/test/junit/scala/jdk/StepperTest.scala
@@ -14,17 +14,14 @@ package scala.jdk
 
 import java.util.Spliterator
 
-import org.junit.Assert.{assertEquals, assertTrue}
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Test
 
 import scala.collection.{AnyStepper, ClassTagIterableFactory, IntStepper, IterableFactory, MapFactory, SortedIterableFactory, SortedMapFactory, SpecificIterableFactory, Stepper, StepperShape, concurrent => cc, immutable => ci, mutable => cm}
 import scala.jdk.StreamConverters._
 import scala.util.chaining._
 
 
-@RunWith(classOf[JUnit4])
 class StepperTest {
   val sizes = List(0, 1, 2, 3, 4, 7, 8, 15, 16, 17, 136, 2123)
 

--- a/test/junit/scala/jdk/StreamConvertersTest.scala
+++ b/test/junit/scala/jdk/StreamConvertersTest.scala
@@ -14,19 +14,16 @@ package scala.jdk
 
 import java.util.stream.{DoubleStream, IntStream, LongStream, Stream => JStream}
 
-import org.junit.Assert.{assertEquals, assertTrue}
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Test
 
 import scala.jdk.StreamConverters._
 
-@RunWith(classOf[JUnit4])
 class StreamConvertersTest {
-  def assertEq[A](a1: A, a2: A, s: String): Unit = { assertEquals(s, a1, a2) }  // Weird order normally!
+  def assertEq[A](a1: A, a2: A, s: String): Unit = { assertEquals(a1, a2, s) }  // Weird order normally!
   def assertEq[A](a1: A, a2: A): Unit = { assertEq(a1, a2, "not equal") }
   def assert(b: Boolean): Unit = { assertTrue(b) }
-  def assert(b: Boolean, s: String): Unit = { assertTrue(s, b) }
+  def assert(b: Boolean, s: String): Unit = { assertTrue(b, s) }
 
   def arrayO(n: Int) = (1 to n).map(_.toString).toArray
   def arrayD(n: Int) = (1 to n).map(_.toDouble).toArray

--- a/test/junit/scala/jdk/StreamConvertersTypingTest.scala
+++ b/test/junit/scala/jdk/StreamConvertersTypingTest.scala
@@ -14,8 +14,8 @@ package scala.jdk
 
 import java.util.stream._
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.annotation.unused
 import scala.collection.Stepper.EfficientSplit

--- a/test/junit/scala/jdk/javaapi/FunctionConvertersJavaTest.java
+++ b/test/junit/scala/jdk/javaapi/FunctionConvertersJavaTest.java
@@ -12,14 +12,14 @@
 
 package scala.jdk.javaapi;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import scala.Function2;
 import scala.runtime.BoxedUnit;
 
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.ObjDoubleConsumer;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class FunctionConvertersJavaTest {
     Function2<String, String, BoxedUnit> sf = (x, y) -> BoxedUnit.UNIT;

--- a/test/junit/scala/jdk/javaapi/OptionConvertersJavaTest.java
+++ b/test/junit/scala/jdk/javaapi/OptionConvertersJavaTest.java
@@ -12,10 +12,10 @@
 
 package scala.jdk.javaapi;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import scala.Option;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Optional;
 import java.util.OptionalInt;

--- a/test/junit/scala/jdk/javaapi/StreamConvertersJavaTest.java
+++ b/test/junit/scala/jdk/javaapi/StreamConvertersJavaTest.java
@@ -12,7 +12,7 @@
 
 package scala.jdk.javaapi;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import scala.Tuple2;
 import scala.collection.Map;
 import scala.collection.immutable.List;
@@ -22,7 +22,7 @@ import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class StreamConvertersJavaTest {
     public List<String> ls = CollectionConverters.asScala(Arrays.asList("a", "b")).toList();

--- a/test/junit/scala/lang/annotations/BytecodeTest.scala
+++ b/test/junit/scala/lang/annotations/BytecodeTest.scala
@@ -1,7 +1,7 @@
 package scala.lang.annotations
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.jdk.CollectionConverters._
 import scala.tools.nsc.backend.jvm.AsmUtils
@@ -65,7 +65,7 @@ class BytecodeTest extends BytecodeTesting {
     def check(classfile: String, annotName: String) = {
       val f = (outfiles collect { case (`classfile`, bytes) => AsmUtils.readClass(bytes) }).head
       val descs = f.visibleAnnotations.asScala.map(_.desc).toList
-      assertTrue(descs.toString, descs exists (_ contains annotName))
+      assertTrue(descs exists (_ contains annotName), descs.toString)
     }
 
     check("A.class", "AnnotA")

--- a/test/junit/scala/lang/annotations/RunTest.scala
+++ b/test/junit/scala/lang/annotations/RunTest.scala
@@ -1,13 +1,10 @@
 package scala.lang.annotations
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.RunTesting
 
-@RunWith(classOf[JUnit4])
 class RunTest extends RunTesting {
   import runner._
 

--- a/test/junit/scala/lang/primitives/NaNTest.scala
+++ b/test/junit/scala/lang/primitives/NaNTest.scala
@@ -1,13 +1,10 @@
 package scala.lang.primitives
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.RunTesting
 
-@RunWith(classOf[JUnit4])
 class NaNTest extends RunTesting {
 
   @Test

--- a/test/junit/scala/lang/primitives/PredefAutoboxingTest.scala
+++ b/test/junit/scala/lang/primitives/PredefAutoboxingTest.scala
@@ -1,11 +1,8 @@
 package scala.lang.primitives
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class PredefAutoboxingTest {
   @Test def unboxNullByte() =
     assertEquals(Predef.Byte2byte(null), 0.toByte)

--- a/test/junit/scala/lang/stringinterpol/StringContextTest.scala
+++ b/test/junit/scala/lang/stringinterpol/StringContextTest.scala
@@ -1,12 +1,9 @@
 package scala.lang.stringinterpol
 
+import org.junit.jupiter.api.Assertions.{assertThrows => _, _}
+import org.junit.jupiter.api.Test
+
 import java.text.DecimalFormat
-
-import org.junit.Assert.{ assertThrows => _, _ }
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-
 import scala.language.implicitConversions
 import scala.tools.testkit.AssertUtil._
 
@@ -31,7 +28,6 @@ object StringContextTestUtils {
   }
 }
 
-@RunWith(classOf[JUnit4])
 class StringContextTest {
 
   import StringContext._
@@ -83,7 +79,6 @@ class StringContextTest {
   // verifying that the standard interpolators can be supplanted
   @Test def antiHijack_?() = {
     object AllYourStringsAreBelongToMe { case class StringContext(args: Any*) { def s(args: Any*) = "!!!!" } }
-    import AllYourStringsAreBelongToMe._
     //assertEquals("????", s"????")
     assertEquals("!!!!", s"????") // OK to hijack core interpolator ids
   }

--- a/test/junit/scala/lang/traits/BytecodeTest.scala
+++ b/test/junit/scala/lang/traits/BytecodeTest.scala
@@ -1,9 +1,7 @@
 package scala.lang.traits
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.jdk.CollectionConverters._
 import scala.tools.asm.Opcodes
@@ -13,7 +11,6 @@ import scala.tools.testkit.ASMConverters._
 import scala.tools.testkit.BytecodeTesting
 import scala.tools.testkit.BytecodeTesting._
 
-@RunWith(classOf[JUnit4])
 class BytecodeTest extends BytecodeTesting {
   import compiler._
 

--- a/test/junit/scala/lang/traits/RunTest.scala
+++ b/test/junit/scala/lang/traits/RunTest.scala
@@ -1,13 +1,10 @@
 package scala.lang.traits
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.RunTesting
 
-@RunWith(classOf[JUnit4])
 class RunTest extends RunTesting {
   import runner._
 

--- a/test/junit/scala/math/BigDecimalTest.scala
+++ b/test/junit/scala/math/BigDecimalTest.scala
@@ -1,6 +1,6 @@
 package scala.math
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.math.{BigDecimal => BD, MathContext => MC}
 
 /* Tests various maps by making sure they all agree on the same answers. */

--- a/test/junit/scala/math/BigIntTest.scala
+++ b/test/junit/scala/math/BigIntTest.scala
@@ -1,6 +1,6 @@
 package scala.math
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class BigIntTest {
 

--- a/test/junit/scala/math/DoubleTest.scala
+++ b/test/junit/scala/math/DoubleTest.scala
@@ -1,12 +1,9 @@
 package scala.math
 
 import java.lang.Double.doubleToLongBits
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class DoubleTest {
 
   /* Test for scala/bug#11386 */

--- a/test/junit/scala/math/EquivTest.scala
+++ b/test/junit/scala/math/EquivTest.scala
@@ -1,6 +1,6 @@
 package scala.math
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import scala.annotation.unused
 
 class EquivTest {

--- a/test/junit/scala/math/NumericTest.scala
+++ b/test/junit/scala/math/NumericTest.scala
@@ -1,11 +1,8 @@
 package scala.math
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class NumericTest {
 
   /* Test for scala/bug#8102 */

--- a/test/junit/scala/math/OrderingTest.scala
+++ b/test/junit/scala/math/OrderingTest.scala
@@ -1,16 +1,13 @@
 package scala.math
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import java.{lang => jl}
 
 import scala.collection.SortedSet
 import scala.math.Ordering.Double.TotalOrdering
 
-@RunWith(classOf[JUnit4])
 class OrderingTest {
   val floats = Seq(
     Float.NegativeInfinity,
@@ -166,29 +163,28 @@ class OrderingTest {
         val msg = s"for i=$i, j=$j"
 
         // consistency with `compare`
-        assertEquals(msg, O.compare(i, j) < 0, O.lt(i, j))
-        assertEquals(msg, O.compare(i, j) <= 0, O.lteq(i, j))
-        assertEquals(msg, O.compare(i, j) == 0, O.equiv(i, j))
-        assertEquals(msg, O.compare(i, j) >= 0, O.gteq(i, j))
-        assertEquals(msg, O.compare(i, j) > 0, O.gt(i, j))
+        assertEquals(O.compare(i, j) < 0, O.lt(i, j), msg)
+        assertEquals(O.compare(i, j) <= 0, O.lteq(i, j), msg)
+        assertEquals(O.compare(i, j) == 0, O.equiv(i, j), msg)
+        assertEquals(O.compare(i, j) >= 0, O.gteq(i, j), msg)
+        assertEquals(O.compare(i, j) > 0, O.gt(i, j), msg)
 
         // consistency with other ops
-        assertTrue(msg, O.lteq(i, j) || O.gteq(i, j))
-        assertTrue(msg, O.lteq(i, j) || O.gt(i, j))
-        assertTrue(msg, O.lteq(i, j) != O.gt(i, j))
-        assertTrue(msg, O.lt(i, j) || O.gteq(i, j))
-        assertTrue(msg, O.lt(i, j) != O.gteq(i, j))
+        assertTrue(O.lteq(i, j) || O.gteq(i, j), msg)
+        assertTrue(O.lteq(i, j) || O.gt(i, j), msg)
+        assertTrue(O.lteq(i, j) != O.gt(i, j), msg)
+        assertTrue(O.lt(i, j) || O.gteq(i, j), msg)
+        assertTrue(O.lt(i, j) != O.gteq(i, j), msg)
         // exactly one of `lt`, `equiv`, `gt` is true
-        assertTrue(msg,
-          (O.lt(i, j) ^ O.equiv(i, j) ^ O.gt(i, j))
-            && !(O.lt(i, j) && O.equiv(i, j) && O.gt(i, j)))
+        assertTrue((O.lt(i, j) ^ O.equiv(i, j) ^ O.gt(i, j))
+            && !(O.lt(i, j) && O.equiv(i, j) && O.gt(i, j)), msg)
 
         // consistency with `max` and `min`
-        assertEquals(msg, O.compare(i, j) >= 0, same(O.max(i, j), i))
-        assertEquals(msg, O.compare(i, j) <= 0, same(O.min(i, j), i))
+        assertEquals(O.compare(i, j) >= 0, same(O.max(i, j), i), msg)
+        assertEquals(O.compare(i, j) <= 0, same(O.min(i, j), i), msg)
         if (!same(i, j)) {
-          assertEquals(msg, O.compare(i, j) < 0, same(O.max(i, j), j))
-          assertEquals(msg, O.compare(i, j) > 0, same(O.min(i, j), j))
+          assertEquals(O.compare(i, j) < 0, same(O.max(i, j), j), msg)
+          assertEquals(O.compare(i, j) > 0, same(O.min(i, j), j), msg)
         }
       }
     }
@@ -206,29 +202,28 @@ class OrderingTest {
         val msg = s"for i=$i, j=$j"
 
         // consistency with `compare`
-        assertEquals(msg, O.compare(i, j) < 0, O.lt(i, j))
-        assertEquals(msg, O.compare(i, j) <= 0, O.lteq(i, j))
-        assertEquals(msg, O.compare(i, j) == 0, O.equiv(i, j))
-        assertEquals(msg, O.compare(i, j) >= 0, O.gteq(i, j))
-        assertEquals(msg, O.compare(i, j) > 0, O.gt(i, j))
+        assertEquals(O.compare(i, j) < 0, O.lt(i, j), msg)
+        assertEquals(O.compare(i, j) <= 0, O.lteq(i, j), msg)
+        assertEquals(O.compare(i, j) == 0, O.equiv(i, j), msg)
+        assertEquals(O.compare(i, j) >= 0, O.gteq(i, j), msg)
+        assertEquals(O.compare(i, j) > 0, O.gt(i, j), msg)
 
         // consistency with other ops
-        assertTrue(msg, O.lteq(i, j) || O.gteq(i, j))
-        assertTrue(msg, O.lteq(i, j) || O.gt(i, j))
-        assertTrue(msg, O.lteq(i, j) != O.gt(i, j))
-        assertTrue(msg, O.lt(i, j) || O.gteq(i, j))
-        assertTrue(msg, O.lt(i, j) != O.gteq(i, j))
+        assertTrue(O.lteq(i, j) || O.gteq(i, j), msg)
+        assertTrue(O.lteq(i, j) || O.gt(i, j), msg)
+        assertTrue(O.lteq(i, j) != O.gt(i, j), msg)
+        assertTrue(O.lt(i, j) || O.gteq(i, j), msg)
+        assertTrue(O.lt(i, j) != O.gteq(i, j), msg)
         // exactly one of `lt`, `equiv`, `gt` is true
-        assertTrue(msg,
-          (O.lt(i, j) ^ O.equiv(i, j) ^ O.gt(i, j))
-            && !(O.lt(i, j) && O.equiv(i, j) && O.gt(i, j)))
+        assertTrue((O.lt(i, j) ^ O.equiv(i, j) ^ O.gt(i, j))
+            && !(O.lt(i, j) && O.equiv(i, j) && O.gt(i, j)), msg)
 
         // consistency with `max` and `min`
-        assertEquals(msg, O.compare(i, j) >= 0, same(O.max(i, j), i))
-        assertEquals(msg, O.compare(i, j) <= 0, same(O.min(i, j), i))
+        assertEquals(O.compare(i, j) >= 0, same(O.max(i, j), i), msg)
+        assertEquals(O.compare(i, j) <= 0, same(O.min(i, j), i), msg)
         if (!same(i, j)) {
-          assertEquals(msg, O.compare(i, j) < 0, same(O.max(i, j), j))
-          assertEquals(msg, O.compare(i, j) > 0, same(O.min(i, j), j))
+          assertEquals(O.compare(i, j) < 0, same(O.max(i, j), j), msg)
+          assertEquals(O.compare(i, j) > 0, same(O.min(i, j), j), msg)
         }
       }
     }

--- a/test/junit/scala/math/PartialOrderingTest.scala
+++ b/test/junit/scala/math/PartialOrderingTest.scala
@@ -1,6 +1,6 @@
 package scala.math
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import scala.annotation.unused
 
 class PartialOrderingTest {

--- a/test/junit/scala/reflect/ClassOfTest.scala
+++ b/test/junit/scala/reflect/ClassOfTest.scala
@@ -1,9 +1,7 @@
 package scala.reflect
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.RunTesting
 
@@ -11,7 +9,6 @@ object ClassOfTest {
   class VC(val x: Any) extends AnyVal
 }
 
-@RunWith(classOf[JUnit4])
 class ClassOfTest extends RunTesting {
   import runner._
 

--- a/test/junit/scala/reflect/ClassTagTest.scala
+++ b/test/junit/scala/reflect/ClassTagTest.scala
@@ -1,13 +1,10 @@
 package scala.reflect
 
-import org.junit.Test
-import org.junit.Assert._
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 class Misc
 
-@RunWith(classOf[JUnit4])
 class ClassTagTest {
   def checkNotString[A: ClassTag](a: Any)  = a match { case x: String  => false case x: A => true case _ => false }
   def checkNotInt[A: ClassTag](a: Any)  = a match { case x: Int  => false case x: A => true case _ => false }

--- a/test/junit/scala/reflect/FieldAccessTest.scala
+++ b/test/junit/scala/reflect/FieldAccessTest.scala
@@ -1,7 +1,7 @@
 package scala.reflect
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 class FieldAccessTest {
 

--- a/test/junit/scala/reflect/QTest.scala
+++ b/test/junit/scala/reflect/QTest.scala
@@ -1,8 +1,8 @@
 
 package scala.reflect
 
-import org.junit.Test
-import org.junit.Assert._
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions._
 
 class QTest {
 

--- a/test/junit/scala/reflect/internal/InferTest.scala
+++ b/test/junit/scala/reflect/internal/InferTest.scala
@@ -1,7 +1,7 @@
 package scala.reflect.internal
 
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.BytecodeTesting
 

--- a/test/junit/scala/reflect/internal/MirrorsTest.scala
+++ b/test/junit/scala/reflect/internal/MirrorsTest.scala
@@ -1,18 +1,15 @@
 package scala.reflect.internal
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class MirrorsTest {
   @Test def rootCompanionsAreConnected(): Unit = {
     val cm = scala.reflect.runtime.currentMirror
     import cm._
-    assertEquals("RootPackage.moduleClass == RootClass", RootClass, RootPackage.moduleClass)
-    assertEquals("RootClass.module == RootPackage", RootPackage, RootClass.module)
-    assertEquals("EmptyPackage.moduleClass == EmptyPackageClass", EmptyPackageClass, EmptyPackage.moduleClass)
-    assertEquals("EmptyPackageClass.module == EmptyPackage", EmptyPackage, EmptyPackageClass.module)
+    assertEquals(RootClass, RootPackage.moduleClass, "RootPackage.moduleClass == RootClass")
+    assertEquals(RootPackage, RootClass.module, "RootClass.module == RootPackage")
+    assertEquals(EmptyPackageClass, EmptyPackage.moduleClass, "EmptyPackage.moduleClass == EmptyPackageClass")
+    assertEquals(EmptyPackage, EmptyPackageClass.module, "EmptyPackageClass.module == EmptyPackage")
   }
 }

--- a/test/junit/scala/reflect/internal/NamesTest.scala
+++ b/test/junit/scala/reflect/internal/NamesTest.scala
@@ -1,13 +1,10 @@
 package scala.reflect.internal
 
 import scala.tools.testkit.AssertUtil._
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Test
-import org.junit.Assert.{ assertThrows => _, _ }
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.{ assertThrows => _, _ }
 import scala.tools.nsc.symtab.SymbolTableForUnitTesting
 
-@RunWith(classOf[JUnit4])
 class NamesTest {
   object symbolTable extends SymbolTableForUnitTesting
   import symbolTable._
@@ -123,7 +120,7 @@ class NamesTest {
     def check(name: Name, sub: String): Unit = {
       val javaResult = name.toString.lastIndexOf(sub)
       val nameResult = name.lastIndexOf(sub)
-      assertEquals(s""""$name".lastIndexOf("$sub")""", javaResult, nameResult)
+      assertEquals(javaResult, nameResult, s""""$name".lastIndexOf("$sub")""")
     }
     val d = TermName("x$default$42")
     val e = TermName("")

--- a/test/junit/scala/reflect/internal/PositionsTest.scala
+++ b/test/junit/scala/reflect/internal/PositionsTest.scala
@@ -1,7 +1,7 @@
 package scala.reflect.internal
 
-import org.junit.Test
-import org.junit.Assert.assertFalse
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertFalse
 
 import scala.reflect.internal.util.NoSourceFile
 import scala.tools.nsc.reporters.StoreReporter

--- a/test/junit/scala/reflect/internal/PrintersTest.scala
+++ b/test/junit/scala/reflect/internal/PrintersTest.scala
@@ -1,12 +1,10 @@
 package scala.reflect.internal
 
-import org.junit.Test
-import org.junit.Assert._
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions._
 import scala.tools.reflect._
 import scala.reflect.runtime.universe._
 import scala.reflect.runtime.{currentMirror=>cm}
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
 object PrinterHelper {
   val toolbox = cm.mkToolBox()
@@ -65,7 +63,6 @@ object PrinterHelper {
 
 import PrinterHelper._
 
-@RunWith(classOf[JUnit4])
 class BasePrintTest {
   @Test def testIdent(): Unit = assertTreeCode(Ident(TermName("*")))("*")
 
@@ -361,7 +358,6 @@ class BasePrintTest {
   @Test def testImport4(): Unit = assertPrintedCode("import scala.collection._")
 }
 
-@RunWith(classOf[JUnit4])
 class ClassPrintTest {
   @Test def testClass(): Unit = assertPrintedCode("class *")
 
@@ -847,7 +843,6 @@ class ClassPrintTest {
     |}""")
 }
 
-@RunWith(classOf[JUnit4])
 class TraitPrintTest {
   @Test def testTrait(): Unit = assertPrintedCode("trait *")
 
@@ -968,7 +963,6 @@ class TraitPrintTest {
     |}""")
 }
 
-@RunWith(classOf[JUnit4])
 class ValAndDefPrintTest {
   @Test def testVal1(): Unit = assertPrintedCode("val a: scala.Unit = ()")
 
@@ -1103,7 +1097,6 @@ class ValAndDefPrintTest {
     |}""", wrapCode = true)
 }
 
-@RunWith(classOf[JUnit4])
 class PackagePrintTest {
   @Test def testPackage1(): Unit = assertPrintedCode(sm"""
     |package foo.bar {
@@ -1142,7 +1135,6 @@ class PackagePrintTest {
     |}""", checkTypedTree = false)
 }
 
-@RunWith(classOf[JUnit4])
 class QuasiTreesPrintTest {
   @Test def testQuasiIdent(): Unit = assertTreeCode(q"*")("*")
 

--- a/test/junit/scala/reflect/internal/ScopeTest.scala
+++ b/test/junit/scala/reflect/internal/ScopeTest.scala
@@ -1,7 +1,7 @@
 package scala.reflect.internal
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.tools.nsc.symtab.SymbolTableForUnitTesting
 

--- a/test/junit/scala/reflect/internal/TreeGenTest.scala
+++ b/test/junit/scala/reflect/internal/TreeGenTest.scala
@@ -1,14 +1,11 @@
 package scala.reflect.internal
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.runtime.ScalaRunTime
 import scala.tools.nsc.symtab.SymbolTableForUnitTesting
 
-@RunWith(classOf[JUnit4])
 class TreeGenTest {
   object symbolTable extends SymbolTableForUnitTesting
 

--- a/test/junit/scala/reflect/internal/TypesTest.scala
+++ b/test/junit/scala/reflect/internal/TypesTest.scala
@@ -1,15 +1,13 @@
 package scala.reflect.internal
 
-import org.junit.Assert._
-import org.junit.{After, Assert, Before, Test}
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.{AfterEach, Assertions, BeforeEach, Test}
+
 import scala.collection.mutable
 import scala.tools.nsc.settings.ScalaVersion
 import scala.tools.nsc.symtab.SymbolTableForUnitTesting
 import language.existentials
 
-@RunWith(classOf[JUnit4])
 class TypesTest {
 
   object symbolTable extends SymbolTableForUnitTesting
@@ -62,7 +60,7 @@ class TypesTest {
     results.toList match {
       case Nil => // okay
       case xs =>
-        Assert.fail(xs.mkString("\n"))
+        Assertions.fail(xs.mkString("\n"))
     }
   }
 
@@ -81,7 +79,7 @@ class TypesTest {
       if (!(a =:= b))
         results += s"expected a =:= b; where a=${showRaw(a)} b=${showRaw(b)}"
     }
-    assertTrue(s"Mismatches:\n${results.mkString("\n")}", results.isEmpty)
+    assertTrue(results.isEmpty, s"Mismatches:\n${results.mkString("\n")}")
   }
 
   @Test
@@ -192,11 +190,11 @@ class TypesTest {
   }
 
   var storedXsource: ScalaVersion = null
-  @Before
+  @BeforeEach
   def storeXsource(): Unit = {
     storedXsource = settings.source.value
   }
-  @After
+  @AfterEach
   def restoreXsource(): Unit = {
     settings.source.value = storedXsource
   }

--- a/test/junit/scala/reflect/internal/util/AbstractFileClassLoaderTest.scala
+++ b/test/junit/scala/reflect/internal/util/AbstractFileClassLoaderTest.scala
@@ -1,18 +1,14 @@
 package scala.reflect.internal.util
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class AbstractFileClassLoaderTest {
 
-  import scala.reflect.io._
-  import scala.io.Source
+  import java.net.{URL, URLClassLoader}
   import scala.io.Codec.UTF8
-  import scala.reflect.io.Streamable
-  import java.net.{ URLClassLoader, URL }
+  import scala.io.Source
+  import scala.reflect.io.{Streamable, _}
 
   implicit def `we love utf8` = UTF8
   implicit class `abs file ops`(f: AbstractFile) {

--- a/test/junit/scala/reflect/internal/util/FileUtilsTest.scala
+++ b/test/junit/scala/reflect/internal/util/FileUtilsTest.scala
@@ -2,7 +2,7 @@ package scala.reflect.internal.util
 
 import java.io._
 
-import org.junit.Assert._
+import org.junit.jupiter.api.Assertions._
 import org.junit._
 
 class FileUtilsTest {

--- a/test/junit/scala/reflect/internal/util/SourceFileTest.scala
+++ b/test/junit/scala/reflect/internal/util/SourceFileTest.scala
@@ -1,13 +1,10 @@
 package scala.reflect.internal.util
 
-import org.junit.Assert.{ assertThrows => _, _ }
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.{assertThrows => _, _}
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.AssertUtil._
 
-@RunWith(classOf[JUnit4])
 class SourceFileTest {
   def lineContentOf(code: String, offset: Int) =
     Position.offset(new BatchSourceFile("", code), offset).lineContent

--- a/test/junit/scala/reflect/internal/util/StringOpsTest.scala
+++ b/test/junit/scala/reflect/internal/util/StringOpsTest.scala
@@ -1,11 +1,8 @@
 package scala.reflect.internal.util
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class StringOpsTest {
   @Test
   def prefixOfNone(): Unit = {

--- a/test/junit/scala/reflect/internal/util/WeakHashSetTest.scala
+++ b/test/junit/scala/reflect/internal/util/WeakHashSetTest.scala
@@ -1,11 +1,8 @@
 package scala.reflect.internal.util
 
-import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class WeakHashSetTest {
 
   // a class guaranteed to provide hash collisions

--- a/test/junit/scala/reflect/io/AbstractFileTest.scala
+++ b/test/junit/scala/reflect/io/AbstractFileTest.scala
@@ -1,14 +1,10 @@
 package scala.reflect.io
 
+import org.junit.jupiter.api.{Assertions, Test}
+
 import java.nio.file.Files
-
-import org.junit.{Assert, Test}
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-
 import scala.tools.testkit.TempDir
 
-@RunWith(classOf[JUnit4])
 class AbstractFileTest {
   @Test
   def handleURLEscapedCharacters(): Unit = {
@@ -19,9 +15,9 @@ class AbstractFileTest {
 
     try {
       val fileFromURLPath = new java.io.File(scalaFile.toURI.toURL.getPath)
-      Assert.assertTrue(!fileFromURLPath.exists())
+      Assertions.assertTrue(!fileFromURLPath.exists())
       val scalacFile = AbstractFile.getURL(scalaFile.toURI.toURL)
-      Assert.assertTrue(scalacFile.file.exists())
+      Assertions.assertTrue(scalacFile.file.exists())
     } finally {
       Files.deleteIfExists(scalaPath)
       Files.deleteIfExists(tempDir)

--- a/test/junit/scala/reflect/io/ZipArchiveTest.scala
+++ b/test/junit/scala/reflect/io/ZipArchiveTest.scala
@@ -5,8 +5,8 @@ import java.net.{URI, URL}
 import java.nio.file.{Files, Path, Paths}
 import java.util.jar.{Attributes, Manifest, JarEntry, JarOutputStream}
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.reflect.internal.util.ScalaClassLoader
 import scala.tools.testkit.AssertUtil._

--- a/test/junit/scala/reflect/macros/AttachmentsTest.scala
+++ b/test/junit/scala/reflect/macros/AttachmentsTest.scala
@@ -1,12 +1,9 @@
 package scala.reflect.macros
 
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Test
 
 import scala.reflect.internal.util._
 
-@RunWith(classOf[JUnit4])
 class AttachmentsTest {
   def emptyAtt: Attachments = NoPosition
 

--- a/test/junit/scala/reflect/runtime/ThreadSafetyTest.scala
+++ b/test/junit/scala/reflect/runtime/ThreadSafetyTest.scala
@@ -14,7 +14,7 @@ package scala.reflect.runtime
 
 import java.util.concurrent.{Callable, Executors}
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class ThreadSafetyTest {
   import scala.reflect.runtime.universe._

--- a/test/junit/scala/runtime/LambdaDeserializerTest.java
+++ b/test/junit/scala/runtime/LambdaDeserializerTest.java
@@ -1,7 +1,7 @@
 package scala.runtime;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.Serializable;
 import java.lang.invoke.*;
@@ -15,19 +15,19 @@ public final class LambdaDeserializerTest {
     @Test
     public void serializationPrivate() {
         F1<Boolean, String> f1 = lambdaHost.lambdaBackedByPrivateImplMethod();
-        Assert.assertEquals(f1.apply(true), reconstitute(f1).apply(true));
+        Assertions.assertEquals(f1.apply(true), reconstitute(f1).apply(true));
     }
 
     @Test
     public void serializationStatic() {
         F1<Boolean, String> f1 = lambdaHost.lambdaBackedByStaticImplMethod();
-        Assert.assertEquals(f1.apply(true), reconstitute(f1).apply(true));
+        Assertions.assertEquals(f1.apply(true), reconstitute(f1).apply(true));
     }
 
     @Test
     public void serializationVirtualMethodReference() {
         F1<Boolean, String> f1 = lambdaHost.lambdaBackedByVirtualMethodReference();
-        Assert.assertEquals(f1.apply(true), reconstitute(f1).apply(true));
+        Assertions.assertEquals(f1.apply(true), reconstitute(f1).apply(true));
     }
 
     @Test
@@ -35,19 +35,19 @@ public final class LambdaDeserializerTest {
         F1<I, Object> f1 = lambdaHost.lambdaBackedByInterfaceMethodReference();
         I i = new I() {
         };
-        Assert.assertEquals(f1.apply(i), reconstitute(f1).apply(i));
+        Assertions.assertEquals(f1.apply(i), reconstitute(f1).apply(i));
     }
 
     @Test
     public void serializationStaticMethodReference() {
         F1<Boolean, String> f1 = lambdaHost.lambdaBackedByStaticMethodReference();
-        Assert.assertEquals(f1.apply(true), reconstitute(f1).apply(true));
+        Assertions.assertEquals(f1.apply(true), reconstitute(f1).apply(true));
     }
 
     @Test
     public void serializationNewInvokeSpecial() {
         F0<Object> f1 = lambdaHost.lambdaBackedByConstructorCall();
-        Assert.assertEquals(f1.apply(), reconstitute(f1).apply());
+        Assertions.assertEquals(f1.apply(), reconstitute(f1).apply());
     }
 
     @Test
@@ -55,7 +55,7 @@ public final class LambdaDeserializerTest {
         F0<Object> f1 = lambdaHost.lambdaBackedByConstructorCall();
         F0<Object> reconstituted1 = reconstitute(f1);
         F0<Object> reconstituted2 = reconstitute(f1);
-        Assert.assertNotEquals(reconstituted1.getClass(), reconstituted2.getClass());
+        Assertions.assertNotEquals(reconstituted1.getClass(), reconstituted2.getClass());
     }
 
     @Test
@@ -64,7 +64,7 @@ public final class LambdaDeserializerTest {
         F0<Object> f1 = lambdaHost.lambdaBackedByConstructorCall();
         F0<Object> reconstituted1 = reconstitute(f1, cache);
         F0<Object> reconstituted2 = reconstitute(f1, cache);
-        Assert.assertEquals(reconstituted1.getClass(), reconstituted2.getClass());
+        Assertions.assertEquals(reconstituted1.getClass(), reconstituted2.getClass());
     }
 
     @Test
@@ -73,10 +73,10 @@ public final class LambdaDeserializerTest {
         F1<Boolean, String> f1 = lambdaHost.lambdaBackedByStaticImplMethod();
         // Check that deserialization of a static lambda always returns the
         // same instance.
-        Assert.assertSame(reconstitute(f1, cache), reconstitute(f1, cache));
+        Assertions.assertSame(reconstitute(f1, cache), reconstitute(f1, cache));
 
         // (as is the case with regular invocation.)
-        Assert.assertSame(f1, lambdaHost.lambdaBackedByStaticImplMethod());
+        Assertions.assertSame(f1, lambdaHost.lambdaBackedByStaticImplMethod());
     }
 
     @Test
@@ -100,7 +100,7 @@ public final class LambdaDeserializerTest {
             throw new AssertionError();
         } catch (IllegalArgumentException iae) {
             if (!iae.getMessage().contains("Illegal lambda deserialization")) {
-                Assert.fail("Unexpected message: " + iae.getMessage());
+                Assertions.fail("Unexpected message: " + iae.getMessage());
             }
         }
     }

--- a/test/junit/scala/runtime/ScalaRunTimeTest.scala
+++ b/test/junit/scala/runtime/ScalaRunTimeTest.scala
@@ -1,12 +1,9 @@
 package scala.runtime
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 /** Tests for the runtime object ScalaRunTime */
-@RunWith(classOf[JUnit4])
 class ScalaRunTimeTest {
   @Test
   def testStringOf(): Unit = {

--- a/test/junit/scala/runtime/ZippedTest.scala
+++ b/test/junit/scala/runtime/ZippedTest.scala
@@ -3,8 +3,8 @@ package scala.runtime
 
 import scala.language.postfixOps
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.collection.Seq
 import scala.collection.immutable.{List, Vector}

--- a/test/junit/scala/sys/env.scala
+++ b/test/junit/scala/sys/env.scala
@@ -1,7 +1,7 @@
 package scala.sys
 
-import org.junit.Test
-import org.junit.Assert._
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions._
 
 import java.util.NoSuchElementException
 

--- a/test/junit/scala/sys/process/ParserTest.scala
+++ b/test/junit/scala/sys/process/ParserTest.scala
@@ -1,14 +1,12 @@
 package scala.sys.process
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
 import scala.tools.testkit.AssertUtil.assertThrows
 
-@RunWith(classOf[JUnit4])
 class ParserTest {
-  import Parser.{tokenize, ParseException}
+  import Parser.{ParseException, tokenize}
 
   @Test
   def parserTokenizes(): Unit = {

--- a/test/junit/scala/sys/process/PipedProcessTest.scala
+++ b/test/junit/scala/sys/process/PipedProcessTest.scala
@@ -1,20 +1,16 @@
 package scala.sys.process
 
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Test
-import java.io.{InputStream, OutputStream, PipedInputStream, PipedOutputStream, ByteArrayInputStream,
-  ByteArrayOutputStream, IOException, Closeable}
-import java.lang.reflect.InvocationTargetException
-import scala.concurrent.{Await, Future}
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.util.control.Exception.ignoring
-import org.junit.Assert._
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
+import java.io._
+import java.lang.reflect.InvocationTargetException
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{Await, Future}
 import scala.tools.testkit.AssertUtil.{readyOrNot, waitForIt}
 import scala.tools.testkit.TestDuration
+import scala.util.control.Exception.ignoring
 
-@RunWith(classOf[JUnit4])
 class PipedProcessTest {
 
   // PipedProcesses need not to release resources when it normally end
@@ -52,7 +48,7 @@ class PipedProcessTest {
     //p.exitValue()
     p.callRunAndExitValue(source, sink)
 
-    assertFalse("Source is alive", source.isAlive)
+    assertFalse(source.isAlive, "Source is alive")
   }
 
   // PipedProcesses must release resources when b.run() failed
@@ -136,7 +132,6 @@ class PipedProcessTest {
   }
 }
 
-@RunWith(classOf[JUnit4])
 class PipeSourceSinkTest {
   def throwsIOException(f: => Unit) = {
     try { f; false }

--- a/test/junit/scala/sys/process/ProcessBuilderTest.scala
+++ b/test/junit/scala/sys/process/ProcessBuilderTest.scala
@@ -1,12 +1,9 @@
 package scala.sys.process
 
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Test
-import org.junit.Assert._
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions._
 import scala.tools.testkit.AssertUtil._
 
-@RunWith(classOf[JUnit4])
 class ProcessBuilderTest {
 
   @Test
@@ -19,7 +16,7 @@ class ProcessBuilderTest {
       val p = Try(("does-not-exist" #< new ByteArrayInputStream("foo".getBytes(UTF_8))).lazyLines)
       assertTrue(p.isSuccess)
       val q = p.map(_.toList)
-      assertTrue("Expected realizing bad command to fail.", q.isFailure)
+      assertTrue(q.isFailure, "Expected realizing bad command to fail.")
     }
   }
 }

--- a/test/junit/scala/sys/process/ProcessTest.scala
+++ b/test/junit/scala/sys/process/ProcessTest.scala
@@ -17,8 +17,8 @@ import scala.util.Properties._
 import scala.util.Using
 import scala.util.chaining._
 
-import org.junit.Test
-import org.junit.Assert._
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions._
 
 class ProcessTest {
   private def testily(body: => Unit) = if (!isWin) body

--- a/test/junit/scala/tools/cmd/CommandLineParserTest.scala
+++ b/test/junit/scala/tools/cmd/CommandLineParserTest.scala
@@ -1,12 +1,9 @@
 package scala.tools.cmd
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 import scala.tools.testkit.AssertUtil.assertThrows
 
-@RunWith(classOf[JUnit4])
 class CommandLineParserTest {
   import CommandLineParser.{tokenize, ParseException}
 

--- a/test/junit/scala/tools/nsc/DeterminismTest.scala
+++ b/test/junit/scala/tools/nsc/DeterminismTest.scala
@@ -1,6 +1,6 @@
 package scala.tools.nsc
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import scala.reflect.internal.util.{BatchSourceFile, SourceFile}
 

--- a/test/junit/scala/tools/nsc/GlobalCustomizeClassloaderTest.scala
+++ b/test/junit/scala/tools/nsc/GlobalCustomizeClassloaderTest.scala
@@ -2,17 +2,14 @@ package scala.tools.nsc
 
 import java.io.Closeable
 
-import org.junit.Assert.{assertEquals, assertTrue, fail}
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue, fail}
+import org.junit.jupiter.api.Test
 
 import scala.reflect.internal.util.ScalaClassLoader.URLClassLoader
 import scala.reflect.internal.util.{AbstractFileClassLoader, NoSourceFile}
 import scala.reflect.io.{Path, VirtualDirectory}
 import scala.tools.nsc.plugins.{Plugin, PluginComponent}
 
-@RunWith(classOf[JUnit4])
 class GlobalCustomizeClassloaderTest {
   // Demonstrate extension points to customise creation of the classloaders used to load compiler
   // plugins and macro implementations.

--- a/test/junit/scala/tools/nsc/PhaseAssemblyTest.scala
+++ b/test/junit/scala/tools/nsc/PhaseAssemblyTest.scala
@@ -12,8 +12,8 @@
 
 package scala.tools.nsc
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 class PhaseAssemblyTest {
   @Test

--- a/test/junit/scala/tools/nsc/PickleWriteTest.scala
+++ b/test/junit/scala/tools/nsc/PickleWriteTest.scala
@@ -1,10 +1,9 @@
 package scala.tools.nsc
 
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
+
 import java.nio.file.{Files, Path}
 import java.util.regex.Pattern
-
-import org.junit.{After, Before, Test}
-
 import scala.reflect.io.{AbstractFile, VirtualDirectory}
 import scala.tools.nsc.FileUtils._
 import scala.tools.nsc.settings.{DefaultPathFactory, PathFactory}
@@ -16,11 +15,13 @@ class PickleWriteTest {
   private val debug = false
   private val deleteBaseAfterTest = true
 
-  @Before def before(): Unit = {
+  @BeforeEach
+  def before(): Unit = {
     base = Files.createTempDirectory("pickleWriteTest")
   }
 
-  @After def after(): Unit = {
+  @AfterEach
+  def after(): Unit = {
     if (base != null && !debug && deleteBaseAfterTest) {
       deleteRecursive(base)
     }

--- a/test/junit/scala/tools/nsc/PipelineMainTest.scala
+++ b/test/junit/scala/tools/nsc/PipelineMainTest.scala
@@ -1,11 +1,10 @@
 package scala.tools.nsc
 
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
+
 import java.io.IOException
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
-
-import org.junit.{After, Before, Test}
-
 import scala.jdk.CollectionConverters._
 import FileUtils._
 import scala.tools.nsc.PipelineMain._
@@ -18,11 +17,13 @@ class PipelineMainTest {
   private val debug = false
   private var deleteBaseAfterTest = true
 
-  @Before def before(): Unit = {
+  @BeforeEach
+  def before(): Unit = {
     base = Files.createTempDirectory("pipelineBase")
   }
 
-  @After def after(): Unit = {
+  @AfterEach
+  def after(): Unit = {
     if (base != null && !debug && deleteBaseAfterTest) {
       deleteRecursive(base)
     }

--- a/test/junit/scala/tools/nsc/ScriptRunnerTest.scala
+++ b/test/junit/scala/tools/nsc/ScriptRunnerTest.scala
@@ -1,10 +1,7 @@
 package scala.tools.nsc
 
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class ScriptRunnerTest {
   @Test
   def testEmptyScriptSucceeds(): Unit = {

--- a/test/junit/scala/tools/nsc/async/AnnotationDrivenAsyncTest.scala
+++ b/test/junit/scala/tools/nsc/async/AnnotationDrivenAsyncTest.scala
@@ -5,8 +5,9 @@ import java.io.File
 import java.lang.reflect.InvocationTargetException
 import java.nio.file.{Files, Paths}
 import java.util.concurrent.CompletableFuture
-import org.junit.Assert.assertEquals
-import org.junit.{Assert, Ignore, Test}
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.{Disabled, Test}
 
 import scala.annotation.{StaticAnnotation, nowarn, unused}
 import scala.concurrent.duration.Duration
@@ -19,8 +20,9 @@ import scala.tools.nsc.transform.TypingTransformers
 import scala.tools.testkit.async.AsyncStateMachine
 
 class AnnotationDrivenAsyncTest {
+
   @Test
-  @Ignore // TODO XASYNC
+  @Disabled // TODO XASYNC
   def testBoxedUnitNotImplemented(): Unit = {
     val code =
       """
@@ -369,7 +371,7 @@ class AnnotationDrivenAsyncTest {
 
   // Handy to debug the compiler or to collect code coverage statistics in IntelliJ.
   @Test
-  @Ignore
+  @Disabled
   def testManualRunPartestUnderJUnit(): Unit = {
     import scala.jdk.CollectionConverters._
     for (path <- List(Paths.get("../async/run"), Paths.get("../async/neg"))) {
@@ -430,8 +432,8 @@ class AnnotationDrivenAsyncTest {
       def showInfo(info: StoreReporter#Info): String = {
         Position.formatMessage(info.pos, info.severity.toString.toLowerCase + " : " + info.msg, false)
       }
-      Assert.assertTrue(reporter.infos.map(showInfo).mkString("\n"), !reporter.hasErrors)
-      Assert.assertTrue(reporter.infos.map(showInfo).mkString("\n"), !reporter.hasWarnings)
+      assertTrue(!reporter.hasErrors, reporter.infos.map(showInfo).mkString("\n"))
+      assertTrue(!reporter.hasWarnings, reporter.infos.map(showInfo).mkString("\n"))
       val loader = new URLClassLoader(Seq(new File(settings.outdir.value).toURI.toURL), global.getClass.getClassLoader)
       val cls = loader.loadClass("Test")
       val result = try {

--- a/test/junit/scala/tools/nsc/backend/jvm/BTypesTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/BTypesTest.scala
@@ -1,16 +1,13 @@
 package scala.tools.nsc
 package backend.jvm
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.collection.mutable
 import scala.tools.asm.Opcodes
 import scala.tools.testkit.BytecodeTesting
 
-@RunWith(classOf[JUnit4])
 class BTypesTest extends BytecodeTesting {
   override def compilerArgs = "-opt:l:none"
   import compiler.global
@@ -229,8 +226,8 @@ class BTypesTest extends BytecodeTesting {
       val a1 = ArrayBType(p1)
       val a2 = ArrayBType(p2)
       val expect = p1 == p2
-      assertEquals(s"$a1 $a2", expect, a1.conformsTo(a2).get)
-      assertEquals(s"$a1 $a2", expect, a2.conformsTo(a1).get)
+      assertEquals(expect, a1.conformsTo(a2).get, s"$a1 $a2")
+      assertEquals(expect, a2.conformsTo(a1).get, s"$a1 $a2")
     }
     assertTrue(ArrayBType(s).conformsTo(ArrayBType(o)).get)
   }

--- a/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
@@ -1,7 +1,7 @@
 package scala.tools.nsc.backend.jvm
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.annotation.unused
 import scala.jdk.CollectionConverters._

--- a/test/junit/scala/tools/nsc/backend/jvm/DefaultMethodTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/DefaultMethodTest.scala
@@ -1,7 +1,7 @@
 package scala.tools.nsc.backend.jvm
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.jdk.CollectionConverters._
 import scala.reflect.internal.Flags
@@ -27,7 +27,7 @@ class DefaultMethodTest extends BytecodeTesting {
     }
     val asmClasses: List[ClassNode] = compiler.compileClassesTransformed(code, Nil, makeFooDefaultMethod.transform(_))
     val foo = asmClasses.head.methods.iterator.asScala.toList.last
-    assertTrue("default method should not be abstract", (foo.access & Opcodes.ACC_ABSTRACT) == 0)
-    assertTrue("default method body emitted", foo.instructions.size() > 0)
+    assertTrue((foo.access & Opcodes.ACC_ABSTRACT) == 0, "default method should not be abstract")
+    assertTrue(foo.instructions.size() > 0, "default method body emitted")
   }
 }

--- a/test/junit/scala/tools/nsc/backend/jvm/DirectCompileTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/DirectCompileTest.scala
@@ -1,16 +1,13 @@
 package scala.tools.nsc.backend.jvm
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.tools.asm.Opcodes._
 import scala.tools.testkit.ASMConverters._
 import scala.tools.testkit.BytecodeTesting
 import scala.tools.testkit.BytecodeTesting._
 
-@RunWith(classOf[JUnit4])
 class DirectCompileTest extends BytecodeTesting {
   override def compilerArgs = "-opt:l:method"
   import compiler._

--- a/test/junit/scala/tools/nsc/backend/jvm/GenericSignaturesTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/GenericSignaturesTest.scala
@@ -1,14 +1,11 @@
 package scala.tools.nsc.backend.jvm
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 import scala.jdk.CollectionConverters._
 import scala.tools.testkit.BytecodeTesting
 
-@RunWith(classOf[JUnit4])
 class GenericSignaturesTest extends BytecodeTesting {
   import compiler._
 

--- a/test/junit/scala/tools/nsc/backend/jvm/IndyLambdaTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/IndyLambdaTest.scala
@@ -1,7 +1,7 @@
 package scala.tools.nsc.backend.jvm
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.jdk.CollectionConverters._
 import scala.tools.asm.Handle

--- a/test/junit/scala/tools/nsc/backend/jvm/IndySammyTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/IndySammyTest.scala
@@ -1,10 +1,8 @@
 package scala.tools.nsc
 package backend.jvm
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 import scala.tools.asm.Opcodes._
 import scala.tools.nsc.reporters.StoreReporter
@@ -13,7 +11,6 @@ import scala.tools.testkit.BytecodeTesting
 import scala.tools.testkit.BytecodeTesting._
 
 
-@RunWith(classOf[JUnit4])
 class IndySammyTest extends BytecodeTesting {
   import compiler._
 

--- a/test/junit/scala/tools/nsc/backend/jvm/InnerClassAttributeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/InnerClassAttributeTest.scala
@@ -1,16 +1,13 @@
 package scala.tools.nsc.backend.jvm
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 import scala.jdk.CollectionConverters._
 import scala.tools.asm.Opcodes._
 import scala.tools.testkit.BytecodeTesting
 import scala.tools.testkit.BytecodeTesting._
 
-@RunWith(classOf[JUnit4])
 class InnerClassAttributeTest extends BytecodeTesting {
   import compiler._
 

--- a/test/junit/scala/tools/nsc/backend/jvm/LineNumberTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/LineNumberTest.scala
@@ -1,15 +1,12 @@
 package scala.tools.nsc
 package backend.jvm
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.BytecodeTesting
 import scala.tools.testkit.BytecodeTesting._
 
-@RunWith(classOf[JUnit4])
 class LineNumberTest extends BytecodeTesting {
 
   import compiler._
@@ -35,6 +32,6 @@ class LineNumberTest extends BytecodeTesting {
         |""".stripMargin
     val cls = compileClass(code)
     val m = getMethod(cls, "$anonfun$main$2")
-    assertEquals(m.localVars.toString, m.localVars.map(_.name).sorted, List("a", "a1", "x$1"))
+    assertEquals(m.localVars.map(_.name).sorted, List("a", "a1", "x$1"), m.localVars.toString)
   }
 }

--- a/test/junit/scala/tools/nsc/backend/jvm/NestedClassesCollectorTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/NestedClassesCollectorTest.scala
@@ -1,9 +1,7 @@
 package scala.tools.nsc.backend.jvm
 
-import org.junit.{Ignore, Test}
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Assert._
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.{Disabled, Test}
 
 import scala.jdk.CollectionConverters._
 import scala.tools.nsc.backend.jvm.BTypes.InternalName
@@ -16,7 +14,6 @@ class Collector extends NestedClassesCollector[String](nestedOnly = false) {
     throw e.getOrElse(new Exception(msg + " " + sig))
 }
 
-@RunWith(classOf[JUnit4])
 class NestedClassesCollectorTest {
   val c = new Collector {
     override def visitInternalName(internalName: String, offset: Int, length: Int): Unit = {
@@ -103,7 +100,7 @@ class NestedClassesCollectorTest {
   }
 
   @Test
-  @Ignore("manually run test")
+  @Disabled("manually run test")
   def rtJar(): Unit = {
     import java.nio.file._
     val zipfile = Paths.get("/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre/lib/rt.jar")
@@ -119,7 +116,7 @@ class NestedClassesCollectorTest {
   }
 
   @Test
-  @Ignore("manually run test")
+  @Disabled("manually run test")
   def allJars(): Unit = {
     // for i in $(find /Users/jz/.ivy2/cache -name jars); do find $i -name '*.jar' | head -1; done > /tmp/jars.txt
     import java.nio.file._

--- a/test/junit/scala/tools/nsc/backend/jvm/OptimizedBytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/OptimizedBytecodeTest.scala
@@ -1,15 +1,12 @@
 package scala.tools.nsc.backend.jvm
 
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Test
 
 import scala.tools.asm.Opcodes._
 import scala.tools.testkit.ASMConverters._
 import scala.tools.testkit.BytecodeTesting
 import scala.tools.testkit.BytecodeTesting._
 
-@RunWith(classOf[JUnit4])
 class OptimizedBytecodeTest extends BytecodeTesting {
   override def compilerArgs = "-opt:l:inline -opt-inline-from:** -opt-warnings"
   import compiler._

--- a/test/junit/scala/tools/nsc/backend/jvm/PerRunInitTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/PerRunInitTest.scala
@@ -2,7 +2,7 @@ package scala.tools.nsc.backend.jvm
 import java.util
 
 import org.junit._
-import org.junit.Assert._
+import org.junit.jupiter.api.Assertions._
 
 import scala.collection.mutable
 import scala.ref.WeakReference
@@ -88,12 +88,12 @@ abstract class PerRunInitTest {
 
     add(1, data)
 
-    assertEquals(s"$data", 1, sizeOf(data))
+    assertEquals(1, sizeOf(data), s"$data")
     doGc()
-    assertEquals(s"$data", 1, sizeOf(data))
+    assertEquals(1, sizeOf(data), s"$data")
 
     clearCaches()
-    assertEquals(s"$data", 0, sizeOf(data))
+    assertEquals(0, sizeOf(data), s"$data")
   }
 
   @Test
@@ -115,11 +115,11 @@ abstract class PerRunInitTest {
     dontClear(data)
 
     add(1, data)
-    assertEquals(s"$data", 1, sizeOf(data))
+    assertEquals(1, sizeOf(data), s"$data")
     doGc()
-    assertEquals(s"$data", 1, sizeOf(data))
+    assertEquals(1, sizeOf(data), s"$data")
     clearCaches()
-    assertEquals(s"$data", 1, sizeOf(data))
+    assertEquals(1, sizeOf(data), s"$data")
   }
 
 

--- a/test/junit/scala/tools/nsc/backend/jvm/StringConcatTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/StringConcatTest.scala
@@ -1,16 +1,13 @@
 package scala.tools.nsc
 package backend.jvm
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.ASMConverters._
 import scala.tools.testkit.BytecodeTesting
 import scala.tools.testkit.BytecodeTesting._
 
-@RunWith(classOf[JUnit4])
 class StringConcatTest extends BytecodeTesting {
   import compiler._
 

--- a/test/junit/scala/tools/nsc/backend/jvm/analysis/NullnessAnalyzerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/analysis/NullnessAnalyzerTest.scala
@@ -2,10 +2,8 @@ package scala.tools.nsc
 package backend.jvm
 package analysis
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.jdk.CollectionConverters._
 import scala.tools.asm.tree.MethodNode
@@ -15,7 +13,6 @@ import scala.tools.nsc.backend.jvm.opt.BytecodeUtils._
 import scala.tools.testkit.BytecodeTesting
 import scala.tools.testkit.BytecodeTesting._
 
-@RunWith(classOf[JUnit4])
 class NullnessAnalyzerTest extends BytecodeTesting {
   override def compilerArgs = "-opt:l:none"
   import compiler._
@@ -26,7 +23,7 @@ class NullnessAnalyzerTest extends BytecodeTesting {
   def testNullness(analyzer: AsmAnalyzer[NullnessValue], method: MethodNode, query: String, index: Int, nullness: NullnessValue): Unit = {
     for (i <- findInstrs(method, query)) {
       val r = analyzer.frameAt(i).getValue(index)
-      assertTrue(s"Expected: $nullness, found: $r. At instr ${textify(i)}", nullness == r)
+      assertTrue(nullness == r, s"Expected: $nullness, found: $r. At instr ${textify(i)}")
     }
   }
 

--- a/test/junit/scala/tools/nsc/backend/jvm/analysis/ProdConsAnalyzerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/analysis/ProdConsAnalyzerTest.scala
@@ -2,8 +2,8 @@ package scala.tools.nsc
 package backend.jvm
 package analysis
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.tools.asm.Opcodes
 import scala.tools.asm.tree.AbstractInsnNode
@@ -26,20 +26,20 @@ class ProdConsAnalyzerTest extends BytecodeTesting {
   }
 
   def testMultiInsns(insns: Iterable[AbstractInsnNode], expected: Iterable[String]): Unit = {
-    assertTrue(s"Sizes don't match: ${insns.size} vs ${expected.size}", insns.size == expected.size)
+    assertTrue(insns.size == expected.size, s"Sizes don't match: ${insns.size} vs ${expected.size}")
     for (insn <- insns) {
       val txt = prodToString(insn)
-      assertTrue(s"Instruction $txt not found in ${expected mkString ", "}", expected.exists(txt.contains))
+      assertTrue(expected.exists(txt.contains), s"Instruction $txt not found in ${expected mkString ", "}")
     }
   }
 
   def testInsn(insn: AbstractInsnNode, expected: String): Unit = {
     val txt = prodToString(insn)
-    assertTrue(s"Expected $expected, found $txt", txt contains expected)
+    assertTrue(txt contains expected, s"Expected $expected, found $txt")
   }
 
   def single[T](c: Iterable[T]): T = {
-    assertTrue(s"Expected singleton collection, got $c", c.size == 1)
+    assertTrue(c.size == 1, s"Expected singleton collection, got $c")
     c.head
   }
 

--- a/test/junit/scala/tools/nsc/backend/jvm/analysis/TypeFlowAnalyzerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/analysis/TypeFlowAnalyzerTest.scala
@@ -2,10 +2,8 @@ package scala.tools.nsc
 package backend.jvm
 package analysis
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.tools.asm.Type
 import scala.tools.asm.tree.analysis.BasicValue
@@ -13,7 +11,6 @@ import scala.tools.nsc.backend.jvm.analysis.TypeFlowInterpreter.{AaloadValue, LM
 import scala.tools.testkit.BytecodeTesting
 import scala.tools.testkit.BytecodeTesting._
 
-@RunWith(classOf[JUnit4])
 class TypeFlowAnalyzerTest extends BytecodeTesting {
   override def compilerArgs = "-opt:l:none"
   import compiler._

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/AnalyzerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/AnalyzerTest.scala
@@ -2,10 +2,8 @@ package scala.tools.nsc
 package backend.jvm
 package opt
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.tools.asm.tree.analysis._
 import scala.tools.nsc.backend.jvm.analysis.{AliasingAnalyzer, AliasingFrame}
@@ -13,7 +11,6 @@ import scala.tools.nsc.backend.jvm.opt.BytecodeUtils._
 import scala.tools.testkit.BytecodeTesting
 import scala.tools.testkit.BytecodeTesting._
 
-@RunWith(classOf[JUnit4])
 class AnalyzerTest extends BytecodeTesting {
   override def compilerArgs = "-opt:l:none"
   import compiler._

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/BTypesFromClassfileTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/BTypesFromClassfileTest.scala
@@ -2,9 +2,7 @@ package scala.tools.nsc
 package backend.jvm
 package opt
 
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Test
 
 import scala.collection.mutable
 import scala.tools.asm.Opcodes._
@@ -12,7 +10,6 @@ import scala.tools.nsc.backend.jvm.BTypes.InternalName
 import scala.tools.nsc.backend.jvm.BackendReporting._
 import scala.tools.testkit.BytecodeTesting
 
-@RunWith(classOf[JUnit4])
 class BTypesFromClassfileTest extends BytecodeTesting {
   // inliner enabled -> inlineInfos are collected (and compared) in ClassBTypes
   override def compilerArgs = "-opt:inline -opt-inline-from:**"

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/BoxUnboxTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/BoxUnboxTest.scala
@@ -2,10 +2,8 @@ package scala.tools.nsc
 package backend.jvm
 package opt
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.tools.asm.Opcodes._
 import scala.tools.testkit.ASMConverters._
@@ -15,7 +13,6 @@ import scala.tools.testkit.BytecodeTesting._
 /**
   * Tests for boxing/unboxing optimizations.
   */
-@RunWith(classOf[JUnit4])
 class BoxUnboxTest extends BytecodeTesting {
   override def compilerArgs = "-opt:l:method"
   import compiler._

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/CallGraphTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/CallGraphTest.scala
@@ -2,8 +2,8 @@ package scala.tools.nsc
 package backend.jvm
 package opt
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.annotation.unused
 import scala.collection.immutable.IntMap
@@ -45,7 +45,7 @@ class CallGraphTest extends BytecodeTesting {
       val callee = callsite.callee.get
       assert(callee.callee == target)
       assert(callee.calleeDeclarationClass == calleeDeclClass)
-      assertEquals("safeToInline", safeToInline, callee.safeToInline)
+      assertEquals(safeToInline, callee.safeToInline, "safeToInline")
       assert(callee.annotatedInline == atInline)
       assert(callee.annotatedNoInline == atNoInline)
       assert(callsite.argInfos == argInfos)

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/ClosureOptimizerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/ClosureOptimizerTest.scala
@@ -2,16 +2,13 @@ package scala.tools.nsc
 package backend.jvm
 package opt
 
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Test
 
 import scala.tools.asm.Opcodes._
 import scala.tools.testkit.ASMConverters._
 import scala.tools.testkit.BytecodeTesting
 import scala.tools.testkit.BytecodeTesting._
 
-@RunWith(classOf[JUnit4])
 class ClosureOptimizerTest extends BytecodeTesting {
   override def compilerArgs = "-opt:l:inline -opt-inline-from:** -opt-warnings:_"
   import compiler._

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/CompactLocalVariablesTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/CompactLocalVariablesTest.scala
@@ -2,16 +2,13 @@ package scala.tools.nsc
 package backend.jvm
 package opt
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.ASMConverters._
 import scala.tools.testkit.BytecodeTesting._
 import scala.tools.testkit.ClearAfterClass
 
-@RunWith(classOf[JUnit4])
 class CompactLocalVariablesTest extends ClearAfterClass {
   // recurse-unreachable-jumps is required for eliminating catch blocks, in the first dce round they
   // are still live.only after eliminating the empty handler the catch blocks become unreachable.
@@ -65,8 +62,8 @@ class CompactLocalVariablesTest extends ClearAfterClass {
     val varOpSlots = convertMethod(withCompact).instructions collect {
       case VarOp(_, v) => v
     }
-    assertTrue(varOpSlots.toString, varOpSlots == List(1, 2, 4, 5, 7, 8, 10, 11,  // stores
-                                                       1, 7, 2, 8, 4, 10, 5, 11)) // loads
+    assertTrue(varOpSlots == List(1, 2, 4, 5, 7, 8, 10, 11,  // stores
+                                                       1, 7, 2, 8, 4, 10, 5, 11), varOpSlots.toString) // loads
 
     // the local variables descriptor table is cleaned up to remove stale entries after dce,
     // also when the slots are not compacted

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/EmptyExceptionHandlersTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/EmptyExceptionHandlersTest.scala
@@ -2,10 +2,8 @@ package scala.tools.nsc
 package backend.jvm
 package opt
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.tools.asm.Opcodes._
 import scala.tools.testkit.ASMConverters._
@@ -13,7 +11,6 @@ import scala.tools.testkit.BytecodeTesting
 import scala.tools.testkit.BytecodeTesting._
 
 
-@RunWith(classOf[JUnit4])
 class EmptyExceptionHandlersTest extends BytecodeTesting {
   override def compilerArgs = "-opt:unreachable-code"
   def dceCompiler = compiler

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/EmptyLabelsAndLineNumbersTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/EmptyLabelsAndLineNumbersTest.scala
@@ -2,17 +2,14 @@ package scala.tools.nsc
 package backend.jvm
 package opt
 
-import org.junit.Assert.{ assertThrows => _, _ }
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.{ assertThrows => _, _ }
+import org.junit.jupiter.api.Test
 
 import scala.tools.asm.Opcodes._
 import scala.tools.testkit.ASMConverters._
 import scala.tools.testkit.AssertUtil._
 import scala.tools.testkit.BytecodeTesting._
 
-@RunWith(classOf[JUnit4])
 class EmptyLabelsAndLineNumbersTest {
   @Test
   def removeEmptyLineNumbers(): Unit = {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlineInfoTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlineInfoTest.scala
@@ -2,10 +2,8 @@ package scala.tools.nsc
 package backend.jvm
 package opt
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.jdk.CollectionConverters._
 import scala.reflect.internal.util.JavaClearable
@@ -13,7 +11,6 @@ import scala.tools.nsc.backend.jvm.BTypes.MethodInlineInfo
 import scala.tools.nsc.backend.jvm.BackendReporting._
 import scala.tools.testkit.BytecodeTesting
 
-@RunWith(classOf[JUnit4])
 class InlineInfoTest extends BytecodeTesting {
   import compiler._
   import global.genBCode.{bTypes, postProcessor}

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlineSourceMatcherTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlineSourceMatcherTest.scala
@@ -1,9 +1,7 @@
 package scala.tools.nsc.backend.jvm.opt
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.tools.nsc.backend.jvm.BTypes.InternalName
 import scala.tools.nsc.backend.jvm.opt.InlineSourceMatcherTest._
@@ -11,7 +9,6 @@ import scala.tools.nsc.backend.jvm.opt.InlinerHeuristics._
 import scala.tools.testkit.BytecodeTesting
 import scala.tools.testkit.BytecodeTesting._
 
-@RunWith(classOf[JUnit4])
 class InlineSourceMatcherTest extends BytecodeTesting {
   import compiler._
 

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlineWarningTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlineWarningTest.scala
@@ -2,14 +2,11 @@ package scala.tools.nsc
 package backend.jvm
 package opt
 
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.BytecodeTesting
 import scala.tools.testkit.BytecodeTesting._
 
-@RunWith(classOf[JUnit4])
 class InlineWarningTest extends BytecodeTesting {
   def optInline = "-opt:l:inline -opt-inline-from:**"
   override def compilerArgs = s"$optInline -opt-warnings"

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerIllegalAccessTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerIllegalAccessTest.scala
@@ -2,9 +2,7 @@ package scala.tools.nsc
 package backend.jvm
 package opt
 
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Test
 
 import scala.jdk.CollectionConverters._
 import scala.tools.asm.Opcodes._
@@ -13,7 +11,6 @@ import scala.tools.nsc.backend.jvm.AsmUtils._
 import scala.tools.testkit.AssertUtil.fail
 import scala.tools.testkit.BytecodeTesting
 
-@RunWith(classOf[JUnit4])
 class InlinerIllegalAccessTest extends BytecodeTesting {
   override def compilerArgs = "-opt:l:none"
 

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerSeparateCompilationTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerSeparateCompilationTest.scala
@@ -2,13 +2,10 @@ package scala.tools.nsc
 package backend.jvm
 package opt
 
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.BytecodeTesting._
 
-@RunWith(classOf[JUnit4])
 class InlinerSeparateCompilationTest {
   val args = "-opt:l:inline -opt-inline-from:**"
 

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
@@ -2,10 +2,8 @@ package scala.tools.nsc
 package backend.jvm
 package opt
 
-import org.junit.Assert._
-import org.junit.{Ignore, Test}
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.{Disabled, Test}
 
 import scala.jdk.CollectionConverters._
 import scala.reflect.internal.util.JavaClearable
@@ -16,7 +14,6 @@ import scala.tools.testkit.ASMConverters._
 import scala.tools.testkit.BytecodeTesting
 import scala.tools.testkit.BytecodeTesting._
 
-@RunWith(classOf[JUnit4])
 class InlinerTest extends BytecodeTesting {
   override def compilerArgs = "-opt:l:inline -opt-inline-from:** -opt-warnings"
 
@@ -1950,7 +1947,8 @@ class InlinerTest extends BytecodeTesting {
     assertInvokedMethods(getMethod(c, "t5b"), List("C.$anonfun$t5b$1"))
   }
 
-  @Test @Ignore
+  @Test
+  @Disabled
   def cleanArrayPartition(): Unit = {
     // need to
     //   - inline ArrayOps$.elemTag$extension

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/MethodLevelOptsTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/MethodLevelOptsTest.scala
@@ -2,10 +2,8 @@ package scala.tools.nsc
 package backend.jvm
 package opt
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.jdk.CollectionConverters._
 import scala.tools.asm.Opcodes._
@@ -15,7 +13,6 @@ import scala.tools.testkit.ASMConverters._
 import scala.tools.testkit.BytecodeTesting
 import scala.tools.testkit.BytecodeTesting._
 
-@RunWith(classOf[JUnit4])
 class MethodLevelOptsTest extends BytecodeTesting {
   override def compilerArgs = "-opt:l:method"
   import compiler._

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/ScalaInlineInfoTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/ScalaInlineInfoTest.scala
@@ -2,10 +2,8 @@ package scala.tools.nsc
 package backend.jvm
 package opt
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.jdk.CollectionConverters._
 import scala.collection.immutable.TreeMap
@@ -14,7 +12,6 @@ import scala.tools.nsc.backend.jvm.BTypes.{InlineInfo, MethodInlineInfo}
 import scala.tools.testkit.BytecodeTesting
 import scala.tools.testkit.BytecodeTesting._
 
-@RunWith(classOf[JUnit4])
 class ScalaInlineInfoTest extends BytecodeTesting {
   override def compilerArgs = "-opt:l:none"
   import compiler._

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/SimplifyJumpsTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/SimplifyJumpsTest.scala
@@ -2,8 +2,8 @@ package scala.tools.nsc
 package backend.jvm
 package opt
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.annotation.unused
 import scala.tools.asm.Opcodes._

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/UnreachableCodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/UnreachableCodeTest.scala
@@ -2,10 +2,8 @@ package scala.tools.nsc
 package backend.jvm
 package opt
 
-import org.junit.Assert.{ assertThrows => _, _ }
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.{ assertThrows => _, _ }
+import org.junit.jupiter.api.Test
 
 import scala.tools.asm.Opcodes._
 import scala.tools.asm.tree.ClassNode
@@ -14,7 +12,6 @@ import scala.tools.testkit.AssertUtil._
 import scala.tools.testkit.BytecodeTesting._
 import scala.tools.testkit.ClearAfterClass
 
-@RunWith(classOf[JUnit4])
 class UnreachableCodeTest extends ClearAfterClass {
   // jvm-1.6 enables emitting stack map frames, which impacts the code generation wrt dead basic blocks,
   // see comment in BCodeBodyBuilder

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/UnusedLocalVariablesTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/UnusedLocalVariablesTest.scala
@@ -2,17 +2,14 @@ package scala.tools.nsc
 package backend.jvm
 package opt
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.jdk.CollectionConverters._
 import scala.tools.testkit.ASMConverters._
 import scala.tools.testkit.BytecodeTesting
 import scala.tools.testkit.BytecodeTesting._
 
-@RunWith(classOf[JUnit4])
 class UnusedLocalVariablesTest extends BytecodeTesting {
   override def compilerArgs = "-opt:unreachable-code"
   import compiler._
@@ -76,7 +73,7 @@ class UnusedLocalVariablesTest extends BytecodeTesting {
   }
 
   def assertLocalVarCount(code: String, numVars: Int): Unit = {
-    assertEquals(compileMethod(code).localVars.toString, numVars, compileMethod(code).localVars.length)
+    assertEquals(numVars, compileMethod(code).localVars.length, compileMethod(code).localVars.toString)
   }
 
 }

--- a/test/junit/scala/tools/nsc/classpath/AggregateClassPathTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/AggregateClassPathTest.scala
@@ -4,10 +4,8 @@
 package scala.tools.nsc.classpath
 
 import java.net.URL
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 import scala.reflect.io.VirtualFile
 import scala.tools.nsc.io.AbstractFile
 import scala.tools.nsc.util.ClassPath
@@ -17,7 +15,6 @@ import scala.tools.nsc.util.ClassPath
  * cp instances used during creating it and whether it preserves the ordering
  * (in the case of the repeated entry for a class or a source it returns the first one).
  */
-@RunWith(classOf[JUnit4])
 class AggregateClassPathTest {
 
   private abstract class TestClassPathBase extends ClassPath {

--- a/test/junit/scala/tools/nsc/classpath/JrtClassPathTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/JrtClassPathTest.scala
@@ -3,17 +3,14 @@
  */
 package scala.tools.nsc.classpath
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.tools.nsc.{CloseableRegistry, Settings}
 import scala.tools.nsc.backend.jvm.AsmUtils
 import scala.tools.nsc.util.ClassPath
 import scala.tools.util.PathResolver
 
-@RunWith(classOf[JUnit4])
 class JrtClassPathTest {
 
   @Test def lookupJavaClasses(): Unit = {
@@ -30,7 +27,7 @@ class JrtClassPathTest {
       else JrtClassPath(None, closeableRegistry).get
 
     assertEquals(Nil, cp.classes(""))
-    assertTrue(cp.packages("java").toString, cp.packages("java").exists(_.name == "java.lang"))
+    assertTrue(cp.packages("java").exists(_.name == "java.lang"), cp.packages("java").toString)
     assertTrue(cp.classes("java.lang").exists(_.name == "Object"))
     val jl_Object = cp.classes("java.lang").find(_.name == "Object").get
     assertEquals("java/lang/Object", AsmUtils.classFromBytes(jl_Object.file.toByteArray).name)

--- a/test/junit/scala/tools/nsc/classpath/MultiReleaseJarTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/MultiReleaseJarTest.scala
@@ -4,7 +4,7 @@ import java.io.ByteArrayOutputStream
 import java.nio.file.{FileSystems, Files, Path}
 import java.util.jar.Attributes
 import java.util.jar.Attributes.Name
-import org.junit.{Assert, Test}
+import org.junit.jupiter.api.{Assertions, Test}
 
 import scala.tools.nsc.{CloseableRegistry, Global, Settings}
 import scala.tools.testkit.{BytecodeTesting, ForDeletion}
@@ -42,8 +42,8 @@ class MultiReleaseJarTest extends BytecodeTesting {
         decls
       }
 
-      Assert.assertEquals(List("newApi", "oldApi"), declsOfC(temp1.path, "9"))
-      Assert.assertEquals(List("oldApi"), declsOfC(temp2.path, "8"))
+      Assertions.assertEquals(List("newApi", "oldApi"), declsOfC(temp1.path, "9"))
+      Assertions.assertEquals(List("oldApi"), declsOfC(temp2.path, "8"))
     }
   }
 
@@ -63,9 +63,9 @@ class MultiReleaseJarTest extends BytecodeTesting {
       rootMirror.getClassIfDefined(className) != NoSymbol
     }
     try {
-      Assert.assertTrue(lookup("java.lang.invoke.LambdaMetafactory", "8"))
-      Assert.assertFalse(lookup("java.lang.invoke.LambdaMetafactory", "7"))
-      Assert.assertTrue(lookup("java.lang.invoke.LambdaMetafactory", "9"))
+      Assertions.assertTrue(lookup("java.lang.invoke.LambdaMetafactory", "8"))
+      Assertions.assertFalse(lookup("java.lang.invoke.LambdaMetafactory", "7"))
+      Assertions.assertTrue(lookup("java.lang.invoke.LambdaMetafactory", "9"))
     } finally {
       cleanup.close()
     }

--- a/test/junit/scala/tools/nsc/classpath/PathResolverBaseTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/PathResolverBaseTest.scala
@@ -5,17 +5,14 @@ package scala.tools.nsc.classpath
 
 import java.io.File
 
-import org.junit.Assert._
+import org.junit.jupiter.api.Assertions._
 import org.junit._
 import org.junit.rules.TemporaryFolder
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
 import scala.tools.nsc.util.ClassPath
 import scala.tools.nsc.{CloseableRegistry, Settings}
 import scala.tools.util.PathResolver
 
-@RunWith(classOf[JUnit4])
 class PathResolverBaseTest {
 
   val tempDir = new TemporaryFolder()
@@ -73,22 +70,22 @@ class PathResolverBaseTest {
 
       val packageNames = packages.map(_.name).sorted
       val packageNamesFromList = packagesFromList.map(_.name).sorted
-      assertEquals(s"Methods list and packages for package '$inPackage' should return the same packages",
-        packageNames, packageNamesFromList)
+      assertEquals(packageNames, packageNamesFromList,
+        s"Methods list and packages for package '$inPackage' should return the same packages")
 
       val classFileNames = classes.map(_.name).sorted
       val classFileNamesFromList = classesAndSourcesFromList.filter(_.binary.isDefined).map(_.name).sorted
-      assertEquals(s"Methods list and classes for package '$inPackage' should return entries for the same class files",
-        classFileNames, classFileNamesFromList)
+      assertEquals(classFileNames, classFileNamesFromList,
+        s"Methods list and classes for package '$inPackage' should return entries for the same class files")
 
       val sourceFileNames = sources.map(_.name).sorted
       val sourceFileNamesFromList = classesAndSourcesFromList.filter(_.source.isDefined).map(_.name).sorted
-      assertEquals(s"Methods list and sources for package '$inPackage' should return entries for the same source files",
-        sourceFileNames, sourceFileNamesFromList)
+      assertEquals(sourceFileNames, sourceFileNamesFromList,
+        s"Methods list and sources for package '$inPackage' should return entries for the same source files")
 
       val uniqueNamesOfClassAndSourceFiles = (classFileNames ++ sourceFileNames).toSet
-      assertEquals(s"Class and source entries with the same name obtained via list for package '$inPackage' should be merged into one containing both files",
-        uniqueNamesOfClassAndSourceFiles.size, classesAndSourcesFromList.length)
+      assertEquals(uniqueNamesOfClassAndSourceFiles.size, classesAndSourcesFromList.length,
+        s"Class and source entries with the same name obtained via list for package '$inPackage' should be merged into one containing both files")
     }
 
     packagesToTest foreach compareEntriesInPackage
@@ -98,7 +95,7 @@ class PathResolverBaseTest {
   def testFindClassFile(): Unit = {
     val classPath = createFlatClassPath(settings)
     classFilesToFind foreach { className =>
-      assertTrue(s"File for $className should be found", classPath.findClassFile(className).isDefined)
+      assertTrue(classPath.findClassFile(className).isDefined, s"File for $className should be found")
     }
   }
 
@@ -106,7 +103,7 @@ class PathResolverBaseTest {
   def testFindClass(): Unit = {
     val classPath = createFlatClassPath(settings)
     classesToFind foreach { className =>
-      assertTrue(s"File for $className should be found", classPath.findClass(className).isDefined)
+      assertTrue(classPath.findClass(className).isDefined, s"File for $className should be found")
     }
   }
 }

--- a/test/junit/scala/tools/nsc/classpath/VirtualDirectoryClassPathTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/VirtualDirectoryClassPathTest.scala
@@ -3,8 +3,8 @@
  */
 package scala.tools.nsc.classpath
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.annotation.unused
 import scala.reflect.io.VirtualDirectory

--- a/test/junit/scala/tools/nsc/classpath/ZipAndJarFileLookupFactoryTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/ZipAndJarFileLookupFactoryTest.scala
@@ -1,8 +1,8 @@
 package scala.tools.nsc
 package classpath
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 import java.net.{URI, URL}
 import java.nio.file._
 import java.nio.file.attribute.FileTime

--- a/test/junit/scala/tools/nsc/doc/html/HtmlDocletTest.scala
+++ b/test/junit/scala/tools/nsc/doc/html/HtmlDocletTest.scala
@@ -1,7 +1,7 @@
 package scala.tools.nsc.doc.html
 
-import org.junit.Test
-import org.junit.Assert._
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions._
 
 class HtmlDocletTest {
   @Test

--- a/test/junit/scala/tools/nsc/doc/html/StringLiteralTest.scala
+++ b/test/junit/scala/tools/nsc/doc/html/StringLiteralTest.scala
@@ -1,11 +1,8 @@
 package scala.tools.nsc.doc.html
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class StringLiteralTest {
   @Test
   def testHighlightingQuote(): Unit = {

--- a/test/junit/scala/tools/nsc/interpreter/CompletionTest.scala
+++ b/test/junit/scala/tools/nsc/interpreter/CompletionTest.scala
@@ -1,7 +1,7 @@
 package scala.tools.nsc.interpreter
 
-import org.junit.Assert.{assertEquals, assertTrue}
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Test
 
 import java.io.{PrintWriter, StringWriter}
 import scala.reflect.internal.util.{BatchSourceFile, SourceFile}

--- a/test/junit/scala/tools/nsc/interpreter/ScriptedTest.scala
+++ b/test/junit/scala/tools/nsc/interpreter/ScriptedTest.scala
@@ -1,10 +1,11 @@
 package scala.tools.nsc
 package interpreter
 
-import org.junit._, Assert._, runner.RunWith, runners.JUnit4
+import org.junit.jupiter.api.Assertions.{assertEquals, assertNotNull}
+import org.junit.jupiter.api.Test
+
 import scala.tools.testkit.AssertUtil.assertThrows
 
-@RunWith(classOf[JUnit4])
 class ScriptedTest {
   import javax.script._
   import scala.tools.nsc.interpreter.shell.Scripted

--- a/test/junit/scala/tools/nsc/interpreter/TabulatorTest.scala
+++ b/test/junit/scala/tools/nsc/interpreter/TabulatorTest.scala
@@ -1,14 +1,11 @@
 package scala.tools.nsc.interpreter.shell
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 case class Tabby(width: Int = 80, isAcross: Boolean = false, marginSize: Int = 3) extends Tabulator
 case class VTabby(width: Int = 80, isAcross: Boolean = false, marginSize: Int = 3) extends VariColumnTabulator
 
-@RunWith(classOf[JUnit4])
 class TabulatorTest {
 
   // à̧̄ is composed using 3 combining characters

--- a/test/junit/scala/tools/nsc/parser/ParserTest.scala
+++ b/test/junit/scala/tools/nsc/parser/ParserTest.scala
@@ -1,13 +1,10 @@
 package scala.tools.nsc.parser
 
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Assert._
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.BytecodeTesting
 
-@RunWith(classOf[JUnit4])
 class ParserTest extends BytecodeTesting{
   override def compilerArgs: String = "-Ystop-after:parser -Yvalidate-pos:parser -Yrangepos"
   @Test

--- a/test/junit/scala/tools/nsc/reporters/ConsoleReporterTest.scala
+++ b/test/junit/scala/tools/nsc/reporters/ConsoleReporterTest.scala
@@ -3,8 +3,8 @@ package tools.nsc
 package reporters
 
 import java.io.{ByteArrayOutputStream, StringReader, BufferedReader, PrintWriter}
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.reflect.internal.util._
 
@@ -40,7 +40,7 @@ class ConsoleReporterTest {
     try {
       test(pos)
       val buf = writerOut.toString
-      if (msg.isEmpty && severity.isEmpty) assertTrue(s"Expected no message output but saw: [$buf]", buf.isEmpty)
+      if (msg.isEmpty && severity.isEmpty) assertTrue(buf.isEmpty, s"Expected no message output but saw: [$buf]")
       else if (!pos.isDefined) assertEquals(severity + msg, buf.linesIterator.next())
       else {
         val it = buf.linesIterator

--- a/test/junit/scala/tools/nsc/reporters/PositionFilterTest.scala
+++ b/test/junit/scala/tools/nsc/reporters/PositionFilterTest.scala
@@ -2,14 +2,11 @@ package scala
 package tools.nsc
 package reporters
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.reflect.internal.util._
 
-@RunWith(classOf[JUnit4])
 class PositionFilterTest {
   val source = "Test_PositionFilter"
   val batchFile = new BatchSourceFile(source, "For testing".toList)

--- a/test/junit/scala/tools/nsc/reporters/WConfTest.scala
+++ b/test/junit/scala/tools/nsc/reporters/WConfTest.scala
@@ -13,8 +13,8 @@
 package scala.tools.nsc
 package reporters
 
-import org.junit.Assert.{assertEquals, assertTrue}
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Test
 import java.io.{File => JFile}
 
 import scala.collection.mutable.ListBuffer
@@ -240,7 +240,7 @@ class WConfTest extends BytecodeTesting {
       case pv: Version.ParseableVersion =>
         assertEquals(ev, pv.copy(orig = ""))
       case nv: Version.NonParseableVersion =>
-        assertTrue(s"failed to parse $s, expected $ev", ev.isInstanceOf[Version.NonParseableVersion])
+        assertTrue(ev.isInstanceOf[Version.NonParseableVersion], s"failed to parse $s, expected $ev")
     }
 
     val v123 = Version.ParseableVersion("", 1, Some(2), Some(3))
@@ -274,7 +274,7 @@ class WConfTest extends BytecodeTesting {
     val name = Map(s -> "!<", e -> "!=", g -> "!>", ns -> "<", ne -> "=", ng -> ">")
 
     def check(a: Version.ParseableVersion, b: Version.ParseableVersion, op: (Version.ParseableVersion, Version.ParseableVersion) => Boolean): Unit ={
-      assertTrue(s"$a ${name(op)} $b", op(a, b))
+      assertTrue(op(a, b), s"$a ${name(op)} $b")
     }
 
     object v {

--- a/test/junit/scala/tools/nsc/settings/ScalaVersionTest.scala
+++ b/test/junit/scala/tools/nsc/settings/ScalaVersionTest.scala
@@ -1,8 +1,8 @@
 package scala.tools.nsc
 package settings
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 import scala.tools.testkit.AssertUtil.assertThrows
 
 class ScalaVersionTest {

--- a/test/junit/scala/tools/nsc/settings/SettingsTest.scala
+++ b/test/junit/scala/tools/nsc/settings/SettingsTest.scala
@@ -1,13 +1,10 @@
 package scala.tools.nsc
 package settings
 
-import org.junit.Assert.{assertTrue => assert, _}
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.{assertTrue => assert, _}
+import org.junit.jupiter.api.Test
 import scala.tools.testkit.AssertUtil.assertThrows
 
-@RunWith(classOf[JUnit4])
 class SettingsTest {
   @Test def booleanSettingColon(): Unit = {
     def check(args: String*): MutableSettings#BooleanSetting = {
@@ -164,8 +161,8 @@ class SettingsTest {
     def check(expected: String, args: String*): Unit = {
       val s = new MutableSettings(msg => throw new IllegalArgumentException(msg))
       val (_, residual) = s.processArguments(args.toList, processAll = true)
-      assert(s"remaining input [$residual]", residual.isEmpty)
-      assert(s"(${s.source.value} == ${ScalaVersion(expected)})", s.source.value == ScalaVersion(expected))
+      assert(residual.isEmpty, s"remaining input [$residual]")
+      assert(s.source.value == ScalaVersion(expected), s"(${s.source.value} == ${ScalaVersion(expected)})")
     }
     check(expected = "2.13.0") // default
     check(expected = "3",      "-Xsource:2.14")
@@ -249,22 +246,22 @@ class SettingsTest {
   @Test def `wildcard doesn't disable everything`(): Unit = {
     val settings = new Settings()
     settings.processArguments("-opt:_" :: Nil, true)
-    assert("has the choice", settings.opt.contains(settings.optChoices.inline))
-    assert("is enabled", settings.optInlinerEnabled)
+    assert(settings.opt.contains(settings.optChoices.inline), "has the choice")
+    assert(settings.optInlinerEnabled, "is enabled")
   }
   @Test def `kill switch can be enabled explicitly`(): Unit = {
     val settings = new Settings()
     settings.processArguments("-opt:inline,l:none" :: Nil, true)
-    assert("has the choice", settings.opt.contains(settings.optChoices.inline))
-    assertFalse("is not enabled", settings.optInlinerEnabled)
+    assert(settings.opt.contains(settings.optChoices.inline), "has the choice")
+    assertFalse(settings.optInlinerEnabled, "is not enabled")
   }
   @Test def `t12036 don't consume dash option as arg`(): Unit = {
     import scala.collection.mutable.ListBuffer
     val errors   = ListBuffer.empty[String]
     val settings = new Settings(errors.addOne)
     val (ok, rest) = settings.processArguments("-Vinline" :: "-Xlint" :: Nil, true)
-    assertFalse("processing should fail", ok)
-    assertEquals("processing stops at bad option", 2, rest.length)
+    assertFalse(ok, "processing should fail")
+    assertEquals(2, rest.length, "processing stops at bad option")
     assertEquals(2, errors.size)  // missing arg and bad option
   }
   @Test def `t12098 MultiStringSetting with prepend handles non-colon args`(): Unit = {
@@ -272,8 +269,8 @@ class SettingsTest {
     val errors   = ListBuffer.empty[String]
     val settings = new Settings(errors.addOne)
     val (ok, rest) = settings.processArguments("-Wconf" :: "help" :: "-Vdebug" :: "x.scala" :: Nil, true)
-    assert("processing should succeed", ok)
-    assertEquals("processing stops at argument", 1, rest.length)
+    assert(ok, "processing should succeed")
+    assertEquals(1, rest.length, "processing stops at argument")
     assertEquals("processing stops at the correct argument", "x.scala", rest.head)
     assertEquals(0, errors.size)
     assert(settings.debug)
@@ -282,7 +279,7 @@ class SettingsTest {
   @Test def `t12098 MultiStringSetting prepends`(): Unit = {
     val settings = new Settings(msg => fail(s"Unexpected error: $msg"))
     val (ok, rest) = settings.processArguments("-Wconf:cat=lint-missing-interpolator:ws" :: "-Xlint" :: "x.scala" :: Nil, true)
-    assert("processing should succeed", ok)
+    assert(ok, "processing should succeed")
     assert(settings.warnMissingInterpolator)
     assert(settings.lintDeprecation)
     // test/files/neg/t12098.scala shows that cat=deprecation:w due to xlint supersedes default cat=deprecation:ws

--- a/test/junit/scala/tools/nsc/settings/TargetTest.scala
+++ b/test/junit/scala/tools/nsc/settings/TargetTest.scala
@@ -13,13 +13,11 @@
 package scala.tools.nsc
 package settings
 
-import org.junit.{Assert, Test}, Assert.{assertEquals, assertFalse, assertTrue, fail}
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue, fail}
+import org.junit.jupiter.api.Test
 
 import scala.collection.mutable.ListBuffer
 
-@RunWith(classOf[JUnit4])
 class TargetTest {
 
   @Test def testSettingTargetSetting(): Unit = {

--- a/test/junit/scala/tools/nsc/symtab/CannotHaveAttrsTest.scala
+++ b/test/junit/scala/tools/nsc/symtab/CannotHaveAttrsTest.scala
@@ -1,15 +1,12 @@
 package scala.tools.nsc
 package symtab
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.{Disabled, Test}
 
-import scala.tools.testkit.AssertUtil.assertThrows
 import scala.reflect.internal.util.OffsetPosition
+import scala.tools.testkit.AssertUtil.assertThrows
 
-@RunWith(classOf[JUnit4])
 class CannotHaveAttrsTest {
   object symbolTable extends SymbolTableForUnitTesting {
     object CHA extends CannotHaveAttrs {
@@ -47,7 +44,8 @@ class CannotHaveAttrsTest {
       assertEquals(t.tpe, NoType)
     }
 
-  @Test @org.junit.Ignore("scala/bug#8816")
+  @Test
+  @Disabled("scala/bug#8816")
   def nonDefaultPosAssignmentFails(): Unit = {
     val pos = new OffsetPosition(null, 0)
     attrlessTrees.foreach { t =>
@@ -56,7 +54,8 @@ class CannotHaveAttrsTest {
     }
   }
 
-  @Test @org.junit.Ignore("scala/bug#8816")
+  @Test
+  @Disabled("scala/bug#8816")
   def nonDefaultTpeAssignmentFails(): Unit = {
     val tpe = typeOf[Int]
     attrlessTrees.foreach { t =>

--- a/test/junit/scala/tools/nsc/symtab/FlagsTest.scala
+++ b/test/junit/scala/tools/nsc/symtab/FlagsTest.scala
@@ -1,14 +1,11 @@
 package scala.tools.nsc
 package symtab
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.BytecodeTesting
 
-@RunWith(classOf[JUnit4])
 class FlagsTest extends BytecodeTesting {
   object symbolTable extends SymbolTableForUnitTesting
   import symbolTable._

--- a/test/junit/scala/tools/nsc/symtab/FreshNameExtractorTest.scala
+++ b/test/junit/scala/tools/nsc/symtab/FreshNameExtractorTest.scala
@@ -1,15 +1,12 @@
 package scala.tools.nsc
 package symtab
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
-import scala.tools.testkit.AssertUtil.assertThrows
 import scala.reflect.internal.util.FreshNameCreator
+import scala.tools.testkit.AssertUtil.assertThrows
 
-@RunWith(classOf[JUnit4])
 class FreshNameExtractorTest {
   object symbolTable extends SymbolTableForUnitTesting
   import symbolTable._

--- a/test/junit/scala/tools/nsc/symtab/StdNamesTest.scala
+++ b/test/junit/scala/tools/nsc/symtab/StdNamesTest.scala
@@ -1,14 +1,11 @@
 package scala.tools.nsc
 package symtab
 
-import org.junit.Assert.{ assertThrows => _, _ }
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.{assertThrows => _, _}
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.AssertUtil._
 
-@RunWith(classOf[JUnit4])
 class StdNamesTest {
   object symbolTable extends SymbolTableForUnitTesting
   import symbolTable._

--- a/test/junit/scala/tools/nsc/symtab/SymbolTableTest.scala
+++ b/test/junit/scala/tools/nsc/symtab/SymbolTableTest.scala
@@ -1,13 +1,9 @@
 package scala.tools.nsc
 package symtab
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
-import org.junit.runners.JUnit4
-
-@RunWith(classOf[JUnit4])
 class SymbolTableTest {
   object symbolTable extends SymbolTableForUnitTesting
 
@@ -21,7 +17,7 @@ class SymbolTableTest {
     symbolTable.definitions.init()
     val listClassTpe = symbolTable.definitions.ListClass.tpe
     val seqClassTpe = symbolTable.definitions.SeqClass.tpe
-    assertTrue("List should be subclass of Seq", listClassTpe <:< seqClassTpe)
+    assertTrue(listClassTpe <:< seqClassTpe, "List should be subclass of Seq")
   }
 
   /**
@@ -40,8 +36,8 @@ class SymbolTableTest {
     val fooTypeRef = TypeRef(fooSymbol.owner.tpe, fooSymbol, Nil)
     val barType = new ClassInfoType(List(fooTypeRef), EmptyScope, barSymbol)
     barSymbol.info = barType
-    assertTrue("Bar should be subclass of Foo", barSymbol.tpe <:< fooSymbol.tpe)
-    assertFalse("Foo should be a superclass of Foo", fooSymbol.tpe <:< barSymbol.tpe)
+    assertTrue(barSymbol.tpe <:< fooSymbol.tpe, "Bar should be subclass of Foo")
+    assertFalse(fooSymbol.tpe <:< barSymbol.tpe, "Foo should be a superclass of Foo")
   }
 
   @Test

--- a/test/junit/scala/tools/nsc/symtab/classfile/PicklerTest.scala
+++ b/test/junit/scala/tools/nsc/symtab/classfile/PicklerTest.scala
@@ -1,15 +1,12 @@
 package scala.tools.nsc.symtab.classfile
 
-import org.junit.{Assert, Test}
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.{Assertions, Test}
 
 import scala.reflect.io.VirtualDirectory
 import scala.tools.nsc.Global
 import scala.tools.nsc.classpath.{AggregateClassPath, VirtualDirectoryClassPath}
 import scala.tools.testkit.BytecodeTesting
 
-@RunWith(classOf[JUnit4])
 class PicklerTest extends BytecodeTesting {
   @Test
   def pickleUnpicklePreserveDeclOrder(): Unit = {
@@ -27,7 +24,7 @@ class PicklerTest extends BytecodeTesting {
       val classSym = global.rootMirror.getClassIfDefined(name)
       val moduleSym = global.rootMirror.getModuleIfDefined(name).moduleClass
       val syms = List(classSym, moduleSym).filter(sym => sym.exists)
-      Assert.assertTrue(syms.nonEmpty)
+      Assertions.assertTrue(syms.nonEmpty)
       syms.flatMap(sym => sym.name.toString :: sym.info.decls.toList.map(decl => global.definitions.fullyInitializeSymbol(decl).defString))
     }
     val decls1 = showDecls(compiler1.global)
@@ -35,6 +32,6 @@ class PicklerTest extends BytecodeTesting {
     compiler2.global.platform.currentClassPath = Some(AggregateClassPath(new VirtualDirectoryClassPath(out) :: compiler2.global.platform.currentClassPath.get :: Nil))
     new compiler2.global.Run
     val decls2 = showDecls(compiler2.global)
-    Assert.assertEquals(decls1, decls2)
+    Assertions.assertEquals(decls1, decls2)
   }
 }

--- a/test/junit/scala/tools/nsc/transform/ErasureTest.scala
+++ b/test/junit/scala/tools/nsc/transform/ErasureTest.scala
@@ -1,7 +1,7 @@
 package scala.tools.nsc.transform
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 import scala.tools.nsc.symtab.SymbolTableForUnitTesting
 import scala.tools.testkit.BytecodeTesting

--- a/test/junit/scala/tools/nsc/transform/MixinTest.scala
+++ b/test/junit/scala/tools/nsc/transform/MixinTest.scala
@@ -1,16 +1,13 @@
 package scala.tools.nsc
 package transform
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.ASMConverters.LineNumber
 import scala.tools.testkit.BytecodeTesting
 import scala.tools.testkit.BytecodeTesting._
 
-@RunWith(classOf[JUnit4])
 class MixinTest extends BytecodeTesting {
   import compiler._
 

--- a/test/junit/scala/tools/nsc/transform/ReleaseFenceTest.scala
+++ b/test/junit/scala/tools/nsc/transform/ReleaseFenceTest.scala
@@ -1,13 +1,10 @@
 package scala.tools.nsc.transform
 
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.BytecodeTesting
 import scala.tools.testkit.BytecodeTesting._
 
-@RunWith(classOf[JUnit4])
 class ReleaseFenceTest extends BytecodeTesting {
   import compiler._
 

--- a/test/junit/scala/tools/nsc/transform/SpecializationTest.scala
+++ b/test/junit/scala/tools/nsc/transform/SpecializationTest.scala
@@ -1,7 +1,7 @@
 package scala.tools.nsc.transform
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 import scala.tools.nsc.symtab.SymbolTableForUnitTesting
 
@@ -25,21 +25,21 @@ class SpecializationTest {
       val cls = FunctionClass.apply(i)
       val actual = cls.typeParams.exists(_.isSpecialized)
       val expected = i <= MaxFunctionAritySpecialized
-      assertEquals(cls.toString, expected, actual)
+      assertEquals(expected, actual, cls.toString)
     }
 
     for (i <- (1 to MaxTupleArity)) {
       val cls = TupleClass.apply(i)
       val actual = cls.typeParams.exists(_.isSpecialized)
       val expected = i <= MaxTupleAritySpecialized
-      assertEquals(cls.toString, expected, actual)
+      assertEquals(expected, actual, cls.toString)
     }
 
     for (i <- (1 to MaxProductArity)) {
       val cls = ProductClass.apply(i)
       val actual = cls.typeParams.exists(_.isSpecialized)
       val expected = i <= MaxProductAritySpecialized
-      assertEquals(cls.toString, expected, actual)
+      assertEquals(expected, actual, cls.toString)
     }
   }
 }

--- a/test/junit/scala/tools/nsc/transform/ThicketTransformerTest.scala
+++ b/test/junit/scala/tools/nsc/transform/ThicketTransformerTest.scala
@@ -1,8 +1,8 @@
 package scala.tools.nsc
 package transform
 
-import org.junit.Assert.assertSame
-import org.junit.{Assert, Test}
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.{Assertions, Test}
 
 import scala.tools.nsc.reporters.StoreReporter
 
@@ -30,7 +30,7 @@ class ThicketTransformerTest {
       }
     }
     def t(t: Tree): Tree = testTransformers.testTransformer.transform(t)
-    def assertTreeEquals(expected: Tree, actual: Tree) = Assert.assertEquals(expected.toString, actual.toString)
+    def assertTreeEquals(expected: Tree, actual: Tree) = Assertions.assertEquals(expected.toString, actual.toString)
 
     def s(s: String) = Literal(Constant(s))
     def i(i: Int) = Literal(Constant(i))

--- a/test/junit/scala/tools/nsc/transform/UncurryTest.scala
+++ b/test/junit/scala/tools/nsc/transform/UncurryTest.scala
@@ -1,13 +1,10 @@
 package scala.tools.nsc
 package transform
 
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.BytecodeTesting
 
-@RunWith(classOf[JUnit4])
 class UncurryTest {
   import BytecodeTesting._
 

--- a/test/junit/scala/tools/nsc/transform/delambdafy/DelambdafyTest.scala
+++ b/test/junit/scala/tools/nsc/transform/delambdafy/DelambdafyTest.scala
@@ -1,16 +1,13 @@
 package scala.tools.nsc.transform.delambdafy
 
-import org.junit.Assert.assertTrue
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 
 import scala.reflect.io.Path.jfile2path
 import scala.tools.nsc.io.AbstractFile
 import scala.tools.testkit.BytecodeTesting._
 import scala.tools.testkit.TempDir
 
-@RunWith(classOf[JUnit4])
 class DelambdafyTest {
   def compileToMultipleOutputWithDelambdafyMethod(): List[(String, Array[Byte])] = {
     val codeForMultiOutput = """

--- a/test/junit/scala/tools/nsc/transform/patmat/PatmatBytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/transform/patmat/PatmatBytecodeTest.scala
@@ -1,9 +1,7 @@
 package scala.tools.nsc
 package transform.patmat
 
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Test
 
 import scala.tools.asm.Opcodes._
 import scala.tools.nsc.backend.jvm.AsmUtils._
@@ -13,7 +11,6 @@ import scala.tools.testkit.BytecodeTesting._
 
 import PartialFunction.cond
 
-@RunWith(classOf[JUnit4])
 class PatmatBytecodeTest extends BytecodeTesting {
   val optCompiler = cached("optCompiler", () => newCompiler(extraArgs = "-opt:l:inline -opt-inline-from:**"))
 

--- a/test/junit/scala/tools/nsc/transform/patmat/SolvingTest.scala
+++ b/test/junit/scala/tools/nsc/transform/patmat/SolvingTest.scala
@@ -1,7 +1,7 @@
 package scala.tools.nsc.transform.patmat
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.collection.mutable
 import scala.reflect.internal.util.Position

--- a/test/junit/scala/tools/nsc/typechecker/ImplicitsTest.scala
+++ b/test/junit/scala/tools/nsc/typechecker/ImplicitsTest.scala
@@ -1,8 +1,8 @@
 package scala.tools.nsc
 package typechecker
 
-import org.junit.Assert.{assertEquals, assertNotEquals, assertTrue}
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.{assertEquals, assertNotEquals, assertTrue}
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.BytecodeTesting
 

--- a/test/junit/scala/tools/nsc/typechecker/InferencerTest.scala
+++ b/test/junit/scala/tools/nsc/typechecker/InferencerTest.scala
@@ -1,10 +1,8 @@
 package scala.tools.nsc
 package typechecker
 
-import org.junit.Assert.assertTrue
-import org.junit.{After, Before, Test}
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 
 import scala.tools.nsc.settings.ScalaVersion
 import scala.tools.testkit.BytecodeTesting
@@ -22,16 +20,17 @@ trait Quux[-T] extends Z[T]
 trait SubZB extends Z[B]
 trait ZwC[-T] extends Z[T] with C
 
-@RunWith(classOf[JUnit4])
 class InferencerTests extends BytecodeTesting {
   import compiler.global._, analyzer._
 
   var storedXsource: ScalaVersion = null
-  @Before
+
+  @BeforeEach
   def storeXsource(): Unit = {
     storedXsource = settings.source.value
   }
-  @After
+
+  @AfterEach
   def restoreXsource(): Unit = {
     settings.source.value = storedXsource
   }

--- a/test/junit/scala/tools/nsc/typechecker/NamerTest.scala
+++ b/test/junit/scala/tools/nsc/typechecker/NamerTest.scala
@@ -1,12 +1,9 @@
 package scala.tools.nsc.typechecker
 
-import org.junit.{Assert, Test}
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.{Assertions, Test}
 
 import scala.tools.testkit.BytecodeTesting
 
-@RunWith(classOf[JUnit4])
 class NamerTest extends BytecodeTesting {
 
   import compiler.global._
@@ -18,6 +15,6 @@ class NamerTest extends BytecodeTesting {
     compiler.compileClasses("package p1; class Test { C.b(); C.a() }; object C { def a(x: Int = 0) = 0; def b(x: Int = 0) = 0 }")
     val methods = compiler.global.rootMirror.getRequiredModule("p1.C").info.decls.toList.map(_.name.toString).filter(_.matches("""(a|b).*"""))
     def getterName(s: String) = nme.defaultGetterName(TermName(s), 1).toString
-    Assert.assertEquals(List("a", getterName("a"), "b", getterName("b")), methods) // order no longer depends on order of lazy type completion :)
+    Assertions.assertEquals(List("a", getterName("a"), "b", getterName("b")), methods) // order no longer depends on order of lazy type completion :)
   }
 }

--- a/test/junit/scala/tools/nsc/typechecker/OverridingPairsTest.scala
+++ b/test/junit/scala/tools/nsc/typechecker/OverridingPairsTest.scala
@@ -1,7 +1,7 @@
 package scala.tools.nsc.typechecker
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.BytecodeTesting
 

--- a/test/junit/scala/tools/nsc/typechecker/ParamAliasTest.scala
+++ b/test/junit/scala/tools/nsc/typechecker/ParamAliasTest.scala
@@ -1,7 +1,7 @@
 package scala.tools.nsc.typechecker
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 import scala.annotation.unused
 import scala.reflect.io.VirtualDirectory

--- a/test/junit/scala/tools/nsc/typechecker/TypedTreeTest.scala
+++ b/test/junit/scala/tools/nsc/typechecker/TypedTreeTest.scala
@@ -1,7 +1,7 @@
 package scala.tools.nsc.typechecker
 
-import org.junit.Assert.{assertEquals, assertNotEquals}
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.{assertEquals, assertNotEquals}
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.BytecodeTesting
 

--- a/test/junit/scala/tools/nsc/util/StackTraceTest.scala
+++ b/test/junit/scala/tools/nsc/util/StackTraceTest.scala
@@ -3,12 +3,9 @@ package scala.tools.nsc.util
 
 import scala.util.{Failure, Success, Try}
 
-import org.junit.Assert.{assertEquals, assertTrue}
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
 class StackTraceTest {
   val CausedBy   = "Caused by: "
   val Suppressed = "Suppressed: "

--- a/test/junit/scala/tools/testkit/AssertThrowsTest.scala
+++ b/test/junit/scala/tools/testkit/AssertThrowsTest.scala
@@ -12,13 +12,11 @@
 
 package scala.tools.testkit
 
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import AssertUtil.{assertThrown, assertThrows}
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
-@RunWith(classOf[JUnit4])
+import scala.tools.testkit.AssertUtil.{assertThrown, assertThrows}
+
 class AssertThrowsTest {
   class Foo extends Exception
   class SubFoo extends Foo
@@ -32,7 +30,7 @@ class AssertThrowsTest {
 
   @Test
   def wrongThrow(): Unit =
-    assertTrue("Wrong exception thrown", {
+    assertTrue({
       try {
         assertThrows[Foo] { throw new Bar }
         false
@@ -41,7 +39,7 @@ class AssertThrowsTest {
         case e: AssertionError => true
         case t: Throwable => fail(s"expected AssertionError but got $t"); false
       }
-    })
+    }, "Wrong exception thrown")
 
   @Test
   def errorIfNoThrow(): Unit = {

--- a/test/junit/scala/tools/testkit/AssertUtilTest.scala
+++ b/test/junit/scala/tools/testkit/AssertUtilTest.scala
@@ -12,17 +12,13 @@
 
 package scala.tools.testkit
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import AssertUtil._
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 import java.lang.ref._
-
 import scala.annotation.unused
+import scala.tools.testkit.AssertUtil._
 
-@RunWith(classOf[JUnit4])
 class AssertUtilTest {
   @Test def assertThrowsAssertion(): Unit = {
     assertThrows[AssertionError](throw new AssertionError("meme"), _ == "meme")

--- a/test/junit/scala/tools/testkit/ReflectUtilTest.scala
+++ b/test/junit/scala/tools/testkit/ReflectUtilTest.scala
@@ -12,8 +12,8 @@
 
 package scala.tools.testkit
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 import AssertUtil._
 
 class ReflectUtilTest {

--- a/test/junit/scala/util/ChainingOpsTest.scala
+++ b/test/junit/scala/util/ChainingOpsTest.scala
@@ -1,7 +1,7 @@
 package scala.util
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.tools.reflect.ToolBoxError
 import scala.tools.testkit.AssertUtil.assertThrows

--- a/test/junit/scala/util/EitherTest.scala
+++ b/test/junit/scala/util/EitherTest.scala
@@ -1,7 +1,7 @@
 package scala.util
 
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 class EitherTest {
 

--- a/test/junit/scala/util/PropertiesTest.scala
+++ b/test/junit/scala/util/PropertiesTest.scala
@@ -1,8 +1,8 @@
 package scala.util
 
 import org.junit.Before
-import org.junit.Test
-import org.junit.Assert._
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions._
 
 class PropertiesTest {
   final val TestProperty = "scala.util.PropertiesTest.__test_property__"
@@ -29,7 +29,7 @@ class PropertiesTest {
 
     var done = false
     assertEquals(Properties.propOrElse(TestProperty, { done = true; "bar" }), "foo")
-    assertFalse("Does not evaluate alt if not needed", done)
+    assertFalse(done, "Does not evaluate alt if not needed")
   }
 
   @Test
@@ -39,6 +39,6 @@ class PropertiesTest {
     var done = false
     val envName = System.getenv().keySet().iterator().next()
     assertNotEquals(Properties.envOrElse(envName, { done = true; "bar" }), "bar")
-    assertFalse("Does not evaluate alt if not needed", done)
+    assertFalse(done, "Does not evaluate alt if not needed")
   }
 }

--- a/test/junit/scala/util/RandomTest.scala
+++ b/test/junit/scala/util/RandomTest.scala
@@ -1,6 +1,6 @@
 package scala.util
 
-import org.junit.{Assert, Test}
+import org.junit.jupiter.api.{Assertions, Test}
 
 import scala.annotation.unused
 import scala.collection.immutable.WrappedString
@@ -12,7 +12,7 @@ class RandomTest {
 
     val items = Random.alphanumeric.take(100000)
     for (c <- items) {
-      Assert.assertTrue(s"$c should be alphanumeric", isAlphaNum(c))
+      Assertions.assertTrue(isAlphaNum(c), s"$c should be alphanumeric")
     }
   }
 

--- a/test/junit/scala/util/RandomUtilTest.scala
+++ b/test/junit/scala/util/RandomUtilTest.scala
@@ -1,18 +1,18 @@
 package scala.util
 
-import org.junit.{Assert, Test}
+import org.junit.jupiter.api.{Assertions, Test}
 import scala.tools.testkit.AssertUtil.assertThrows
 
 class RandomUtilTest {
   @Test def testBetween(): Unit = {
     val rand = new Random()
-    Assert.assertTrue("Random between Int must be inclusive-exclusive", rand.between(0, 1).equals(0))
-    Assert.assertTrue("Random between Long must be inclusive-exclusive", rand.between(0L, 1L).equals(0L))
-    Assert.assertTrue("Random nextLong must be inclusive-exclusive", rand.nextLong(1L).equals(0L))
+    Assertions.assertTrue(rand.between(0, 1).equals(0), "Random between Int must be inclusive-exclusive")
+    Assertions.assertTrue(rand.between(0L, 1L).equals(0L), "Random between Long must be inclusive-exclusive")
+    Assertions.assertTrue(rand.nextLong(1L).equals(0L), "Random nextLong must be inclusive-exclusive")
     val float: Float = rand.between(0.0f, 1.0f)
-    Assert.assertTrue("Float Random should be inclusive-exclusive", 0.0f <= float && float < 1.0f)
+    Assertions.assertTrue(0.0f <= float && float < 1.0f, "Float Random should be inclusive-exclusive")
     val double: Double = rand.between(0.0f.toDouble, 1.0f.toDouble)
-    Assert.assertTrue("Random between Double should be inclusive-exclusive", 0.0f.toDouble <= double && double < 1.0f.toDouble)
+    Assertions.assertTrue(0.0f.toDouble <= double && double < 1.0f.toDouble, "Random between Double should be inclusive-exclusive")
   }
 
   @Test def testBetweenIntException(): Unit = assertThrows[IllegalArgumentException] {

--- a/test/junit/scala/util/SortingTest.scala
+++ b/test/junit/scala/util/SortingTest.scala
@@ -1,7 +1,7 @@
 package scala.util
 
-import org.junit.Test
-import org.junit.Assert._
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions._
 import scala.math.{Ordered, Ordering}
 
 class SortingTest {
@@ -35,16 +35,16 @@ class SortingTest {
     val rxs = { val temp = xs.clone; Sorting.stableSort(temp)(backwardsN); temp }
     val sys = Sorting.stableSort(ys.clone.toIndexedSeq, (i: Int) => xs(i))
     
-    assertTrue("Quicksort should be in order", isSorted(qxs))
-    assertTrue("Quicksort should be in reverse order", isAntisorted(pxs))
-    assertTrue("Stable sort should be sorted and stable", isStable(sxs))
-    assertTrue("Stable sort should be reverse sorted but stable", isAntistable(rxs))
-    assertTrue("Stable sorting by proxy should produce sorted stable list", isStable(sys.map(i => xs(i))))
-    assertTrue("Quicksort should produce canonical ordering", (qxs zip zs).forall{ case (a,b) => a.i == b.i })
-    assertTrue("Reverse quicksort should produce canonical ordering", (pxs.reverse zip zs).forall{ case (a,b) => a.i == b.i })
-    assertTrue("Stable sort should produce exact ordering", (sxs zip zs).forall{ case (a,b) => a == b })
-    assertTrue("Reverse stable sort should produce canonical ordering", (rxs.reverse zip zs).forall{ case (a,b) => a.i == b.i })
-    assertTrue("Proxy sort and direct sort should produce exactly the same thing", (sxs zip sys.map(i => xs(i))).forall{ case (a,b) => a == b })
+    assertTrue(isSorted(qxs), "Quicksort should be in order")
+    assertTrue(isAntisorted(pxs), "Quicksort should be in reverse order")
+    assertTrue(isStable(sxs), "Stable sort should be sorted and stable")
+    assertTrue(isAntistable(rxs), "Stable sort should be reverse sorted but stable")
+    assertTrue(isStable(sys.map(i => xs(i))), "Stable sorting by proxy should produce sorted stable list")
+    assertTrue((qxs zip zs).forall{ case (a,b) => a.i == b.i }, "Quicksort should produce canonical ordering")
+    assertTrue((pxs.reverse zip zs).forall{ case (a,b) => a.i == b.i }, "Reverse quicksort should produce canonical ordering")
+    assertTrue((sxs zip zs).forall{ case (a,b) => a == b }, "Stable sort should produce exact ordering")
+    assertTrue((rxs.reverse zip zs).forall{ case (a,b) => a.i == b.i }, "Reverse stable sort should produce canonical ordering")
+    assertTrue((sxs zip sys.map(i => xs(i))).forall{ case (a,b) => a == b }, "Proxy sort and direct sort should produce exactly the same thing")
   }
   
   @Test def testSortConsistency(): Unit = {
@@ -58,11 +58,11 @@ class SortingTest {
       val b = Array.fill(size)(rng.nextBoolean())
       val bfwd = Sorting.stableSort(b.clone.toIndexedSeq)
       val bbkw = Sorting.stableSort(b.clone.toIndexedSeq, (x: Boolean, y: Boolean) => x && !y)
-      assertTrue("All falses should be first", bfwd.dropWhile(_ == false).forall(_ == true))
-      assertTrue("All falses should be last when sorted backwards", bbkw.dropWhile(_ == true).forall(_ == false))
-      assertTrue("Sorting booleans should preserve the number of trues", b.count(_ == true) == bfwd.count(_ == true))
-      assertTrue("Backwards sorting booleans should preserve the number of trues", b.count(_ == true) == bbkw.count(_ == true))
-      assertTrue("Sorting should not change the sizes of arrays", b.length == bfwd.length && b.length == bbkw.length)
+      assertTrue(bfwd.dropWhile(_ == false).forall(_ == true), "All falses should be first")
+      assertTrue(bbkw.dropWhile(_ == true).forall(_ == false), "All falses should be last when sorted backwards")
+      assertTrue(b.count(_ == true) == bfwd.count(_ == true), "Sorting booleans should preserve the number of trues")
+      assertTrue(b.count(_ == true) == bbkw.count(_ == true), "Backwards sorting booleans should preserve the number of trues")
+      assertTrue(b.length == bfwd.length && b.length == bbkw.length, "Sorting should not change the sizes of arrays")
     }
   }
 }

--- a/test/junit/scala/util/SpecVersionTest.scala
+++ b/test/junit/scala/util/SpecVersionTest.scala
@@ -1,9 +1,7 @@
 package scala.util
 
-import org.junit.Assert.{ assertThrows => _, _ }
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.{ assertThrows => _, _ }
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.AssertUtil._
 
@@ -11,7 +9,6 @@ import scala.tools.testkit.AssertUtil._
  *  and must work for legacy "major.minor" and plain version_number,
  *  and fail otherwise.
  */
-@RunWith(classOf[JUnit4])
 class SpecVersionTest {
   class TestProperties(versionAt: String) extends PropertiesTrait {
     override def javaSpecVersion = versionAt

--- a/test/junit/scala/util/SystemPropertiesTest.scala
+++ b/test/junit/scala/util/SystemPropertiesTest.scala
@@ -1,27 +1,24 @@
 package scala.util
 
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Test
-import org.junit.Assert._
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions._
 
-@RunWith(classOf[JUnit4])
 class SystemPropertiesTest {
   @Test
   def filterAll(): Unit = {
     val isEmpty = sys.props.filter(_ => false).size == 0
-    assertTrue("A filter matching nothing should produce an empty result", isEmpty)
+    assertTrue(isEmpty, "A filter matching nothing should produce an empty result")
   }
 
   @Test
   def filterNone(): Unit = {
     val isUnchanged = sys.props.filter(_ => true) == sys.props
-    assertTrue("A filter matching everything should not change the result", isUnchanged)
+    assertTrue(isUnchanged, "A filter matching everything should not change the result")
   }
 
   @Test
   def empty(): Unit = {
     val hasSize0 = sys.props.empty.size == 0
-    assertTrue("SystemProperties.empty should have size of 0", hasSize0)
+    assertTrue(hasSize0, "SystemProperties.empty should have size of 0")
   }
 }

--- a/test/junit/scala/util/TryTest.scala
+++ b/test/junit/scala/util/TryTest.scala
@@ -1,7 +1,7 @@
 package scala.util
 
-import org.junit.Test
-import org.junit.Assert._
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions._
 
 import scala.annotation.unused
 import scala.tools.testkit.AssertUtil.assertThrows

--- a/test/junit/scala/util/UsingTest.scala
+++ b/test/junit/scala/util/UsingTest.scala
@@ -1,7 +1,7 @@
 package scala.util
 
-import org.junit.Test
-import org.junit.Assert._
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions._
 
 import scala.annotation.unused
 import scala.reflect.ClassTag
@@ -786,7 +786,7 @@ object UsingTest {
   case object IgnoresSuppressed extends SuppressionBehavior
 
   def assertThrowableClass[T <: Throwable: ClassTag](t: Throwable): Unit = {
-    assertEquals(s"Caught [${t.getMessage}]", implicitly[ClassTag[T]].runtimeClass, t.getClass)
+    assertEquals(implicitly[ClassTag[T]].runtimeClass, t.getClass, s"Caught [${t.getMessage}]")
   }
 
   def assertSingleSuppressed[T <: Throwable: ClassTag](t: Throwable): Unit = {

--- a/test/junit/scala/util/control/ControlThrowableTest.scala
+++ b/test/junit/scala/util/control/ControlThrowableTest.scala
@@ -12,13 +12,11 @@
 
 package scala.util.control
 
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Test
-import org.junit.Assert._
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
 import scala.tools.testkit.AssertUtil.assertThrown
 
-@RunWith(classOf[JUnit4])
 @deprecated("Test me, don't judge me", since = "forever")
 class ControlThrowableTest {
 

--- a/test/junit/scala/util/control/ExceptionTest.scala
+++ b/test/junit/scala/util/control/ExceptionTest.scala
@@ -12,16 +12,12 @@
 
 package scala.util
 
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
-import org.junit.Test
-import org.junit.Assert._
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 import scala.collection.mutable.ListBuffer
-
 import scala.util.control.Exception._
 
-@RunWith(classOf[JUnit4])
 class ExceptionTest {
 
   @Test

--- a/test/junit/scala/util/hashing/MurmurHash3Test.scala
+++ b/test/junit/scala/util/hashing/MurmurHash3Test.scala
@@ -1,8 +1,8 @@
 package scala.util.hashing
 
 import scala.collection.immutable.ArraySeq
-import org.junit.Assert._
-import org.junit.Test
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
 
 class MurmurHash3Test {
 

--- a/test/junit/scala/util/matching/CharRegexTest.scala
+++ b/test/junit/scala/util/matching/CharRegexTest.scala
@@ -1,7 +1,8 @@
 
 package scala.util.matching
 
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
 
 import PartialFunction._
 
@@ -43,12 +44,12 @@ class CharRegexTest {
     cond(d) { case rnc() => true } .no()
   }
 
-  @Test(expected = classOf[MatchError])
+  @Test
   def failCorrectly(): Unit = {
     val headAndTail = """(\p{Lower})([a-z]+)""".r
-    val n = "cat"(0) match {
+    assertThrows(classOf[MatchError], () => "cat"(0) match {
       case headAndTail(ht @ _*) => ht.size
-    }
-    assert(false, s"Match size $n")
+    })
+
   }
 }

--- a/test/junit/scala/util/matching/RegexTest.scala
+++ b/test/junit/scala/util/matching/RegexTest.scala
@@ -1,13 +1,10 @@
 package scala.util.matching
 
-import org.junit.Assert.{ assertThrows => _, _ }
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.{assertThrows => _, _}
+import org.junit.jupiter.api.Test
 
 import scala.tools.testkit.AssertUtil._
 
-@RunWith(classOf[JUnit4])
 class RegexTest {
   @Test def t8022CharSequence(): Unit = {
     val full = """.*: (.)$""".r


### PR DESCRIPTION
Development of junit4 has been slow while junit5 are becoming mature and easy to use.

replace junit4 in other modules will be done in some following up PRs.