### PR TITLE
Add -h abbreviation to scaladoc help.

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
@@ -48,7 +48,7 @@ trait StandardScalaSettings { _: MutableSettings =>
     else Wconf.tryToSet(List(s"cat=feature:s"))
   }
   val g =               ChoiceSetting ("-g", "level", "Set level of generated debugging info.", List("none", "source", "line", "vars", "notailcalls"), "vars")
-  val help =           BooleanSetting ("-help", "Print a synopsis of standard options") withAbbreviation "--help"
+  val help =           BooleanSetting ("-help", "Print a synopsis of standard options") withAbbreviation "--help" withAbbreviation("-h")
   val nowarn =         BooleanSetting ("-nowarn", "Generate no warnings.") withAbbreviation "--no-warnings" withPostSetHook { s => if (s) maxwarns.value = 0 }
   val optimise:        BooleanSetting // depends on post hook which mutates other settings
   val print =          BooleanSetting ("-print", "Print program with Scala-specific features removed.") withAbbreviation "--print"


### PR DESCRIPTION
I've never used scaladoc cli before so tonight I downloaded it and the
first thing I tried was:

```
❯ scaladoc -h
scaladoc error: bad option: '-h'
  scaladoc -help  gives more information
error: IO error while decoding -h with UTF-8: -h (No such file or directory)
Please try specifying another one using the -encoding option
```

This is great that it then tells you to use `-help`, but I'm always
slightly annoyed when cli tools don't just default all `-help`,
`--help`, and `-h` to help. So if this doesn't conflict with anything
else (and looking I didn't see that it does), would it be alright to
also have `-h` as an abbreviation for `-help`?