### PR TITLE
Avoid `case _: C[_]#K` type test for higher-kinded `C`

### DIFF
--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -404,11 +404,10 @@ final class TreeMap[A, +B] private (tree: RB.Tree[A, B])(implicit val ordering: 
   }
   private def sameCBF(bf: CanBuildFrom[_,_,_]): Boolean = {
     bf match {
-      case cbf: SortedMapFactory[_]#SortedMapCanBuildFrom[_,_] => {
+      case cbf: TreeMap.SortedMapCanBuildFrom[_, _] =>
         val factory:AnyRef = cbf.factory
         ((factory eq TreeMap) || (factory eq immutable.SortedMap) || (factory eq collection.SortedMap)) &&
           cbf.ordering == ordering
-      }
       case w: WrappedCanBuildFrom[_,_,_] => sameCBF(w.wrapped)
       case _ => false
     }

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -264,11 +264,10 @@ final class TreeSet[A] private[immutable] (private[immutable] val tree: RB.Tree[
 
   private def sameCBF(bf: CanBuildFrom[_,_,_]): Boolean = {
     bf match {
-      case cbf: SortedSetFactory[_]#SortedSetCanBuildFrom[_] => {
+      case cbf: TreeSet.SortedSetCanBuildFrom[_] =>
         val factory:AnyRef = cbf.factory
         ((factory eq TreeSet) || (factory eq immutable.SortedSet) || (factory eq collection.SortedSet)) &&
           cbf.ordering == ordering
-      }
       case w: WrappedCanBuildFrom[_,_,_] => sameCBF(w.wrapped)
       case _ => false
     }


### PR DESCRIPTION
The code compiles fine with vanilla 2.12.15, but fails when
enabling the semanticdb compiler plugin. I assume the plugin
forces some `TypeTreeWithDeferredRefCheck` that's otherwise
left alone.

The deferred refcheck is created here:
https://github.com/scala/scala/blob/v2.12.15/src/compiler/scala/tools/nsc/typechecker/Typers.scala#L5167

Workaround for https://github.com/scala/bug/issues/12463