### PR TITLE
[2.12] Upgrade scala-parser-combinators to latest 2.0.0

### DIFF
--- a/src/intellij/scala.ipr.SAMPLE
+++ b/src/intellij/scala.ipr.SAMPLE
@@ -400,7 +400,7 @@
         <root url="jar://$USER_HOME$/.ivy2/cache/com.typesafe/config/bundles/config-1.3.3.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/com.typesafe/ssl-config-core_2.12/jars/ssl-config-core_2.12-0.4.0.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-xml_2.12/bundles/scala-xml_2.12-1.2.0.jar!/" />
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-parser-combinators_2.12/jars/scala-parser-combinators_2.12-1.1.2.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-parser-combinators_2.12/jars/scala-parser-combinators_2.12-2.0.0.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/jline/jline/jars/jline-2.14.6.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/net.java.dev.jna/jna/jars/jna-4.5.0.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/net.java.dev.jna/jna-platform/jars/jna-platform-4.5.0.jar!/" />

--- a/versions.properties
+++ b/versions.properties
@@ -19,7 +19,7 @@ scala.binary.version=2.12
 #  - scala-asm: jar content included in scala-compiler
 #  - jline: shaded with JarJar and included in scala-compiler
 scala-xml.version.number=1.0.6
-scala-parser-combinators.version.number=1.0.7
+scala-parser-combinators.version.number=2.0.0
 scala-swing.version.number=2.0.3
 scala-asm.version=9.2.0-scala-1
 jline.version=2.14.6


### PR DESCRIPTION
Same story as in #9743: If a sbt-plugin bumps its scala-parser-combinators dependency to 2.0.0, and later you add that sbt-plugin to your `project/plugins.sbt` you will not be able to access the sbt console without adding `ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-parser-combinators" % VersionScheme.Always` to `project/plugins.sbt`.
An example would be sbt-native-packager: https://github.com/sbt/sbt-native-packager/blob/e72f2f45b8cab5881add1cd62743bfc69c2b9b4d/build.sbt#L43