### PR TITLE
Fix outer tests when pattern has a refined prefix

### DIFF
--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -149,6 +149,7 @@ abstract class TreeGen {
   def mkAttributedQualifierIfPossible(prefix: Type): Option[Tree] = prefix match {
     case NoType | NoPrefix | ErrorType => None
     case TypeRef(_, sym, _) if sym.isModule || sym.isClass || sym.isType => None
+    case RefinedType(parents, _) if !parents.exists(_.isStable) => None
     case pre => Some(mkAttributedQualifier(prefix))
   }
 

--- a/test/files/pos/t12467.scala
+++ b/test/files/pos/t12467.scala
@@ -1,0 +1,15 @@
+object PagedResponse {
+  type Aux[Item0] = PagedResponse { type Item = Item0 }
+}
+
+trait PagedResponse {
+  type Item
+  sealed trait NextPage
+  case class NoMorePages() extends NextPage
+}
+
+object Test {
+  def foo[A](next: PagedResponse.Aux[A]#NextPage): Unit = next match {
+    case _: PagedResponse.Aux[A]#NoMorePages => ???
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/12467