### PR TITLE
Module does not trigger missing interpolator

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5843,7 +5843,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             }
             def isNullaryTerm: Boolean = {
               val maybe = context.lookupSymbol(TermName(id), _ => true).symbol
-              maybe != NoSymbol && !maybe.hasPackageFlag && maybe.alternatives.exists(x => requiresNoArgs(x.info))
+              maybe != NoSymbol && !maybe.hasPackageFlag && !maybe.isModule && maybe.alternatives.exists(x => requiresNoArgs(x.info))
             }
             id == "this" || isNullaryTerm
           }

--- a/test/files/neg/forgot-interpolator.scala
+++ b/test/files/neg/forgot-interpolator.scala
@@ -93,3 +93,21 @@ package curry {
     def f5 = "I draw the line at $palomino" // no warn
   }
 }
+
+package companions {
+  class X
+  object X
+  class C {
+    def f1 = "$X"   // nowarn companion
+    def f2 = "$Byte"   // nowarn companion
+    def f3 = "$Char"   // nowarn companion
+    def f4 = "$Short"   // nowarn companion
+    def f5 = "$Int"   // nowarn companion
+    def f6 = "$Float"   // nowarn companion
+    def f7 = "$Double"   // nowarn companion
+    def f8 = "$Character"   // nowarn companion
+    def f9 = "$Integer"   // nowarn companion
+    def f0 = "$companions"   // nowarn companion
+  }
+}
+package object companions


### PR DESCRIPTION
`"$Void"` is not missing interpolator.
Modules generally don't have interesting `toString`,
let alone companions of common Java types or primitives.
For simplicity, ignore modules for purposes of warning.