### PR TITLE
BigInt delegates for inputs not in domain

### DIFF
--- a/src/library/scala/math/BigInt.scala
+++ b/src/library/scala/math/BigInt.scala
@@ -56,9 +56,9 @@ object BigInt {
    *  @return  the constructed `BigInt`
    */
   def apply(l: Long): BigInt =
-    if (minCached <= l && l <= maxCached) getCached(l.toInt) else {
-      if (l == Long.MinValue) longMinValue else new BigInt(null, l)
-  }
+    if (minCached <= l && l <= maxCached) getCached(l.toInt)
+    else if (l == Long.MinValue) longMinValue
+    else new BigInt(null, l)
 
   /** Translates a byte array containing the two's-complement binary
    *  representation of a BigInt into a BigInt.
@@ -436,7 +436,7 @@ final class BigInt private (private var _bigInteger: BigInteger, private val _lo
    *  @param that A positive number
    */
   def mod(that: BigInt): BigInt =
-    if (this.longEncoding && that.longEncoding) {
+    if (this.longEncoding && that.longEncoding && that._long > 0) {
       val res = this._long % that._long
       if (res >= 0) BigInt(res) else BigInt(res + that._long)
     } else BigInt(this.bigInteger.mod(that.bigInteger))
@@ -495,7 +495,7 @@ final class BigInt private (private var _bigInteger: BigInteger, private val _lo
   /** Returns true if and only if the designated bit is set.
    */
   def testBit(n: Int): Boolean =
-    if (longEncoding) {
+    if (longEncoding && n >= 0) {
       if (n <= 63)
         (_long & (1L << n)) != 0
       else
@@ -505,17 +505,17 @@ final class BigInt private (private var _bigInteger: BigInteger, private val _lo
   /** Returns a BigInt whose value is equivalent to this BigInt with the designated bit set.
    */
   def setBit(n: Int): BigInt  = // note that we do not operate on the Long sign bit #63
-    if (longEncoding && n <= 62) BigInt(_long | (1L << n)) else BigInt(this.bigInteger.setBit(n))
+    if (longEncoding && n <= 62 && n >= 0) BigInt(_long | (1L << n)) else BigInt(this.bigInteger.setBit(n))
 
   /** Returns a BigInt whose value is equivalent to this BigInt with the designated bit cleared.
    */
   def clearBit(n: Int): BigInt  = // note that we do not operate on the Long sign bit #63
-    if (longEncoding && n <= 62) BigInt(_long & ~(1L << n)) else BigInt(this.bigInteger.clearBit(n))
+    if (longEncoding && n <= 62 && n >= 0) BigInt(_long & ~(1L << n)) else BigInt(this.bigInteger.clearBit(n))
 
   /** Returns a BigInt whose value is equivalent to this BigInt with the designated bit flipped.
    */
   def flipBit(n: Int): BigInt  = // note that we do not operate on the Long sign bit #63
-    if (longEncoding && n <= 62) BigInt(_long ^ (1L << n)) else BigInt(this.bigInteger.flipBit(n))
+    if (longEncoding && n <= 62 && n >= 0) BigInt(_long ^ (1L << n)) else BigInt(this.bigInteger.flipBit(n))
 
   /** Returns the index of the rightmost (lowest-order) one bit in this BigInt
    * (the number of zero bits to the right of the rightmost one bit).

--- a/test/junit/scala/math/BigIntTest.scala
+++ b/test/junit/scala/math/BigIntTest.scala
@@ -1,10 +1,36 @@
 package scala.math
 
 import org.junit.Test
+import org.junit.Assert.{assertFalse, assertTrue}
+import scala.tools.testkit.AssertUtil.assertThrows
 
 class BigIntTest {
 
-  @Test
-  def testIsComparable(): Unit =
-    assert(BigInt(1).isInstanceOf[java.lang.Comparable[_]])
+  private val bigint = BigInt(42)
+
+  @Test def testIsComparable: Unit = assertTrue(BigInt(42).isInstanceOf[java.lang.Comparable[_]])
+
+  @Test def `mod respects BigInteger`: Unit = assertThrows[ArithmeticException](bigint mod BigInt(-3), _.contains("modulus not positive"))
+
+  @Test def `modPow respects BigInteger`: Unit = assertThrows[ArithmeticException](bigint.modPow(BigInt(1), BigInt(-3)), _.contains("modulus not positive"))
+
+  @Test def `modInverse respects BigInteger`: Unit = assertThrows[ArithmeticException](bigint.modInverse(BigInt(-3)), _.contains("modulus not positive"))
+
+  @Test def `pow respects BigInteger`: Unit = assertThrows[ArithmeticException](bigint pow -2, _.contains("Negative exponent"))
+
+  @Test def `% respects BigInteger`: Unit = assertThrows[ArithmeticException](bigint % 0, _.contains("/ by zero"))
+
+  @Test def `setBit respects BigInteger`: Unit = assertThrows[ArithmeticException](bigint setBit -1, _.contains("Negative bit address"))
+
+  @Test def `clearBit respects BigInteger`: Unit = assertThrows[ArithmeticException](bigint clearBit -1, _.contains("Negative bit address"))
+
+  @Test def `flipBit respects BigInteger`: Unit = assertThrows[ArithmeticException](bigint flipBit -1, _.contains("Negative bit address"))
+
+  @Test def `/ respects BigInteger`: Unit = assertThrows[ArithmeticException](bigint / BigInt(0), _.contains("/ by zero"))
+
+  @Test def `/% respects BigInteger`: Unit = assertThrows[ArithmeticException](bigint /% BigInt(0), _.contains("/ by zero"))
+
+  @Test def `testBit respects BigInteger`: Unit = assertThrows[ArithmeticException](bigint.testBit(-3), _.contains("Negative bit address"))
+
+  @Test def `testBit 0`: Unit = assertFalse(bigint.testBit(0))
 }


### PR DESCRIPTION
It errors identically as the underlying BigInteger.

Follow-up for https://github.com/scala/scala/pull/9628