### PR TITLE
Do not compute size in TrieMap#isEmpty

### DIFF
--- a/src/library/scala/collection/concurrent/MainNode.java
+++ b/src/library/scala/collection/concurrent/MainNode.java
@@ -24,6 +24,9 @@ abstract class MainNode<K, V> extends BasicNode {
 
     public abstract int cachedSize(Object ct);
 
+    // standard contract
+    public abstract int knownSize();
+
     public boolean CAS_PREV(MainNode<K, V> oldval, MainNode<K, V> nval) {
         return updater.compareAndSet(this, oldval, nval);
     }

--- a/test/junit/scala/collection/concurrent/TrieMapTest.scala
+++ b/test/junit/scala/collection/concurrent/TrieMapTest.scala
@@ -5,6 +5,7 @@ import org.junit.Assert.assertEquals
 
 import scala.util.hashing.Hashing
 import scala.tools.testkit.AssertUtil.assertThrows
+import scala.util.chaining._
 
 @deprecated("Tests deprecated API", since="2.13")
 class TrieMapTest {
@@ -658,5 +659,40 @@ class TrieMapTest {
     val hashMap4 = TrieMap(1 -> "a")
     assertEquals(hashMap4.updateWith(2)(noneAnytime), None)
     assertEquals(hashMap4, TrieMap(1 -> "a"))
+  }
+
+  @Test
+  def knownSizeConsistency(): Unit = {
+    def check(tm: TrieMap[_, _]): Unit = {
+      def msg = s"for ${tm.toString()}"
+      val snapshot = tm.readOnlySnapshot()
+      val initialKS = snapshot.knownSize
+      val size = snapshot.size
+      assert(initialKS == -1 || initialKS == size, msg)
+      val laterKS = snapshot.knownSize
+      assert(laterKS == -1 || laterKS == size, msg)
+      assert(laterKS >= initialKS, msg) // assert we haven't forgotten the size
+    }
+
+    check(TrieMap.empty)
+    check(TrieMap())
+    check(TrieMap("k" -> "v"))
+    check(TrieMap.empty[String, String].tap(_("k") = "v"))
+    check(TrieMap.empty[String, String].tap(_.put("k", "v")))
+    check(TrieMap.from((1 to 5).map(x => x -> x)))
+    check(TrieMap.from((1 to 10).map(x => x -> x)))
+    check(TrieMap.from((1 to 100).map(x => x -> x)))
+  }
+
+  @Test
+  def isEmptyCorrectness(): Unit = {
+    assert(TrieMap.empty.isEmpty)
+    assert(TrieMap().isEmpty)
+    assert(!TrieMap("k" -> "v").isEmpty)
+    assert(!TrieMap.empty[String, String].tap(_("k") = "v").isEmpty)
+    assert(!TrieMap.empty[String, String].tap(_.put("k", "v")).isEmpty)
+    assert(!TrieMap.from((1 to 5).map(x => x -> x)).isEmpty)
+    assert(!TrieMap.from((1 to 10).map(x => x -> x)).isEmpty)
+    assert(!TrieMap.from((1 to 100).map(x => x -> x)).isEmpty)
   }
 }


### PR DESCRIPTION
Do not compute size in `TrieMap#isEmpty`.

Override `TrieMap#knownSize`.

Fixes scala/bug#12445