### PR TITLE
Deprecate `IterableOps.toIterable`

### DIFF
--- a/src/library/scala/Enumeration.scala
+++ b/src/library/scala/Enumeration.scala
@@ -310,8 +310,8 @@ abstract class Enumeration (initial: Int) extends Serializable {
     override protected def fromSpecific(coll: IterableOnce[Value]): ValueSet = ValueSet.fromSpecific(coll)
     override protected def newSpecificBuilder = ValueSet.newBuilder
 
-    def map(f: Value => Value): ValueSet = fromSpecific(new View.Map(toIterable, f))
-    def flatMap(f: Value => IterableOnce[Value]): ValueSet = fromSpecific(new View.FlatMap(toIterable, f))
+    def map(f: Value => Value): ValueSet = fromSpecific(new View.Map(this, f))
+    def flatMap(f: Value => IterableOnce[Value]): ValueSet = fromSpecific(new View.FlatMap(this, f))
 
     // necessary for disambiguation:
     override def map[B](f: Value => B)(implicit @implicitNotFound(ValueSet.ordMsg) ev: Ordering[B]): immutable.SortedSet[B] =

--- a/src/library/scala/collection/BitSet.scala
+++ b/src/library/scala/collection/BitSet.scala
@@ -295,11 +295,11 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
     * @return a new bitset resulting from applying the given function ''f'' to
     *         each element of this bitset and collecting the results
     */
-  def map(f: Int => Int): C = fromSpecific(new View.Map(toIterable, f))
+  def map(f: Int => Int): C = fromSpecific(new View.Map(this, f))
 
-  def flatMap(f: Int => IterableOnce[Int]): C = fromSpecific(new View.FlatMap(toIterable, f))
+  def flatMap(f: Int => IterableOnce[Int]): C = fromSpecific(new View.FlatMap(this, f))
 
-  def collect(pf: PartialFunction[Int, Int]): C = fromSpecific(super[SortedSetOps].collect(pf).toIterable)
+  def collect(pf: PartialFunction[Int, Int]): C = fromSpecific(super[SortedSetOps].collect(pf))
 
   override def partition(p: Int => Boolean): (C, C) = {
     val left = filter(p)

--- a/src/library/scala/collection/LinearSeq.scala
+++ b/src/library/scala/collection/LinearSeq.scala
@@ -248,7 +248,7 @@ trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] with LinearSeq
 trait StrictOptimizedLinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] with StrictOptimizedLinearSeqOps[A, CC, C]] extends Any with LinearSeqOps[A, CC, C] with StrictOptimizedSeqOps[A, CC, C] {
   // A more efficient iterator implementation than the default LinearSeqIterator
   override def iterator: Iterator[A] = new AbstractIterator[A] {
-    private[this] var current: Iterable[A] = toIterable
+    private[this] var current = StrictOptimizedLinearSeqOps.this
     def hasNext = !current.isEmpty
     def next() = { val r = current.head; current = current.tail; r }
   }

--- a/src/library/scala/collection/Map.scala
+++ b/src/library/scala/collection/Map.scala
@@ -71,7 +71,7 @@ trait Map[K, +V]
         false
     })
 
-  override def hashCode(): Int = MurmurHash3.mapHash(toIterable)
+  override def hashCode(): Int = MurmurHash3.mapHash(this)
 
   // These two methods are not in MapOps so that MapView is not forced to implement them
   @deprecated("Use - or removed on an immutable Map", "2.13.0")
@@ -296,7 +296,7 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
     *  @return       a new $coll resulting from applying the given function
     *                `f` to each element of this $coll and collecting the results.
     */
-  def map[K2, V2](f: ((K, V)) => (K2, V2)): CC[K2, V2] = mapFactory.from(new View.Map(toIterable, f))
+  def map[K2, V2](f: ((K, V)) => (K2, V2)): CC[K2, V2] = mapFactory.from(new View.Map(this, f))
 
   /** Builds a new collection by applying a partial function to all elements of this $coll
     *  on which the function is defined.
@@ -309,7 +309,7 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
     *                The order of the elements is preserved.
     */
   def collect[K2, V2](pf: PartialFunction[(K, V), (K2, V2)]): CC[K2, V2] =
-    mapFactory.from(new View.Collect(toIterable, pf))
+    mapFactory.from(new View.Collect(this, pf))
 
   /** Builds a new map by applying a function to all elements of this $coll
     *  and using the elements of the resulting collections.
@@ -318,7 +318,7 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
     *  @return       a new $coll resulting from applying the given collection-valued function
     *                `f` to each element of this $coll and concatenating the results.
     */
-  def flatMap[K2, V2](f: ((K, V)) => IterableOnce[(K2, V2)]): CC[K2, V2] = mapFactory.from(new View.FlatMap(toIterable, f))
+  def flatMap[K2, V2](f: ((K, V)) => IterableOnce[(K2, V2)]): CC[K2, V2] = mapFactory.from(new View.FlatMap(this, f))
 
   /** Returns a new $coll containing the elements from the left hand operand followed by the elements from the
     *  right hand operand. The element type of the $coll is the most specific superclass encompassing
@@ -329,7 +329,7 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
     *                of this $coll followed by all elements of `suffix`.
     */
   def concat[V2 >: V](suffix: collection.IterableOnce[(K, V2)]): CC[K, V2] = mapFactory.from(suffix match {
-    case it: Iterable[(K, V2)] => new View.Concat(toIterable, it)
+    case it: Iterable[(K, V2)] => new View.Concat(this, it)
     case _ => iterator.concat(suffix.iterator)
   })
 
@@ -343,11 +343,11 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
 
   @deprecated("Consider requiring an immutable Map or fall back to Map.concat.", "2.13.0")
   def + [V1 >: V](kv: (K, V1)): CC[K, V1] =
-    mapFactory.from(new View.Appended(toIterable, kv))
+    mapFactory.from(new View.Appended(this, kv))
 
   @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
   def + [V1 >: V](elem1: (K, V1), elem2: (K, V1), elems: (K, V1)*): CC[K, V1] =
-    mapFactory.from(new View.Concat(new View.Appended(new View.Appended(toIterable, elem1), elem2), elems))
+    mapFactory.from(new View.Concat(new View.Appended(new View.Appended(this, elem1), elem2), elems))
 
   @deprecated("Consider requiring an immutable Map.", "2.13.0")
   @`inline` def -- (keys: IterableOnce[K]): C = {
@@ -361,7 +361,7 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
       case that: Iterable[(K, V1)] => that
       case that => View.from(that)
     }
-    mapFactory.from(new View.Concat(thatIterable, toIterable))
+    mapFactory.from(new View.Concat(thatIterable, this))
   }
 }
 

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -38,7 +38,7 @@ trait Seq[+A]
       case _ => false
     })
 
-  override def hashCode(): Int = MurmurHash3.seqHash(toIterable)
+  override def hashCode(): Int = MurmurHash3.seqHash(this)
 
   override def toString(): String = super[Iterable].toString()
 

--- a/src/library/scala/collection/Set.scala
+++ b/src/library/scala/collection/Set.scala
@@ -70,7 +70,7 @@ trait Set[A]
         false
     })
 
-  override def hashCode(): Int = MurmurHash3.setHash(toIterable)
+  override def hashCode(): Int = MurmurHash3.setHash(this)
 
   override def iterableFactory: IterableFactory[Set] = Set
 
@@ -115,7 +115,7 @@ trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
     */
   def subsets(len: Int): Iterator[C] = {
     if (len < 0 || len > size) Iterator.empty
-    else new SubsetsItr(toIterable.to(IndexedSeq), len)
+    else new SubsetsItr(this.to(IndexedSeq), len)
   }
 
   /** An iterator over all subsets of this set.
@@ -123,7 +123,7 @@ trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
     *  @return     the iterator.
     */
   def subsets(): Iterator[C] = new AbstractIterator[C] {
-    private[this] val elms = toIterable.to(IndexedSeq)
+    private[this] val elms = SetOps.this.to(IndexedSeq)
     private[this] var len = 0
     private[this] var itr: Iterator[C] = Iterator.empty
 
@@ -221,15 +221,15 @@ trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
     *  @return a new $coll with the given elements added, omitting duplicates.
     */
   def concat(that: collection.IterableOnce[A]): C = fromSpecific(that match {
-    case that: collection.Iterable[A] => new View.Concat(toIterable, that)
+    case that: collection.Iterable[A] => new View.Concat(this, that)
     case _ => iterator.concat(that.iterator)
   })
 
   @deprecated("Consider requiring an immutable Set or fall back to Set.union", "2.13.0")
-  def + (elem: A): C = fromSpecific(new View.Appended(toIterable, elem))
+  def + (elem: A): C = fromSpecific(new View.Appended(this, elem))
 
   @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
-  def + (elem1: A, elem2: A, elems: A*): C = fromSpecific(new View.Concat(new View.Appended(new View.Appended(toIterable, elem1), elem2), elems))
+  def + (elem1: A, elem2: A, elems: A*): C = fromSpecific(new View.Concat(new View.Appended(new View.Appended(this, elem1), elem2), elems))
 
   /** Alias for `concat` */
   @`inline` final def ++ (that: collection.IterableOnce[A]): C = concat(that)

--- a/src/library/scala/collection/SortedMap.scala
+++ b/src/library/scala/collection/SortedMap.scala
@@ -153,7 +153,7 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _],
     *                `f` to each element of this $coll and collecting the results.
     */
   def map[K2, V2](f: ((K, V)) => (K2, V2))(implicit @implicitNotFound(SortedMapOps.ordMsg) ordering: Ordering[K2]): CC[K2, V2] =
-    sortedMapFactory.from(new View.Map[(K, V), (K2, V2)](toIterable, f))
+    sortedMapFactory.from(new View.Map[(K, V), (K2, V2)](this, f))
 
   /** Builds a new sorted map by applying a function to all elements of this $coll
     *  and using the elements of the resulting collections.
@@ -163,7 +163,7 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _],
     *                `f` to each element of this $coll and concatenating the results.
     */
   def flatMap[K2, V2](f: ((K, V)) => IterableOnce[(K2, V2)])(implicit @implicitNotFound(SortedMapOps.ordMsg) ordering: Ordering[K2]): CC[K2, V2] =
-    sortedMapFactory.from(new View.FlatMap(toIterable, f))
+    sortedMapFactory.from(new View.FlatMap(this, f))
 
   /** Builds a new sorted map by applying a partial function to all elements of this $coll
     *  on which the function is defined.
@@ -174,10 +174,10 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _],
     *                The order of the elements is preserved.
     */
   def collect[K2, V2](pf: PartialFunction[(K, V), (K2, V2)])(implicit @implicitNotFound(SortedMapOps.ordMsg) ordering: Ordering[K2]): CC[K2, V2] =
-    sortedMapFactory.from(new View.Collect(toIterable, pf))
+    sortedMapFactory.from(new View.Collect(this, pf))
 
   override def concat[V2 >: V](suffix: IterableOnce[(K, V2)]): CC[K, V2] = sortedMapFactory.from(suffix match {
-    case it: Iterable[(K, V2)] => new View.Concat(toIterable, it)
+    case it: Iterable[(K, V2)] => new View.Concat(this, it)
     case _ => iterator.concat(suffix.iterator)
   })(ordering)
 
@@ -185,10 +185,10 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _],
   @`inline` override final def ++ [V2 >: V](xs: IterableOnce[(K, V2)]): CC[K, V2] = concat(xs)
 
   @deprecated("Consider requiring an immutable Map or fall back to Map.concat", "2.13.0")
-  override def + [V1 >: V](kv: (K, V1)): CC[K, V1] = sortedMapFactory.from(new View.Appended(toIterable, kv))(ordering)
+  override def + [V1 >: V](kv: (K, V1)): CC[K, V1] = sortedMapFactory.from(new View.Appended(this, kv))(ordering)
 
   @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
-  override def + [V1 >: V](elem1: (K, V1), elem2: (K, V1), elems: (K, V1)*): CC[K, V1] = sortedMapFactory.from(new View.Concat(new View.Appended(new View.Appended(toIterable, elem1), elem2), elems))(ordering)
+  override def + [V1 >: V](elem1: (K, V1), elem2: (K, V1), elems: (K, V1)*): CC[K, V1] = sortedMapFactory.from(new View.Concat(new View.Appended(new View.Appended(this, elem1), elem2), elems))(ordering)
 }
 
 object SortedMapOps {

--- a/src/library/scala/collection/SortedSet.scala
+++ b/src/library/scala/collection/SortedSet.scala
@@ -118,7 +118,7 @@ trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
     *                `f` to each element of this $coll and collecting the results.
     */
   def map[B](f: A => B)(implicit @implicitNotFound(SortedSetOps.ordMsg) ev: Ordering[B]): CC[B] =
-    sortedIterableFactory.from(new View.Map(toIterable, f))
+    sortedIterableFactory.from(new View.Map(this, f))
 
   /** Builds a new sorted collection by applying a function to all elements of this $coll
     *  and using the elements of the resulting collections.
@@ -129,7 +129,7 @@ trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
     *                `f` to each element of this $coll and concatenating the results.
     */
   def flatMap[B](f: A => IterableOnce[B])(implicit @implicitNotFound(SortedSetOps.ordMsg) ev: Ordering[B]): CC[B] =
-    sortedIterableFactory.from(new View.FlatMap(toIterable, f))
+    sortedIterableFactory.from(new View.FlatMap(this, f))
 
   /** Returns a $coll formed from this $coll and another iterable collection
     *  by combining corresponding elements in pairs.
@@ -142,7 +142,7 @@ trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
     */
   def zip[B](that: IterableOnce[B])(implicit @implicitNotFound(SortedSetOps.zipOrdMsg) ev: Ordering[(A @uncheckedVariance, B)]): CC[(A @uncheckedVariance, B)] = // sound bcs of VarianceNote
     sortedIterableFactory.from(that match {
-      case that: Iterable[B] => new View.Zip(toIterable, that)
+      case that: Iterable[B] => new View.Zip(this, that)
       case _ => iterator.zip(that)
     })
 
@@ -156,7 +156,7 @@ trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
     *                The order of the elements is preserved.
     */
   def collect[B](pf: scala.PartialFunction[A, B])(implicit @implicitNotFound(SortedSetOps.ordMsg) ev: Ordering[B]): CC[B] =
-    sortedIterableFactory.from(new View.Collect(toIterable, pf))
+    sortedIterableFactory.from(new View.Collect(this, pf))
 }
 
 object SortedSetOps {

--- a/src/library/scala/collection/StrictOptimizedIterableOps.scala
+++ b/src/library/scala/collection/StrictOptimizedIterableOps.scala
@@ -13,6 +13,7 @@
 package scala
 package collection
 
+import scala.annotation.nowarn
 import scala.annotation.unchecked.uncheckedVariance
 import scala.runtime.Statics
 
@@ -254,7 +255,7 @@ trait StrictOptimizedIterableOps[+A, +CC[_], +C]
     */
   override def takeRight(n: Int): C = {
     val b = newSpecificBuilder
-    b.sizeHintBounded(n, toIterable)
+    b.sizeHintBounded(n, toIterable: @nowarn("cat=deprecation"))
     val lead = iterator drop n
     val it = iterator
     while (lead.hasNext) {

--- a/src/library/scala/collection/StrictOptimizedIterableOps.scala
+++ b/src/library/scala/collection/StrictOptimizedIterableOps.scala
@@ -203,7 +203,7 @@ trait StrictOptimizedIterableOps[+A, +CC[_], +C]
 
   override def scanLeft[B](z: B)(op: (B, A) => B): CC[B] = {
     val b = iterableFactory.newBuilder[B]
-    b.sizeHint(toIterable, delta = 0)
+    b.sizeHint(this, delta = 0)
     var acc = z
     b += acc
     val it = iterator
@@ -271,7 +271,7 @@ trait StrictOptimizedIterableOps[+A, +CC[_], +C]
     */
   override def dropRight(n: Int): C = {
     val b = newSpecificBuilder
-    if (n >= 0) b.sizeHint(toIterable, delta = -n)
+    if (n >= 0) b.sizeHint(this, delta = -n)
     val lead = iterator drop n
     val it = iterator
     while (lead.hasNext) {

--- a/src/library/scala/collection/immutable/IntMap.scala
+++ b/src/library/scala/collection/immutable/IntMap.scala
@@ -323,9 +323,9 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
     case IntMap.Nil => IntMap.Tip(key, value)
   }
 
-  def map[V2](f: ((Int, T)) => (Int, V2)): IntMap[V2] = intMapFrom(new View.Map(toIterable, f))
+  def map[V2](f: ((Int, T)) => (Int, V2)): IntMap[V2] = intMapFrom(new View.Map(this, f))
 
-  def flatMap[V2](f: ((Int, T)) => IterableOnce[(Int, V2)]): IntMap[V2] = intMapFrom(new View.FlatMap(toIterable, f))
+  def flatMap[V2](f: ((Int, T)) => IterableOnce[(Int, V2)]): IntMap[V2] = intMapFrom(new View.FlatMap(this, f))
 
   override def concat[V1 >: T](that: collection.IterableOnce[(Int, V1)]): IntMap[V1] =
     super.concat(that).asInstanceOf[IntMap[V1]] // Already has correct type but not declared as such

--- a/src/library/scala/collection/immutable/Set.scala
+++ b/src/library/scala/collection/immutable/Set.scala
@@ -57,7 +57,7 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   @`inline` final override def - (elem: A): C = excl(elem)
 
   def diff(that: collection.Set[A]): C =
-    toIterable.foldLeft(empty)((result, elem) => if (that contains elem) result else result + elem)
+    foldLeft(empty)((result, elem) => if (that contains elem) result else result + elem)
 
   /** Creates a new $coll from this $coll by removing all elements of another
     *  collection.

--- a/src/library/scala/collection/mutable/AnyRefMap.scala
+++ b/src/library/scala/collection/mutable/AnyRefMap.scala
@@ -393,7 +393,7 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K => V, initi
   }
 
   @deprecated("Consider requiring an immutable Map or fall back to Map.concat", "2.13.0")
-  override def + [V1 >: V](kv: (K, V1)): AnyRefMap[K, V1] = AnyRefMap.from(new View.Appended(toIterable, kv))
+  override def + [V1 >: V](kv: (K, V1)): AnyRefMap[K, V1] = AnyRefMap.from(new View.Appended(this, kv))
 
   @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
   override def + [V1 >: V](elem1: (K, V1), elem2: (K, V1), elems: (K, V1)*): AnyRefMap[K, V1] = {
@@ -477,9 +477,9 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K => V, initi
 
   // The implicit dummy parameter is necessary to distinguish these methods from the base methods they overload (not override)
   def map[K2 <: AnyRef, V2](f: ((K, V)) => (K2, V2))(implicit dummy: DummyImplicit): AnyRefMap[K2, V2] =
-    AnyRefMap.from(new View.Map(toIterable, f))
+    AnyRefMap.from(new View.Map(this, f))
   def flatMap[K2 <: AnyRef, V2](f: ((K, V)) => IterableOnce[(K2, V2)])(implicit dummy: DummyImplicit): AnyRefMap[K2, V2] =
-    AnyRefMap.from(new View.FlatMap(toIterable, f))
+    AnyRefMap.from(new View.FlatMap(this, f))
   def collect[K2 <: AnyRef, V2](pf: PartialFunction[(K, V), (K2, V2)])(implicit dummy: DummyImplicit): AnyRefMap[K2, V2] =
     strictOptimizedCollect(AnyRefMap.newBuilder[K2, V2], pf)
 

--- a/src/library/scala/collection/mutable/Builder.scala
+++ b/src/library/scala/collection/mutable/Builder.scala
@@ -68,9 +68,11 @@ trait Builder[-A, +To] extends Growable[A] { self =>
     *                       an IndexedSeqLike, then sizes larger
     *                       than collection's size are reduced.
     */
+  // should probably be `boundingColl: IterableOnce[_]`, but binary compatibility
   final def sizeHintBounded(size: Int, boundingColl: scala.collection.Iterable[_]): Unit = {
-    if (boundingColl.knownSize != -1) {
-      sizeHint(scala.math.min(boundingColl.knownSize, size))
+    val s = boundingColl.knownSize
+    if (s != -1) {
+      sizeHint(scala.math.min(s, size))
     }
   }
 

--- a/src/library/scala/collection/mutable/CollisionProofHashMap.scala
+++ b/src/library/scala/collection/mutable/CollisionProofHashMap.scala
@@ -417,7 +417,7 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
     */
   def map[K2, V2](f: ((K, V)) => (K2, V2))
       (implicit @implicitNotFound(CollisionProofHashMap.ordMsg) ordering: Ordering[K2]): CollisionProofHashMap[K2, V2] =
-    sortedMapFactory.from(new View.Map[(K, V), (K2, V2)](toIterable, f))
+    sortedMapFactory.from(new View.Map[(K, V), (K2, V2)](this, f))
 
   /** Builds a new `CollisionProofHashMap` by applying a function to all elements of this $coll
     *  and using the elements of the resulting collections.
@@ -428,7 +428,7 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
     */
   def flatMap[K2, V2](f: ((K, V)) => IterableOnce[(K2, V2)])
       (implicit @implicitNotFound(CollisionProofHashMap.ordMsg) ordering: Ordering[K2]): CollisionProofHashMap[K2, V2] =
-    sortedMapFactory.from(new View.FlatMap(toIterable, f))
+    sortedMapFactory.from(new View.FlatMap(this, f))
 
   /** Builds a new sorted map by applying a partial function to all elements of this $coll
     *  on which the function is defined.
@@ -440,10 +440,10 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
     */
   def collect[K2, V2](pf: PartialFunction[(K, V), (K2, V2)])
       (implicit @implicitNotFound(CollisionProofHashMap.ordMsg) ordering: Ordering[K2]): CollisionProofHashMap[K2, V2] =
-    sortedMapFactory.from(new View.Collect(toIterable, pf))
+    sortedMapFactory.from(new View.Collect(this, pf))
 
   override def concat[V2 >: V](suffix: IterableOnce[(K, V2)]): CollisionProofHashMap[K, V2] = sortedMapFactory.from(suffix match {
-    case it: Iterable[(K, V2)] => new View.Concat(toIterable, it)
+    case it: Iterable[(K, V2)] => new View.Concat(this, it)
     case _ => iterator.concat(suffix.iterator)
   })
 
@@ -452,11 +452,11 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
 
   @deprecated("Consider requiring an immutable Map or fall back to Map.concat", "2.13.0")
   override def + [V1 >: V](kv: (K, V1)): CollisionProofHashMap[K, V1] =
-     sortedMapFactory.from(new View.Appended(toIterable, kv))
+     sortedMapFactory.from(new View.Appended(this, kv))
 
   @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
   override def + [V1 >: V](elem1: (K, V1), elem2: (K, V1), elems: (K, V1)*): CollisionProofHashMap[K, V1] =
-     sortedMapFactory.from(new View.Concat(new View.Appended(new View.Appended(toIterable, elem1), elem2), elems))
+     sortedMapFactory.from(new View.Concat(new View.Appended(new View.Appended(this, elem1), elem2), elems))
 
   ///////////////////// RedBlackTree code derived from mutable.RedBlackTree:
 

--- a/src/library/scala/collection/mutable/Map.scala
+++ b/src/library/scala/collection/mutable/Map.scala
@@ -160,7 +160,7 @@ trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
 
   def clear(): Unit = { keysIterator foreach -= }
 
-  override def clone(): C = empty ++= toIterable
+  override def clone(): C = empty ++= this
 
   @deprecated("Use filterInPlace instead", "2.13.0")
   @inline final def retain(p: (K, V) => Boolean): this.type = filterInPlace(p)

--- a/src/library/scala/collection/mutable/Seq.scala
+++ b/src/library/scala/collection/mutable/Seq.scala
@@ -41,7 +41,7 @@ trait SeqOps[A, +CC[_], +C <: AnyRef]
 
   override def clone(): C = {
     val b = newSpecificBuilder
-    b ++= toIterable
+    b ++= this
     b.result()
   }
 

--- a/src/library/scala/collection/mutable/Set.scala
+++ b/src/library/scala/collection/mutable/Set.scala
@@ -78,7 +78,7 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   }
 
   def diff(that: collection.Set[A]): C =
-    toIterable.foldLeft(empty)((result, elem) => if (that contains elem) result else result += elem)
+    foldLeft(empty)((result, elem) => if (that contains elem) result else result += elem)
 
   @deprecated("Use filterInPlace instead", "2.13.0")
   @inline final def retain(p: A => Boolean): Unit = filterInPlace(p)
@@ -104,7 +104,7 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
     this
   }
 
-  override def clone(): C = empty ++= toIterable
+  override def clone(): C = empty ++= this
 
   override def knownSize: Int = super[IterableOps].knownSize
 }

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/IndexScript.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/IndexScript.scala
@@ -29,7 +29,7 @@ class IndexScript(universe: doc.Universe) extends Page {
   }
 
   val packages = {
-    val pairs = allPackagesWithTemplates.toIterable.map(_ match {
+    val pairs = allPackagesWithTemplates.map(_ match {
       case (pack, templates) => {
         val merged = mergeByQualifiedName(templates)
 

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/ArraySeqBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/ArraySeqBenchmark.scala
@@ -50,7 +50,7 @@ class ArraySeqBenchmark {
   private[this] def oldSorted[A](seq: ArraySeq[A])(implicit ord: Ordering[A], tag: ClassTag[A]): ArraySeq[A] = {
     val len = seq.length
     val b = ArraySeq.newBuilder[A](tag)
-    if (len == 1) b ++= seq.toIterable
+    if (len == 1) b ++= seq
     else if (len > 1) {
       b.sizeHint(len)
       val arr = new Array[AnyRef](len)

--- a/test/files/run/colltest1.scala
+++ b/test/files/run/colltest1.scala
@@ -34,7 +34,7 @@ object Test extends App {
     val (o, e) = ten.partition(_ % 2 == 0)
     assert(o.size == e.size)
     val gs = ten groupBy (x => x / 4)
-    val vs1 = (for (k <- gs.keysIterator; v <- gs(k).toIterable.iterator) yield v).toList.sorted
+    val vs1 = (for (k <- gs.keysIterator; v <- gs(k).iterator) yield v).toList.sorted
     val vs2 = gs.values.toList.flatten.sorted
 //    val vs2 = gs.values.toList flatMap (xs => xs)
     assert(ten.head == 1)
@@ -60,7 +60,6 @@ object Test extends App {
     assert(buf == ten, buf)
     assert(ten.toArray.size == 10)
     assert(ten.toArray.toSeq == ten, ten.toArray.toSeq)
-    assert(ten.toIterable == ten)
     assert(ten.toList == ten)
     assert(ten.toSeq == ten)
     assert(ten.toStream == ten)

--- a/test/files/run/t4930.scala
+++ b/test/files/run/t4930.scala
@@ -2,7 +2,7 @@ import collection.immutable.SortedMap
 import scala.math.Ordering.Implicits._
 
 object Test {
-  implicit val ord: Ordering[Array[Byte]] = Ordering.by(x => x.toIterable: collection.Seq[Byte])
+  implicit val ord: Ordering[Array[Byte]] = Ordering.by(x => x: collection.Seq[Byte])
 
   def main(args: Array[String]): Unit = {
     val m = SortedMap(Array[Byte](1) -> 0)

--- a/test/junit/scala/collection/IterableTest.scala
+++ b/test/junit/scala/collection/IterableTest.scala
@@ -1,7 +1,9 @@
 package scala.collection
 
-import org.junit.{Assert, Test}, Assert.{assertEquals, assertTrue}
+import org.junit.{Assert, Test}
+import Assert.{assertEquals, assertTrue}
 
+import scala.annotation.nowarn
 import scala.collection.immutable.{ArraySeq, List, Range, Vector}
 import scala.tools.testkit.AssertUtil._
 
@@ -135,8 +137,7 @@ class IterableTest {
     check(new Array(10), l.copyToArray(_, 0, -1), 0, 0, 0)
   }
 
-  @deprecated("Uses deprecated toTraversable", since="2.13.0")
-  @Test
+  @Test @nowarn("cat=deprecation")
   def emptyToTraversable(): Unit = {
     assert(Iterable.empty == Array.empty.toIterable)
     assert(Iterable.empty == Array.empty.toTraversable)

--- a/test/junit/scala/collection/ToConserveTest.scala
+++ b/test/junit/scala/collection/ToConserveTest.scala
@@ -26,8 +26,6 @@ class ToConserveTest {
     assertSame(l, l.toSeq)
     assertSame(l, l.toIterable)
 
-    assertSame(l, l.to(List))
-
     assertSame(l, l.to(c.Iterable))
     assertSame(l, l.to(i.Iterable))
 
@@ -41,7 +39,7 @@ class ToConserveTest {
   }
 
   @Test def toConserveImmutableHashSet: Unit = {
-    val s: c.Iterable[Int] = (1 to 10).to(immutable.HashSet)
+    val s: c.Iterable[Int] = (1 to 10).to(i.HashSet)
     assertSame(s, s.toSet)
     assertSame(s, s.toIterable)
 
@@ -55,7 +53,7 @@ class ToConserveTest {
   }
 
   @Test def toConserveImmutableHashMap: Unit = {
-    val m: c.Iterable[(Int, Int)] = (1 to 10).map(x => (x, x)).to(immutable.HashMap): i.Map[Int, Int]
+    val m: c.Iterable[(Int, Int)] = (1 to 10).map(x => (x, x)).to(i.HashMap): i.Map[Int, Int]
 
     assertSame(m, m.toMap)
     assertSame(m, m.toIterable)
@@ -67,6 +65,24 @@ class ToConserveTest {
     assertSame(m, m.to(i.Map))
 
     assertSame(m, m.to(i.HashMap))
+  }
+
+  @Test def toConserveLazyList: Unit = {
+    val l: c.Iterable[Int] = LazyList.from(1 to 10)
+
+    assertSame(l, l.toSeq)
+    assertSame(l, l.toIterable)
+
+    assertSame(l, l.to(c.Iterable))
+    assertSame(l, l.to(i.Iterable))
+
+    assertSame(l, l.to(c.Seq))
+    assertSame(l, l.to(i.Seq))
+
+    assertSame(l, l.to(c.LinearSeq))
+    assertSame(l, l.to(i.LinearSeq))
+
+    assertSame(l, l.to(LazyList))
   }
 
   @Test def toRebuildMutable: Unit = {

--- a/test/junit/scala/collection/ToConserveTest.scala
+++ b/test/junit/scala/collection/ToConserveTest.scala
@@ -5,11 +5,13 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
+import scala.annotation.nowarn
 import scala.collection.{immutable => i, mutable => m}
 import scala.language.implicitConversions
 import scala.{collection => c}
 
 @RunWith(classOf[JUnit4])
+@nowarn("cat=deprecation")
 class ToConserveTest {
   // scala/bug#12188
   implicit def toAnyRefFactory[A, CC[_] <: AnyRef](factory: c.IterableFactory[CC]): c.Factory[A, AnyRef] =

--- a/test/junit/scala/collection/mutable/ArraySortingTest.scala
+++ b/test/junit/scala/collection/mutable/ArraySortingTest.scala
@@ -25,7 +25,7 @@ class ArraySortingTest {
     java.util.Arrays.sort(test)
     scala.util.Sorting.quickSort(cant)(CanOrder)
     assert( test(6) == 1 )
-    assert( test.toIterable.lazyZip(cant).forall(_ == _.i) )
+    assert( test.lazyZip(cant).forall(_ == _.i) )
   }
 
   @Test


### PR DESCRIPTION
The method is a noop on any `Iterable`, it only does something for an object that is an `IterableOps` but not an `Iterable`. This should never be the case in user code.

The method is cofusing because its name is like `toList` or `toSeq`, but `toIterable` returns non-immutable collections unchanged. `toIterable` is therefore also different from `to(Iterable)`.