### PR TITLE
Avoid widening type variables when typing implicits

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -698,8 +698,8 @@ trait Implicits extends splain.SplainData {
               } else {
                 // we can't usefully prune views any further because we would need to type an application
                 // of the view to the term as is done in the computation of itree2 in typedImplicit1.
-                tvars.foreach(_.constr.stopWideningIfPrecluded())
                 val targs = solvedTypes(tvars, allUndetparams, varianceInType(wildPt), upper = false, lubDepth(tpInstantiated :: wildPt :: Nil))
+                tvars.foreach(_.constr.stopWideningIfPrecluded())
                 val adjusted = adjustTypeArgs(allUndetparams, tvars, targs)
                 val tpSubst = deriveTypeWithWildcards(adjusted.undetParams)(tp.instantiateTypeParams(adjusted.okParams, adjusted.okArgs))
                 if(!matchesPt(tpSubst, wildPt, adjusted.undetParams)) {

--- a/test/files/pos/t12447.scala
+++ b/test/files/pos/t12447.scala
@@ -1,0 +1,9 @@
+object Test {
+  class Outer {
+    type Member
+    def self: Outer { type Member = Outer.this.Member } = this
+  }
+
+  val outer = new Outer
+  implicitly[outer.type <:< (Outer { type Member = outer.Member })]
+}


### PR DESCRIPTION
We are not free to widen the type variables of implicits because
their constraints come from the expected type and a widening can
result in a type mismatch as shown by the included test.

Fixes scala/bug#12447