### PR TITLE
Allow concrete private interface methods in Java sources

### DIFF
--- a/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
@@ -613,7 +613,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
           val vparams = formalParams()
           if (!isVoid) rtpt = optArrayBrackets(rtpt)
           optThrows()
-          val isConcreteInterfaceMethod = !inInterface || (mods hasFlag Flags.JAVA_DEFAULTMETHOD) || (mods hasFlag Flags.STATIC)
+          val isConcreteInterfaceMethod = !inInterface || (mods hasFlag Flags.JAVA_DEFAULTMETHOD) || (mods hasFlag Flags.STATIC) || (mods hasFlag Flags.PRIVATE)
           val bodyOk = !(mods1 hasFlag Flags.DEFERRED) && isConcreteInterfaceMethod
           val body =
             if (bodyOk && in.token == LBRACE) {

--- a/test/files/pos/t12393/R1.java
+++ b/test/files/pos/t12393/R1.java
@@ -1,0 +1,7 @@
+// javaVersion: 9+
+public interface R1 {
+
+    private void foo() {
+        return;
+    }
+}


### PR DESCRIPTION
Java 9+ allows concrete private interface methods. This PR makes scalac's Java parser accept them.

fixes [scala/bug#12393](https://github.com/scala/bug/issues/12393)