### PR TITLE
Use subcolon args to simplify optimizer options

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -682,7 +682,7 @@ lazy val bench = project.in(file("test") / "benchmarks")
       if (benchmarkScalaVersion == "") Nil
       else "org.scala-lang" % "scala-compiler" % benchmarkScalaVersion :: Nil
     },
-    //scalacOptions ++= Seq("-feature", "-opt:all", "-opt:inline:scala/**", "-Wopt"),
+    //scalacOptions ++= Seq("-feature", "-opt:inline:scala/**", "-Wopt"),
     scalacOptions ++= Seq("-feature", "-opt:l:inline", "-opt-inline-from:scala/**", "-opt-warnings"),
     // Skips JMH source generators during IDE import to avoid needing to compile scala-library during the import
     // should not be needed once sbt-jmh 0.4.3 is out (https://github.com/sbt/sbt-jmh/pull/207)

--- a/build.sbt
+++ b/build.sbt
@@ -682,6 +682,7 @@ lazy val bench = project.in(file("test") / "benchmarks")
       if (benchmarkScalaVersion == "") Nil
       else "org.scala-lang" % "scala-compiler" % benchmarkScalaVersion :: Nil
     },
+    //scalacOptions ++= Seq("-feature", "-opt:all", "-opt:inline:scala/**", "-Wopt"),
     scalacOptions ++= Seq("-feature", "-opt:l:inline", "-opt-inline-from:scala/**", "-opt-warnings"),
     // Skips JMH source generators during IDE import to avoid needing to compile scala-library during the import
     // should not be needed once sbt-jmh 0.4.3 is out (https://github.com/sbt/sbt-jmh/pull/207)

--- a/project/ScriptCommands.scala
+++ b/project/ScriptCommands.scala
@@ -161,7 +161,7 @@ object ScriptCommands {
   }
 
   private[this] val enableOptimizer = Seq(
-    //ThisBuild / Compile / scalacOptions ++= Seq("-opt:all", "-opt:inline:scala/**")
+    //ThisBuild / Compile / scalacOptions ++= Seq("-opt:inline:scala/**")
     ThisBuild / Compile / scalacOptions ++= Seq("-opt:l:inline", "-opt-inline-from:scala/**")
   )
 

--- a/project/ScriptCommands.scala
+++ b/project/ScriptCommands.scala
@@ -161,6 +161,7 @@ object ScriptCommands {
   }
 
   private[this] val enableOptimizer = Seq(
+    //ThisBuild / Compile / scalacOptions ++= Seq("-opt:all", "-opt:inline:scala/**")
     ThisBuild / Compile / scalacOptions ++= Seq("-opt:l:inline", "-opt-inline-from:scala/**")
   )
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/PostProcessorFrontendAccess.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/PostProcessorFrontendAccess.scala
@@ -211,7 +211,7 @@ object PostProcessorFrontendAccess {
       val optAllowSkipClassLoading: Boolean = s.optAllowSkipClassLoading
 
       val optInlinerEnabled: Boolean = s.optInlinerEnabled
-      val optInlineFrom: List[String] = s.optInlineFrom.value
+      val optInlineFrom: List[String] = s.optInlineFrom
       val optInlineHeuristics: String = s.YoptInlineHeuristics.value
 
       val optWarningNoInlineMixed: Boolean = s.optWarningNoInlineMixed

--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -122,11 +122,7 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
       args: List[String],
       setter: (Setting) => (List[String] => Option[List[String]])
     ): Option[List[String]] =
-      lookupSetting(cmd) match {
-        //case None       => errorFn("Parameter '" + cmd + "' is not recognised by Scalac.") ; None
-        case None       => None //error reported in processArguments
-        case Some(cmd)  => setter(cmd)(args)
-      }
+      lookupSetting(cmd).flatMap(setter(_)(args))
 
     // -Xfoo: clears Clearables
     def clearIfExists(cmd: String): Option[List[String]] = lookupSetting(cmd) match {
@@ -139,14 +135,14 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
     // the entire arg is consumed, so return None for failure
     // any non-Nil return value means failure and we return s unmodified
     def parseColonArg(s: String): Option[List[String]] =
-      if (s endsWith ":") {
+      if (s endsWith ":")
         clearIfExists(s.init)
-      } else {
+      else
         StringOps.splitWhere(s, _ == ':', doDropIndex = true).flatMap {
-          case (p, args) =>
-            tryToSetIfExists(p, (args split ",").toList, (s: Setting) => s.tryToSetColon(_))
+          // p:arg:a,b,c is taken as arg with selections a,b,c for a multichoice setting
+          case (p, args) if args.contains(":") && lookupSetting(p).map(_.isInstanceOf[MultiChoiceSetting[_]]).getOrElse(false) => tryToSetIfExists(p, List(args), (s: Setting) => s.tryToSetColon(_))
+          case (p, args) => tryToSetIfExists(p, args.split(",").toList, (s: Setting) => s.tryToSetColon(_))
         }
-      }
 
     // if arg is of form -Xfoo or -Xfoo bar (name = "-Xfoo")
     def parseNormalArg(p: String, args: List[String]): Option[List[String]] =
@@ -559,7 +555,9 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
    * not present in the multiChoiceSetting.value set, only their expansion.
    */
   abstract class MultiChoiceEnumeration extends Enumeration {
-    case class Choice(name: String, help: String = "", expandsTo: List[Choice] = Nil) extends Val(name)
+    case class Choice(name: String, help: String = "", expandsTo: List[Choice] = Nil) extends Val(name) {
+      var selections: List[String] = Nil
+    }
     def wildcardChoices: ValueSet = values.filter { case c: Choice => c.expandsTo.isEmpty case _ => true }
   }
 
@@ -614,10 +612,10 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
     private var sawAll  = false
 
     private def badChoice(s: String) = errorFn(s"'$s' is not a valid choice for '$name'")
-    private def isChoice(s: String) = (s == "_") || (choices contains pos(s))
+    private def isChoice(s: String) = s == "_" || choices.contains(pos(s))
 
-    private def pos(s: String) = s stripPrefix "-"
-    private def isPos(s: String) = !(s startsWith "-")
+    private def pos(s: String) = s.stripPrefix("-")
+    private def isPos(s: String) = !s.startsWith("-")
 
     override val choices: List[String] = domain.values.toList map {
       case ChoiceOrVal(name, _, _) => name
@@ -629,7 +627,7 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
       case _                           => ""
     }
 
-    /** (Re)compute from current yeas, nays, wildcard status. */
+    /** (Re)compute from current yeas, nays, wildcard status. Assign option value. */
     def compute() = {
       def simple(v: domain.Value) = v match {
         case c: domain.Choice => c.expandsTo.isEmpty
@@ -648,8 +646,8 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
       }
 
       // yeas from _ or expansions are weak: an explicit nay will disable them
-      val weakYeas = if (sawAll) domain.wildcardChoices else expand(yeas filterNot simple)
-      value = (yeas filter simple) | (weakYeas &~ nays)
+      val weakYeas = if (sawAll) domain.wildcardChoices else expand(yeas.filterNot(simple))
+      value = yeas.filter(simple) | (weakYeas &~ nays)
     }
 
     /** Add a named choice to the multichoice value. */
@@ -660,16 +658,22 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
         sawAll = true
         compute()
       case _ if isPos(arg) =>
-        yeas += domain withName arg
+        yeas += domain.withName(arg)
         compute()
       case _ =>
-        val choice = domain withName pos(arg)
+        val choice = domain.withName(pos(arg))
         choice match {
           case ChoiceOrVal(_, _, _ :: _) => errorFn(s"'${pos(arg)}' cannot be negated, it enables other arguments")
           case _ =>
         }
         nays += choice
         compute()
+    }
+
+    // refine a choice with selections. -opt:inline:**
+    def add(arg: String, selections: List[String]): Unit = {
+      add(arg)
+      domain.withName(arg).asInstanceOf[domain.Choice].selections ++= selections
     }
 
     def tryToSet(args: List[String])                  = tryToSetArgs(args, halting = true)
@@ -680,37 +684,56 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
      *  The "halting" parameter means args were "-option a b c -else" so halt
      *  on "-else" or other non-choice. Otherwise, args were "-option:a,b,c,d",
      *  so process all and report non-choices as errors.
+     *
+     *  If a choice is seen as colonated, then set the choice selections:
+     *  "-option:choice:selection1,selection2"
+     *
      *  @param args args to process
      *  @param halting stop on non-arg
      */
     private def tryToSetArgs(args: List[String], halting: Boolean) = {
-      val added = collection.mutable.ListBuffer.empty[String]
-
-      def tryArg(arg: String) = arg match {
-        case "help"           => sawHelp = true
-        case s if isChoice(s) => added += s // this case also adds "_"
-        case s                => badChoice(s)
+      val colonnade = raw"([^:]+):(.*)".r
+      var count = 0
+      val rest = {
+        @tailrec
+        def loop(args: List[String]): List[String] = args match {
+          case "help" :: rest =>
+            sawHelp = true
+            count += 1
+            loop(rest)
+          case arg :: rest =>
+            val (argx, selections) = arg match {
+              case colonnade(x, y) => (x, y)
+              case _ => (arg, "")
+            }
+            if (halting && (!isPos(argx) || !isChoice(argx)))
+              args
+            else {
+              if (isChoice(argx)) {
+                if (selections.nonEmpty) add(argx, selections.split(",").toList)
+                else add(argx)  // this case also adds "_"
+                postSetHook()   // support -opt:l:method
+              }
+              else
+                badChoice(argx)
+              count += 1
+              loop(rest)
+            }
+          case _ => Nil
+        }
+        loop(args)
       }
-      @tailrec
-      def loop(args: List[String]): List[String] = args match {
-        case arg :: _ if halting && (!isPos(arg) || !isChoice(arg)) => args
-        case arg :: rest => tryArg(arg) ; loop(rest)
-        case Nil         => Nil
-      }
-      val rest = loop(args)
 
-      // if no arg consumed, use defaults or error; otherwise, add what they added
-      if (rest.size == args.size) default match {
-        case Some(defaults) => defaults foreach add
-        case None => errorFn(s"'$name' requires an option. See '$name:help'.")
-      } else {
-        added foreach add
-      }
-
+      // if no arg applied, use defaults or error; otherwise, add what they added
+      if (count == 0)
+        default match {
+          case Some(defaults) => defaults.foreach(add)
+          case None => errorFn(s"'$name' requires an option. See '$name:help'.")
+        }
       Some(rest)
     }
 
-    def contains(choice: domain.Value): Boolean = value contains choice
+    def contains(choice: domain.Value): Boolean = value.contains(choice)
 
     // programmatically.
     def enable(choice: domain.Value): Unit = { nays -= choice ; yeas += choice ; compute() }
@@ -736,14 +759,15 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
       choices.zipAll(descriptions, "", "").map(describe).mkString(f"${descr}%n", f"%n", orelse)
     }
 
-    def clear(): Unit         = {
+    def clear(): Unit = {
+      domain.values.foreach { case c: domain.Choice => c.selections = Nil ; case _ => }
       v = domain.ValueSet.empty
       yeas = domain.ValueSet.empty
       nays = domain.ValueSet.empty
       sawAll = false
       sawHelp = false
     }
-    def unparse: List[String] = value.toList map (s => s"$name:$s")
+    def unparse: List[String] = value.toList.map(s => s"$name:$s")
     def contains(s: String)   = domain.values.find(_.toString == s).exists(value.contains)
   }
 

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -307,30 +307,30 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
     val allowSkipCoreModuleInit = Choice("allow-skip-core-module-init", "Allow eliminating unused module loads for core modules of the standard library (e.g., Predef, ClassTag).")
     val assumeModulesNonNull    = Choice("assume-modules-non-null",     "Assume loading a module never results in null (happens if the module is accessed in its super constructor).")
     val allowSkipClassLoading   = Choice("allow-skip-class-loading",    "Allow optimizations that can skip or delay class loading.")
-    val inline                  = Choice("inline",                      "Inline method invocations according to -Yopt-inline-heuristics and -opt-inline-from.")
+    val inline                  = Choice("inline",                      "Inline method invocations from specified sites; also see -Yopt-inline-heuristics.")
+    val ell                     = Choice("l",                           "Deprecated l:none, l:default, l:method, l:inline.")
 
-    // l:none is not an expanding option, unlike the other l: levels. But it is excluded from -opt:_ below.
-    val lNone = Choice("l:none",
-      "Disable optimizations. Takes precedence: `-opt:l:none,+box-unbox` / `-opt:l:none -opt:box-unbox` don't enable box-unbox.")
+    // none is not an expanding option. It is excluded from -opt:_ below.
+    val lNone = Choice("none", "Disable all optimizations, including explicit options.")
 
-    private val defaultChoices = List(unreachableCode)
+    private val defaultOptimizations = List(unreachableCode)
     val lDefault = Choice(
-      "l:default",
-      "Enable default optimizations: " + defaultChoices.mkString("", ",", "."),
-      expandsTo = defaultChoices)
+      "default",
+      defaultOptimizations.mkString("Enable default optimizations: ", ",", "."),
+      expandsTo = defaultOptimizations)
 
-    private val methodChoices = List(unreachableCode, simplifyJumps, compactLocals, copyPropagation, redundantCasts, boxUnbox, nullnessTracking, closureInvocations, allowSkipCoreModuleInit, assumeModulesNonNull, allowSkipClassLoading)
+    val localOptimizations = List(simplifyJumps, compactLocals, copyPropagation, redundantCasts, boxUnbox, nullnessTracking, closureInvocations, allowSkipCoreModuleInit, assumeModulesNonNull, allowSkipClassLoading)
     val lMethod = Choice(
-      "l:method",
-      "Enable intra-method optimizations: " + methodChoices.mkString("", ",", "."),
-      expandsTo = methodChoices)
+      "local",
+      localOptimizations.mkString("Enable intra-method optimizations: ", ",", "."),
+      expandsTo = defaultOptimizations ::: localOptimizations)
 
-    private val inlineChoices = List(lMethod, inline)
-    val lInline = Choice("l:inline",
-      "Enable cross-method optimizations (note: inlining requires -opt-inline-from): " + inlineChoices.mkString("", ",", "."),
-      expandsTo = inlineChoices)
+    val lInline = Choice(
+      "all",
+      "Enable inlining, cross-method and local optimizations. To restrict inlining, use -opt:inline:sites as follows:\n" + inlineHelp,
+      expandsTo = inline :: defaultOptimizations ::: localOptimizations)
 
-    // "l:none" is excluded from wildcard expansion so that -opt:_ does not disable all settings
+    // "none" is excluded from wildcard expansion so that -opt:_ does not disable all settings
     override def wildcardChoices = super.wildcardChoices.filter(_ ne lNone)
   }
 
@@ -342,14 +342,26 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
     helpArg = "optimization",
     descr = "Enable optimizations, `help` for details.",
     domain = optChoices,
-  )
+  ).withPostSetHook { ss =>
+    // kludge alert: will be invoked twice, with selections available 2nd time
+    // for -opt:l:method reset the ell selections then enable local
+    if (ss.contains(optChoices.ell) && optChoices.ell.selections.nonEmpty) {
+      val todo = optChoices.ell.selections.map {
+        case "none"    => "none"
+        case "default" => "default"
+        case "method"  => "local"
+        case "inline"  => "all"
+      }
+      optChoices.ell.selections = Nil
+      ss.tryToSetColon(todo)
+    }
+  }
 
-  private def optEnabled(choice: optChoices.Choice) = {
+  private def optEnabled(choice: optChoices.Choice) =
     !opt.contains(optChoices.lNone) && {
       opt.contains(choice) ||
       !opt.isSetByUser && optChoices.lDefault.expandsTo.contains(choice)
     }
-  }
 
   def optNone                    = opt.contains(optChoices.lNone)
   def optUnreachableCode         = optEnabled(optChoices.unreachableCode)
@@ -369,11 +381,13 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
   def optAddToBytecodeRepository = optBuildCallGraph || optInlinerEnabled || optClosureInvocations
   def optUseAnalyzerCache        = opt.isSetByUser && !optNone && (optBuildCallGraph || opt.value.size > 1)
 
-  val optInlineFrom = MultiStringSetting(
-    "-opt-inline-from",
-    "patterns",
-    "Patterns for classfile names from which to allow inlining, `help` for details.",
-    helpText = Some(
+  def optInlineFrom: List[String] =
+    optChoices.inline.selections match {
+      case Nil  => List("**")
+      case sels => sels
+    }
+
+  def inlineHelp =
       """Patterns for classfile names from which the inliner is allowed to pull in code.
         |  *              Matches classes in the empty package
         |  **             All classes
@@ -387,13 +401,25 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
         |  <sources>      Classes defined in source files compiled in the current compilation, either
         |                 passed explicitly to the compiler or picked up from the `-sourcepath`
         |
-        |The setting accepts a list of patterns: `-opt-inline-from:p1,p2`. The setting can be passed
+        |The setting accepts a list of patterns: `-opt:inline:p1,p2`. The setting can be passed
         |multiple times, the list of patterns gets extended. A leading `!` marks a pattern excluding.
         |The last matching pattern defines whether a classfile is included or excluded (default: excluded).
         |For example, `a.**,!a.b.**` includes classes in a and sub-packages, but not in a.b and sub-packages.
         |
         |Note: on the command-line you might need to quote patterns containing `*` to prevent the shell
-        |from expanding it to a list of files in the current directory.""".stripMargin))
+        |from expanding it to a list of files in the current directory.""".stripMargin
+
+  @deprecated("Deprecated alias", since="2.13.8")
+  val xoptInlineFrom = MultiStringSetting(
+    "-opt-inline-from",
+    "patterns",
+    "Patterns for classfile names from which to allow inlining, `help` for details.",
+    helpText = Some(inlineHelp))
+      //.withDeprecationMessage("use -opt:inline:**")
+      .withPostSetHook { from =>
+        opt.add("inline")
+        optChoices.inline.selections = from.value
+      }
 
   val YoptInlineHeuristics = ChoiceSetting(
     name = "-Yopt-inline-heuristics",
@@ -413,15 +439,26 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
   }
 
   val optWarnings = MultiChoiceSetting(
-    name = "-opt-warnings",
+    name = "-Wopt",
     helpArg = "warning",
     descr = "Enable optimizer warnings, `help` for details.",
     domain = optWarningsChoices,
-    default = Some(List(optWarningsChoices.atInlineFailed.name))) withPostSetHook { _ =>
+    default = Some(List(optWarningsChoices.atInlineFailed.name))
+  ).withPostSetHook { _ =>
     // no need to set `Wconf` to `silent` if optWarnings is none, since no warnings are reported
     if (optWarningsSummaryOnly) Wconf.tryToSet(List(s"cat=optimizer:ws"))
     else Wconf.tryToSet(List(s"cat=optimizer:w"))
   }
+  @deprecated("Deprecated alias", since="2.13.8")
+  val xoptWarnings = MultiChoiceSetting(
+    name = "-opt-warnings",
+    helpArg = "warning",
+    descr = "Enable optimizer warnings, `help` for details.",
+    domain = optWarningsChoices,
+    default = Some(List(optWarningsChoices.atInlineFailed.name))
+  ).withPostSetHook { ow =>
+    optWarnings.value = ow.value
+  }//.withDeprecationMessage("Use -Wopt instead.")
 
   def optWarningsSummaryOnly: Boolean = optWarnings.value subsetOf Set(optWarningsChoices.none, optWarningsChoices.atInlineFailedSummary)
 
@@ -519,11 +556,11 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
   val future        = BooleanSetting("-Xfuture", "Replaced by -Xsource.").withDeprecationMessage("Not used since 2.13.")
   val optimise      = BooleanSetting("-optimize", "Enables optimizations.")
     .withAbbreviation("-optimise")
-    .withDeprecationMessage("Since 2.12, enables -opt:l:inline -opt-inline-from:**. See -opt:help.")
-    .withPostSetHook(_ => {
+    .withDeprecationMessage("Since 2.12, enables -opt:inline:**. This can be dangerous.")
+    .withPostSetHook { _ =>
       opt.enable(optChoices.lInline)
-      optInlineFrom.value = List("**")
-    })
+      optChoices.inline.selections = List("**")
+    }
   val Xexperimental = BooleanSetting("-Xexperimental", "Former graveyard for language-forking extensions.")
     .withDeprecationMessage("Not used since 2.13.")
 

--- a/src/reflect/scala/reflect/internal/util/StringOps.scala
+++ b/src/reflect/scala/reflect/internal/util/StringOps.scala
@@ -65,6 +65,8 @@ trait StringOps {
   def splitWhere(str: String, f: Char => Boolean, doDropIndex: Boolean = false): Option[(String, String)] =
     splitAt(str, str indexWhere f, doDropIndex)
 
+  def splitAround(str: String, idx: Int): Option[(String, String)] = splitAt(str, idx, doDropIndex = true)
+
   def splitAt(str: String, idx: Int, doDropIndex: Boolean = false): Option[(String, String)] =
     if (idx == -1) None
     else Some((str take idx, str drop (if (doDropIndex) idx + 1 else idx)))

--- a/test/files/instrumented/inline-in-constructors/assert_1.scala
+++ b/test/files/instrumented/inline-in-constructors/assert_1.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:**
+// scalac: -opt:inline:** -Wopt
 package instrumented
 
 object MyPredef {

--- a/test/files/instrumented/inline-in-constructors/bar_2.scala
+++ b/test/files/instrumented/inline-in-constructors/bar_2.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:**
+// scalac: -opt:inline:**
 package instrumented
 
 /** Class that uses assert compiled in previous compiler run so we check if

--- a/test/files/instrumented/inline-in-constructors/test_3.scala
+++ b/test/files/instrumented/inline-in-constructors/test_3.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:**
+// scalac: -opt:inline:** -Wopt
 import scala.tools.partest.instrumented.Instrumentation._
 import instrumented._
 

--- a/test/files/neg/deprecated-options.check
+++ b/test/files/neg/deprecated-options.check
@@ -1,6 +1,6 @@
 warning: -Xsource is deprecated: instead of -Xsource:2.14, use -Xsource:3
 warning: -Xfuture is deprecated: Not used since 2.13.
-warning: -optimize is deprecated: Since 2.12, enables -opt:l:inline -opt-inline-from:**. See -opt:help.
+warning: -optimize is deprecated: Since 2.12, enables -opt:inline:**. This can be dangerous.
 warning: -Xexperimental is deprecated: Not used since 2.13.
 error: No warnings can be incurred under -Werror.
 4 warnings

--- a/test/files/neg/deprecated.scala
+++ b/test/files/neg/deprecated.scala
@@ -1,4 +1,4 @@
-// scalac: -Xlint:deprecation -Xfatal-warnings -opt:inline -opt-inline-from:<sources>
+// scalac: -Xlint:deprecation -Werror -opt:inline:<sources>
 //
 
 trait T {

--- a/test/files/neg/inlineIndyLambdaPrivate/Test_2.scala
+++ b/test/files/neg/inlineIndyLambdaPrivate/Test_2.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:all -opt:inline:** -Yopt-inline-heuristics:everything -Wopt:_ -Werror
+// scalac: -opt:inline:** -Yopt-inline-heuristics:everything -Wopt:_ -Werror
 class Test {
   def foo = A_1.test
 }

--- a/test/files/neg/inlineIndyLambdaPrivate/Test_2.scala
+++ b/test/files/neg/inlineIndyLambdaPrivate/Test_2.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:** -Yopt-inline-heuristics:everything -opt-warnings:_ -Werror
+// scalac: -opt:all -opt:inline:** -Yopt-inline-heuristics:everything -Wopt:_ -Werror
 class Test {
   def foo = A_1.test
 }

--- a/test/files/neg/sealed-final-neg.scala
+++ b/test/files/neg/sealed-final-neg.scala
@@ -1,4 +1,4 @@
-// scalac: -Xfatal-warnings -opt:l:inline -opt-inline-from:** -opt-warnings
+// scalac: -Werror -opt:inline:** -Wopt
 //
 package neg1 {
   sealed abstract class Foo {

--- a/test/files/neg/t11746.scala
+++ b/test/files/neg/t11746.scala
@@ -1,5 +1,5 @@
 //
-// scalac: -Werror -opt:all -opt:inline:** -Wopt:none,_
+// scalac: -Werror -opt:inline:** -Wopt:none,_
 //
 // compare -opt-warnings:none,at-inline-failed-summary
 

--- a/test/files/neg/t11746.scala
+++ b/test/files/neg/t11746.scala
@@ -1,5 +1,5 @@
 //
-// scalac: -Werror -opt:l:inline -opt-inline-from:'**' -opt-warnings:none,_
+// scalac: -Werror -opt:all -opt:inline:** -Wopt:none,_
 //
 // compare -opt-warnings:none,at-inline-failed-summary
 

--- a/test/files/pos/inline-access-levels/A_1.scala
+++ b/test/files/pos/inline-access-levels/A_1.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:** -opt-warnings -Werror
+// scalac: -opt:inline:** -Wopt -Werror
 package test
 
 object A {

--- a/test/files/pos/inline-access-levels/Test_2.scala
+++ b/test/files/pos/inline-access-levels/Test_2.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:** -opt-warnings -Werror
+// scalac: -opt:inline:** -Wopt -Werror
 package test
 
 object Test {

--- a/test/files/pos/t11663/B_2.scala
+++ b/test/files/pos/t11663/B_2.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:inline:** -Wopt
+// scalac: -opt:inline:** -Wopt:_
 class B {
    def bar(c: A) = c.m
 }

--- a/test/files/pos/t11663/B_2.scala
+++ b/test/files/pos/t11663/B_2.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:** -opt-warnings:_
+// scalac: -opt:inline:** -Wopt
 class B {
    def bar(c: A) = c.m
 }

--- a/test/files/pos/t3234.scala
+++ b/test/files/pos/t3234.scala
@@ -1,5 +1,5 @@
 
-// scalac: -opt:l:inline -opt-inline-from:** -opt-warnings -Xfatal-warnings
+// scalac: -opt:inline:** -Wopt -Werror
 //
 trait Trait1 {
   @inline final def foo2(n: Int) = n*n

--- a/test/files/pos/t3420.scala
+++ b/test/files/pos/t3420.scala
@@ -1,5 +1,5 @@
 
-// scalac: -opt-warnings -opt:l:inline -opt-inline-from:** -Xfatal-warnings
+// scalac: -opt:inline:** -Wopt -Werror
 //
 class C {
     val cv = Map[Int, Int](1 -> 2)

--- a/test/files/pos/t4840.scala
+++ b/test/files/pos/t4840.scala
@@ -1,5 +1,5 @@
 
-// scalac: -opt:l:inline -opt-inline-from:**
+// scalac: -opt:inline:** -Wopt
 //
 class Crashy {
   def g(): Option[Any] = None

--- a/test/files/pos/t8410.scala
+++ b/test/files/pos/t8410.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:** -Xfatal-warnings -deprecation:false -opt-warnings:none
+// scalac: -opt:inline:** -Wopt:none -Werror -deprecation:false
 //
 
 object Test extends App {

--- a/test/files/pos/t9111-inliner-workaround/Test_1.scala
+++ b/test/files/pos/t9111-inliner-workaround/Test_1.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:**
+// scalac: -opt:inline:** -Wopt
 //
 object Test extends App {
   println(new A_1.Inner())

--- a/test/files/run/bcodeInlinerMixed/B_1.scala
+++ b/test/files/run/bcodeInlinerMixed/B_1.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:**
+// scalac: -opt:inline:**
 //
 // Since 1.0.18, partest does mixed compilation only in two stages 
 //   1. scalac *.scala *.java

--- a/test/files/run/bcodeInlinerMixed/Test_2.scala
+++ b/test/files/run/bcodeInlinerMixed/Test_2.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:**
+// scalac: -opt:inline:**
 //
 import scala.tools.partest.BytecodeTest
 import scala.tools.testkit.ASMConverters

--- a/test/files/run/classfile-format-51.scala
+++ b/test/files/run/classfile-format-51.scala
@@ -17,7 +17,7 @@ import Opcodes._
 // verify. So the test includes a version check that short-circuits the whole test
 // on JDK 6
 object Test extends DirectTest {
-  override def extraSettings: String = s"-opt:l:inline -opt-inline-from:** -usejavacp -cp ${testOutput.path}"
+  override def extraSettings: String = s"-opt:inline:** -usejavacp -cp ${testOutput.path}"
 
   def generateClass(): Unit = {
     val invokerClassName =  "DynamicInvoker"

--- a/test/files/run/classfile-format-52.scala
+++ b/test/files/run/classfile-format-52.scala
@@ -14,7 +14,7 @@ import Opcodes._
 // By its nature the test can only work on JDK 8+ because under JDK 7- the
 // interface won't verify.
 object Test extends DirectTest {
-  override def extraSettings: String = s"-opt:l:inline -opt-inline-from:** -usejavacp -cp ${testOutput.path}"
+  override def extraSettings: String = s"-opt:inline:** -usejavacp -cp ${testOutput.path}"
 
   def generateInterface(): Unit = {
     val interfaceName =  "HasDefaultMethod"

--- a/test/files/run/icode-reader-dead-code.scala
+++ b/test/files/run/icode-reader-dead-code.scala
@@ -36,7 +36,7 @@ object Test extends DirectTest {
 
     // If inlining fails, the compiler will issue an inliner warning that is not present in the
     // check file
-    compileString(newCompiler("-cp", testOutput.path, "-opt:l:inline", "-opt-inline-from:**"))(bCode)
+    compileString(newCompiler("-cp", testOutput.path, "-opt:inline:**"))(bCode)
   }
 
   def readClass(file: String) = {

--- a/test/files/run/indyLambdaKinds.check
+++ b/test/files/run/indyLambdaKinds.check
@@ -35,7 +35,7 @@ Inlining into Main$.t2b
 Inlining into Main$.t3b
  inlined A_1.c (the callsite is annotated `@inline`). Before: 10 ins, after: 21 ins.
  rewrote invocations of closure allocated in Main$.t3b with body <init>: INVOKEINTERFACE java/util/function/Function.apply (Ljava/lang/Object;)Ljava/lang/Object; (itf)
-warning: 6 optimizer warnings; re-run enabling -opt-warnings for details, or try -help
+warning: 6 optimizer warnings; re-run enabling -Wopt for details, or try -help
 m1
 m1
 m2

--- a/test/files/run/indyLambdaKinds/Test_2.scala
+++ b/test/files/run/indyLambdaKinds/Test_2.scala
@@ -3,7 +3,7 @@ import reflect.internal.util._
 
 object Test extends DirectTest {
 
-  override def extraSettings: String = s"-usejavacp -cp ${testOutput.path} -opt:all -Vinline _"
+  override def extraSettings: String = s"-usejavacp -cp ${testOutput.path} -opt:inline:** -Vinline _"
 
   override def code = """object Main {
   @noinline def t1a(a: A_1) = a.a(): @inline

--- a/test/files/run/indyLambdaKinds/Test_2.scala
+++ b/test/files/run/indyLambdaKinds/Test_2.scala
@@ -3,7 +3,7 @@ import reflect.internal.util._
 
 object Test extends DirectTest {
 
-  override def extraSettings: String = s"-usejavacp -cp ${testOutput.path} -opt:l:inline -opt-inline-from:** -Yopt-log-inline _"
+  override def extraSettings: String = s"-usejavacp -cp ${testOutput.path} -opt:all -Vinline _"
 
   override def code = """object Main {
   @noinline def t1a(a: A_1) = a.a(): @inline

--- a/test/files/run/inline-stack-map-frames/A_1.scala
+++ b/test/files/run/inline-stack-map-frames/A_1.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:**
+// scalac: -opt:inline:**
 class A {
   @noinline final def b: B = null
   @inline final def a: A = b

--- a/test/files/run/inline-stack-map-frames/Test_2.scala
+++ b/test/files/run/inline-stack-map-frames/Test_2.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:**
+// scalac: -opt:inline:**
 class C {
   def t(a: A): AnyRef = {
     // a.a is inlined, resulting in a.b, which has return type B

--- a/test/files/run/noInlineUnknownIndy/Test.scala
+++ b/test/files/run/noInlineUnknownIndy/Test.scala
@@ -11,7 +11,7 @@ object Test extends DirectTest {
 
   override def extraSettings = {
     val classpath = List(sys.props("partest.lib"), testOutput.path).mkString(sys.props("path.separator"))
-    s"-cp $classpath -opt:l:inline -opt-inline-from:** -Yopt-inline-heuristics:everything -opt-warnings:_"
+    s"-cp $classpath -opt:all -opt:inline:** -Yopt-inline-heuristics:everything -Wopt:_"
   }
 
   override def show(): Unit = {

--- a/test/files/run/noInlineUnknownIndy/Test.scala
+++ b/test/files/run/noInlineUnknownIndy/Test.scala
@@ -11,7 +11,7 @@ object Test extends DirectTest {
 
   override def extraSettings = {
     val classpath = List(sys.props("partest.lib"), testOutput.path).mkString(sys.props("path.separator"))
-    s"-cp $classpath -opt:all -opt:inline:** -Yopt-inline-heuristics:everything -Wopt:_"
+    s"-cp $classpath -opt:inline:** -Yopt-inline-heuristics:everything -Wopt:_"
   }
 
   override def show(): Unit = {

--- a/test/files/run/repl-inline.scala
+++ b/test/files/run/repl-inline.scala
@@ -16,7 +16,7 @@ assert(h == "h", h)
   def main(args: Array[String]): Unit = {
     def test(f: Settings => Unit): Unit = {
       val settings = new Settings()
-      settings.processArgumentString("-opt:l:inline -opt-inline-from:** -opt-warnings")
+      settings.processArgumentString("-opt:inline:** -Wopt")
       f(settings)
       settings.usejavacp.value = true
       val repl = new interpreter.IMain(settings, new ReplReporterImpl(settings))

--- a/test/files/run/synchronized.scala
+++ b/test/files/run/synchronized.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:**
+// scalac: -opt:inline:**
 //
 /*
  * filter: optimizer warnings;

--- a/test/files/run/t11255/A_1.scala
+++ b/test/files/run/t11255/A_1.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:**
+// scalac: -opt:inline:**
 class K(val f: Int => Int) extends Serializable
 class A {
   @inline final def f = new K(x => x + 1)

--- a/test/files/run/t11255/Test_2.scala
+++ b/test/files/run/t11255/Test_2.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:**
+// scalac: -opt:inline:**
 object Test {
   def serializeDeserialize(obj: Object): Object = {
     import java.io._

--- a/test/files/run/t2106.scala
+++ b/test/files/run/t2106.scala
@@ -1,4 +1,4 @@
-// scalac: -opt-warnings -opt:l:inline -opt-inline-from:**
+// scalac: -opt:inline:** -Wopt
 //
 class A extends Cloneable {
   @inline final def foo = clone()

--- a/test/files/run/t3326.scala
+++ b/test/files/run/t3326.scala
@@ -1,4 +1,4 @@
-// scalac: -opt-warnings
+// scalac: -Wopt
 import scala.math.Ordering
 
 /** The heart of the problem - we want to retain the ordering when

--- a/test/files/run/t3509.scala
+++ b/test/files/run/t3509.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:**
+// scalac: -opt:inline:**
 //
 object Test {
 

--- a/test/files/run/t3569.scala
+++ b/test/files/run/t3569.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:**
+// scalac: -opt:inline:**
 //
 object Test {
   final val bippy1 = 1

--- a/test/files/run/t4285.scala
+++ b/test/files/run/t4285.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:**
+// scalac: -opt:inline:**
 //
 import scala.tools.partest.ReplTest
 object Test extends ReplTest {

--- a/test/files/run/t4935.scala
+++ b/test/files/run/t4935.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:**
+// scalac: -opt:inline:**
 //
 object Test extends App {
   for (i <- 0 to 1) {

--- a/test/files/run/t5789.scala
+++ b/test/files/run/t5789.scala
@@ -4,7 +4,7 @@ import scala.tools.partest.{Lambdaless, ReplTest}
 
 
 object Test extends ReplTest with Lambdaless {
-  override def extraSettings = "-opt:l:inline -opt-inline-from:**"
+  override def extraSettings = "-opt:inline:**"
   def code = """
     val n = 2
     () => n

--- a/test/files/run/t6102.scala
+++ b/test/files/run/t6102.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:** -Werror
+// scalac: -opt:inline:** -Werror
 //
 // scala/bug#6102 Wrong bytecode in lazyval + no-op finally clause
 

--- a/test/files/run/t6188.scala
+++ b/test/files/run/t6188.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:**
+// scalac: -opt:inline:**
 //
 // scala/bug#6188 Optimizer incorrectly removes method invocations containing throw expressions
 

--- a/test/files/run/t7459b-optimize.scala
+++ b/test/files/run/t7459b-optimize.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:**
+// scalac: -opt:inline:**
 //
 class LM {
   class Node[B1]

--- a/test/files/run/t7582/InlineHolder_2.scala
+++ b/test/files/run/t7582/InlineHolder_2.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:** -opt-warnings
+// scalac: -opt:inline:** -Wopt
 package p1 {
   object InlineHolder {
     @inline def inlinable = (p1.PackageProtectedJava_1.protectedMethod(): @noinline) + 1

--- a/test/files/run/t7582b/InlineHolder_2.scala
+++ b/test/files/run/t7582b/InlineHolder_2.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:** -opt-warnings
+// scalac: -opt:inline:** -Wopt
 package p1 {
   object InlineHolder {
     @inline def inlinable = (p1.PackageProtectedJava_1.protectedMethod(): @noinline) + 1

--- a/test/files/run/t8601-closure-elim.scala
+++ b/test/files/run/t8601-closure-elim.scala
@@ -1,4 +1,4 @@
-// scalac: -Ydelambdafy:method -opt:l:inline -opt-inline-from:**
+// scalac: -Ydelambdafy:method -opt:inline:**
 //
 import scala.tools.partest.BytecodeTest
 import scala.tools.testkit.ASMConverters.instructionsFromMethod

--- a/test/files/run/t8601.scala
+++ b/test/files/run/t8601.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:**
+// scalac: -opt:inline:**
 //
 object Test {
   def idiv(x: Int): Unit = x / 0

--- a/test/files/run/t8601b.scala
+++ b/test/files/run/t8601b.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:**
+// scalac: -opt:inline:**
 //
 object Test {
   def len(x: Array[String]): Unit = x.length

--- a/test/files/run/t8601c.scala
+++ b/test/files/run/t8601c.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:**
+// scalac: -opt:inline:**
 //
 object Test {
   def loadField(x: scala.runtime.IntRef): Unit = x.elem

--- a/test/files/run/t8601d.scala
+++ b/test/files/run/t8601d.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:**
+// scalac: -opt:inline:**
 //
 object Test {
   def monitor(x: AnyRef): Unit = {x.synchronized(()); ()}

--- a/test/files/run/t8601e/Test.scala
+++ b/test/files/run/t8601e/Test.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:**
+// scalac: -opt:inline:**
 class C {
   def foo: Unit = {StaticInit.fld}
 }

--- a/test/files/run/t9003.scala
+++ b/test/files/run/t9003.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:**
+// scalac: -opt:inline:**
 //
 object Single {
   var i = 0

--- a/test/files/run/t9403/C_1.scala
+++ b/test/files/run/t9403/C_1.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:**
+// scalac: -opt:inline:**
 package p
 class C {
   @inline final def f(x: Int): Long = 10L / (if (x < 0) -2 else 2)

--- a/test/files/run/t9403/Test_2.scala
+++ b/test/files/run/t9403/Test_2.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:inline -opt-inline-from:**
+// scalac: -opt:inline:**
 import p.C
 import scala.tools.asm.Opcodes
 import scala.tools.partest.BytecodeTest

--- a/test/junit/scala/tools/nsc/backend/jvm/InnerClassAttributeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/InnerClassAttributeTest.scala
@@ -14,7 +14,7 @@ import scala.tools.testkit.BytecodeTesting._
 class InnerClassAttributeTest extends BytecodeTesting {
   import compiler._
 
-  val optCompiler = cached("optCompiler", () => newCompiler(extraArgs = "-opt:all -opt:inline:**"))
+  val optCompiler = cached("optCompiler", () => newCompiler(extraArgs = "-opt:inline:**"))
 
   @Test
   def javaInnerClassInGenericSignatureOnly(): Unit = {

--- a/test/junit/scala/tools/nsc/backend/jvm/InnerClassAttributeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/InnerClassAttributeTest.scala
@@ -14,7 +14,7 @@ import scala.tools.testkit.BytecodeTesting._
 class InnerClassAttributeTest extends BytecodeTesting {
   import compiler._
 
-  val optCompiler = cached("optCompiler", () => newCompiler(extraArgs = "-opt:l:inline -opt-inline-from:**"))
+  val optCompiler = cached("optCompiler", () => newCompiler(extraArgs = "-opt:all -opt:inline:**"))
 
   @Test
   def javaInnerClassInGenericSignatureOnly(): Unit = {

--- a/test/junit/scala/tools/nsc/backend/jvm/OptimizedBytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/OptimizedBytecodeTest.scala
@@ -11,7 +11,7 @@ import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class OptimizedBytecodeTest extends BytecodeTesting {
-  override def compilerArgs = "-opt:all -Wopt"
+  override def compilerArgs = "-opt:inline:** -Wopt"
   import compiler._
 
   @Test

--- a/test/junit/scala/tools/nsc/backend/jvm/OptimizedBytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/OptimizedBytecodeTest.scala
@@ -11,7 +11,7 @@ import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class OptimizedBytecodeTest extends BytecodeTesting {
-  override def compilerArgs = "-opt:l:inline -opt-inline-from:** -opt-warnings"
+  override def compilerArgs = "-opt:all -Wopt"
   import compiler._
 
   @Test

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/BTypesFromClassfileTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/BTypesFromClassfileTest.scala
@@ -15,7 +15,7 @@ import scala.tools.testkit.BytecodeTesting
 @RunWith(classOf[JUnit4])
 class BTypesFromClassfileTest extends BytecodeTesting {
   // inliner enabled -> inlineInfos are collected (and compared) in ClassBTypes
-  override def compilerArgs = "-opt:inline -opt-inline-from:**"
+  override def compilerArgs = "-opt:inline:**"
 
   import compiler.global._
   import definitions._

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/BoxUnboxAndInlineTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/BoxUnboxAndInlineTest.scala
@@ -17,7 +17,7 @@ import scala.tools.testkit.BytecodeTesting._
   */
 @RunWith(classOf[JUnit4])
 class BoxUnboxAndInlineTest extends BytecodeTesting {
-  override def compilerArgs = "-opt:l:inline -opt-inline-from:**/*"
+  override def compilerArgs = "-opt:all -opt:inline:**/*"
   import compiler._
 
   // Was crashing in 2.13.x once https://github.com/scala/scala/pull/9433 was merged in.

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/BoxUnboxAndInlineTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/BoxUnboxAndInlineTest.scala
@@ -17,7 +17,7 @@ import scala.tools.testkit.BytecodeTesting._
   */
 @RunWith(classOf[JUnit4])
 class BoxUnboxAndInlineTest extends BytecodeTesting {
-  override def compilerArgs = "-opt:all -opt:inline:**/*"
+  override def compilerArgs = "-opt:inline:**/*"
   import compiler._
 
   // Was crashing in 2.13.x once https://github.com/scala/scala/pull/9433 was merged in.

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/CallGraphTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/CallGraphTest.scala
@@ -16,7 +16,7 @@ import scala.tools.testkit.BytecodeTesting
 import scala.tools.testkit.BytecodeTesting._
 
 class CallGraphTest extends BytecodeTesting {
-  override def compilerArgs = "-opt:inline -opt-inline-from:** -opt-warnings"
+  override def compilerArgs = "-opt:inline:** -Wopt"
   import compiler._
   import global.genBCode.{bTypes, postProcessor}
   import postProcessor.{byteCodeRepository, callGraph}

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/ClosureOptimizerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/ClosureOptimizerTest.scala
@@ -13,7 +13,7 @@ import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class ClosureOptimizerTest extends BytecodeTesting {
-  override def compilerArgs = "-opt:all -opt:inline:** -Wopt"
+  override def compilerArgs = "-opt:inline:** -Wopt:_"
   import compiler._
 
   @Test

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/ClosureOptimizerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/ClosureOptimizerTest.scala
@@ -13,7 +13,7 @@ import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class ClosureOptimizerTest extends BytecodeTesting {
-  override def compilerArgs = "-opt:l:inline -opt-inline-from:** -opt-warnings:_"
+  override def compilerArgs = "-opt:all -opt:inline:** -Wopt"
   import compiler._
 
   @Test

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlineInfoTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlineInfoTest.scala
@@ -18,7 +18,7 @@ class InlineInfoTest extends BytecodeTesting {
   import compiler._
   import global.genBCode.{bTypes, postProcessor}
 
-  override def compilerArgs = "-opt:l:inline -opt-inline-from:**"
+  override def compilerArgs = "-opt:inline:**"
 
   compiler.keepPerRunCachesAfterRun(List(
     JavaClearable.forMap(bTypes.classBTypeCache),

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlineSourceMatcherTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlineSourceMatcherTest.scala
@@ -15,9 +15,10 @@ import scala.tools.testkit.BytecodeTesting._
 class InlineSourceMatcherTest extends BytecodeTesting {
   import compiler._
 
-  override def compilerArgs = "-opt:l:inline -opt-warnings"
+  override def compilerArgs = "-opt:inline -Wopt"
   def setInlineFrom(s: String): Unit = {
-    global.settings.optInlineFrom.value = s.split(':').toList
+    //global.settings.optInlineFrom.value = s.split(':').toList
+    global.settings.optChoices.inline.selections = s.split(':').toList
   }
 
   case class E(regex: String, negated: Boolean = false, terminal: Boolean = true)

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlineWarningTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlineWarningTest.scala
@@ -11,12 +11,12 @@ import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class InlineWarningTest extends BytecodeTesting {
-  def optInline = "-opt:l:inline -opt-inline-from:**"
-  override def compilerArgs = s"$optInline -opt-warnings"
+  def optInline = "-opt:inline:**"
+  override def compilerArgs = s"$optInline -Wopt"
 
   import compiler._
 
-  val compilerWarnAll = cached("compilerWarnAll", () => newCompiler(extraArgs = s"$optInline -opt-warnings:_"))
+  val compilerWarnAll = cached("compilerWarnAll", () => newCompiler(extraArgs = s"$optInline -Wopt:_"))
 
   @Test
   def nonFinal(): Unit = {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerSeparateCompilationTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerSeparateCompilationTest.scala
@@ -10,7 +10,7 @@ import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class InlinerSeparateCompilationTest {
-  val args = "-opt:l:inline -opt-inline-from:**"
+  val args = "-opt:inline:**"
 
   @Test
   def inlineMixedinMember(): Unit = {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
@@ -18,13 +18,13 @@ import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class InlinerTest extends BytecodeTesting {
-  override def compilerArgs = "-opt:all -opt:inline:** -Wopt"
-
-  val inlineOnlyCompiler = cached("inlineOnlyCompiler", () => newCompiler(extraArgs = "-opt:inline -opt-inline-from:**"))
-
   import compiler._
   import global.genBCode.{bTypes, postProcessor}
 
+  override def compilerArgs = "-opt:inline:** -Wopt"
+
+  val inlineOnly = global.settings.optChoices.inlineFrom.expandsTo.map(c => s"-${c.name}").mkString("-opt:inline:** -opt:", ",", "")
+  val inlineOnlyCompiler = cached("inlineOnlyCompiler", () => newCompiler(extraArgs = inlineOnly))
 
   compiler.keepPerRunCachesAfterRun(List(
     JavaClearable.forMap(bTypes.classBTypeCache),

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
@@ -18,7 +18,7 @@ import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
 class InlinerTest extends BytecodeTesting {
-  override def compilerArgs = "-opt:l:inline -opt-inline-from:** -opt-warnings"
+  override def compilerArgs = "-opt:all -opt:inline:** -Wopt"
 
   val inlineOnlyCompiler = cached("inlineOnlyCompiler", () => newCompiler(extraArgs = "-opt:inline -opt-inline-from:**"))
 

--- a/test/junit/scala/tools/nsc/settings/SettingsTest.scala
+++ b/test/junit/scala/tools/nsc/settings/SettingsTest.scala
@@ -252,13 +252,20 @@ class SettingsTest {
   @Test def `wildcard doesn't disable everything`(): Unit = {
     val settings = new Settings()
     settings.processArguments("-opt:_" :: Nil, true)
-    assertTrue("has the choice", settings.opt.contains(settings.optChoices.inline))
-    assertTrue("is enabled", settings.optInlinerEnabled)
+    assertTrue("has the choice", settings.opt.contains(settings.optChoices.unreachableCode))
+    assertTrue("is enabled", settings.optUnreachableCode)
+    assertFalse("inliner is not enabled", settings.optInlinerEnabled)
   }
   @Test def `kill switch can be enabled explicitly`(): Unit = {
     val settings = new Settings()
-    settings.processArguments("-opt:inline,none" :: Nil, true)
-    assertTrue("has the choice", settings.opt.contains(settings.optChoices.inline))
+    settings.processArguments("-opt:unreachable-code,none" :: Nil, true)
+    assertTrue("has the choice", settings.opt.contains(settings.optChoices.unreachableCode))
+    assertFalse("is not enabled", settings.optUnreachableCode)
+  }
+  @Test def `kill switch disables inline`(): Unit = {
+    val settings = new Settings()
+    settings.processArguments("-opt:inline:**" :: "-opt:none" :: Nil, true)
+    assertTrue("has the choice", settings.optInlineFrom.nonEmpty)
     assertFalse("is not enabled", settings.optInlinerEnabled)
   }
   @Test def `t12036 don't consume dash option as arg`(): Unit = {

--- a/test/junit/scala/tools/nsc/settings/SettingsTest.scala
+++ b/test/junit/scala/tools/nsc/settings/SettingsTest.scala
@@ -1,7 +1,7 @@
 package scala.tools.nsc
 package settings
 
-import org.junit.Assert.{assertTrue => assert, _}
+import org.junit.Assert._
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -9,18 +9,20 @@ import scala.tools.testkit.AssertUtil.assertThrows
 
 @RunWith(classOf[JUnit4])
 class SettingsTest {
+  private def settings = new MutableSettings(msg => throw new IllegalArgumentException(msg))
+
   @Test def booleanSettingColon(): Unit = {
     def check(args: String*): MutableSettings#BooleanSetting = {
       val s = new MutableSettings(msg => throw new IllegalArgumentException(msg))
       val b1 = new s.BooleanSetting("-Ytest-setting", descr="", default=false)
       s.allSettings(b1.name) = b1
       val (ok, residual) = s.processArguments(args.toList, processAll = true)
-      assert(residual.isEmpty)
+      assertTrue(residual.isEmpty)
       b1
     }
-    assert(check("-Ytest-setting").value)
-    assert(check("-Ytest-setting:true").value)
-    assert(check("-Ytest-setting:TRUE").value)
+    assertTrue(check("-Ytest-setting").value)
+    assertTrue(check("-Ytest-setting:true").value)
+    assertTrue(check("-Ytest-setting:TRUE").value)
     assertFalse(check("-Ytest-setting:false").value)
     assertFalse(check("-Ytest-setting:FALSE").value)
     assertThrows[IllegalArgumentException](check("-Ytest-setting:rubbish"))
@@ -30,44 +32,44 @@ class SettingsTest {
   private def check(args: String*)(b: MutableSettings => Boolean): Boolean = {
     val s = new MutableSettings(msg => throw new IllegalArgumentException(msg))
     val (ok, residual) = s.processArguments(args.toList, processAll = true)
-    assert(residual.isEmpty)
+    assertTrue(residual.isEmpty)
     b(s)
   }
 
   @Test def `deprecation and xlint deprecation play well together`(): Unit = {
-    assert(check("-deprecation")(_.deprecation))
-    assert(check("--deprecation")(_.deprecation))
-    assert(check("-deprecation")(!_.lintDeprecation))
-    assert(check("-Xlint:deprecation")(_.deprecation))
-    assert(check("-Xlint:deprecation")(_.lintDeprecation))
-    assert(check("-deprecation", "-Xlint:deprecation")(ss => ss.deprecation && ss.lintDeprecation))
-    assert(check("-deprecation", "-Xlint:-deprecation")(ss => ss.deprecation && !ss.lintDeprecation))
+    assertTrue(check("-deprecation")(_.deprecation))
+    assertTrue(check("--deprecation")(_.deprecation))
+    assertTrue(check("-deprecation")(!_.lintDeprecation))
+    assertTrue(check("-Xlint:deprecation")(_.deprecation))
+    assertTrue(check("-Xlint:deprecation")(_.lintDeprecation))
+    assertTrue(check("-deprecation", "-Xlint:deprecation")(ss => ss.deprecation && ss.lintDeprecation))
+    assertTrue(check("-deprecation", "-Xlint:-deprecation")(ss => ss.deprecation && !ss.lintDeprecation))
     // normally, explicit yes overrides explicit no, but here we treat them as different settings.
     // lint will enable deprecation if not explicitly disabled, otherwise just lints the usage.
-    assert(check("-deprecation:false", "-Xlint:deprecation")(ss => !ss.deprecation && ss.lintDeprecation))
-    assert(check("-deprecation:false", "-Xlint:-deprecation")(ss => !ss.deprecation && !ss.lintDeprecation))
+    assertTrue(check("-deprecation:false", "-Xlint:deprecation")(ss => !ss.deprecation && ss.lintDeprecation))
+    assertTrue(check("-deprecation:false", "-Xlint:-deprecation")(ss => !ss.deprecation && !ss.lintDeprecation))
     // same behavior with -Xlint:_
-    assert(check("-deprecation", "-Xlint")(ss => ss.deprecation && ss.lintDeprecation))
-    assert(check("-deprecation", "-Xlint:-deprecation,_")(ss => ss.deprecation && !ss.lintDeprecation))
-    assert(check("-deprecation:false", "-Xlint")(ss => !ss.deprecation && ss.lintDeprecation))
+    assertTrue(check("-deprecation", "-Xlint")(ss => ss.deprecation && ss.lintDeprecation))
+    assertTrue(check("-deprecation", "-Xlint:-deprecation,_")(ss => ss.deprecation && !ss.lintDeprecation))
+    assertTrue(check("-deprecation:false", "-Xlint")(ss => !ss.deprecation && ss.lintDeprecation))
   }
 
   @Test def userSettingsHavePrecedenceOverLint(): Unit = {
-    assert(check("-Xlint")(_.warnUnusedImport))
+    assertTrue(check("-Xlint")(_.warnUnusedImport))
     assertFalse(check("-Xlint", "-Ywarn-unused:-imports")(_.warnUnusedImport))
     assertFalse(check("-Ywarn-unused:-imports", "-Xlint")(_.warnUnusedImport))
   }
 
   @Test def anonymousLintersCanBeNamed(): Unit = {
-    assert(check("-Xlint")(_.warnMissingInterpolator)) // among Xlint
+    assertTrue(check("-Xlint")(_.warnMissingInterpolator)) // among Xlint
     assertFalse(check("-Xlint:-missing-interpolator")(_.warnMissingInterpolator))
 
     // positive overrides negative, but not the other way around
-    assert(check("-Xlint:-missing-interpolator,missing-interpolator")(_.warnMissingInterpolator))
-    assert(check("-Xlint:-missing-interpolator", "-Xlint:missing-interpolator")(_.warnMissingInterpolator))
+    assertTrue(check("-Xlint:-missing-interpolator,missing-interpolator")(_.warnMissingInterpolator))
+    assertTrue(check("-Xlint:-missing-interpolator", "-Xlint:missing-interpolator")(_.warnMissingInterpolator))
 
-    assert(check("-Xlint:missing-interpolator,-missing-interpolator")(_.warnMissingInterpolator))
-    assert(check("-Xlint:missing-interpolator", "-Xlint:-missing-interpolator")(_.warnMissingInterpolator))
+    assertTrue(check("-Xlint:missing-interpolator,-missing-interpolator")(_.warnMissingInterpolator))
+    assertTrue(check("-Xlint:missing-interpolator", "-Xlint:-missing-interpolator")(_.warnMissingInterpolator))
 
     // -Xlint:_ adds all possible choices, but explicit negative settings will override
     assertFalse(check("-Xlint:-missing-interpolator,_")(_.warnMissingInterpolator))
@@ -80,11 +82,11 @@ class SettingsTest {
     assertFalse(check("-Xlint", "-Xlint:-missing-interpolator")(_.warnMissingInterpolator))
 
     // combination of positive, negative and _
-    assert(check("-Xlint:_,-missing-interpolator,missing-interpolator")(_.warnMissingInterpolator))
-    assert(check("-Xlint:-missing-interpolator,_,missing-interpolator")(_.warnMissingInterpolator))
-    assert(check("-Xlint:-missing-interpolator,missing-interpolator,_")(_.warnMissingInterpolator))
-    assert(check("-Xlint:missing-interpolator,-missing-interpolator,_")(_.warnMissingInterpolator))
-    assert(check("-Xlint:missing-interpolator,_,-missing-interpolator")(_.warnMissingInterpolator))
+    assertTrue(check("-Xlint:_,-missing-interpolator,missing-interpolator")(_.warnMissingInterpolator))
+    assertTrue(check("-Xlint:-missing-interpolator,_,missing-interpolator")(_.warnMissingInterpolator))
+    assertTrue(check("-Xlint:-missing-interpolator,missing-interpolator,_")(_.warnMissingInterpolator))
+    assertTrue(check("-Xlint:missing-interpolator,-missing-interpolator,_")(_.warnMissingInterpolator))
+    assertTrue(check("-Xlint:missing-interpolator,_,-missing-interpolator")(_.warnMissingInterpolator))
   }
 
   @Test def xLintInvalidChoices(): Unit = {
@@ -93,9 +95,9 @@ class SettingsTest {
   }
 
   @Test def xLintNonColonated(): Unit = {
-    assert(check("-Xlint", "adapted-args", "-deprecation")(_.warnAdaptedArgs))
+    assertTrue(check("-Xlint", "adapted-args", "-deprecation")(_.warnAdaptedArgs))
     assertFalse(check("-Xlint", "adapted-args", "-deprecation")(_.warnMissingInterpolator))
-    assert(check("-Xlint", "adapted-args", "missing-interpolator", "-deprecation")(s => s.warnMissingInterpolator && s.warnAdaptedArgs))
+    assertTrue(check("-Xlint", "adapted-args", "missing-interpolator", "-deprecation")(s => s.warnMissingInterpolator && s.warnAdaptedArgs))
     assertThrows[IllegalArgumentException](check("-Xlint", "adapted-args", "-missing-interpolator")(_.warnAdaptedArgs)) // non-colonated: cannot provide negative args
   }
 
@@ -107,11 +109,11 @@ class SettingsTest {
       r
     }
 
-    assert(check("-Xlint")(t(_, "adapted-args")))
-    assert(check("-Xlint:_")(t(_, "adapted-args")))
+    assertTrue(check("-Xlint")(t(_, "adapted-args")))
+    assertTrue(check("-Xlint:_")(t(_, "adapted-args")))
     assertFalse(check("-Xlint:_,-adapted-args")(t(_, "adapted-args")))
     assertFalse(check("-Xlint:-adapted-args,_")(t(_, "adapted-args")))
-    assert(check("-Xlint:-adapted-args,_,adapted-args")(t(_, "adapted-args")))
+    assertTrue(check("-Xlint:-adapted-args,_,adapted-args")(t(_, "adapted-args")))
   }
 
   @Test def expandingMultichoice(): Unit = {
@@ -131,27 +133,27 @@ class SettingsTest {
     def check(args: String*)(t: s.MultiChoiceSetting[mChoices.type] => Boolean): Boolean = {
       m.clear()
       val (ok, rest) = s.processArguments(args.toList, processAll = true)
-      assert(rest.isEmpty)
+      assertTrue(rest.isEmpty)
       t(m)
     }
 
     import mChoices._
 
-    assert(check("-m")(_.value == Set(a,c)))
-    assert(check("-m:a,-b,c")(_.value == Set(a,c)))
+    assertTrue(check("-m")(_.value == Set(a,c)))
+    assertTrue(check("-m:a,-b,c")(_.value == Set(a,c)))
 
     // expanding options don't end up in the value set, only the terminal ones
-    assert(check("-m:ab,ac")(_.value == Set(a,b,c)))
-    assert(check("-m:_")(_.value == Set(a,b,c,d)))
-    assert(check("-m:uber,ac")(_.value == Set(a,b,c,d))) // recursive expansion of uber
+    assertTrue(check("-m:ab,ac")(_.value == Set(a,b,c)))
+    assertTrue(check("-m:_")(_.value == Set(a,b,c,d)))
+    assertTrue(check("-m:uber,ac")(_.value == Set(a,b,c,d))) // recursive expansion of uber
 
     // explicit nays
-    assert(check("-m:_,-b")(_.value == Set(a,c,d)))
-    assert(check("-m:b,_,-b")(_.value == Set(a,b,c,d)))
-    assert(check("-m:ac,-c")(_.value == Set(a)))
-    assert(check("-m:ac,-a,-c")(_.value == Set()))
-    assert(check("-m:-d,ac")(_.value == Set(a,c)))
-    assert(check("-m:-b,ac,uber")(_.value == Set(a,c,d)))
+    assertTrue(check("-m:_,-b")(_.value == Set(a,c,d)))
+    assertTrue(check("-m:b,_,-b")(_.value == Set(a,b,c,d)))
+    assertTrue(check("-m:ac,-c")(_.value == Set(a)))
+    assertTrue(check("-m:ac,-a,-c")(_.value == Set()))
+    assertTrue(check("-m:-d,ac")(_.value == Set(a,c)))
+    assertTrue(check("-m:-b,ac,uber")(_.value == Set(a,c,d)))
 
     assertFalse(check("-m:uber")(_.contains("i-m-not-an-option")))
 
@@ -164,8 +166,8 @@ class SettingsTest {
     def check(expected: String, args: String*): Unit = {
       val s = new MutableSettings(msg => throw new IllegalArgumentException(msg))
       val (_, residual) = s.processArguments(args.toList, processAll = true)
-      assert(s"remaining input [$residual]", residual.isEmpty)
-      assert(s"(${s.source.value} == ${ScalaVersion(expected)})", s.source.value == ScalaVersion(expected))
+      assertTrue(s"remaining input [$residual]", residual.isEmpty)
+      assertTrue(s"(${s.source.value} == ${ScalaVersion(expected)})", s.source.value == ScalaVersion(expected))
     }
     check(expected = "2.13.0") // default
     check(expected = "3",      "-Xsource:2.14")
@@ -198,14 +200,14 @@ class SettingsTest {
     def check(args: String*)(t: s.MultiChoiceSetting[mChoices.type] => Boolean): Boolean = {
       m.clear()
       val (ok, rest) = s.processArguments(args.toList, processAll = true)
-      assert(rest.isEmpty)
+      assertTrue(rest.isEmpty)
       t(m)
     }
 
     import mChoices._
 
-    assert(check("-m")(_.value == Set(b)))
-    assert(check("-m") { _ =>
+    assertTrue(check("-m")(_.value == Set(b)))
+    assertTrue(check("-m") { _ =>
       val expected =
         """|magic sauce
            |  a  help a
@@ -228,14 +230,15 @@ class SettingsTest {
     def check(args: String*)(t: s.MultiChoiceSetting[mChoices.type] => Boolean): Boolean = {
       m.clear()
       val (ok, rest) = s.processArguments(args.toList, processAll = true)
-      assert(rest.isEmpty)
+      assertTrue(ok)
+      assertTrue(rest.isEmpty)
       t(m)
     }
 
     import mChoices._
 
-    assert(check("-m")(_.value == Set(a, b, c)))
-    assert(check("-m") { _ =>
+    assertTrue(check("-m")(_.value == Set(a, b, c)))
+    assertTrue(check("-m") { _ =>
       val expected =
         """|magic sauce
            |  a  help a
@@ -249,13 +252,13 @@ class SettingsTest {
   @Test def `wildcard doesn't disable everything`(): Unit = {
     val settings = new Settings()
     settings.processArguments("-opt:_" :: Nil, true)
-    assert("has the choice", settings.opt.contains(settings.optChoices.inline))
-    assert("is enabled", settings.optInlinerEnabled)
+    assertTrue("has the choice", settings.opt.contains(settings.optChoices.inline))
+    assertTrue("is enabled", settings.optInlinerEnabled)
   }
   @Test def `kill switch can be enabled explicitly`(): Unit = {
     val settings = new Settings()
-    settings.processArguments("-opt:inline,l:none" :: Nil, true)
-    assert("has the choice", settings.opt.contains(settings.optChoices.inline))
+    settings.processArguments("-opt:inline,none" :: Nil, true)
+    assertTrue("has the choice", settings.opt.contains(settings.optChoices.inline))
     assertFalse("is not enabled", settings.optInlinerEnabled)
   }
   @Test def `t12036 don't consume dash option as arg`(): Unit = {
@@ -272,19 +275,70 @@ class SettingsTest {
     val errors   = ListBuffer.empty[String]
     val settings = new Settings(errors.addOne)
     val (ok, rest) = settings.processArguments("-Wconf" :: "help" :: "-Vdebug" :: "x.scala" :: Nil, true)
-    assert("processing should succeed", ok)
+    assertTrue("processing should succeed", ok)
     assertEquals("processing stops at argument", 1, rest.length)
     assertEquals("processing stops at the correct argument", "x.scala", rest.head)
     assertEquals(0, errors.size)
-    assert(settings.debug)
-    assert(settings.Wconf.isHelping)
+    assertTrue(settings.debug)
+    assertTrue(settings.Wconf.isHelping)
   }
   @Test def `t12098 MultiStringSetting prepends`(): Unit = {
     val settings = new Settings(msg => fail(s"Unexpected error: $msg"))
     val (ok, rest) = settings.processArguments("-Wconf:cat=lint-missing-interpolator:ws" :: "-Xlint" :: "x.scala" :: Nil, true)
-    assert("processing should succeed", ok)
-    assert(settings.warnMissingInterpolator)
-    assert(settings.lintDeprecation)
+    assertTrue("processing should succeed", ok)
+    assertTrue(settings.warnMissingInterpolator)
+    assertTrue(settings.lintDeprecation)
     // test/files/neg/t12098.scala shows that cat=deprecation:w due to xlint supersedes default cat=deprecation:ws
+  }
+  @Test def `choices can be multichoices`(): Unit = {
+    val s = new MutableSettings(msg => throw new IllegalArgumentException(msg))
+    object mChoices extends s.MultiChoiceEnumeration {
+      val a = Choice("a")
+      val b = Choice("b")
+      val c = Choice("c")
+      val d = Choice("d")
+    }
+    val m = s.MultiChoiceSetting("-m", "args", "magic sauce", mChoices, Some(List("a")))
+    println(s"m $m has value ${m.value}")
+
+    def check(args: String*)(t: s.MultiChoiceSetting[mChoices.type] => Boolean): Boolean = {
+      m.clear()
+      val (ok, rest) = s.processArguments(args.toList, processAll = true)
+      assertTrue(ok)
+      assertTrue(rest.isEmpty)
+      t(m)
+    }
+
+    import mChoices._
+
+    assertTrue(check("-m:a:aval")(choices => choices.value == Set(a) && choices.value.toList.head.asInstanceOf[mChoices.Choice].selections == List("aval")))
+    assertTrue(check("-m:a:aval1,aval2")(choices => choices.value == Set(a) && choices.value.toList.head.asInstanceOf[mChoices.Choice].selections == List("aval1", "aval2")))
+  }
+  @Test def `optimizer flags are sane`: Unit = {
+    val s = settings
+    val args = "-opt:inline:p.*" :: Nil
+    val (ok, rest) = s.processArguments(args.toList, processAll = true)
+    assertTrue(ok)
+    assertTrue(rest.isEmpty)
+    assertTrue(s.optInlinerEnabled)
+    assertEquals("p.*" :: Nil, s.optInlineFrom)
+  }
+  @Test def `optimizer inline patterns are additive`: Unit = {
+    val s = settings
+    val args = "-opt:inline:p.*" :: "-opt:inline:q.C.m" :: Nil
+    val (ok, rest) = s.processArguments(args.toList, processAll = true)
+    assertTrue(ok)
+    assertTrue(rest.isEmpty)
+    assertTrue(s.optInlinerEnabled)
+    assertEquals("p.*" :: "q.C.m" :: Nil, s.optInlineFrom)
+  }
+  @Test def `optimizer old flags are supported`: Unit = {
+    val s = settings
+    val args = "-opt:l:method" :: Nil
+    val (ok, rest) = s.processArguments(args.toList, processAll = true)
+    assertTrue(ok)
+    assertTrue(rest.isEmpty)
+    assertFalse(s.optInlinerEnabled)
+    assertTrue(s.optBoxUnbox)
   }
 }

--- a/test/junit/scala/tools/nsc/transform/patmat/PatmatBytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/transform/patmat/PatmatBytecodeTest.scala
@@ -15,7 +15,7 @@ import PartialFunction.cond
 
 @RunWith(classOf[JUnit4])
 class PatmatBytecodeTest extends BytecodeTesting {
-  val optCompiler = cached("optCompiler", () => newCompiler(extraArgs = "-opt:all -opt:inline:**"))
+  val optCompiler = cached("optCompiler", () => newCompiler(extraArgs = "-opt:inline:**"))
 
   import compiler._
 

--- a/test/junit/scala/tools/nsc/transform/patmat/PatmatBytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/transform/patmat/PatmatBytecodeTest.scala
@@ -15,7 +15,7 @@ import PartialFunction.cond
 
 @RunWith(classOf[JUnit4])
 class PatmatBytecodeTest extends BytecodeTesting {
-  val optCompiler = cached("optCompiler", () => newCompiler(extraArgs = "-opt:l:inline -opt-inline-from:**"))
+  val optCompiler = cached("optCompiler", () => newCompiler(extraArgs = "-opt:all -opt:inline:**"))
 
   import compiler._
 


### PR DESCRIPTION
Optimizer is enabled by `-opt:inline:**`, as described in the [new overview](https://docs.scala-lang.org/overviews/compiler-options/optimizer.html). Warnings are enabled by `-Wopt` and verbose output by `-Vinline`.

Fixes scala/bug#11873