### PR TITLE
Deprecate `AnyVal#formatted(formatString)`, to avoid conflict with JDK 15+ method

### DIFF
--- a/src/compiler/scala/tools/ant/sabbus/Compilers.scala
+++ b/src/compiler/scala/tools/ant/sabbus/Compilers.scala
@@ -45,5 +45,5 @@ object Compilers extends scala.collection.DefaultMap[String, Compiler] {
   }
 
   private def freeMemoryString: String =
-    (Runtime.getRuntime.freeMemory/1048576.0).formatted("%10.2f") + " MB"
+    f"${Runtime.getRuntime.freeMemory/1048576.0}%10.2f MB"
 }

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -327,6 +327,7 @@ object Predef extends LowPriorityImplicits with DeprecatedPredef {
      *  Format strings are as for `String.format`
      *  (@see java.lang.String.format).
      */
+    @deprecated("Use `formatString.format(value)` instead of `value.formatted(formatString)`,\nor use the `f\"\"` string interpolator. In Java 15 and later, `formatted` resolves to the new method in String which has reversed parameters.", "2.12.16")
     @inline def formatted(fmtstr: String): String = fmtstr format self
   }
 

--- a/src/reflect/scala/reflect/internal/util/ChromeTrace.scala
+++ b/src/reflect/scala/reflect/internal/util/ChromeTrace.scala
@@ -43,7 +43,7 @@ final class ChromeTrace(f: Path) extends Closeable {
   private val traceWriter = FileUtils.newAsyncBufferedWriter(f)
   private val context = mutable.ArrayStack[JsonContext](TopContext)
   private val tidCache = new ThreadLocal[String]() {
-    override def initialValue(): String = Thread.currentThread().getId.formatted("%05d")
+    override def initialValue(): String = f"${Thread.currentThread().getId}%05d"
   }
   objStart()
   fld("traceEvents")


### PR DESCRIPTION
Java 15 added an instance method `formatted` with reversed parameters

Fixes https://github.com/scala/bug/issues/12471