### PR TITLE
[backport] Allow `import x.{*, given}` under -Xsource:3

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2618,7 +2618,16 @@ self =>
      *  }}}
      */
     def importSelectors(): List[ImportSelector] = {
-      val selectors = inBracesOrNil(commaSeparated(importSelector()))
+      val selectors0 = inBracesOrNil(commaSeparated(importSelector()))
+
+      // Treat an import of `*, given` or `given, *` as if it was an import of `*`
+      // since the former in Scala 3 has the same semantics as the latter in Scala 2.
+      val selectors =
+        if (currentRun.isScala3 && selectors0.exists(_.name eq nme.WILDCARD))
+          selectors0.filterNot(sel => sel.name == nme.`given` && sel.rename == sel.name)
+        else
+          selectors0
+
       selectors.init foreach {
         case ImportSelector(nme.WILDCARD, pos, _, _)  => syntaxError(pos, "Wildcard import must be in last position")
         case _                                        => ()

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -640,6 +640,9 @@ trait StdNames {
     val infix: NameType           = "infix"
     val open: NameType            = "open"
 
+    // Scala 3 hard keywords
+    val `given`: NameType         = "given"
+
     // Compiler utilized names
 
     val AnnotatedType: NameType        = "AnnotatedType"

--- a/test/files/pos/import-future.scala
+++ b/test/files/pos/import-future.scala
@@ -23,3 +23,11 @@ class C {
   import mut.*
   val ab = ArrayBuffer(1)
 }
+
+object starring {
+
+  import scala.concurrent.{*, given}, duration.{given, Duration as D, *}, ExecutionContext.Implicits.*
+
+  val f = Future(42)
+  val r = Await.result(f, D.Inf)
+}


### PR DESCRIPTION
This backports https://github.com/scala/scala/pull/9724 to Scala 2.12.