### PR TITLE
Fix range positions in selection from parens

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -917,8 +917,8 @@ self =>
       if (opinfo.targs.nonEmpty)
         syntaxError(opinfo.offset, "type application is not allowed for postfix operators")
 
-      val od = stripParens(reduceExprStack(base, opinfo.lhs))
-      makePostfixSelect(start, opinfo.offset, od, opinfo.operator)
+      val lhs = reduceExprStack(base, opinfo.lhs)
+      makePostfixSelect(if (lhs.pos.isDefined) lhs.pos.start else start, opinfo.offset, stripParens(lhs), opinfo.operator)
     }
 
     def finishBinaryOp(isExpr: Boolean, opinfo: OpInfo, rhs: Tree): Tree = {
@@ -1217,11 +1217,12 @@ self =>
 
     def identOrMacro(): Name = if (isMacro) rawIdent() else ident()
 
-    def selector(t: Tree): Tree = {
+    def selector(t0: Tree): Tree = {
+      val t = stripParens(t0)
       val point = if (isIdent) in.offset else in.lastOffset //scala/bug#8459
       //assert(t.pos.isDefined, t)
       if (t != EmptyTree)
-        Select(t, ident(skipIt = false)) setPos r2p(t.pos.start, point, in.lastOffset)
+        Select(t, ident(skipIt = false)) setPos r2p(t0.pos.start, point, in.lastOffset)
       else
         errorTermTree // has already been reported
     }
@@ -1793,14 +1794,14 @@ self =>
       in.token match {
         case DOT =>
           in.nextToken()
-          simpleExprRest(selector(stripParens(t)), canApply = true)
+          simpleExprRest(selector(t), canApply = true)
         case LBRACKET =>
           val t1 = stripParens(t)
           t1 match {
             case Ident(_) | Select(_, _) | Apply(_, _) =>
               var app: Tree = t1
               while (in.token == LBRACKET)
-                app = atPos(app.pos.start, in.offset)(TypeApply(app, exprTypeArgs()))
+                app = atPos(t.pos.start, in.offset)(TypeApply(app, exprTypeArgs()))
 
               simpleExprRest(app, canApply = true)
             case _ =>

--- a/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
@@ -56,8 +56,7 @@ abstract class TreeBuilder {
     ValDef(Modifiers(PRIVATE), name, tpt, EmptyTree)
 
   /** Tree for `od op`, start is start0 if od.pos is borked. */
-  def makePostfixSelect(start0: Int, end: Int, od: Tree, op: Name): Tree = {
-    val start = if (od.pos.isDefined) od.pos.start else start0
+  def makePostfixSelect(start: Int, end: Int, od: Tree, op: Name): Tree = {
     atPos(r2p(start, end, end + op.length)) { new PostfixSelect(od, op.encode) }
   }
 

--- a/test/files/run/t12490.scala
+++ b/test/files/run/t12490.scala
@@ -1,0 +1,33 @@
+import scala.tools.partest._
+import scala.collection.mutable.LinkedHashMap
+
+object Test extends CompilerTest {
+  import global._
+  override def extraSettings = super.extraSettings + " -Yrangepos -Ystop-after:parser"
+  val tests = LinkedHashMap(
+    "class A { def t       = new C()   }" -> (24, 31),
+    "class B { def t       = (new C)   }" -> (25, 30),
+    "class C { def t       = new C     }" -> (24, 29),
+    "class D { def t       = new C().t }" -> (24, 33),
+    "class E { def t       = (new C).t }" -> (24, 33),
+    "class F { def t(c: C) = c         }" -> (24, 25),
+    "class G { def t(c: C) = (c)       }" -> (25, 26),
+    "class H { def t(c: C) = c.t       }" -> (24, 27),
+    "class I { def t(c: C) = (c).t     }" -> (24, 29),
+    "class J { def t[T]: C = (x.t)[C]  }" -> (24, 32),
+    "class K { def t(f: F) = (f) t c   }" -> (24, 31),
+    "class L { def t(c: C) = (c) t     }" -> (24, 29),
+    //                       ^ 24     ^ 33
+  )
+
+  override def sources = tests.toList.map(_._1)
+
+  def check(source: String, unit: CompilationUnit): Unit = unit.body foreach {
+    case dd: DefDef if dd.name.startsWith("t") =>
+      val pos = dd.rhs.pos
+      val (start, end) = tests(source)
+      assert(pos.start == start, pos.start)
+      assert(pos.end == end, pos.end)
+    case _ =>
+  }
+}


### PR DESCRIPTION
In `(c).f`, the range position did not include the opening `(`.

Fixes https://github.com/scala/bug/issues/12490