### PR TITLE
Require backticks when defining a type called `?`

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -709,7 +709,7 @@ self =>
     def checkQMarkUsage() =
       if (!settings.isScala3 && isRawIdent && in.name == raw.QMARK)
         deprecationWarning(in.offset,
-          "`?` in a type will be interpreted as a wildcard in the future, wrap it in backticks to keep the current meaning.", "2.13.6")
+          "Wrap `?` in backticks to continue to use it as an identifier, or use `-Xsource:3` to use it as a wildcard like in Scala 3.", "2.13.6")
     def checkQMarkDefinition() =
       if (isRawIdent && in.name == raw.QMARK)
         syntaxError(in.offset, "using `?` as a type name requires backticks.")

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -712,8 +712,7 @@ self =>
           "`?` in a type will be interpreted as a wildcard in the future, wrap it in backticks to keep the current meaning.", "2.13.6")
     def checkQMarkDefinition() =
       if (isRawIdent && in.name == raw.QMARK)
-        deprecationWarning(in.offset,
-          "using `?` as a type name will require backticks in the future.", "2.13.6")
+        syntaxError(in.offset, "using `?` as a type name requires backticks.")
     def checkKeywordDefinition() =
       if (isRawIdent && scala3Keywords.contains(in.name))
         deprecationWarning(in.offset,

--- a/test/files/neg/qmark-deprecated.check
+++ b/test/files/neg/qmark-deprecated.check
@@ -22,19 +22,19 @@ qmark-deprecated.scala:35: error: using `?` as a type name requires backticks.
 qmark-deprecated.scala:38: error: using `?` as a type name requires backticks.
   type A[?] = Int // error
          ^
-qmark-deprecated.scala:6: warning: `?` in a type will be interpreted as a wildcard in the future, wrap it in backticks to keep the current meaning.
+qmark-deprecated.scala:6: warning: Wrap `?` in backticks to continue to use it as an identifier, or use `-Xsource:3` to use it as a wildcard like in Scala 3.
 class Bar[M[?] <: List[?]] // errors
                        ^
-qmark-deprecated.scala:27: warning: `?` in a type will be interpreted as a wildcard in the future, wrap it in backticks to keep the current meaning.
+qmark-deprecated.scala:27: warning: Wrap `?` in backticks to continue to use it as an identifier, or use `-Xsource:3` to use it as a wildcard like in Scala 3.
   val x: Array[?] = new Array[?](0) // errors
                ^
-qmark-deprecated.scala:27: warning: `?` in a type will be interpreted as a wildcard in the future, wrap it in backticks to keep the current meaning.
+qmark-deprecated.scala:27: warning: Wrap `?` in backticks to continue to use it as an identifier, or use `-Xsource:3` to use it as a wildcard like in Scala 3.
   val x: Array[?] = new Array[?](0) // errors
                               ^
-qmark-deprecated.scala:30: warning: `?` in a type will be interpreted as a wildcard in the future, wrap it in backticks to keep the current meaning.
+qmark-deprecated.scala:30: warning: Wrap `?` in backticks to continue to use it as an identifier, or use `-Xsource:3` to use it as a wildcard like in Scala 3.
   def foo1[T <: Array[?]](x: T): Array[?] = x // errors
                       ^
-qmark-deprecated.scala:30: warning: `?` in a type will be interpreted as a wildcard in the future, wrap it in backticks to keep the current meaning.
+qmark-deprecated.scala:30: warning: Wrap `?` in backticks to continue to use it as an identifier, or use `-Xsource:3` to use it as a wildcard like in Scala 3.
   def foo1[T <: Array[?]](x: T): Array[?] = x // errors
                                        ^
 5 warnings

--- a/test/files/neg/qmark-deprecated.check
+++ b/test/files/neg/qmark-deprecated.check
@@ -1,21 +1,30 @@
-qmark-deprecated.scala:4: warning: using `?` as a type name will require backticks in the future.
+qmark-deprecated.scala:4: error: using `?` as a type name requires backticks.
 class Foo[?] // error
           ^
-qmark-deprecated.scala:6: warning: using `?` as a type name will require backticks in the future.
+qmark-deprecated.scala:6: error: using `?` as a type name requires backticks.
 class Bar[M[?] <: List[?]] // errors
             ^
+qmark-deprecated.scala:10: error: using `?` as a type name requires backticks.
+  class ? { val x = 1 } // error
+        ^
+qmark-deprecated.scala:16: error: using `?` as a type name requires backticks.
+  trait ? // error
+        ^
+qmark-deprecated.scala:22: error: using `?` as a type name requires backticks.
+  type ? = Int // error
+       ^
+qmark-deprecated.scala:33: error: using `?` as a type name requires backticks.
+  def bar1[?] = {} // error
+           ^
+qmark-deprecated.scala:35: error: using `?` as a type name requires backticks.
+  def bar3[M[?]] = {} // error
+             ^
+qmark-deprecated.scala:38: error: using `?` as a type name requires backticks.
+  type A[?] = Int // error
+         ^
 qmark-deprecated.scala:6: warning: `?` in a type will be interpreted as a wildcard in the future, wrap it in backticks to keep the current meaning.
 class Bar[M[?] <: List[?]] // errors
                        ^
-qmark-deprecated.scala:10: warning: using `?` as a type name will require backticks in the future.
-  class ? { val x = 1 } // error
-        ^
-qmark-deprecated.scala:16: warning: using `?` as a type name will require backticks in the future.
-  trait ? // error
-        ^
-qmark-deprecated.scala:22: warning: using `?` as a type name will require backticks in the future.
-  type ? = Int // error
-       ^
 qmark-deprecated.scala:27: warning: `?` in a type will be interpreted as a wildcard in the future, wrap it in backticks to keep the current meaning.
   val x: Array[?] = new Array[?](0) // errors
                ^
@@ -28,15 +37,5 @@ qmark-deprecated.scala:30: warning: `?` in a type will be interpreted as a wildc
 qmark-deprecated.scala:30: warning: `?` in a type will be interpreted as a wildcard in the future, wrap it in backticks to keep the current meaning.
   def foo1[T <: Array[?]](x: T): Array[?] = x // errors
                                        ^
-qmark-deprecated.scala:33: warning: using `?` as a type name will require backticks in the future.
-  def bar1[?] = {} // error
-           ^
-qmark-deprecated.scala:35: warning: using `?` as a type name will require backticks in the future.
-  def bar3[M[?]] = {} // error
-             ^
-qmark-deprecated.scala:38: warning: using `?` as a type name will require backticks in the future.
-  type A[?] = Int // error
-         ^
-error: No warnings can be incurred under -Werror.
-13 warnings
-1 error
+5 warnings
+8 errors

--- a/test/files/pos/wildcards-future.scala
+++ b/test/files/pos/wildcards-future.scala
@@ -9,8 +9,7 @@ object Test {
     case _ => x
   }
 
-  // Only allowed in Scala 3 under -source 3.0-migration
-  type ? = Int
+  type `?` = Int
 
   val xs2: List[`?`] = List(1)
   val xs3: List[Int] = xs2


### PR DESCRIPTION
Upgrade the deprecation warning from 2.13.6 into an error (but only at
definition site and not use site for now), the ultimate goal would be to
allow and encourage `?` as a wildcard in Scala 2 by default so we can
repurpose `_` in Scala 3 without causing too much disruption.