### PR TITLE
Deprecate ad hoc group names with Regex and .r

### DIFF
--- a/src/library/scala/collection/StringOps.scala
+++ b/src/library/scala/collection/StringOps.scala
@@ -158,13 +158,13 @@ object StringOps {
 }
 
 /** Provides extension methods for strings.
-  * 
+  *
   * Some of these methods treat strings as a plain collection of [[Char]]s
   * without any regard for Unicode handling. Unless the user takes Unicode
   * handling in to account or makes sure the strings don't require such handling,
   * these methods may result in unpaired or invalidly paired surrogate code
   * units.
-  * 
+  *
   * @define unicodeunaware This method treats a string as a plain sequence of
   *                        Char code units and makes no attempt to keep
   *                        surrogate pairs or codepoint sequences together.
@@ -848,9 +848,13 @@ final class StringOps(private val s: String) extends AnyVal {
 
   /** You can follow a string with `.r`, turning it into a `Regex`. E.g.
     *
-    *  `"""A\w*""".r`   is the regular expression for identifiers starting with `A`.
+    *  `"""A\w*""".r`   is the regular expression for ASCII-only identifiers starting with `A`.
+    *
+    *  `"""(?<month>\d\d)-(?<day>\d\d)-(?<year>\d\d\d\d)""".r` matches dates
+    *  and provides its subcomponents through groups named "month", "day" and
+    *  "year".
     */
-  def r: Regex = r()
+  def r: Regex = new Regex(s)
 
   /** You can follow a string with `.r(g1, ... , gn)`, turning it into a `Regex`,
     *  with group names g1 through gn.
@@ -861,6 +865,7 @@ final class StringOps(private val s: String) extends AnyVal {
     *
     *  @param groupNames The names of the groups in the pattern, in the order they appear.
     */
+  @deprecated("use inline group names like (?<year>X) instead", "2.13.7")
   def r(groupNames: String*): Regex = new Regex(s, groupNames: _*)
 
   /**
@@ -1430,7 +1435,7 @@ final class StringOps(private val s: String) extends AnyVal {
     *
     *  @param f    the 'split function' mapping the elements of this string to an [[scala.util.Either]]
     *
-    *  @return     a pair of strings: the first one made of those characters returned by `f` that were wrapped in [[scala.util.Left]], 
+    *  @return     a pair of strings: the first one made of those characters returned by `f` that were wrapped in [[scala.util.Left]],
     *              and the second one made of those wrapped in [[scala.util.Right]].
     */
   def partitionMap(f: Char => Either[Char,Char]): (String, String) = {

--- a/test/files/run/t5045.scala
+++ b/test/files/run/t5045.scala
@@ -4,8 +4,8 @@ object Test extends App {
  import scala.util.matching.{ Regex, UnanchoredRegex }
 
  val dateP1 = """(\d\d\d\d)-(\d\d)-(\d\d)""".r.unanchored
- val dateP2 = """(\d\d\d\d)-(\d\d)-(\d\d)""".r("year", "month", "day").unanchored
- val dateP3 =  new Regex("""(\d\d\d\d)-(\d\d)-(\d\d)""", "year", "month", "day") with UnanchoredRegex
+ val dateP2 = """(?<year>\d\d\d\d)-(?<month>\d\d)-(?<day>\d\d)""".r.unanchored
+ val dateP3 =  new Regex("""(?<year>\d\d\d\d)-(?<month>\d\d)-(?<day>\d\d)""") with UnanchoredRegex
 
  val yearStr = "2011"
  val dateStr = List(yearStr,"07","15").mkString("-")

--- a/test/scalacheck/t2460.scala
+++ b/test/scalacheck/t2460.scala
@@ -8,15 +8,15 @@ object SI2460Test extends Properties("Regex : Ticket 2460") {
   val vowel = Gen.oneOf("a", "z")
 
   val numberOfMatch = forAll(vowel) {
-    (s: String) => "\\s*([a-z])\\s*".r("data").findAllMatchIn((1 to 20).map(_ => s).mkString).size == 20
+    (s: String) => "\\s*([a-z])\\s*".r.findAllMatchIn((1 to 20).map(_ => s).mkString).size == 20
   }
 
   val numberOfGroup = forAll(vowel) {
-    (s: String) => "\\s*([a-z])\\s*([a-z])\\s*".r("data").findAllMatchIn((1 to 20).map(_ => s).mkString).next().groupCount == 2
+    (s: String) => "\\s*([a-z])\\s*([a-z])\\s*".r.findAllMatchIn((1 to 20).map(_ => s).mkString).next().groupCount == 2
   }
 
   val nameOfGroup = forAll(vowel) {
-    (s: String) => "([a-z])".r("data").findAllMatchIn(s).next().group("data") == s
+    (s: String) => "(?<data>[a-z])".r.findAllMatchIn(s).next().group("data") == s
   }
 
   val tests = List(


### PR DESCRIPTION
The deprecation was first proposed in https://github.com/scala/scala/pull/4990 but had been rejected because Scala.js did not support inline group names. Now that Scala.js 1.7.0 has been released with full inline group name support, there is no reason to perpetuate this API.

Unfortunately, we cannot actually put `@deprecated` on the constructor of Regex with group names, since there is no alternative that does not take any group name. We *could* deprecate it anyway, with the replacement being to use `.r`, but perhaps that goes a bit too far.