### PR TITLE
test on JDK 18-ea

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ templates: # this has no effect on travis, it's just a place to put our template
   pr-jdk8: &pr-jdk8
     if: type = pull_request OR repo != scala/scala
 
-  cron-jdk17: &cron-jdk17
+  cron-jdk18: &cron-jdk18
     if: type = cron AND repo = scala/scala
-    env: ADOPTOPENJDK=17
+    env: ADOPTOPENJDK=18
 
   build-for-testing: &build-for-testing
     # pull request validation (w/ bootstrap)
@@ -97,13 +97,13 @@ jobs:
       <<: *pr-jdk8
 
     - <<: *build-for-testing
-      <<: *cron-jdk17
+      <<: *cron-jdk18
 
     - <<: *test1
-      <<: *cron-jdk17
+      <<: *cron-jdk18
 
     - <<: *test2
-      <<: *cron-jdk17
+      <<: *cron-jdk18
 
     - stage: test
       name: build library with Scala 3


### PR DESCRIPTION
it's not clear what we "ought" to do here. SDKMAN dropped 17 early access builds (scala/scala-dev#788), but Temurin (aka Adoptium/AdoptOpenJDK) 17 isn't available yet.

we could use a Zulu or Java.net build of 17, but I suggest we simply start testing on 18 instead, for now anyway. once Temurin 17 is out we could consider also adding it