### PR TITLE
 Allow `import x.{*, given}` under `-Xsource:3`

### DIFF
--- a/test/files/pos/import-future.scala
+++ b/test/files/pos/import-future.scala
@@ -26,7 +26,7 @@ class C {
 
 object starring {
 
-  import scala.concurrent.*, duration.{Duration as D, *}, ExecutionContext.Implicits.*
+  import scala.concurrent.{*, given}, duration.{given, Duration as D, *}, ExecutionContext.Implicits.*
 
   val f = Future(42)
   val r = Await.result(f, D.Inf)


### PR DESCRIPTION
Note: This PR sits on top of https://github.com/scala/scala/pull/9722 but could be made independent if needed.

<hr>

Imagine a Scala 3 library containing:
```
object A {
  val a: Int = 1
  given b: Int = 2
}
```
To import all members of `A` from Scala 2, we write `import A.*`,
but to do the same from Scala 3, we need to write `import A.{*, given}`
instead. This complicates cross-compilation for projects which depend on
Scala 3 libraries (unless these libraries exclusively use `implicit`
which is not something we want to encourage).

This commit remedies this by allowing `import x.{*, given}` (and `import
x.{given, *}`), this is easy to do since we can just pretend the user
wrote `import x.*` which will give us both regular and given members in
Scala 2 code and therefore match the semantics of Scala 3.