### PR TITLE
Fix range position end for infix calls

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -924,7 +924,7 @@ self =>
     def finishBinaryOp(isExpr: Boolean, opinfo: OpInfo, rhs: Tree): Tree = {
       import opinfo._
       val operatorPos: Position = Position.range(rhs.pos.source, offset, offset, offset + operator.length)
-      val pos                   = lhs.pos union rhs.pos union operatorPos withPoint offset
+      val pos                   = lhs.pos.union(rhs.pos).union(operatorPos).withEnd(in.lastOffset).withPoint(offset)
 
       atPos(pos)(makeBinop(isExpr, lhs, operator, rhs, operatorPos, opinfo.targs))
     }

--- a/test/files/run/infix-rangepos.scala
+++ b/test/files/run/infix-rangepos.scala
@@ -1,0 +1,21 @@
+import scala.tools.partest._
+
+object Test extends CompilerTest {
+  import global._
+  override def extraSettings = super.extraSettings + " -Yrangepos"
+  override def sources = List(
+    "class C1 { def t = List(1).map ( x => x ) }",
+    "class C2 { def t = List(1).map { x => x } }",
+    "class C3 { def t = List(1).map ({x => x}) }",
+    "class C4 { def t = List(1) map ( x => x ) }",
+    "class C5 { def t = List(1) map { x => x } }",
+    "class C6 { def t = List(1) map ({x => x}) }")
+
+  def check(source: String, unit: CompilationUnit): Unit = unit.body foreach {
+    case dd: DefDef if dd.name.startsWith("t") =>
+      val pos = dd.rhs.pos
+      assert(pos.start == 19, pos.start)
+      assert(pos.end == 41, pos.end)
+    case _ =>
+  }
+}


### PR DESCRIPTION
The range position for the Apply node `qual fun { arg }` ended at
`arg` instead of the closing brace.

The use of `in.lastOffset` in the patch is the same as in method
`r2p` (which is used for non-infix calls).