### PR TITLE
Fix `IO error while decoding <directory path> with UTF-8: <directory path> (Is a directory)` error

### DIFF
--- a/src/compiler/scala/tools/nsc/io/SourceReader.scala
+++ b/src/compiler/scala/tools/nsc/io/SourceReader.scala
@@ -14,9 +14,9 @@ package scala.tools.nsc
 package io
 
 import java.io.{FileInputStream, IOException}
-import java.nio.{ByteBuffer, CharBuffer}
 import java.nio.channels.{Channels, ClosedByInterruptException, ReadableByteChannel}
 import java.nio.charset.{CharsetDecoder, CoderResult}
+import java.nio.{ByteBuffer, CharBuffer}
 import scala.reflect.internal.Reporter
 
 /** This class implements methods to read and decode source files. */
@@ -40,17 +40,18 @@ class SourceReader(decoder: CharsetDecoder, reporter: Reporter) {
   }
 
   /** Reads the specified file. */
-  def read(file: JFile): Array[Char] = {
-    val c = new FileInputStream(file).getChannel
+  def read(file: JFile): Array[Char] =
+    if (file.isFile) {
+      val c = new FileInputStream(file).getChannel
 
-    try read(c)
-    catch {
-      case ex: InterruptedException => throw ex
-      case _: ClosedByInterruptException => throw new InterruptedException
-      case e: Exception => reportEncodingError("" + file, e) ; Array()
-    }
-    finally c.close()
-  }
+      try read(c)
+      catch {
+        case ex: InterruptedException => throw ex
+        case _: ClosedByInterruptException => throw new InterruptedException
+        case e: Exception => reportEncodingError("" + file, e) ; Array()
+      }
+      finally c.close()
+    } else new Array[Char](0)
 
   /** Reads the specified file.
    */


### PR DESCRIPTION
Hi, 

While developing an sbt plugin generating some directories and some files, we experienced this weird error:

```scala
[info] [info] compiling 23 Scala sources to /tmp/sbt_92d4e638/modules/caliban-clients/target/scala-2.12/classes ...
[info] [error] IO error while decoding /tmp/sbt_92d4e638/modules/caliban-clients/src/main/scala/poc/caliban/client/generated/posts/split with UTF-8: /tmp/sbt_92d4e638/modules/caliban-clients/src/main/scala/poc/caliban/client/generated/posts/split (Is a directory)
[info] [error] Please try specifying another one using the -encoding option
[info] [error] one error found
[info] [error] (caliban-clients / Compile / compileIncremental) Compilation failed
```
(More details, see: See: https://app.circleci.com/pipelines/github/ghostdogpr/caliban/2891/workflows/0172a930-b600-4ea3-8315-e5595bf40bb7/jobs/12955)

It doesn't happen all the time. It's not deterministic.

I reported this bug initially in sbt, thinking it was a bug in sbt.
See: https://github.com/sbt/sbt/issues/6655

Experienced in this PR: https://github.com/ghostdogpr/caliban/pull/1037