### PR TITLE
hide deprecated `scala.Stream`

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -30,6 +30,11 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.Predef#SeqCharSequence.isEmpty"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.Predef#ArrayCharSequence.isEmpty"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.ArrayCharSequence.isEmpty"),
+
+    // KEEP: when the `scala.Stream` val became package-private this static forward was no longer
+    // emitted. only Java clients could possibly be affected; it seems extremely unlikely they'd
+    // be accessing `Stream` via this route
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.package.Stream"),
   )
 
   override val buildSettings = Seq(

--- a/src/library/scala/package.scala
+++ b/src/library/scala/package.scala
@@ -80,10 +80,12 @@ package object scala {
   val +: = scala.collection.+:
   val :+ = scala.collection.:+
 
+  // we cannot remove these entirely from Scala 2 because bincompat, but
+  // we can make them package-private to prevent usage
   @deprecated("Use LazyList instead of Stream", "2.13.0")
-  type Stream[+A] = scala.collection.immutable.Stream[A]
+  private[scala] type Stream[+A] = scala.collection.immutable.Stream[A]
   @deprecated("Use LazyList instead of Stream", "2.13.0")
-  val Stream = scala.collection.immutable.Stream
+  private[scala] val Stream = scala.collection.immutable.Stream
 
   type LazyList[+A] = scala.collection.immutable.LazyList[A]
   val LazyList = scala.collection.immutable.LazyList
@@ -93,7 +95,7 @@ package object scala {
     def unapply[A](s: LazyList[A]): Option[(A, LazyList[A])] =
       if (s.nonEmpty) Some((s.head, s.tail)) else None
     @deprecated("Prefer LazyList instead", since = "2.13.0")
-    def unapply[A](s: Stream[A]): Option[(A, Stream[A])] =
+    def unapply[A](s: scala.collection.immutable.Stream[A]): Option[(A, scala.collection.immutable.Stream[A])] =
       if (s.nonEmpty) Some((s.head, s.tail)) else None
   }
 

--- a/src/library/scala/sys/process/BasicIO.scala
+++ b/src/library/scala/sys/process/BasicIO.scala
@@ -62,11 +62,12 @@ object BasicIO {
   private[process] final class Streamed[T](
     val process:   T => Unit,
     val    done: Int => Unit,
-    val  stream:  () => Stream[T]
+    val  stream:  () => scala.collection.immutable.Stream[T]
   )
 
   @deprecated("internal", since = "2.13.4")
   private[process] object Streamed {
+    import scala.collection.immutable.Stream
     def apply[T](nonzeroException: Boolean, capacity: Integer): Streamed[T] = {
       val q = new LinkedBlockingQueue[Either[Int, T]](capacity)
       def next(): Stream[T] = q.take() match {

--- a/src/library/scala/sys/process/ProcessBuilder.scala
+++ b/src/library/scala/sys/process/ProcessBuilder.scala
@@ -16,6 +16,7 @@ package process
 
 import processInternal._
 import ProcessBuilder.{Sink, Source}
+import scala.collection.immutable.Stream  // used in deprecated APIs
 
 /** Represents a sequence of one or more external processes that can be
   * executed. A `ProcessBuilder` can be a single external process, or a

--- a/src/library/scala/sys/process/ProcessBuilderImpl.scala
+++ b/src/library/scala/sys/process/ProcessBuilderImpl.scala
@@ -22,6 +22,7 @@ import Uncloseable.protect
 import java.io.{FileInputStream, FileOutputStream}
 import java.util.concurrent.LinkedBlockingQueue
 
+import scala.collection.immutable.Stream  // used in deprecated APIs
 import scala.util.control.NonFatal
 
 private[process] trait ProcessBuilderImpl {

--- a/test/files/pos/depmet_implicit_chaining_zw.scala
+++ b/test/files/pos/depmet_implicit_chaining_zw.scala
@@ -1,3 +1,5 @@
+import scala.collection.immutable.Stream
+
 trait Zero
 trait Succ[N]
 

--- a/test/files/pos/depmet_implicit_norm_ret.scala
+++ b/test/files/pos/depmet_implicit_norm_ret.scala
@@ -1,3 +1,5 @@
+import scala.collection.immutable.Stream
+
 object Test{
   def ?[S <: AnyRef](implicit w : S) : w.type = w
 

--- a/test/files/pos/depmet_implicit_oopsla_zipwith.scala
+++ b/test/files/pos/depmet_implicit_oopsla_zipwith.scala
@@ -1,3 +1,5 @@
+import scala.collection.immutable.Stream
+
 case class Zero()
 case class Succ[N](x: N)
 import Stream.{cons, continually}

--- a/test/files/pos/iterator-traversable-mix.scala
+++ b/test/files/pos/iterator-traversable-mix.scala
@@ -1,3 +1,5 @@
+import scala.collection.immutable.Stream
+
 object Test {
   for {
     x1 <- List(1, 2)

--- a/test/files/pos/t1279a.scala
+++ b/test/files/pos/t1279a.scala
@@ -1,3 +1,5 @@
+import scala.collection.immutable.Stream
+
 // covariant linked list
 abstract class M {
   self =>

--- a/test/files/pos/t2234.scala
+++ b/test/files/pos/t2234.scala
@@ -1,3 +1,5 @@
+import scala.collection.immutable.Stream
+
 object Test extends App {
   val res0 = 1 #:: Stream.empty
   res0 match { case 1 #:: xs => xs }

--- a/test/files/pos/t2310.scala
+++ b/test/files/pos/t2310.scala
@@ -1,4 +1,4 @@
-import scala.Stream._
+import scala.collection.immutable.Stream
 
 object consistencyError {
   /* this gives an error:

--- a/test/files/pos/t3731.scala
+++ b/test/files/pos/t3731.scala
@@ -1,3 +1,5 @@
+import scala.collection.immutable.Stream
+
 object Test{
   trait ZW[S]{type T}
   def ZipWith[S, M <: ZW[S]]: M#T = sys.error("ZW")

--- a/test/files/pos/t927.scala
+++ b/test/files/pos/t927.scala
@@ -1,3 +1,5 @@
+import scala.collection.immutable.Stream
+
 object Test {
 
   def sum(stream: Stream[Int]): Int =

--- a/test/files/run/colltest1.scala
+++ b/test/files/run/colltest1.scala
@@ -206,7 +206,7 @@ object Test extends App {
 
   sequenceTest(Nil)
   sequenceTest(List())
-  sequenceTest(Stream.empty)
+  sequenceTest(immutable.Stream.empty)
   sequenceTest(Array[Int]())
   sequenceTest(mutable.ArrayBuffer())
   sequenceTest(mutable.ListBuffer())

--- a/test/files/run/serialize-stream.scala
+++ b/test/files/run/serialize-stream.scala
@@ -1,4 +1,4 @@
-
+import scala.collection.immutable.Stream
 
 object Test {
   def ser[T](s: Seq[T]): Unit = {

--- a/test/files/run/t12292.check
+++ b/test/files/run/t12292.check
@@ -2,27 +2,30 @@
 scala> import scala.annotation.nowarn
 import scala.annotation.nowarn
 
+scala> import scala.collection.immutable.Stream
+import scala.collection.immutable.Stream
+
 scala> scala.#::.unapply(Stream(1))
                  ^
        warning: method unapply in object #:: is deprecated (since 2.13.0): Prefer LazyList instead
                          ^
-       warning: value Stream in package scala is deprecated (since 2.13.0): Use LazyList instead of Stream
-val res0: Option[(Int, Stream[Int])] = Some((1,Stream()))
+       warning: object Stream in package immutable is deprecated (since 2.13.0): Use LazyList (which is fully lazy) instead of Stream (which has a lazy tail only)
+val res0: Option[(Int, scala.collection.immutable.Stream[Int])] = Some((1,Stream()))
 
 scala> scala.#::.unapply(Stream(1)): @nowarn
-val res1: Option[(Int, Stream[Int])] @scala.annotation.nowarn = Some((1,Stream()))
+val res1: Option[(Int, scala.collection.immutable.Stream[Int])] @scala.annotation.nowarn = Some((1,Stream()))
 
 scala> (scala.#::.unapply(Stream(1)): @nowarn)
-val res2: Option[(Int, Stream[Int])] @scala.annotation.nowarn = Some((1,Stream()))
+val res2: Option[(Int, scala.collection.immutable.Stream[Int])] @scala.annotation.nowarn = Some((1,Stream()))
 
 scala> scala.#::.unapply(Stream(1)): @inline
                  ^
        warning: method unapply in object #:: is deprecated (since 2.13.0): Prefer LazyList instead
                          ^
-       warning: value Stream in package scala is deprecated (since 2.13.0): Use LazyList instead of Stream
+       warning: object Stream in package immutable is deprecated (since 2.13.0): Use LazyList (which is fully lazy) instead of Stream (which has a lazy tail only)
                                       ^
-       warning: type Stream in package scala is deprecated (since 2.13.0): Use LazyList instead of Stream
-val res3: Option[(Int, Stream[Int])] @inline = Some((1,Stream()))
+       warning: class Stream in package immutable is deprecated (since 2.13.0): Use LazyList (which is fully lazy) instead of Stream (which has a lazy tail only)
+val res3: Option[(Int, scala.collection.immutable.Stream[Int])] @inline = Some((1,Stream()))
 
 scala> (scala.#::.unapply(Stream(1)): @nowarn).isEmpty
 val res4: Boolean = false

--- a/test/files/run/t12292.scala
+++ b/test/files/run/t12292.scala
@@ -5,6 +5,7 @@ object Test extends ReplTest {
 
   def code = """
 import scala.annotation.nowarn
+import scala.collection.immutable.Stream
 scala.#::.unapply(Stream(1))
 scala.#::.unapply(Stream(1)): @nowarn
 (scala.#::.unapply(Stream(1)): @nowarn)


### PR DESCRIPTION
it's deprecated anyway, and it's really unfortunate IMO that it's occupying top-level namespace under `scala.`, especially for a super common word like `Stream`

thanks @mpilquist for the nudge