### PR TITLE
Fix source position of templates with empty body/parents

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -3233,7 +3233,7 @@ self =>
         deprecationWarning(in.offset, "Using `<:` for `extends` is deprecated", since = "2.12.5")
         true
       }
-      val (parents, self, body) = (
+      val (parents, self, body) =
         if (in.token == EXTENDS || in.token == SUBTYPE && mods.isTrait && deprecatedUsage()) {
           in.nextToken()
           template()
@@ -3243,27 +3243,25 @@ self =>
           val (self, body) = templateBodyOpt(parenMeansSyntaxError = mods.isTrait || name.isTermName)
           (List(), self, body)
         }
-      )
-      def anyvalConstructor() = (
-        // Not a well-formed constructor, has to be finished later - see note
-        // regarding AnyVal constructor in AddInterfaces.
-        DefDef(NoMods, nme.CONSTRUCTOR, Nil, ListOfNil, TypeTree(), Block(Nil, literalUnit))
-      )
-      val tstart1 = if (body.isEmpty && in.lastOffset < tstart) in.lastOffset else tstart
-      val parentPos = if (parents.isEmpty) o2p(tstart1) else o2p(in.offset)
+      // Not a well-formed constructor, has to be finished later - see note
+      // regarding AnyVal constructor in AddInterfaces.
+      def anyvalConstructor() = DefDef(NoMods, nme.CONSTRUCTOR, Nil, ListOfNil, TypeTree(), Block(Nil, literalUnit))
+      // tstart is the offset of the token after `class C[A]` (which may be LPAREN, EXTENDS, LBRACE).
+      // if there is no template body, then tstart may be in the next program element, so back up to just after the `class C[A]`.
+      val templateOffset = if (body.isEmpty && in.lastOffset < tstart) in.lastOffset else tstart
+      val templatePos = o2p(templateOffset)
 
-      // we can't easily check this later, because `gen.mkParents` adds the default AnyRef parent, and we need to warn based on what the user wrote
-      if (name == nme.PACKAGEkw && parents.nonEmpty && settings.isScala3)
-        deprecationWarning(tstart, s"package object inheritance is deprecated (https://github.com/scala/scala-dev/issues/441);\n" +
-                                   s"drop the `extends` clause or use a regular object instead", "3.0.0")
+      // warn now if user wrote parents for package object; `gen.mkParents` adds AnyRef to parents
+      if (currentRun.isScala3 && name == nme.PACKAGEkw && !parents.isEmpty)
+        deprecationWarning(tstart, """package object inheritance is deprecated (https://github.com/scala/scala-dev/issues/441);
+                                     |drop the `extends` clause or use a regular object instead""".stripMargin, "3.0.0")
 
-      atPos(tstart1) {
+      atPos(templateOffset) {
         // Exclude only the 9 primitives plus AnyVal.
         if (inScalaRootPackage && ScalaValueClassNames.contains(name))
           Template(parents, self, anyvalConstructor() :: body)
         else
-          gen.mkTemplate(gen.mkParents(mods, parents, parentPos),
-                         self, constrMods, vparamss, body, o2p(tstart1))
+          gen.mkTemplate(gen.mkParents(mods, parents, templatePos), self, constrMods, vparamss, body, templatePos)
       }
     }
 

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -3078,10 +3078,13 @@ self =>
      *  }}}
      */
     def classDef(start: Offset, mods: Modifiers): ClassDef = {
+      def isAfterLineEnd: Boolean = in.lastOffset < in.lineStartOffset && (in.lineStartOffset <= in.offset || in.lastOffset < in.lastLineStartOffset && in.lastLineStartOffset <= in.offset)
       in.nextToken()
       checkKeywordDefinition()
       val nameOffset = in.offset
       val name = identForType()
+      if (currentRun.isScala3 && in.token == LBRACKET && isAfterLineEnd)
+        deprecationWarning(in.offset, "type parameters should not follow newline", "2.13.7")
       atPos(start, if (name == tpnme.ERROR) start else nameOffset) {
         savingClassContextBounds {
           val contextBoundBuf = new ListBuffer[Tree]

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -3246,8 +3246,8 @@ self =>
         // regarding AnyVal constructor in AddInterfaces.
         DefDef(NoMods, nme.CONSTRUCTOR, Nil, ListOfNil, TypeTree(), Block(Nil, literalUnit))
       )
-      val parentPos = o2p(in.offset)
       val tstart1 = if (body.isEmpty && in.lastOffset < tstart) in.lastOffset else tstart
+      val parentPos = if (parents.isEmpty) o2p(tstart1) else o2p(in.offset)
 
       // we can't easily check this later, because `gen.mkParents` adds the default AnyRef parent, and we need to warn based on what the user wrote
       if (name == nme.PACKAGEkw && parents.nonEmpty && settings.isScala3)
@@ -3260,7 +3260,7 @@ self =>
           Template(parents, self, anyvalConstructor() :: body)
         else
           gen.mkTemplate(gen.mkParents(mods, parents, parentPos),
-                         self, constrMods, vparamss, body, o2p(tstart))
+                         self, constrMods, vparamss, body, o2p(tstart1))
       }
     }
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -478,8 +478,7 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
     def isAtProgramPoint(lbl: asm.Label): Boolean = {
       (lastInsn match { case labnode: asm.tree.LabelNode => (labnode.getLabel == lbl); case _ => false } )
     }
-    def lineNumber(tree: Tree): Unit = {
-      if (!emitLines || !tree.pos.isDefined) return
+    def lineNumber(tree: Tree): Unit = if (emitLines && tree.pos.isDefined) {
       val nr = tree.pos.finalPosition.line
       if (nr != lastEmittedLineNr) {
         lastEmittedLineNr = nr

--- a/src/testkit/scala/tools/testkit/BytecodeTesting.scala
+++ b/src/testkit/scala/tools/testkit/BytecodeTesting.scala
@@ -32,7 +32,7 @@ import scala.tools.testkit.ASMConverters._
 
 trait BytecodeTesting extends ClearAfterClass {
   /**
-   * Overwrite to set additional compiler flags
+   * Override to set additional compiler flags.
    */
   def compilerArgs = ""
 

--- a/test/files/run/dynamic-applyDynamic.check
+++ b/test/files/run/dynamic-applyDynamic.check
@@ -1,8 +1,8 @@
 [[syntax trees at end of                     typer]] // newSource1.scala
 [0:67]package [0:0]<empty> {
-  [0:67]object X extends [9:67][67]scala.AnyRef {
-    [67]def <init>(): [9]X.type = [67]{
-      [67][67][67]X.super.<init>();
+  [0:67]object X extends [9:67][9]scala.AnyRef {
+    [9]def <init>(): [9]X.type = [9]{
+      [9][9][9]X.super.<init>();
       [9]()
     };
     [17:30]private[this] val d: [21]D = [25:30][25:30][25:30]new [29:30]D();

--- a/test/files/run/dynamic-applyDynamicNamed.check
+++ b/test/files/run/dynamic-applyDynamicNamed.check
@@ -1,8 +1,8 @@
 [[syntax trees at end of                     typer]] // newSource1.scala
 [0:97]package [0:0]<empty> {
-  [0:97]object X extends [9:97][97]scala.AnyRef {
-    [97]def <init>(): [9]X.type = [97]{
-      [97][97][97]X.super.<init>();
+  [0:97]object X extends [9:97][9]scala.AnyRef {
+    [9]def <init>(): [9]X.type = [9]{
+      [9][9][9]X.super.<init>();
       [9]()
     };
     [17:30]private[this] val d: [21]D = [25:30][25:30][25:30]new [29:30]D();

--- a/test/files/run/dynamic-selectDynamic.check
+++ b/test/files/run/dynamic-selectDynamic.check
@@ -1,8 +1,8 @@
 [[syntax trees at end of                     typer]] // newSource1.scala
 [0:50]package [0:0]<empty> {
-  [0:50]object X extends [9:50][50]scala.AnyRef {
-    [50]def <init>(): [9]X.type = [50]{
-      [50][50][50]X.super.<init>();
+  [0:50]object X extends [9:50][9]scala.AnyRef {
+    [9]def <init>(): [9]X.type = [9]{
+      [9][9][9]X.super.<init>();
       [9]()
     };
     [17:30]private[this] val d: [21]D = [25:30][25:30][25:30]new [29:30]D();

--- a/test/files/run/dynamic-updateDynamic.check
+++ b/test/files/run/dynamic-updateDynamic.check
@@ -1,8 +1,8 @@
 [[syntax trees at end of                     typer]] // newSource1.scala
 [0:69]package [0:0]<empty> {
-  [0:69]object X extends [9:69][69]scala.AnyRef {
-    [69]def <init>(): [9]X.type = [69]{
-      [69][69][69]X.super.<init>();
+  [0:69]object X extends [9:69][9]scala.AnyRef {
+    [9]def <init>(): [9]X.type = [9]{
+      [9][9][9]X.super.<init>();
       [9]()
     };
     [17:30]private[this] val d: [21]D = [25:30][25:30][25:30]new [29:30]D();

--- a/test/files/run/existential-rangepos.check
+++ b/test/files/run/existential-rangepos.check
@@ -1,8 +1,8 @@
 [[syntax trees at end of                    patmat]] // newSource1.scala
 [0:76]package [0:0]<empty> {
-  [0:76]abstract class A[[17:18]T[17:18]] extends [20:76][76]scala.AnyRef {
-    [76]def <init>(): [20]A[T] = [76]{
-      [76][76][76]A.super.<init>();
+  [0:76]abstract class A[[17:18]T[17:18]] extends [20:76][20]scala.AnyRef {
+    [20]def <init>(): [20]A[T] = [20]{
+      [20][20][20]A.super.<init>();
       [20]()
     };
     [24:51]private[this] val foo: [28]Set[_ <: T] = [47:51]null;

--- a/test/files/run/literals-parsing.check
+++ b/test/files/run/literals-parsing.check
@@ -1,6 +1,6 @@
 [[syntax trees at end of                    parser]] // newSource1.scala
 [0:161]package [0:0]<empty> {
-  [0:161]abstract trait T extends [8:161][161]scala.AnyRef {
+  [0:161]abstract trait T extends [8:161][8]scala.AnyRef {
     [8]def $init$() = [8]{
       [8]()
     };

--- a/test/files/run/sd187.check
+++ b/test/files/run/sd187.check
@@ -1,8 +1,8 @@
 [[syntax trees at end of                    patmat]] // newSource1.scala
 [1:2302]package [1:1]<empty> {
-  [1:2302]class C extends [9:2302][2302]scala.AnyRef {
-    [2302]def <init>(): [9]C = [2302]{
-      [2302][2302][2302]C.super.<init>();
+  [1:2302]class C extends [9:2302][9]scala.AnyRef {
+    [9]def <init>(): [9]C = [9]{
+      [9][9][9]C.super.<init>();
       [9]()
     };
     [103:904]def commonSubPattern([124:130]x: [127:130]<type: [127:130]scala.Any>): [107]AnyVal = [206:220]{

--- a/test/files/run/string-switch-pos.check
+++ b/test/files/run/string-switch-pos.check
@@ -1,8 +1,8 @@
 [[syntax trees at end of                    patmat]] // newSource1.scala
 [0:216]package [0:0]<empty> {
-  [0:216]class Switch extends [13:216][216]scala.AnyRef {
-    [216]def <init>(): [13]Switch = [216]{
-      [216][216][216]Switch.super.<init>();
+  [0:216]class Switch extends [13:216][13]scala.AnyRef {
+    [13]def <init>(): [13]Switch = [13]{
+      [13][13][13]Switch.super.<init>();
       [13]()
     };
     [17:214]def switch([28:37]s: [31:37]<type: [31:37]scala.Predef.String>, [39:52]cond: [45:52]<type: [45:52]scala.Boolean>): [21]Int = [56:57]{
@@ -67,8 +67,8 @@
         }
       }
     };
-    [216]def <init>(): [13]Switch = [216]{
-      [216][216][216]Switch.super.<init>();
+    [13]def <init>(): [13]Switch = [13]{
+      [13][13][13]Switch.super.<init>();
       [13]()
     }
   }

--- a/test/files/run/t10203.check
+++ b/test/files/run/t10203.check
@@ -1,8 +1,8 @@
 [[syntax trees at end of                     typer]] // newSource1.scala
 [0:88]package [0:0]<empty> {
-  [0:88]object X extends [9:88][88]scala.AnyRef {
-    [88]def <init>(): [9]X.type = [88]{
-      [88][88][88]X.super.<init>();
+  [0:88]object X extends [9:88][9]scala.AnyRef {
+    [9]def <init>(): [9]X.type = [9]{
+      [9][9][9]X.super.<init>();
       [9]()
     };
     [17:24][17:18][17:18]D.selectDynamic[[17]Nothing](<19:24>"aaaaa");

--- a/test/files/run/t10751.check
+++ b/test/files/run/t10751.check
@@ -1,8 +1,8 @@
 [[syntax trees at end of                     typer]] // newSource1.scala
 [0:201]package [0:0]<empty> {
-  [0:201]object Test extends [12:201][201]scala.AnyRef {
-    [201]def <init>(): [12]Test.type = [201]{
-      [201][201][201]Test.super.<init>();
+  [0:201]object Test extends [12:201][12]scala.AnyRef {
+    [12]def <init>(): [12]Test.type = [12]{
+      [12][12][12]Test.super.<init>();
       [12]()
     };
     [20:43]private[this] val n: [38]Int = [42:43]1;

--- a/test/files/run/t12062.check
+++ b/test/files/run/t12062.check
@@ -1,7 +1,7 @@
 warning: 6 deprecations (since 2.13.0); re-run with -deprecation for details
 
 class TestByte
-source-newSource1.scala,line-28 TestByte.super.<init>()
+source-newSource1.scala,line-2 TestByte.super.<init>()
 source-newSource1.scala,line-3 1.toByte()
 source-newSource1.scala,line-6 java.lang.Byte.toString(TestByte.this.value())
 source-newSource1.scala,line-6 TestByte.this.value()
@@ -51,7 +51,7 @@ source-newSource1.scala,line-27 TestByte.this.value()
 
 
 class TestShort
-source-newSource2.scala,line-28 TestShort.super.<init>()
+source-newSource2.scala,line-2 TestShort.super.<init>()
 source-newSource2.scala,line-3 1.toShort()
 source-newSource2.scala,line-6 java.lang.Short.toString(TestShort.this.value())
 source-newSource2.scala,line-6 TestShort.this.value()
@@ -101,7 +101,7 @@ source-newSource2.scala,line-27 TestShort.this.value()
 
 
 class TestInt
-source-newSource3.scala,line-28 TestInt.super.<init>()
+source-newSource3.scala,line-2 TestInt.super.<init>()
 source-newSource3.scala,line-3 1.toInt()
 source-newSource3.scala,line-6 java.lang.Integer.toString(TestInt.this.value())
 source-newSource3.scala,line-6 TestInt.this.value()
@@ -150,7 +150,7 @@ source-newSource3.scala,line-27 TestInt.this.value()
 
 
 class TestLong
-source-newSource4.scala,line-28 TestLong.super.<init>()
+source-newSource4.scala,line-2 TestLong.super.<init>()
 source-newSource4.scala,line-3 1.toLong()
 source-newSource4.scala,line-6 java.lang.Long.toString(TestLong.this.value())
 source-newSource4.scala,line-6 TestLong.this.value()
@@ -200,7 +200,7 @@ source-newSource4.scala,line-27 TestLong.this.value()
 
 
 class TestBoolean
-source-newSource5.scala,line-9 TestBoolean.super.<init>()
+source-newSource5.scala,line-2 TestBoolean.super.<init>()
 source-newSource5.scala,line-6 java.lang.Boolean.toString(TestBoolean.this.value())
 source-newSource5.scala,line-6 TestBoolean.this.value()
 source-newSource5.scala,line-7 java.lang.Boolean.hashCode(TestBoolean.this.value())
@@ -209,7 +209,7 @@ source-newSource5.scala,line-8 TestBoolean.this.value()
 
 
 class TestChar
-source-newSource6.scala,line-9 TestChar.super.<init>()
+source-newSource6.scala,line-2 TestChar.super.<init>()
 source-newSource6.scala,line-6 java.lang.Character.toString(TestChar.this.value())
 source-newSource6.scala,line-6 TestChar.this.value()
 source-newSource6.scala,line-7 java.lang.Character.hashCode(TestChar.this.value())
@@ -219,7 +219,7 @@ source-newSource6.scala,line-8 TestChar.this.value()
 
 
 class TestFloat
-source-newSource7.scala,line-39 TestFloat.super.<init>()
+source-newSource7.scala,line-2 TestFloat.super.<init>()
 source-newSource7.scala,line-3 1.toFloat()
 source-newSource7.scala,line-6 java.lang.Float.toString(TestFloat.this.value())
 source-newSource7.scala,line-6 TestFloat.this.value()
@@ -296,7 +296,7 @@ source-newSource7.scala,line-38 TestFloat.this.value()
 
 
 class TestDouble
-source-newSource8.scala,line-39 TestDouble.super.<init>()
+source-newSource8.scala,line-2 TestDouble.super.<init>()
 source-newSource8.scala,line-3 1.toDouble()
 source-newSource8.scala,line-6 java.lang.Double.toString(TestDouble.this.value())
 source-newSource8.scala,line-6 TestDouble.this.value()

--- a/test/files/run/t5064.check
+++ b/test/files/run/t5064.check
@@ -7,9 +7,9 @@ newSource1.scala:5: warning: a pure expression does nothing in statement positio
 newSource1.scala:6: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
   Nil
   ^
-[53]            T5064.super.<init>()
-[53]            T5064.super.<init>
-[53]            this
+[12]            T5064.super.<init>()
+[12]            T5064.super.<init>
+[12]            this
 [16:23]         scala.`package`.List().apply(scala.runtime.ScalaRunTime.wrapIntArray(Array[Int]{1}))
 [16:20]         scala.`package`.List().apply
 <16:20>         scala.`package`.List()

--- a/test/files/run/t5603.check
+++ b/test/files/run/t5603.check
@@ -1,6 +1,6 @@
 [[syntax trees at end of                    parser]] // newSource1.scala
 [0:241]package [0:0]<empty> {
-  [0:82]abstract trait Greeting extends [15:82][83]scala.AnyRef {
+  [0:82]abstract trait Greeting extends [15:82][15]scala.AnyRef {
     [15]def $init$() = [15]{
       [15]()
     };

--- a/test/files/run/t6288.check
+++ b/test/files/run/t6288.check
@@ -1,8 +1,8 @@
 [[syntax trees at end of                    patmat]] // newSource1.scala
 [0:553]package [0:0]<empty> {
-  [0:151]object Case3 extends [13:151][152]scala.AnyRef {
-    [152]def <init>(): [13]Case3.type = [152]{
-      [152][152][152]Case3.super.<init>();
+  [0:151]object Case3 extends [13:151][13]scala.AnyRef {
+    [13]def <init>(): [13]Case3.type = [13]{
+      [13][13][13]Case3.super.<init>();
       [13]()
     };
     [17:60]def unapply([29:35]z: [32:35]<type: [32:35]scala.Any>): [21]Option[Int] = [52:60][52:56][52:56]new [52:56]Some[Int]([57:59]-1);
@@ -28,9 +28,9 @@
       }
     }
   };
-  [152:308]object Case4 extends [165:308][309]scala.AnyRef {
-    [309]def <init>(): [165]Case4.type = [309]{
-      [309][309][309]Case4.super.<init>();
+  [152:308]object Case4 extends [165:308][165]scala.AnyRef {
+    [165]def <init>(): [165]Case4.type = [165]{
+      [165][165][165]Case4.super.<init>();
       [165]()
     };
     [169:217]def unapplySeq([184:190]z: [187:190]<type: [187:190]scala.Any>): [173]Option[List[Int]] = [213:217]scala.None;
@@ -56,9 +56,9 @@
       }
     }
   };
-  [309:448]object Case5 extends [322:448][449]scala.AnyRef {
-    [449]def <init>(): [322]Case5.type = [449]{
-      [449][449][449]Case5.super.<init>();
+  [309:448]object Case5 extends [322:448][322]scala.AnyRef {
+    [322]def <init>(): [322]Case5.type = [322]{
+      [322][322][322]Case5.super.<init>();
       [322]()
     };
     [326:361]def unapply([338:344]z: [341:344]<type: [341:344]scala.Any>): [330]Boolean = [357:361]true;
@@ -84,9 +84,9 @@
       }
     }
   };
-  [449:553]object Case6 extends [462:553][553]scala.AnyRef {
-    [553]def <init>(): [462]Case6.type = [553]{
-      [553][553][553]Case6.super.<init>();
+  [449:553]object Case6 extends [462:553][462]scala.AnyRef {
+    [462]def <init>(): [462]Case6.type = [462]{
+      [462][462][462]Case6.super.<init>();
       [462]()
     };
     [466:509]def unapply([478:484]z: [481:484]<type: [481:484]scala.Int>): [470]Option[Int] = [501:509][501:505][501:505]new [501:505]Some[Int]([506:508]-1);

--- a/test/files/run/t7271.check
+++ b/test/files/run/t7271.check
@@ -1,6 +1,6 @@
 [[syntax trees at end of                    parser]] // newSource1.scala
 [0:91]package [0:0]<empty> {
-  [0:91]class C extends [8:91][91]scala.AnyRef {
+  [0:91]class C extends [8:91][8]scala.AnyRef {
     [8]def <init>() = [8]{
       [NoPosition][NoPosition][NoPosition]super.<init>();
       [8]()

--- a/test/files/run/t7569.check
+++ b/test/files/run/t7569.check
@@ -1,8 +1,8 @@
 source-newSource1.scala,line-3,offset=49 A.this.one
 source-newSource1.scala,line-3,offset=49 A.this
-source-newSource1.scala,line-4,offset=67 A.super.<init>()
-source-newSource1.scala,line-4,offset=67 A.super.<init>
-source-newSource1.scala,line-4,offset=67 this
+source-newSource1.scala,line-2,offset=41 A.super.<init>()
+source-newSource1.scala,line-2,offset=41 A.super.<init>
+source-newSource1.scala,line-2,offset=41 this
 source-newSource1.scala,line-3,offset=49 A.this.one
 source-newSource1.scala,line-3,offset=49 A.this
 RangePosition(newSource1.scala, 55, 57, 65) java.lang.Integer.toString(1)


### PR DESCRIPTION
The position of those absent elements was incorrectly taken as following on the next line.

Fixes scala/bug#12470