### PR TITLE
[backport] RefCheck types uniformly, handle existentials and annotations

### DIFF
--- a/test/files/neg/ref-checks.check
+++ b/test/files/neg/ref-checks.check
@@ -1,0 +1,7 @@
+ref-checks.scala:8: error: type arguments [Int] do not conform to trait Chars's type parameter bounds [A <: CharSequence]
+  @ann[Chars[Int]] val x = 42
+                       ^
+ref-checks.scala:9: error: type arguments [Double] do not conform to trait Chars's type parameter bounds [A <: CharSequence]
+  val y: Two[Chars[Long] @uncheckedBounds, Chars[Double]] = null
+         ^
+two errors found

--- a/test/files/neg/ref-checks.scala
+++ b/test/files/neg/ref-checks.scala
@@ -1,0 +1,10 @@
+import scala.annotation.StaticAnnotation
+import scala.reflect.internal.annotations.uncheckedBounds
+
+object Test {
+  trait Chars[A <: CharSequence]
+  trait Two[A, B]
+  class ann[A] extends StaticAnnotation
+  @ann[Chars[Int]] val x = 42
+  val y: Two[Chars[Long] @uncheckedBounds, Chars[Double]] = null
+}

--- a/test/files/run/t12481.check
+++ b/test/files/run/t12481.check
@@ -1,0 +1,2 @@
+Test$Universe[_ <: Any]
+Test$Universe[<?>]

--- a/test/files/run/t12481.scala
+++ b/test/files/run/t12481.scala
@@ -1,0 +1,6 @@
+object Test extends App {
+  trait Txn[T <: Txn[T]]
+  trait Universe[T <: Txn[T]]
+  println(implicitly[Manifest[Universe[_]]])
+  println(implicitly[OptManifest[Universe[_]]])
+}


### PR DESCRIPTION
 - All existentially bound skolems are replaced with wildcards
 - Annotation types are checked deeply
 - Nesting of `@uncheckedBounds` is handled properly

Backport of https://github.com/scala/scala/pull/9806