### PR TITLE
Allow `ArrayBuffer` to access elements during `insertAll`

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -88,6 +88,9 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[MissingClassProblem]("scala.runtime.ClassValueCompat$ClassValueInterface"),
     ProblemFilters.exclude[MissingClassProblem]("scala.runtime.ClassValueCompat$JavaClassValue"),
     ProblemFilters.exclude[MissingClassProblem]("scala.runtime.ClassValueCompat$FallbackClassValue"),
+
+    // #9782
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.mutable.ArrayBuffer$SplitInfo"), // ArrayBuffer#private[this]
   )
 
   override val buildSettings = Seq(

--- a/test/junit/scala/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBufferTest.scala
@@ -1,5 +1,7 @@
 package scala.collection.mutable
 
+import java.util.ConcurrentModificationException
+
 import org.junit.Test
 import org.junit.Assert.{assertEquals, assertTrue}
 
@@ -448,12 +450,53 @@ class ArrayBufferTest {
     assertEquals(21, resizeDown(42, 17))
   }
 
-  // scala/bug#12121
+  /* tests for scala/bug#12121 */
+
   @Test
-  def insertAll_self(): Unit = {
-    val buf = ArrayBuffer(1, 2, 3)
-    buf.insertAll(1, buf)
-    assertSameElements(List(1, 1, 2, 3, 2, 3), buf)
+  def self_insertAll(): Unit = {
+    val b1 = ArrayBuffer(1, 2, 3)
+    b1.insertAll(1, b1)
+    assertSameElements(List(1, 1, 2, 3, 2, 3), b1)
+
+    val b2 = ArrayBuffer(1, 2, 3)
+    b2.insertAll(1, b2.view)
+    assertSameElements(List(1, 1, 2, 3, 2, 3), b2)
+
+    val b3 = ArrayBuffer(1, 2, 3)
+    b3.insertAll(1, b3.iterator)
+    assertSameElements(List(1, 1, 2, 3, 2, 3), b3)
+  }
+
+  @Test
+  def self_addAll(): Unit = {
+    val b1 = ArrayBuffer(1, 2, 3)
+    b1.addAll(b1)
+    assertSameElements(List(1, 2, 3, 1, 2, 3), b1)
+
+    val b2 = ArrayBuffer(1, 2, 3)
+    //b2.addAll(b2.view)
+    //assertSameElements(List(1, 2, 3, 1, 2, 3), b2)
+    assertThrows[ConcurrentModificationException](b2.addAll(b2.view))
+  }
+
+  @Test
+  def self_subtractAll(): Unit = {
+    val b1 = ArrayBuffer(1, 2, 3)
+    b1.subtractAll(b1)
+    assertSameElements(Nil, b1)
+
+    val b2 = ArrayBuffer(1, 2, 3)
+    // b2.subtractAll(b2.view)
+    //assertSameElements(Nil, b2)
+    assertThrows[ConcurrentModificationException](b2.subtractAll(b2.view))
+  }
+
+  @Test
+  def self_patchInPlace(): Unit = {
+    val b1 = ArrayBuffer(1, 2, 3)
+    //b1.patchInPlace(1, b1, 1)
+    //assertSameElements(List(1, 1, 2, 3, 3), b1)
+    assertThrows[ConcurrentModificationException](b1.patchInPlace(1, b1, 1))
   }
 
   // scala/bug#12284

--- a/test/junit/scala/collection/mutable/ListBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ListBufferTest.scala
@@ -3,8 +3,8 @@ package scala.collection.mutable
 import org.junit.Assert.{assertEquals, assertTrue}
 import org.junit.Test
 
-import scala.tools.testkit.AssertUtil.assertSameElements
-
+import java.util.ConcurrentModificationException
+import scala.tools.testkit.AssertUtil.{assertSameElements, assertThrows}
 import scala.annotation.nowarn
 
 class ListBufferTest {
@@ -235,16 +235,32 @@ class ListBufferTest {
 
   @Test
   def self_addAll(): Unit = {
-    val b = ListBuffer(1, 2, 3)
-    b ++= b
-    assertSameElements(List(1, 2, 3, 1, 2, 3), b)
+    val b1 = ListBuffer(1, 2, 3)
+    b1 ++= b1
+    assertSameElements(List(1, 2, 3, 1, 2, 3), b1)
+
+    val b2 = ListBuffer(1, 2, 3)
+    b2 ++= b2.view
+    assertSameElements(List(1, 2, 3, 1, 2, 3), b2)
+
+    val b3 = ListBuffer(1, 2, 3)
+    b3 ++= b3.iterator
+    assertSameElements(List(1, 2, 3, 1, 2, 3), b3)
   }
 
   @Test
   def self_prependAll(): Unit = {
-    val b = ListBuffer(1, 2, 3)
-    b prependAll b
-    assertSameElements(List(1, 2, 3, 1, 2, 3), b)
+    val b1 = ListBuffer(1, 2, 3)
+    b1.prependAll(b1)
+    assertSameElements(List(1, 2, 3, 1, 2, 3), b1)
+
+    val b2 = ListBuffer(1, 2, 3)
+    b2.prependAll(b2.view)
+    assertSameElements(List(1, 2, 3, 1, 2, 3), b2)
+
+    val b3 = ListBuffer(1, 2, 3)
+    b3.prependAll(b3.iterator)
+    assertSameElements(List(1, 2, 3, 1, 2, 3), b3)
   }
 
   @Test
@@ -256,13 +272,26 @@ class ListBufferTest {
     val b2 = ListBuffer(1, 2, 3)
     b2.insertAll(3, b2)
     assertSameElements(List(1, 2, 3, 1, 2, 3), b2)
+
+    val b3 = ListBuffer(1, 2, 3)
+    b3.insertAll(1, b3.view)
+    assertSameElements(List(1, 1, 2, 3, 2, 3), b3)
+
+    val b4 = ListBuffer(1, 2, 3)
+    b4.insertAll(1, b4.iterator)
+    assertSameElements(List(1, 1, 2, 3, 2, 3), b4)
   }
 
   @Test
   def self_subtractAll(): Unit = {
-    val b = ListBuffer(1, 2, 3)
-    b --= b
-    assertSameElements(Nil, b)
+    val b1 = ListBuffer(1, 2, 3)
+    b1 --= b1
+    assertSameElements(Nil, b1)
+
+    val b2 = ListBuffer(1, 2, 3)
+    //b2 --= b2.view
+    //assertSameElements(Nil, b2)
+    assertThrows[ConcurrentModificationException](b2 --= b2.view)
   }
 
   @Test
@@ -274,5 +303,13 @@ class ListBufferTest {
     val b2 = ListBuffer(1, 2, 3)
     b2.patchInPlace(3, b2, 1)
     assertSameElements(List(1, 2, 3, 1, 2, 3), b2)
+
+    val b3 = ListBuffer(1, 2, 3)
+    b3.patchInPlace(1, b3.view, 1)
+    assertSameElements(List(1, 1, 2, 3, 3), b3)
+
+    val b4 = ListBuffer(1, 2, 3)
+    b4.patchInPlace(1, b4.iterator, 1)
+    assertSameElements(List(1, 1, 2, 3, 3), b4)
   }
 }


### PR DESCRIPTION
Allow proxies of `ArrayBuffer` to access elements correctly during calls to
`ArrayBuffer#insertAll` by keeping track of where the gap between the
beginning and end of the buffer is.

As part of this, update `ArrayBuffer#mutationCount` only when
elements of the buffer are changed or moved, and not when the
backing array is resized without changing the collection.

This is more work on the eternal scala/bug#12121