### PR TITLE
[backport] emit deprecations for classOf arguments

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1857,6 +1857,10 @@ abstract class RefChecks extends Transform {
           case x @ Select(_, _) =>
             transformSelect(x)
 
+          case Literal(Constant(tp: Type)) =>
+            checkTypeRef(tp, tree, skipBounds = false)
+            tree
+
           case UnApply(fun, args) =>
             transform(fun) // just make sure we enterReference for unapply symbols, note that super.transform(tree) would not transform(fun)
                            // transformTrees(args) // TODO: is this necessary? could there be forward references in the args??

--- a/test/files/neg/classOfDeprecation.check
+++ b/test/files/neg/classOfDeprecation.check
@@ -1,0 +1,9 @@
+classOfDeprecation.scala:6: warning: class C is deprecated (since like, forever): no no!
+  val t = classOf[C]
+                 ^
+classOfDeprecation.scala:7: warning: class C is deprecated (since like, forever): no no!
+  @ann(classOf[C]) def u = 1
+              ^
+error: No warnings can be incurred under -Xfatal-warnings.
+two warnings found
+one error found

--- a/test/files/neg/classOfDeprecation.scala
+++ b/test/files/neg/classOfDeprecation.scala
@@ -1,0 +1,8 @@
+// scalac: -deprecation -Xfatal-warnings
+
+@deprecated("no no!", "like, forever") class C
+class ann(x: Any) extends annotation.Annotation
+object T {
+  val t = classOf[C]
+  @ann(classOf[C]) def u = 1
+}

--- a/test/files/run/t4813.check
+++ b/test/files/run/t4813.check
@@ -1,1 +1,15 @@
-warning: two deprecations (since 2.11.0); re-run with -deprecation for details
+t4813.scala:19: warning: object DoubleLinkedList in package mutable is deprecated (since 2.11.0): low-level linked lists are deprecated
+  runTest(DoubleLinkedList(1,2,3))(_.clone) { buf => buf transform (_ + 1) }
+          ^
+t4813.scala:19: warning: class DoubleLinkedList in package mutable is deprecated (since 2.11.0): low-level linked lists are deprecated due to idiosyncrasies in interface and incomplete features
+  runTest(DoubleLinkedList(1,2,3))(_.clone) { buf => buf transform (_ + 1) }
+                                            ^
+t4813.scala:22: warning: object LinkedList in package mutable is deprecated (since 2.11.0): low-level linked lists are deprecated
+  runTest(LinkedList(1,2,3))(_.clone) { buf => buf transform (_ + 1) }
+          ^
+t4813.scala:22: warning: class LinkedList in package mutable is deprecated (since 2.11.0): low-level linked lists are deprecated due to idiosyncrasies in interface and incomplete features
+  runTest(LinkedList(1,2,3))(_.clone) { buf => buf transform (_ + 1) }
+                                      ^
+t4813.scala:26: warning: class Stack in package mutable is deprecated (since 2.12.0): Stack is an inelegant and potentially poorly-performing wrapper around List. Use a List assigned to a var instead.
+  runTest(Stack(1,2,3))(_.clone) { buf => buf transform (_ + 1) }
+                                 ^

--- a/test/files/run/t4813.scala
+++ b/test/files/run/t4813.scala
@@ -1,3 +1,5 @@
+// scalac: -deprecation
+
 import collection.mutable._
 import reflect._
 


### PR DESCRIPTION
backport of https://github.com/scala/scala/pull/9776