### PR TITLE
Fix BTypes.LONG.maxValueType(BTypes.FLOAT)

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -297,7 +297,7 @@ abstract class BTypes {
 
         case LONG =>
           if (other.isIntegralType)  LONG
-          else if (other.isRealType) DOUBLE
+          else if (other.isRealType) other
           else                       uncomparable
 
         case FLOAT =>

--- a/test/junit/scala/tools/nsc/backend/jvm/BTypesTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/BTypesTest.scala
@@ -19,7 +19,8 @@ class BTypesTest extends BytecodeTesting {
   }
   import global.genBCode.bTypes._
 
-  def classBTFS(sym: global.Symbol) = global.exitingDelambdafy(classBTypeFromSymbol(sym))
+  def duringBackend[T](f: => T) = global.exitingDelambdafy(f)
+  def classBTFS(sym: global.Symbol) = duringBackend { classBTypeFromSymbol(sym) }
 
   def jlo = global.definitions.ObjectClass
   def jls = global.definitions.StringClass
@@ -220,5 +221,31 @@ class BTypesTest extends BytecodeTesting {
   @Test
   def maxTypeTest() {
 
+  }
+
+  @Test
+  def maxValueTypeATest(): Unit = duringBackend {
+    assertEquals(LONG, LONG.maxValueType(BYTE))
+    assertEquals(LONG, LONG.maxValueType(SHORT))
+    assertEquals(LONG, LONG.maxValueType(CHAR))
+    assertEquals(LONG, LONG.maxValueType(INT))
+    assertEquals(LONG, LONG.maxValueType(LONG))
+    assertEquals(FLOAT, LONG.maxValueType(FLOAT))
+    assertEquals(DOUBLE, LONG.maxValueType(DOUBLE))
+
+    assertUncomparable(LONG, UNIT)
+    assertUncomparable(LONG, BOOL)
+    assertUncomparable(LONG, o)
+    assertUncomparable(LONG, s)
+    assertUncomparable(LONG, oArr)
+    assertUncomparable(LONG, method)
+
+    def assertUncomparable(t1: PrimitiveBType, t2: BType): Unit = {
+      try {
+        t1.maxValueType(t2)
+      } catch {
+        case e: AssertionError => assertEquals(s"Cannot compute maxValueType: $t1, $t2", e.getMessage)
+      }
+    }
   }
 }

--- a/test/junit/scala/tools/nsc/backend/jvm/BTypesTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/BTypesTest.scala
@@ -51,7 +51,7 @@ class BTypesTest extends BytecodeTesting {
     assert(FLOAT.typedOpcode(Opcodes.IALOAD)  == Opcodes.FALOAD)
     assert(LONG.typedOpcode(Opcodes.IALOAD)   == Opcodes.LALOAD)
     assert(DOUBLE.typedOpcode(Opcodes.IALOAD) == Opcodes.DALOAD)
-    assert(classBTFS(jls).typedOpcode(Opcodes.IALOAD) == Opcodes.AALOAD)
+    assert(s.typedOpcode(Opcodes.IALOAD) == Opcodes.AALOAD)
 
     assert(UNIT.typedOpcode(Opcodes.IRETURN)   == Opcodes.RETURN)
     assert(BOOL.typedOpcode(Opcodes.IRETURN)   == Opcodes.IRETURN)
@@ -62,7 +62,7 @@ class BTypesTest extends BytecodeTesting {
     assert(FLOAT.typedOpcode(Opcodes.IRETURN)  == Opcodes.FRETURN)
     assert(LONG.typedOpcode(Opcodes.IRETURN)   == Opcodes.LRETURN)
     assert(DOUBLE.typedOpcode(Opcodes.IRETURN) == Opcodes.DRETURN)
-    assert(classBTFS(jls).typedOpcode(Opcodes.IRETURN)   == Opcodes.ARETURN)
+    assert(s.typedOpcode(Opcodes.IRETURN)   == Opcodes.ARETURN)
   }
 
   @Test

--- a/test/junit/scala/tools/nsc/backend/jvm/BTypesTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/BTypesTest.scala
@@ -8,6 +8,7 @@ import org.junit.runners.JUnit4
 
 import scala.collection.mutable
 import scala.tools.asm.Opcodes
+import scala.tools.testing.AssertUtil.assertThrows
 import scala.tools.testing.BytecodeTesting
 
 @RunWith(classOf[JUnit4])
@@ -241,11 +242,10 @@ class BTypesTest extends BytecodeTesting {
     assertUncomparable(LONG, method)
 
     def assertUncomparable(t1: PrimitiveBType, t2: BType): Unit = {
-      try {
-        t1.maxValueType(t2)
-      } catch {
-        case e: AssertionError => assertEquals(s"Cannot compute maxValueType: $t1, $t2", e.getMessage)
-      }
+      assertThrows[AssertionError](
+        t1.maxValueType(t2),
+        _.equals(s"Cannot compute maxValueType: $t1, $t2")
+        )
     }
   }
 }


### PR DESCRIPTION
Backport of https://github.com/scala/scala/pull/7435, but not marked `[backport]` because the cleanup and test case can be forward-ported to 2.13.x.

The result must be BTypes.FLOAT instead of BTypes.DOUBLE.

This implementation incorporates the suggestion at https://github.com/scala/scala/pull/7435#pullrequestreview-176328267.

It also adds unit tests for BTypes.LONG receivers of this method.