### PR TITLE
fix scala/bug#12409: tasty - fix case class apply default params

### DIFF
--- a/test/tasty/run/src-2/tastytest/TestCaseClassDefault.scala
+++ b/test/tasty/run/src-2/tastytest/TestCaseClassDefault.scala
@@ -1,0 +1,14 @@
+package tastytest
+
+object TestCaseClassDefault extends Suite("TestCaseClassDefault") {
+
+  test(assert(CaseClassDefault.apply().value === 23))
+
+  test {
+    val i = new CaseClassDefault.Inner()
+    assert(i.Local.apply().value === 47)
+  }
+
+  test(assert(CaseClassDefault.FakeCaseClass.apply().value === 97))
+
+}

--- a/test/tasty/run/src-3/tastytest/CaseClassDefault.scala
+++ b/test/tasty/run/src-3/tastytest/CaseClassDefault.scala
@@ -1,0 +1,16 @@
+package tastytest
+
+case class CaseClassDefault(value: Int = 23)
+
+object CaseClassDefault {
+
+  class Inner {
+    case class Local(value: Int = 47)
+  }
+
+  class FakeCaseClass(val value: Int = 47)
+  object FakeCaseClass {
+    def apply(value: Int = 97): FakeCaseClass = new FakeCaseClass(value)
+  }
+
+}


### PR DESCRIPTION
Here we special case insertion of default parameters for a synthetic `apply` method from scala 3, in this case, the constructor's default parameters should be used instead.

fixes scala/bug#12409