### PR TITLE
Remove unused code for NL before LBRACKET

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2607,7 +2607,6 @@ self =>
         }
         param
       }
-      newLineOptWhenFollowedBy(LBRACKET)
       if (in.token == LBRACKET) inBrackets(commaSeparated(typeParam(NoMods withAnnotations annotations(skipNewLines = true))))
       else Nil
     }


### PR DESCRIPTION
If there is a newline between the identifier and type parameter section, it is consumed on next token. NL is not inserted because LBRACKET can no longer start a statement, although this behavior has reverted in Scala 3.