### PR TITLE
[backport] fix publishing: only use bionic in spec job, not main job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 version: ~> 1.0 # needed for imports
-
 import: scala/scala-dev:travis/default.yml
 
+dist: xenial  # GPG stuff breaks on bionic; scala/scala-dev#764
 language: scala
 
 stages:
@@ -46,6 +46,9 @@ jobs:
 
       # build the spec using jekyll
       - stage: build
+        name: language spec (Jekyll)
+        # wkhtmltopdf requires libssl1.1, which we can't install on xenial
+        dist: bionic
         language: ruby
         install:
           - ruby -v


### PR DESCRIPTION
backport 96acb813f (scala/scala#9516) from 2.13.x to 2.12.x

fingers crossed this might fix scala/scala-dev#783