### PR TITLE
language syntax spec: add a note to `op ::= `rule

### DIFF
--- a/spec/13-syntax-summary.md
+++ b/spec/13-syntax-summary.md
@@ -33,6 +33,7 @@ hexDigit         ::=  ‘0’ | … | ‘9’ | ‘A’ | … | ‘F’ | ‘a�
 charEscapeSeq    ::=  ‘\’ (‘b’ | ‘t’ | ‘n’ | ‘f’ | ‘r’ | ‘"’ | ‘'’ | ‘\’)
 escapeSeq        ::=  UnicodeEscape | charEscapeSeq
 op               ::=  opchar {opchar}
+                      note that ‘#’, ‘:’, ‘-’ and ‘@’ can't be used as one-symbol operators, they have a reserved semantics in the grammar
 varid            ::=  lower idrest
 boundvarid       ::=  varid
                    |  ‘`’ varid ‘`’


### PR DESCRIPTION
Single ‘#’, ‘:’, ‘-’, ‘@’ symbols are accepted by `op ::=  opchar {opchar}` rule but they can't be used as an operator