### PR TITLE
clean up deprecation warning suppression

### DIFF
--- a/src/library/scala/runtime/ModuleSerializationProxy.scala
+++ b/src/library/scala/runtime/ModuleSerializationProxy.scala
@@ -19,12 +19,12 @@ import scala.annotation.nowarn
 
 private[runtime] object ModuleSerializationProxy {
   private val instances = new ClassValueCompat[Object] {
-    @deprecated("", "") // because AccessController is deprecated on JDK 17
+    @nowarn("cat=deprecation") // AccessController is deprecated on JDK 17
     def getModule(cls: Class[_]): Object =
       java.security.AccessController.doPrivileged(
         (() => cls.getField("MODULE$").get(null)): PrivilegedExceptionAction[Object])
     override protected def computeValue(cls: Class[_]): Object =
-      try getModule(cls): @nowarn("cat=deprecation")
+      try getModule(cls)
       catch {
         case e: PrivilegedActionException =>
           rethrowRuntime(e.getCause)

--- a/test/files/run/t2318.scala
+++ b/test/files/run/t2318.scala
@@ -4,13 +4,14 @@
 import java.security._
 
 import scala.language.reflectiveCalls
+import scala.annotation.nowarn
 
-// SecurityManager is deprecated on JDK 17, so we sprinkle `@deprecated` around
+// SecurityManager is deprecated on JDK 17, so we sprinkle `@nowarn` around
 
 object Test {
   trait Bar { def bar: Unit }
 
-  @deprecated
+  @nowarn("cat=deprecation")
   object Mgr extends SecurityManager {
     def allowedProperty(name: String) =
       name == "sun.net.inetaddr.ttl" ||
@@ -32,7 +33,8 @@ object Test {
     def doDestroy( obj : Destroyable ) : Unit = obj.destroy();
     doDestroy( p );
   }
-  @deprecated
+
+  @nowarn("cat=deprecation")
   def t2() = {
     System.setSecurityManager(Mgr)
 
@@ -48,6 +50,6 @@ object Test {
     try t1()
     catch { case _: java.io.IOException => () }
 
-    t2(): @annotation.nowarn("cat=deprecation")
+    t2()
   }
 }


### PR DESCRIPTION
fixes scala/scala-dev#794

CI won't test this on JDK 17 until after we merge it, but I tested it on JDK 17 locally with `set every fatalWarnings := true` followed by `library/compile` and `partest test/files/run/t2318.scala`