### PR TITLE
Fix scala/bug#12449: keep ThisType prefix in more places

### DIFF
--- a/src/compiler/scala/tools/nsc/tasty/bridge/ContextOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/ContextOps.scala
@@ -64,9 +64,12 @@ trait ContextOps { self: TastyUniverse =>
   }
 
   final def location(owner: Symbol): String = {
-    if (!isSymbol(owner)) "<NoSymbol>"
-    else if (owner.isClass) s"${owner.kindString} ${owner.fullNameString}"
-    else s"${describeOwner(owner)} in ${location(owner.owner)}"
+    if (!isSymbol(owner))
+      "<NoSymbol>"
+    else if (owner.isClass || owner.isPackageClass || owner.isPackageObjectOrClass)
+      s"${owner.kindString} ${owner.fullNameString}"
+    else
+      s"${describeOwner(owner)} in ${location(owner.owner)}"
   }
 
   @inline final def typeError[T](msg: String): T = throw new u.TypeError(msg)

--- a/src/compiler/scala/tools/nsc/tasty/bridge/TreeOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/TreeOps.scala
@@ -57,10 +57,10 @@ trait TreeOps { self: TastyUniverse =>
       new TastyIdent(name).setType(tpe)
 
     @inline final def Select(qual: Tree, name: TastyName)(implicit ctx: Context): Tree =
-      selectImpl(qual, name)(implicit ctx => namedMemberOfPrefix(qual.tpe, name))
+      selectImpl(qual, name)(implicit ctx => lookupTypeFrom(qual.tpe)(qual.tpe, name))
 
     @inline final def Select(owner: Type)(qual: Tree, name: TastyName)(implicit ctx: Context): Tree =
-      selectImpl(qual, name)(implicit ctx => namedMemberOfTypeWithPrefix(qual.tpe, owner, name))
+      selectImpl(qual, name)(implicit ctx => lookupTypeFrom(owner)(qual.tpe, name))
 
     private def selectImpl(qual: Tree, name: TastyName)(lookup: Context => Type)(implicit ctx: Context): Tree = {
 

--- a/test/tasty/neg/src-2/TestThisTypes.check
+++ b/test/tasty/neg/src-2/TestThisTypes.check
@@ -1,0 +1,6 @@
+TestThisTypes_fail.scala:12: error: type mismatch;
+ found   : b.Base
+ required: a.Base
+    aBase = b.doTest.get // error
+                     ^
+1 error

--- a/test/tasty/neg/src-2/TestThisTypes_fail.scala
+++ b/test/tasty/neg/src-2/TestThisTypes_fail.scala
@@ -1,0 +1,15 @@
+package tastytest
+
+import ThisTypes._
+
+object TestThisTypes {
+
+  def test = {
+    val a = new Sub3()
+    val b = new Sub3()
+
+    var aBase = a.doTest.get
+    aBase = b.doTest.get // error
+  }
+
+}

--- a/test/tasty/neg/src-3/ThisTypes.scala
+++ b/test/tasty/neg/src-3/ThisTypes.scala
@@ -1,0 +1,15 @@
+package tastytest
+
+object ThisTypes {
+
+  abstract class Wrap3 {
+    class Base
+    final type Res = Option[Base]
+    def doTest: Res
+  }
+
+  class Sub3 extends Wrap3 {
+    def doTest: Res = Some(new Base())
+  }
+
+}

--- a/test/tasty/run/src-2/tastytest/TestAsyncSuite.scala
+++ b/test/tasty/run/src-2/tastytest/TestAsyncSuite.scala
@@ -1,0 +1,7 @@
+package tastytest
+
+object TestAsyncSuite extends Suite("TestAsyncSuite") {
+
+  class MySuite extends testsuite.AsyncSuite
+
+}

--- a/test/tasty/run/src-2/tastytest/TestThisTypes.scala
+++ b/test/tasty/run/src-2/tastytest/TestThisTypes.scala
@@ -1,0 +1,10 @@
+package tastytest
+
+import ThisTypes._
+
+object TestThisTypes extends Suite("TestThisTypes") {
+
+  test(assert(new Sub().doTest.get.x === 23))
+  test(assert(new Sub2().doTest.get.x === 23))
+
+}

--- a/test/tasty/run/src-3/tastytest/ThisTypes.scala
+++ b/test/tasty/run/src-3/tastytest/ThisTypes.scala
@@ -1,0 +1,33 @@
+package tastytest
+
+object ThisTypes {
+
+  abstract class Wrap[T] {
+    type Base[A] <: { // if not resolved to Sub.this.Base then reflective calls will be needed
+      def x: A
+    }
+    final type Res = Option[Base[T]]
+    def doTest: Res
+  }
+
+  class Sub extends Wrap[Int] {
+    class BaseImpl[A](a: A) {
+      def x: A = a
+    }
+    override type Base[A] = BaseImpl[A]
+    def doTest: Res = Some(new BaseImpl(23))
+  }
+
+  abstract class Wrap2[T] {
+    class Base[A](a: A) {
+      def x: A = a
+    }
+    final type Res = Option[Base[T]]
+    def doTest: Res
+  }
+
+  class Sub2 extends Wrap2[Int] {
+    def doTest: Res = Some(new Base(23))
+  }
+
+}

--- a/test/tasty/run/src-3/tastytest/testsuite/testsuites.scala
+++ b/test/tasty/run/src-3/tastytest/testsuite/testsuites.scala
@@ -1,0 +1,22 @@
+package tastytest.testsuite
+
+import scala.concurrent.Future
+
+class AsyncSuite extends TestSuite {
+  final type TestBody = Future[Any]
+
+  def testsuiteTests(): Seq[Test] = ???
+}
+
+abstract class TestSuite {
+
+  type TestBody
+  final type Test = TestImpl[TestBody]
+
+  def testsuiteTests(): Seq[Test]
+
+}
+
+class TestImpl[T]
+
+class MySuite extends AsyncSuite


### PR DESCRIPTION
Sometimes the prefix of a type member was being dropped, leading to the wrong type being resolved, leading to overriding problems when reading munit.

The check to preserve a `ThisType` prefix was too restrictive, and now a `ThisType` prefix would only be dropped for a type parameter reference

second commit adds refactoring

fixes scala/bug#12449