### PR TITLE
For Android compatibility, make `Statics.releaseFence()` also catch `NoSuchMethodException` for `java.lang.invoke.VarHandle.releaseFence()` call

### DIFF
--- a/src/library/scala/runtime/Statics.java
+++ b/src/library/scala/runtime/Statics.java
@@ -159,7 +159,7 @@ public final class Statics {
           MethodHandles.Lookup lookup = MethodHandles.lookup();
           try {
               return lookup.findStatic(Class.forName("java.lang.invoke.VarHandle"), "releaseFence", MethodType.methodType(Void.TYPE));
-          } catch (ClassNotFoundException e) {
+          } catch (NoSuchMethodException | ClassNotFoundException e) {
               try {
                   Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
                   return lookup.findVirtual(unsafeClass, "storeFence", MethodType.methodType(void.class)).bindTo(findUnsafe(unsafeClass));
@@ -168,7 +168,7 @@ public final class Statics {
                   error.addSuppressed(e);
                   throw error;
               }
-          } catch (NoSuchMethodException | IllegalAccessException e) {
+          } catch (IllegalAccessException e) {
               throw new ExceptionInInitializerError(e);
           }
       }


### PR DESCRIPTION
Currently Statics.releaseFence() call catches ClassNotFoundException only for the java.lang.invoke.VarHandle.releaseFence() call. However, there are cases where java.lang.invoke.VarHandle exists but not releaseFence() such as Android, this commit tries to handle such cases more properly by catching NoSuchMethodException thus allowing such systems to fallback to sun.misc.Unsafe.storeFence()