### PR TITLE
Fix #12459: Warn instead of error if TASTy is not in sync with classfile

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -1265,7 +1265,12 @@ abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
         val expectedUUID = new UUID(reader.readUncompressedLong(), reader.readUncompressedLong())
         val tastyUUID = new TastyHeaderUnpickler(TASTYBytes).readHeader()
         if (expectedUUID != tastyUUID) {
-          reporter.error(NoPosition, s"Tasty UUID ($tastyUUID) file did not correspond the tasty UUID ($expectedUUID) declared in the classfile $file.")
+          loaders.warning(
+            NoPosition,
+            s"$file is out of sync with its TASTy file. Loaded TASTy file. Try cleaning the project to fix this issue",
+            WarningCategory.Other,
+            clazz.fullNameString
+          )
         }
         TASTYBytes
       }


### PR DESCRIPTION
This updates Scala 2.13 to match the current behavior in Scala 3 when
TASTy is not in sync with classfile, which is to print a warning and
suggest cleaning instead of erroring. The same change for Scala 3 happened
in the following pull request:
https://github.com/lampepfl/dotty/pull/9125

The Scala 3 change was made as a result of the following issue:
https://github.com/lampepfl/dotty/issues/8839

The commit message from the Scala 3 fix is as follows:
> Only warn if TASTy is not in sync with classfile
>
> If they are not in sync, we warn and suggest to clean.
> We assume that the TASTy is up to date (arbitrary choise) and load it regardless.
> This way we are resiliant to the failiure if the loaded class API did not change or
> did not have an impact on the code we are compiling."

Fixes: https://github.com/scala/scala/pull/9755