### PR TITLE
Enhance warning message for the case of using "-Ystatistics" setting along with "-Ybackend-parallelism"

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/GeneratedClassHandler.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GeneratedClassHandler.scala
@@ -60,7 +60,13 @@ private[jvm] object GeneratedClassHandler {
 
       case maxThreads =>
         if (settings.areStatisticsEnabled)
-          runReporting.warning(NoPosition, "jvm statistics are not reliable with multi-threaded jvm class writing", WarningCategory.Other, site = "")
+          runReporting.warning(
+            NoPosition,
+            "JVM statistics are not reliable with multi-threaded JVM class writing.\n" +
+            "To collect compiler statistics remove the " + settings.YaddBackendThreads.name + " setting.",
+            WarningCategory.Other,
+            site = ""
+          )
         val additionalThreads = maxThreads - 1
         // The thread pool queue is limited in size. When it's full, the `CallerRunsPolicy` causes
         // a new task to be executed on the main thread, which provides back-pressure.


### PR DESCRIPTION
This is a minor thing but makes the warning message a bit user-friendly for a case of using the `-Ystatistics` setting along with `-Ybackend-parallelism`.