### PR TITLE
Fix `isStaticAnnotation` for un-initialized Java annotations

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -124,7 +124,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def isJavaEnum: Boolean = hasJavaEnumFlag
     def isJavaAnnotation: Boolean = hasJavaAnnotationFlag
     def isStaticAnnotation: Boolean =
-      hasJavaAnnotationFlag || isNonBottomSubClass(StaticAnnotationClass) && this != NowarnClass
+      initialize.hasJavaAnnotationFlag || isNonBottomSubClass(StaticAnnotationClass) && this != NowarnClass
 
     def newNestedSymbol(name: Name, pos: Position, newFlags: Long, isClass: Boolean): Symbol = name match {
       case n: TermName => newTermSymbol(n, pos, newFlags)


### PR DESCRIPTION
Java annotations are identified by flag since 2.13.0
(https://github.com/scala/scala/pull/6869).

If the annotation's `typeSymbol` still has a lazy `ClassfileLoader`
info, the flags are not there yet.

This leads to spurious API changes and recompilations in zinc
(sbt/zinc#998).