### PR TITLE
Change `private[concurrent]` for methods used outside `concurrent`

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -73,11 +73,8 @@ object MimaFilters extends AutoPlugin {
 
     // #9733
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.concurrent.TrieMap$RemovalPolicy$"),                                        // private[concurrent]
-    // is this a MiMa bug? we really should need these two filters
-    //ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.concurrent.TrieMap.removeRefEq"),                                    // private[concurrent]
-    //ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.concurrent.TrieMap.replaceRefEq"),                                   // private[concurrent]
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.convert.JavaCollectionWrappers#JConcurrentMapWrapper.removeRefEq"),  // private[concurrent]
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.convert.JavaCollectionWrappers#JConcurrentMapWrapper.replaceRefEq"), // private[concurrent]
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.convert.JavaCollectionWrappers#JConcurrentMapWrapper.removeRefEq"),  // private[collection]
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.convert.JavaCollectionWrappers#JConcurrentMapWrapper.replaceRefEq"), // private[collection]
 
     // #9741
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.SeqMap$SeqMapBuilderImpl"), // private[SeqMap]

--- a/src/library/scala/collection/concurrent/Map.scala
+++ b/src/library/scala/collection/concurrent/Map.scala
@@ -119,7 +119,7 @@ trait Map[K, V] extends scala.collection.mutable.Map[K, V] {
    * @return    `true` if the removal took place, `false` otherwise
    */
   // TODO: make part of the API in a future version
-  private[concurrent] def removeRefEq(k: K, v: V): Boolean = remove(k, v)
+  private[collection] def removeRefEq(k: K, v: V): Boolean = remove(k, v)
 
   /**
    * Replaces the entry for the given key only if it was previously mapped to
@@ -138,7 +138,7 @@ trait Map[K, V] extends scala.collection.mutable.Map[K, V] {
    * @return          `true` if the entry was replaced, `false` otherwise
    */
   // TODO: make part of the API in a future version
-  private[concurrent] def replaceRefEq(k: K, oldValue: V, newValue: V): Boolean = replace(k, oldValue, newValue)
+  private[collection] def replaceRefEq(k: K, oldValue: V, newValue: V): Boolean = replace(k, oldValue, newValue)
 
   /**
    * Update a mapping for the specified key and its current optionally-mapped value

--- a/src/library/scala/collection/concurrent/TrieMap.scala
+++ b/src/library/scala/collection/concurrent/TrieMap.scala
@@ -972,7 +972,7 @@ final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater
     removehc(k, v, RemovalPolicy.FullEquals, hc).nonEmpty
   }
 
-  override private[concurrent] def removeRefEq(k: K, v: V): Boolean = {
+  override private[collection] def removeRefEq(k: K, v: V): Boolean = {
     val hc = computeHash(k)
     removehc(k, v, RemovalPolicy.ReferenceEq, hc).nonEmpty
   }
@@ -982,7 +982,7 @@ final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater
     insertifhc(k, hc, newvalue, oldvalue.asInstanceOf[AnyRef], fullEquals = true).nonEmpty
   }
 
-  override private[concurrent] def replaceRefEq(k: K, oldValue: V, newValue: V): Boolean = {
+  override private[collection] def replaceRefEq(k: K, oldValue: V, newValue: V): Boolean = {
     val hc = computeHash(k)
     insertifhc(k, hc, newValue, oldValue.asInstanceOf[AnyRef], fullEquals = false).nonEmpty
   }


### PR DESCRIPTION
Mixing forwarders generated for `removeRefEq` / `replaceRefEq`
in `JConcurrentMapWrapper` are outside package `concurrent`, the
methods should be accessible.

See also https://github.com/scala/bug/issues/12457