### PR TITLE
Optimise ArraySeq#map

### DIFF
--- a/src/library/scala/collection/immutable/ArraySeq.scala
+++ b/src/library/scala/collection/immutable/ArraySeq.scala
@@ -72,7 +72,7 @@ sealed abstract class ArraySeq[+A]
     val a = new Array[Any](size)
     var i = 0
     while (i < a.length){
-      a(i) = f(apply(i)).asInstanceOf[Any]
+      a(i) = f(apply(i))
       i += 1
     }
     ArraySeq.unsafeWrapArray(a).asInstanceOf[ArraySeq[B]]

--- a/src/library/scala/collection/immutable/ArraySeq.scala
+++ b/src/library/scala/collection/immutable/ArraySeq.scala
@@ -68,7 +68,15 @@ sealed abstract class ArraySeq[+A]
     ArraySeq.unsafeWrapArray(dest).asInstanceOf[ArraySeq[B]]
   }
 
-  override def map[B](f: A => B): ArraySeq[B] = iterableFactory.tabulate(length)(i => f(apply(i)))
+  override def map[B](f: A => B): ArraySeq[B] = {
+    val a = new Array[Any](size)
+    var i = 0
+    while (i < a.length){
+      a(i) = f(apply(i)).asInstanceOf[Any]
+      i += 1
+    }
+    ArraySeq.unsafeWrapArray(a).asInstanceOf[ArraySeq[B]]
+  }
 
   override def prepended[B >: A](elem: B): ArraySeq[B] =
     ArraySeq.unsafeWrapArray(unsafeArray.prepended[Any](elem)).asInstanceOf[ArraySeq[B]]

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/ArraySeqBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/ArraySeqBenchmark.scala
@@ -19,13 +19,14 @@ class ArraySeqBenchmark {
   var size: Int = _
   var integersS: ArraySeq[Int] = _
   var stringsS: ArraySeq[String] = _
-  val newS = Array("a", "b", "c", "d", "e", "f")
+  var newS: Array[String] = _
 
   @Setup(Level.Trial) def initNumbers: Unit = {
     val integers = (1 to size).toList
     val strings = integers.map(_.toString)
     integersS = ArraySeq.unsafeWrapArray(integers.toArray)
     stringsS = ArraySeq.unsafeWrapArray(strings.toArray)
+    newS = Array("a", "b", "c", "d", "e", "f")
   }
 
   @Benchmark def sortedStringOld(bh: Blackhole): Unit =


### PR DESCRIPTION
This PR benchmarks and improves performance of `ArraySeq#map`

```
[info] Benchmark                  (size)  Mode  Cnt      Score     Error  Units
[info] ArraySeqBenchmark.mapINew       0  avgt   20      4.833 ±   0.112  ns/op
[info] ArraySeqBenchmark.mapINew       1  avgt   20      7.347 ±   0.016  ns/op
[info] ArraySeqBenchmark.mapINew      10  avgt   20     23.167 ±   0.028  ns/op
[info] ArraySeqBenchmark.mapINew    1000  avgt   20   2253.694 ±  76.725  ns/op
[info] ArraySeqBenchmark.mapINew   10000  avgt   20  23247.539 ± 959.033  ns/op
[info] ArraySeqBenchmark.mapIOld       0  avgt   20      5.019 ±   0.508  ns/op
[info] ArraySeqBenchmark.mapIOld       1  avgt   20      8.304 ±   0.012  ns/op
[info] ArraySeqBenchmark.mapIOld      10  avgt   20     44.157 ±   0.039  ns/op
[info] ArraySeqBenchmark.mapIOld    1000  avgt   20   4523.918 ±   8.228  ns/op
[info] ArraySeqBenchmark.mapIOld   10000  avgt   20  48798.297 ± 100.838  ns/op
[info] ArraySeqBenchmark.mapSNew       0  avgt   20      4.784 ±   0.041  ns/op
[info] ArraySeqBenchmark.mapSNew       1  avgt   20      6.977 ±   0.019  ns/op
[info] ArraySeqBenchmark.mapSNew      10  avgt   20     24.696 ±   0.116  ns/op
[info] ArraySeqBenchmark.mapSNew    1000  avgt   20   2294.861 ±  23.570  ns/op
[info] ArraySeqBenchmark.mapSNew   10000  avgt   20  24845.037 ± 193.871  ns/op
[info] ArraySeqBenchmark.mapSOld       0  avgt   20      5.671 ±   0.141  ns/op
[info] ArraySeqBenchmark.mapSOld       1  avgt   20     10.432 ±   0.025  ns/op
[info] ArraySeqBenchmark.mapSOld      10  avgt   20     43.634 ±   0.131  ns/op
[info] ArraySeqBenchmark.mapSOld    1000  avgt   20   4641.602 ±   6.770  ns/op
[info] ArraySeqBenchmark.mapSOld   10000  avgt   20  52043.670 ± 167.759  ns/op
```