### PR TITLE
Prevent compilation of library/reflect/compiler on bsp import

### DIFF
--- a/project/ScaladocSettings.scala
+++ b/project/ScaladocSettings.scala
@@ -1,7 +1,7 @@
 package scala.build
 
 import sbt._
-import sbt.Keys.{ artifact, dependencyClasspath, moduleID, resourceManaged }
+import sbt.Keys.{ artifact, externalDependencyClasspath, moduleID, resourceManaged }
 
 object ScaladocSettings {
 
@@ -15,7 +15,9 @@ object ScaladocSettings {
       s.get(artifact.key).isDefined && s.get(moduleID.key).exists(_.organization == "org.webjars")
     val dest = (resourceManaged.value / "webjars").getAbsoluteFile
     IO.createDirectory(dest)
-    val classpathes = (Compile / dependencyClasspath).value
+    // externalDependencyClasspath (not dependencyClasspath) to avoid compiling
+    // upstream projects (library, reflect, compiler) on bsp `buildTarget/resources`
+    val classpathes = (Compile / externalDependencyClasspath).value
     val files: Seq[File] = classpathes.filter(isWebjar).flatMap { classpathEntry =>
       val jarFile = classpathEntry.data
       IO.unzip(jarFile, dest)


### PR DESCRIPTION
Importing / refreshing the BSP triggers compilation of the compiler
(and library, reflect).

It's rooted in the `buildTarget/resources` bsp call, which runs
`bspBuildTargetResources file:/Users/luc/scala/scala13/#scaladoc/Compile`.
The issue can be reproduced by just calling `scaladoc/resources` in sbt.

The fix is to only look at the `externalDependencyClasspath`
(not the `dependencyClasspath`) when searching for webjars as scaladoc
resources.