### PR TITLE
Overridden methods with wider access don't have it applied in specialized versions

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -1125,7 +1125,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
             }
           } else None
         case (overridden, env) =>
-          val om = specializedOverload(clazz, overridden, env)
+          val om = specializedOverload(clazz, overriding, env, overridden)
           clazz.info.decls.enter(om)
           foreachWithIndex(om.paramss) { (params, i) =>
             foreachWithIndex(params) { (param, j) =>

--- a/test/files/pos/t10211.scala
+++ b/test/files/pos/t10211.scala
@@ -1,0 +1,12 @@
+trait QuitePrivate[@specialized(Int) K] {
+  protected[this] def hasK(k :K) :Boolean
+}
+
+trait MoreOpen extends QuitePrivate[Int] {
+  override def hasK(k :Int) :Boolean
+}
+
+
+object Playground extends App {
+  def check(guy :MoreOpen) = guy.hasK(42)
+}

--- a/test/files/run/t6028.check
+++ b/test/files/run/t6028.check
@@ -30,7 +30,7 @@ package <empty> {
         ()
       };
       final def apply(): Int = $anonfun$foo$1.this.apply$mcI$sp();
-      <specialized> def apply$mcI$sp(): Int = $anonfun$foo$1.this.$outer.classParam.+($anonfun$foo$1.this.$outer.field()).+($anonfun$foo$1.this.methodParam$1).+($anonfun$foo$1.this.methodLocal$1);
+      final <specialized> def apply$mcI$sp(): Int = $anonfun$foo$1.this.$outer.classParam.+($anonfun$foo$1.this.$outer.field()).+($anonfun$foo$1.this.methodParam$1).+($anonfun$foo$1.this.methodLocal$1);
       <synthetic> <paramaccessor> <artifact> private[this] val $outer: T = _;
       <synthetic> <stable> <artifact> def $outer(): T = $anonfun$foo$1.this.$outer;
       <bridge> <artifact> def apply(): Object = scala.Int.box($anonfun$foo$1.this.apply());
@@ -68,7 +68,7 @@ package <empty> {
         ()
       };
       final def apply(): Unit = $anonfun$tryy$1.this.apply$mcV$sp();
-      <specialized> def apply$mcV$sp(): Unit = try {
+      final <specialized> def apply$mcV$sp(): Unit = try {
         $anonfun$tryy$1.this.tryyLocal$1.elem = $anonfun$tryy$1.this.tryyParam$1
       } finally ();
       <synthetic> <paramaccessor> <artifact> private[this] val $outer: T = _;

--- a/test/files/run/t6555.check
+++ b/test/files/run/t6555.check
@@ -12,7 +12,7 @@ package <empty> {
           ()
         };
         final def apply(param: Int): Int = $anonfun.this.apply$mcII$sp(param);
-        <specialized> def apply$mcII$sp(param: Int): Int = param
+        final <specialized> def apply$mcII$sp(param: Int): Int = param
       };
       (new <$anon: Int => Int>(): Int => Int)
     };


### PR DESCRIPTION
When the method is public, the specialized method should be public in override.

scala/bug#10211
