### PR TITLE
junit-interface 0.13.2 (was 0.11)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ import scala.build._, VersionUtil._
 
 // Non-Scala dependencies:
 val junitDep          = "junit"                          % "junit"                            % "4.13.2"
-val junitInterfaceDep = "com.novocode"                   % "junit-interface"                  % "0.11"                            % Test
+val junitInterfaceDep = "com.github.sbt"                 % "junit-interface"                  % "0.13.2"                          % Test
 val scalacheckDep     = "org.scalacheck"                %% "scalacheck"                       % "1.15.4"                          % Test
 val jolDep            = "org.openjdk.jol"                % "jol-core"                         % "0.13"
 val asmDep            = "org.scala-lang.modules"         % "scala-asm"                        % versionProps("scala-asm.version")


### PR DESCRIPTION
I hadn't been aware that newer versions of this were available under a different org. I don't see anything risky-looking in the notes at https://github.com/sbt/junit-interface/releases