### PR TITLE
Allow overriding `protected[Base]` methods

### DIFF
--- a/project/PartestUtil.scala
+++ b/project/PartestUtil.scala
@@ -36,7 +36,8 @@ object PartestUtil {
     val knownUnaryOptions = List(
       "--pos", "--neg", "--run", "--jvm", "--res", "--ant", "--scalap", "--specialized",
       "--instrumented", "--presentation", "--failed", "--update-check", "--no-exec",
-      "--show-diff", "--show-log", "--verbose", "--terse", "--debug", "--realeasy", "--version", "--help")
+      "--show-diff", "--show-log", "--verbose", "--terse", "--debug", "--realeasy", "--branch", "--version",
+      "--help")
     val srcPathOption = "--srcpath"
     val compilerPathOption = "--compilerpath"
     val grepOption = "--grep"

--- a/spec/05-classes-and-objects.md
+++ b/spec/05-classes-and-objects.md
@@ -332,13 +332,13 @@ Furthermore, the following restrictions on modifiers apply to ´M´ and
 
 - ´M'´ must not be labeled `final`.
 - ´M´ must not be [`private`](#modifiers).
-- If ´M´ is labeled `private[´C´]` for some enclosing class or package ´C´,
-  then ´M'´ must be labeled `private[´C'´]` for some class or package ´C'´ where
-  ´C'´ equals ´C´ or ´C'´ is contained in ´C´.
-
-<!-- TODO: check whether this is accurate -->
 - If ´M´ is labeled `protected`, then ´M'´ must also be
   labeled `protected`.
+- If ´M´ is labeled `private[´C´]` (respectively `protected[´C´]`)
+  for some enclosing class or package ´C´,
+  then ´M'´ must be labeled `private[´C'´]` (or, respectively, `protected[´C'´]`)
+  for some class or package ´C'´ where
+  ´C'´ equals ´C´ or the companion of ´C´, or ´C'´ is contained in ´C´.
 - If ´M'´ is not an abstract member, then ´M´ must be labeled `override`.
   Furthermore, one of two possibilities must hold:
     - either ´M´ is defined in a subclass of the class where is ´M'´ is defined,

--- a/src/partest/scala/tools/partest/nest/RunnerSpec.scala
+++ b/src/partest/scala/tools/partest/nest/RunnerSpec.scala
@@ -57,6 +57,7 @@ trait RunnerSpec extends Spec with Meta.StdOpts with Interpolation {
 
   heading("Other options:")
   val optDev     = "realeasy" / "real easy way to test --release 8 and check uncommitted checks" --?
+  val optBranch  = "branch"   / "test changes on this branch"                                    --?
   val optVersion = "version"  / "show Scala version and exit"                                    --?
   val optHelp    = "help"     / "show this page and exit"                                        --?
 

--- a/src/reflect/scala/reflect/internal/util/StripMarginInterpolator.scala
+++ b/src/reflect/scala/reflect/internal/util/StripMarginInterpolator.scala
@@ -23,7 +23,7 @@ trait StripMarginInterpolator {
    * and [[scala.StringContext#raw]].
    *
    * The margin of each line is defined by whitespace leading up to a '|' character.
-   * This margin is stripped '''before''' the arguments are interpolated into to string.
+   * This margin is stripped '''before''' the arguments are interpolated into the string.
    *
    * String escape sequences are '''not''' processed; this interpolator is designed to
    * be used with triple quoted Strings.
@@ -31,23 +31,30 @@ trait StripMarginInterpolator {
    * {{{
    * scala> val foo = "f|o|o"
    * foo: String = f|o|o
-   * scala> sm"""|${foo}
+   * scala> sm"""|${foo}|
    *             |"""
    * res0: String =
-   * "f|o|o
+   * "f|o|o|
    * "
    * }}}
    */
-  final def sm(args: Any*): String = {
+  final def sm(args: Any*): String = impl('|', args: _*)
+
+  private final def impl(sep: Char, args: Any*): String = {
     def isLineBreak(c: Char) = c == '\n' || c == '\f' // compatible with StringOps#isLineBreak
     def stripTrailingPart(s: String) = {
       val (pre, post) = s.span(c => !isLineBreak(c))
-      pre + post.stripMargin
+      pre + post.stripMargin(sep)
     }
     val stripped: List[String] = stringContext.parts.toList match {
-      case head :: tail => head.stripMargin :: (tail map stripTrailingPart)
+      case head :: tail => head.stripMargin(sep) :: tail.map(stripTrailingPart)
       case Nil => Nil
     }
     new StringContext(stripped: _*).raw(args: _*)
   }
+
+  /** Like the `sm` interpolator, but strips quotation-style delimiter `>`
+   *  and merges the resulting lines into a single line string.
+   */
+  final def sq(args: Any*): String = impl('>', args: _*).linesIterator.mkString
 }

--- a/test/files/neg/t12349.check
+++ b/test/files/neg/t12349.check
@@ -31,129 +31,150 @@ def a7(): Unit (defined in class t12349a)
 t12349b.scala:13: error: weaker access privileges in overriding
 def a8(): Unit (defined in class t12349a)
   override should be public
-    protected[this]    override def a8(): Unit = println("Inner12349b#a8()") // weaker access privileges
+    protected[Inner12349b] override def a8(): Unit = println("Inner12349b#a8()") // weaker access privileges
+                                        ^
+t12349b.scala:15: error: weaker access privileges in overriding
+def aA(): Unit (defined in class t12349a)
+  override should be public
+    protected[this]    override def aA(): Unit = println("Inner12349b#aA()") // weaker access privileges
                                     ^
-t12349b.scala:14: error: weaker access privileges in overriding
-def a9(): Unit (defined in class t12349a)
+t12349b.scala:16: error: weaker access privileges in overriding
+def aB(): Unit (defined in class t12349a)
   override should not be private
-      private[this]    override def a9(): Unit = println("Inner12349b#a9()") // weaker access privileges
+      private[this]    override def aB(): Unit = println("Inner12349b#aB()") // weaker access privileges
                                     ^
-t12349b.scala:18: error: weaker access privileges in overriding
+t12349b.scala:20: error: weaker access privileges in overriding
 protected[package t12349] def b3(): Unit (defined in class t12349a)
   override should not be private
       private          override def b3(): Unit = println("Inner12349b#b3()") // weaker access privileges
                                     ^
-t12349b.scala:20: error: weaker access privileges in overriding
+t12349b.scala:22: error: weaker access privileges in overriding
 protected[package t12349] def b5(): Unit (defined in class t12349a)
   override should at least be protected[t12349]
       private[t12349b] override def b5(): Unit = println("Inner12349b#b5()") // weaker access privileges
                                     ^
-t12349b.scala:22: error: weaker access privileges in overriding
+t12349b.scala:24: error: weaker access privileges in overriding
 protected[package t12349] def b7(): Unit (defined in class t12349a)
   override should at least be protected[t12349]
       private[t12349]  override def b7(): Unit = println("Inner12349b#b7()") // weaker access privileges
                                     ^
-t12349b.scala:24: error: weaker access privileges in overriding
-protected[package t12349] def b9(): Unit (defined in class t12349a)
+t12349b.scala:28: error: weaker access privileges in overriding
+protected[package t12349] def bB(): Unit (defined in class t12349a)
   override should not be private
-      private[this]    override def b9(): Unit = println("Inner12349b#b9()") // weaker access privileges
+      private[this]    override def bB(): Unit = println("Inner12349b#bB()") // weaker access privileges
                                     ^
-t12349b.scala:27: error: weaker access privileges in overriding
+t12349b.scala:31: error: weaker access privileges in overriding
 private[package t12349] def c2(): Unit (defined in class t12349a)
   override should at least be private[t12349]
     protected          override def c2(): Unit = println("Inner12349b#c2()") // weaker access privileges
                                     ^
-t12349b.scala:28: error: weaker access privileges in overriding
+t12349b.scala:32: error: weaker access privileges in overriding
 private[package t12349] def c3(): Unit (defined in class t12349a)
   override should not be private
       private          override def c3(): Unit = println("Inner12349b#c3()") // weaker access privileges
                                     ^
-t12349b.scala:29: error: weaker access privileges in overriding
+t12349b.scala:33: error: weaker access privileges in overriding
 private[package t12349] def c4(): Unit (defined in class t12349a)
   override should at least be private[t12349]
     protected[t12349b] override def c4(): Unit = println("Inner12349b#c4()") // weaker access privileges
                                     ^
-t12349b.scala:30: error: weaker access privileges in overriding
+t12349b.scala:34: error: weaker access privileges in overriding
 private[package t12349] def c5(): Unit (defined in class t12349a)
   override should at least be private[t12349]
       private[t12349b] override def c5(): Unit = println("Inner12349b#c5()") // weaker access privileges
                                     ^
-t12349b.scala:33: error: weaker access privileges in overriding
+t12349b.scala:37: error: weaker access privileges in overriding
 private[package t12349] def c8(): Unit (defined in class t12349a)
   override should at least be private[t12349]
-    protected[this]    override def c8(): Unit = println("Inner12349b#c8()") // weaker access privileges
+    protected[Inner12349b] override def c8(): Unit = println("Inner12349b#c8()") // weaker access privileges
+                                        ^
+t12349b.scala:39: error: weaker access privileges in overriding
+private[package t12349] def cA(): Unit (defined in class t12349a)
+  override should at least be private[t12349]
+    protected[this]    override def cA(): Unit = println("Inner12349b#cA()") // weaker access privileges
                                     ^
-t12349b.scala:34: error: weaker access privileges in overriding
-private[package t12349] def c9(): Unit (defined in class t12349a)
+t12349b.scala:40: error: weaker access privileges in overriding
+private[package t12349] def cB(): Unit (defined in class t12349a)
   override should not be private
-      private[this]    override def c9(): Unit = println("Inner12349b#c9()") // weaker access privileges
+      private[this]    override def cB(): Unit = println("Inner12349b#cB()") // weaker access privileges
                                     ^
-t12349b.scala:36: error: method d1 overrides nothing
+t12349b.scala:42: error: method d1 overrides nothing
                        override def d1(): Unit = println("Inner12349b#d1()") // overrides nothing
                                     ^
-t12349b.scala:37: error: method d2 overrides nothing
+t12349b.scala:43: error: method d2 overrides nothing
     protected          override def d2(): Unit = println("Inner12349b#d2()") // overrides nothing
                                     ^
-t12349b.scala:38: error: method d3 overrides nothing
+t12349b.scala:44: error: method d3 overrides nothing
       private          override def d3(): Unit = println("Inner12349b#d3()") // overrides nothing
                                     ^
-t12349b.scala:39: error: method d4 overrides nothing
+t12349b.scala:45: error: method d4 overrides nothing
     protected[t12349b] override def d4(): Unit = println("Inner12349b#d4()") // overrides nothing
                                     ^
-t12349b.scala:40: error: method d5 overrides nothing
+t12349b.scala:46: error: method d5 overrides nothing
       private[t12349b] override def d5(): Unit = println("Inner12349b#d5()") // overrides nothing
                                     ^
-t12349b.scala:41: error: method d6 overrides nothing
+t12349b.scala:47: error: method d6 overrides nothing
     protected[t12349]  override def d6(): Unit = println("Inner12349b#d6()") // overrides nothing
                                     ^
-t12349b.scala:42: error: method d7 overrides nothing
+t12349b.scala:48: error: method d7 overrides nothing
       private[t12349]  override def d7(): Unit = println("Inner12349b#d7()") // overrides nothing
                                     ^
-t12349b.scala:43: error: method d8 overrides nothing
-    protected[this]    override def d8(): Unit = println("Inner12349b#d8()") // overrides nothing
+t12349b.scala:49: error: method d8 overrides nothing
+    protected[Inner12349b] override def d8(): Unit = println("Inner12349b#d8()") // overrides nothing
+                                        ^
+t12349b.scala:51: error: method dA overrides nothing
+    protected[this]    override def dA(): Unit = println("Inner12349b#dA()") // overrides nothing
                                     ^
-t12349b.scala:44: error: method d9 overrides nothing
-      private[this]    override def d9(): Unit = println("Inner12349b#d9()") // overrides nothing
+t12349b.scala:52: error: method dB overrides nothing
+      private[this]    override def dB(): Unit = println("Inner12349b#dB()") // overrides nothing
                                     ^
-t12349c.scala:11: error: weaker access privileges in overriding
+t12349b.scala:50: error: method d9 overrides nothing
+      private[Inner12349b] override def d9(): Unit = println("Inner12349b#d9()") // overrides nothing
+                                        ^
+t12349c.scala:9: error: weaker access privileges in overriding
 def a2(): Unit (defined in class t12349a)
   override should be public
       protected          override def a2(): Unit = println("Inner12349c#a2()") // weaker access privileges
                                       ^
-t12349c.scala:12: error: weaker access privileges in overriding
+t12349c.scala:10: error: weaker access privileges in overriding
 def a3(): Unit (defined in class t12349a)
   override should not be private
         private          override def a3(): Unit = println("Inner12349c#a3()") // weaker access privileges
                                       ^
-t12349c.scala:13: error: weaker access privileges in overriding
+t12349c.scala:11: error: weaker access privileges in overriding
 def a4(): Unit (defined in class t12349a)
   override should be public
       protected[t12349c] override def a4(): Unit = println("Inner12349c#a4()") // weaker access privileges
                                       ^
-t12349c.scala:14: error: weaker access privileges in overriding
+t12349c.scala:12: error: weaker access privileges in overriding
 def a5(): Unit (defined in class t12349a)
   override should be public
         private[t12349c] override def a5(): Unit = println("Inner12349c#a5()") // weaker access privileges
                                       ^
-t12349c.scala:15: error: weaker access privileges in overriding
+t12349c.scala:13: error: weaker access privileges in overriding
 def a6(): Unit (defined in class t12349a)
   override should be public
       protected[pkg]     override def a6(): Unit = println("Inner12349c#a6()") // weaker access privileges
                                       ^
-t12349c.scala:16: error: weaker access privileges in overriding
+t12349c.scala:14: error: weaker access privileges in overriding
 def a7(): Unit (defined in class t12349a)
   override should be public
         private[pkg]     override def a7(): Unit = println("Inner12349c#a7()") // weaker access privileges
                                       ^
-t12349c.scala:17: error: weaker access privileges in overriding
+t12349c.scala:15: error: weaker access privileges in overriding
 def a8(): Unit (defined in class t12349a)
   override should be public
-      protected[this]    override def a8(): Unit = println("Inner12349c#a8()") // weaker access privileges
+      protected[Inner12349c] override def a8(): Unit = println("Inner12349c#a8()") // weaker access privileges
+                                          ^
+t12349c.scala:17: error: weaker access privileges in overriding
+def aA(): Unit (defined in class t12349a)
+  override should be public
+      protected[this]    override def aA(): Unit = println("Inner12349c#aA()") // weaker access privileges
                                       ^
 t12349c.scala:18: error: weaker access privileges in overriding
-def a9(): Unit (defined in class t12349a)
+def aB(): Unit (defined in class t12349a)
   override should not be private
-        private[this]    override def a9(): Unit = println("Inner12349c#a9()") // weaker access privileges
+        private[this]    override def aB(): Unit = println("Inner12349c#aB()") // weaker access privileges
                                       ^
 t12349c.scala:22: error: weaker access privileges in overriding
 protected[package t12349] def b3(): Unit (defined in class t12349a)
@@ -170,79 +191,93 @@ protected[package t12349] def b7(): Unit (defined in class t12349a)
   override should at least be protected[t12349]
         private[pkg]     override def b7(): Unit = println("Inner12349c#b7()") // weaker access privileges
                                       ^
-t12349c.scala:28: error: weaker access privileges in overriding
-protected[package t12349] def b9(): Unit (defined in class t12349a)
+t12349c.scala:30: error: weaker access privileges in overriding
+protected[package t12349] def bB(): Unit (defined in class t12349a)
   override should not be private
-        private[this]    override def b9(): Unit = println("Inner12349c#b9()") // weaker access privileges
+        private[this]    override def bB(): Unit = println("Inner12349c#bB()") // weaker access privileges
                                       ^
-t12349c.scala:31: error: weaker access privileges in overriding
+t12349c.scala:33: error: weaker access privileges in overriding
 private[package t12349] def c2(): Unit (defined in class t12349a)
   override should at least be private[t12349]
       protected          override def c2(): Unit = println("Inner12349c#c2()") // weaker access privileges
                                       ^
-t12349c.scala:32: error: weaker access privileges in overriding
+t12349c.scala:34: error: weaker access privileges in overriding
 private[package t12349] def c3(): Unit (defined in class t12349a)
   override should not be private
         private          override def c3(): Unit = println("Inner12349c#c3()") // weaker access privileges
                                       ^
-t12349c.scala:33: error: weaker access privileges in overriding
+t12349c.scala:35: error: weaker access privileges in overriding
 private[package t12349] def c4(): Unit (defined in class t12349a)
   override should at least be private[t12349]
       protected[t12349c] override def c4(): Unit = println("Inner12349c#c4()") // weaker access privileges
                                       ^
-t12349c.scala:34: error: weaker access privileges in overriding
+t12349c.scala:36: error: weaker access privileges in overriding
 private[package t12349] def c5(): Unit (defined in class t12349a)
   override should at least be private[t12349]
         private[t12349c] override def c5(): Unit = println("Inner12349c#c5()") // weaker access privileges
                                       ^
-t12349c.scala:35: error: weaker access privileges in overriding
+t12349c.scala:37: error: weaker access privileges in overriding
 private[package t12349] def c6(): Unit (defined in class t12349a)
   override should at least be private[t12349]
       protected[pkg]     override def c6(): Unit = println("Inner12349c#c6()") // weaker access privileges
                                       ^
-t12349c.scala:36: error: weaker access privileges in overriding
+t12349c.scala:38: error: weaker access privileges in overriding
 private[package t12349] def c7(): Unit (defined in class t12349a)
   override should at least be private[t12349]
         private[pkg]     override def c7(): Unit = println("Inner12349c#c7()") // weaker access privileges
                                       ^
-t12349c.scala:37: error: weaker access privileges in overriding
+t12349c.scala:39: error: weaker access privileges in overriding
 private[package t12349] def c8(): Unit (defined in class t12349a)
   override should at least be private[t12349]
-      protected[this]    override def c8(): Unit = println("Inner12349c#c8()") // weaker access privileges
+      protected[Inner12349c] override def c8(): Unit = println("Inner12349c#c8()") // weaker access privileges
+                                          ^
+t12349c.scala:41: error: weaker access privileges in overriding
+private[package t12349] def cA(): Unit (defined in class t12349a)
+  override should at least be private[t12349]
+      protected[this]    override def cA(): Unit = println("Inner12349c#cA()") // weaker access privileges
                                       ^
-t12349c.scala:38: error: weaker access privileges in overriding
-private[package t12349] def c9(): Unit (defined in class t12349a)
+t12349c.scala:42: error: weaker access privileges in overriding
+private[package t12349] def cB(): Unit (defined in class t12349a)
   override should not be private
-        private[this]    override def c9(): Unit = println("Inner12349c#c9()") // overrides nothing (invisible)
+        private[this]    override def cB(): Unit = println("Inner12349c#cB()") // weaker access privileges
                                       ^
-t12349c.scala:30: error: method c1 overrides nothing
+t12349c.scala:32: error: method c1 overrides nothing
                          override def c1(): Unit = println("Inner12349c#c1()") // overrides nothing (invisible)
                                       ^
-t12349c.scala:40: error: method d1 overrides nothing
+t12349c.scala:44: error: method d1 overrides nothing
                          override def d1(): Unit = println("Inner12349c#d1()") // overrides nothing
                                       ^
-t12349c.scala:41: error: method d2 overrides nothing
+t12349c.scala:45: error: method d2 overrides nothing
       protected          override def d2(): Unit = println("Inner12349c#d2()") // overrides nothing
                                       ^
-t12349c.scala:42: error: method d3 overrides nothing
+t12349c.scala:46: error: method d3 overrides nothing
         private          override def d3(): Unit = println("Inner12349c#d3()") // overrides nothing
                                       ^
-t12349c.scala:43: error: method d4 overrides nothing
+t12349c.scala:47: error: method d4 overrides nothing
       protected[t12349c] override def d4(): Unit = println("Inner12349c#d4()") // overrides nothing
                                       ^
-t12349c.scala:44: error: method d5 overrides nothing
+t12349c.scala:48: error: method d5 overrides nothing
         private[t12349c] override def d5(): Unit = println("Inner12349c#d5()") // overrides nothing
                                       ^
-t12349c.scala:45: error: method d6 overrides nothing
+t12349c.scala:49: error: method d6 overrides nothing
       protected[pkg]     override def d6(): Unit = println("Inner12349c#d6()") // overrides nothing
                                       ^
-t12349c.scala:46: error: method d7 overrides nothing
+t12349c.scala:50: error: method d7 overrides nothing
         private[pkg]     override def d7(): Unit = println("Inner12349c#d7()") // overrides nothing
                                       ^
-t12349c.scala:47: error: method d8 overrides nothing
-      protected[this]    override def d8(): Unit = println("Inner12349c#d8()") // overrides nothing
+t12349c.scala:51: error: method d8 overrides nothing
+      protected[Inner12349c] override def d8(): Unit = println("Inner12349c#d8()") // overrides nothing
+                                          ^
+t12349c.scala:53: error: method dA overrides nothing
+      protected[this]    override def dA(): Unit = println("Inner12349c#dA()") // overrides nothing
                                       ^
-t12349c.scala:48: error: method d9 overrides nothing
-        private[this]    override def d9(): Unit = println("Inner12349c#d9()") // overrides nothing
+t12349c.scala:54: error: method dB overrides nothing
+        private[this]    override def dB(): Unit = println("Inner12349c#dB()") // overrides nothing
                                       ^
-57 errors
+t12349c.scala:40: error: method c9 overrides nothing
+        private[Inner12349c] override def c9(): Unit = println("Inner12349c#c9()") // weaker access privileges
+                                          ^
+t12349c.scala:52: error: method d9 overrides nothing
+        private[Inner12349c] override def d9(): Unit = println("Inner12349c#d9()") // overrides nothing
+                                          ^
+66 errors

--- a/test/files/neg/t12349/t12349a.java
+++ b/test/files/neg/t12349/t12349a.java
@@ -11,6 +11,8 @@ public class t12349a {
        public void a7() { System.out.println("t12349a#a7()"); }
        public void a8() { System.out.println("t12349a#a8()"); }
        public void a9() { System.out.println("t12349a#a9()"); }
+       public void aA() { System.out.println("t12349a#aA()"); }
+       public void aB() { System.out.println("t12349a#aB()"); }
 
     protected void b1() { System.out.println("t12349a#b1()"); }
     protected void b2() { System.out.println("t12349a#b2()"); }
@@ -21,6 +23,8 @@ public class t12349a {
     protected void b7() { System.out.println("t12349a#b7()"); }
     protected void b8() { System.out.println("t12349a#b8()"); }
     protected void b9() { System.out.println("t12349a#b9()"); }
+    protected void bA() { System.out.println("t12349a#bA()"); }
+    protected void bB() { System.out.println("t12349a#bB()"); }
 
               void c1() { System.out.println("t12349a#c1()"); }
               void c2() { System.out.println("t12349a#c2()"); }
@@ -31,6 +35,8 @@ public class t12349a {
               void c7() { System.out.println("t12349a#c7()"); }
               void c8() { System.out.println("t12349a#c8()"); }
               void c9() { System.out.println("t12349a#c9()"); }
+              void cA() { System.out.println("t12349a#cA()"); }
+              void cB() { System.out.println("t12349a#cB()"); }
 
       private void d1() { System.out.println("t12349a#d1()"); }
       private void d2() { System.out.println("t12349a#d2()"); }
@@ -41,5 +47,7 @@ public class t12349a {
       private void d7() { System.out.println("t12349a#d7()"); }
       private void d8() { System.out.println("t12349a#d8()"); }
       private void d9() { System.out.println("t12349a#d9()"); }
+      private void dA() { System.out.println("t12349a#dA()"); }
+      private void dB() { System.out.println("t12349a#dB()"); }
 
 }

--- a/test/files/neg/t12349/t12349b.scala
+++ b/test/files/neg/t12349/t12349b.scala
@@ -10,8 +10,10 @@ object t12349b {
       private[t12349b] override def a5(): Unit = println("Inner12349b#a5()") // weaker access privileges
     protected[t12349]  override def a6(): Unit = println("Inner12349b#a6()") // weaker access privileges
       private[t12349]  override def a7(): Unit = println("Inner12349b#a7()") // weaker access privileges
-    protected[this]    override def a8(): Unit = println("Inner12349b#a8()") // weaker access privileges
-      private[this]    override def a9(): Unit = println("Inner12349b#a9()") // weaker access privileges
+    protected[Inner12349b] override def a8(): Unit = println("Inner12349b#a8()") // weaker access privileges
+      private[Inner12349b] override def a9(): Unit = println("Inner12349b#a9()") // weaker access privileges
+    protected[this]    override def aA(): Unit = println("Inner12349b#aA()") // weaker access privileges
+      private[this]    override def aB(): Unit = println("Inner12349b#aB()") // weaker access privileges
 
                        override def b1(): Unit = println("Inner12349b#b1()")
     protected          override def b2(): Unit = println("Inner12349b#b2()")
@@ -20,8 +22,10 @@ object t12349b {
       private[t12349b] override def b5(): Unit = println("Inner12349b#b5()") // weaker access privileges
     protected[t12349]  override def b6(): Unit = println("Inner12349b#b6()")
       private[t12349]  override def b7(): Unit = println("Inner12349b#b7()") // weaker access privileges
-    protected[this]    override def b8(): Unit = println("Inner12349b#b8()") // [#12349] - not fixed by PR #9525
-      private[this]    override def b9(): Unit = println("Inner12349b#b9()") // weaker access privileges
+    protected[Inner12349b] override def b8(): Unit = println("Inner12349b#b8()") // [#12349] - not fixed by PR #9525
+      private[Inner12349b] override def b9(): Unit = println("Inner12349b#b9()") // weaker access privileges
+    protected[this]    override def bA(): Unit = println("Inner12349b#bA()") // [#12349] - not fixed by PR #9525
+      private[this]    override def bB(): Unit = println("Inner12349b#bB()") // weaker access privileges
 
                        override def c1(): Unit = println("Inner12349b#c1()")
     protected          override def c2(): Unit = println("Inner12349b#c2()") // weaker access privileges
@@ -30,8 +34,10 @@ object t12349b {
       private[t12349b] override def c5(): Unit = println("Inner12349b#c5()") // weaker access privileges
     protected[t12349]  override def c6(): Unit = println("Inner12349b#c6()")
       private[t12349]  override def c7(): Unit = println("Inner12349b#c7()")
-    protected[this]    override def c8(): Unit = println("Inner12349b#c8()") // weaker access privileges
-      private[this]    override def c9(): Unit = println("Inner12349b#c9()") // weaker access privileges
+    protected[Inner12349b] override def c8(): Unit = println("Inner12349b#c8()") // weaker access privileges
+      private[Inner12349b] override def c9(): Unit = println("Inner12349b#c9()") // weaker access privileges
+    protected[this]    override def cA(): Unit = println("Inner12349b#cA()") // weaker access privileges
+      private[this]    override def cB(): Unit = println("Inner12349b#cB()") // weaker access privileges
 
                        override def d1(): Unit = println("Inner12349b#d1()") // overrides nothing
     protected          override def d2(): Unit = println("Inner12349b#d2()") // overrides nothing
@@ -40,8 +46,10 @@ object t12349b {
       private[t12349b] override def d5(): Unit = println("Inner12349b#d5()") // overrides nothing
     protected[t12349]  override def d6(): Unit = println("Inner12349b#d6()") // overrides nothing
       private[t12349]  override def d7(): Unit = println("Inner12349b#d7()") // overrides nothing
-    protected[this]    override def d8(): Unit = println("Inner12349b#d8()") // overrides nothing
-      private[this]    override def d9(): Unit = println("Inner12349b#d9()") // overrides nothing
+    protected[Inner12349b] override def d8(): Unit = println("Inner12349b#d8()") // overrides nothing
+      private[Inner12349b] override def d9(): Unit = println("Inner12349b#d9()") // overrides nothing
+    protected[this]    override def dA(): Unit = println("Inner12349b#dA()") // overrides nothing
+      private[this]    override def dB(): Unit = println("Inner12349b#dB()") // overrides nothing
   }
 
 }

--- a/test/files/neg/t12349/t12349c.scala
+++ b/test/files/neg/t12349/t12349c.scala
@@ -1,7 +1,5 @@
 package t12349
 
-import t12349.t12349a
-
 package pkg {
 
   object t12349c {
@@ -14,8 +12,10 @@ package pkg {
         private[t12349c] override def a5(): Unit = println("Inner12349c#a5()") // weaker access privileges
       protected[pkg]     override def a6(): Unit = println("Inner12349c#a6()") // weaker access privileges
         private[pkg]     override def a7(): Unit = println("Inner12349c#a7()") // weaker access privileges
-      protected[this]    override def a8(): Unit = println("Inner12349c#a8()") // weaker access privileges
-        private[this]    override def a9(): Unit = println("Inner12349c#a9()") // weaker access privileges
+      protected[Inner12349c] override def a8(): Unit = println("Inner12349c#a8()") // weaker access privileges
+        private[Inner12349c] override def a9(): Unit = println("Inner12349c#a9()") // weaker access privileges
+      protected[this]    override def aA(): Unit = println("Inner12349c#aA()") // weaker access privileges
+        private[this]    override def aB(): Unit = println("Inner12349c#aB()") // weaker access privileges
 
                          override def b1(): Unit = println("Inner12349c#b1()")
       protected          override def b2(): Unit = println("Inner12349c#b2()")
@@ -24,8 +24,10 @@ package pkg {
         private[t12349c] override def b5(): Unit = println("Inner12349c#b5()") // weaker access privileges
       protected[pkg]     override def b6(): Unit = println("Inner12349c#b6()")
         private[pkg]     override def b7(): Unit = println("Inner12349c#b7()") // weaker access privileges
-      protected[this]    override def b8(): Unit = println("Inner12349c#b8()") // [#12349] - not fixed by PR #9525
-        private[this]    override def b9(): Unit = println("Inner12349c#b9()") // weaker access privileges
+      protected[Inner12349c] override def b8(): Unit = println("Inner12349c#b8()") // [#12349] - not fixed by PR #9525
+        private[Inner12349c] override def b9(): Unit = println("Inner12349c#b9()") // weaker access privileges
+      protected[this]    override def bA(): Unit = println("Inner12349c#bA()") // [#12349] - not fixed by PR #9525
+        private[this]    override def bB(): Unit = println("Inner12349c#bB()") // weaker access privileges
 
                          override def c1(): Unit = println("Inner12349c#c1()") // overrides nothing (invisible)
       protected          override def c2(): Unit = println("Inner12349c#c2()") // weaker access privileges
@@ -34,8 +36,10 @@ package pkg {
         private[t12349c] override def c5(): Unit = println("Inner12349c#c5()") // weaker access privileges
       protected[pkg]     override def c6(): Unit = println("Inner12349c#c6()") // weaker access privileges
         private[pkg]     override def c7(): Unit = println("Inner12349c#c7()") // weaker access privileges
-      protected[this]    override def c8(): Unit = println("Inner12349c#c8()") // weaker access privileges
-        private[this]    override def c9(): Unit = println("Inner12349c#c9()") // overrides nothing (invisible)
+      protected[Inner12349c] override def c8(): Unit = println("Inner12349c#c8()") // weaker access privileges
+        private[Inner12349c] override def c9(): Unit = println("Inner12349c#c9()") // weaker access privileges
+      protected[this]    override def cA(): Unit = println("Inner12349c#cA()") // weaker access privileges
+        private[this]    override def cB(): Unit = println("Inner12349c#cB()") // weaker access privileges
 
                          override def d1(): Unit = println("Inner12349c#d1()") // overrides nothing
       protected          override def d2(): Unit = println("Inner12349c#d2()") // overrides nothing
@@ -44,8 +48,10 @@ package pkg {
         private[t12349c] override def d5(): Unit = println("Inner12349c#d5()") // overrides nothing
       protected[pkg]     override def d6(): Unit = println("Inner12349c#d6()") // overrides nothing
         private[pkg]     override def d7(): Unit = println("Inner12349c#d7()") // overrides nothing
-      protected[this]    override def d8(): Unit = println("Inner12349c#d8()") // overrides nothing
-        private[this]    override def d9(): Unit = println("Inner12349c#d9()") // overrides nothing
+      protected[Inner12349c] override def d8(): Unit = println("Inner12349c#d8()") // overrides nothing
+        private[Inner12349c] override def d9(): Unit = println("Inner12349c#d9()") // overrides nothing
+      protected[this]    override def dA(): Unit = println("Inner12349c#dA()") // overrides nothing
+        private[this]    override def dB(): Unit = println("Inner12349c#dB()") // overrides nothing
     }
 
   }

--- a/test/files/neg/t12494.check
+++ b/test/files/neg/t12494.check
@@ -1,0 +1,164 @@
+[running phase parser on t12494.scala]
+[running phase namer on t12494.scala]
+[running phase packageobjects on t12494.scala]
+[running phase typer on t12494.scala]
+[running phase superaccessors on t12494.scala]
+[log superaccessors] [context] ++ t12494.scala / Import(value <import>)
+[log superaccessors] [context] ++ t12494.scala / Import(value <import>)
+[log superaccessors] [context] ++ t12494.scala / Import(value <import>)
+[log superaccessors] [context] ++ t12494.scala / EmptyTree
+[log superaccessors] [context] ++ t12494.scala / term <empty>
+[log superaccessors] [context] ++ t12494.scala / term <empty>
+[log superaccessors] [context] ++ t12494.scala / Ident(<empty>)
+[log superaccessors] [context] ++ t12494.scala / Ident(<empty>)
+[log superaccessors] [context] ++ t12494.scala / term X
+[log superaccessors] [context] ++ t12494.scala / term X
+[log superaccessors] [context] ++ t12494.scala / Template(value <local X>)
+[log superaccessors] [context] ++ t12494.scala / Template(value <local X>)
+[log superaccessors] [context] ++ t12494.scala / term <init>
+[log superaccessors] [context] ++ t12494.scala / term <init>
+[log superaccessors] [context] ++ t12494.scala / term m
+[log superaccessors] [context] ++ t12494.scala / term m
+[log superaccessors] [context] ++ t12494.scala / type C
+[log superaccessors] [context] ++ t12494.scala / type C
+[log superaccessors] [context] ++ t12494.scala / Template(value <local C>)
+[log superaccessors] [context] ++ t12494.scala / Template(value <local C>)
+[log superaccessors] [context] ++ t12494.scala / term f
+[log superaccessors] [context] ++ t12494.scala / term f
+[log superaccessors] [context] ++ t12494.scala / term C
+[log superaccessors] [context] ++ t12494.scala / term C
+[log superaccessors] [context] ++ t12494.scala / Template(value <local C>)
+[log superaccessors] [context] ++ t12494.scala / Template(value <local C>)
+[log superaccessors] [context] ++ t12494.scala / term <init>
+[log superaccessors] [context] ++ t12494.scala / term <init>
+[log superaccessors] [context] ++ t12494.scala / type C2
+[log superaccessors] [context] ++ t12494.scala / type C2
+[log superaccessors] [context] ++ t12494.scala / Template(value <local C2>)
+[log superaccessors] [context] ++ t12494.scala / Template(value <local C2>)
+[log superaccessors] [context] ++ t12494.scala / term <init>
+[log superaccessors] [context] ++ t12494.scala / term <init>
+[log superaccessors] [context] ++ t12494.scala / term f
+[log superaccessors] [context] ++ t12494.scala / term f
+[log superaccessors] [context] ++ t12494.scala / term test
+[log superaccessors] [context] ++ t12494.scala / term test
+[log superaccessors] [context] ++ t12494.scala / term Y
+[log superaccessors] [context] ++ t12494.scala / term Y
+[log superaccessors] [context] ++ t12494.scala / Template(value <local Y>)
+[log superaccessors] [context] ++ t12494.scala / Template(value <local Y>)
+[log superaccessors] [context] ++ t12494.scala / term <init>
+[log superaccessors] [context] ++ t12494.scala / term <init>
+[log superaccessors] [context] ++ t12494.scala / term n
+[log superaccessors] [context] ++ t12494.scala / term n
+[log superaccessors] [context] ++ t12494.scala / type C
+[log superaccessors] [context] ++ t12494.scala / type C
+[log superaccessors] [context] ++ t12494.scala / Template(value <local C>)
+[log superaccessors] [context] ++ t12494.scala / Template(value <local C>)
+[log superaccessors] [context] ++ t12494.scala / term f
+[log superaccessors] [context] ++ t12494.scala / term f
+[log superaccessors] [context] ++ t12494.scala / type X
+[log superaccessors] [context] ++ t12494.scala / type X
+[log superaccessors] [context] ++ t12494.scala / Template(value <local X>)
+[log superaccessors] [context] ++ t12494.scala / Template(value <local X>)
+[log superaccessors] [context] ++ t12494.scala / term <init>
+[log superaccessors] [context] ++ t12494.scala / term <init>
+[log superaccessors] [context] ++ t12494.scala / term x
+[log superaccessors] [context] ++ t12494.scala / term x
+[log superaccessors] [context] ++ t12494.scala / term X
+[log superaccessors] [context] ++ t12494.scala / term X
+[log superaccessors] [context] ++ t12494.scala / Template(value <local X>)
+[log superaccessors] [context] ++ t12494.scala / Template(value <local X>)
+[log superaccessors] [context] ++ t12494.scala / term <init>
+[log superaccessors] [context] ++ t12494.scala / term <init>
+[log superaccessors] [context] ++ t12494.scala / term y
+[log superaccessors] [context] ++ t12494.scala / term y
+[log superaccessors] [context] ++ t12494.scala / term y
+[log superaccessors] [context] ++ t12494.scala / term y
+[log superaccessors] [context] ++ t12494.scala / term C
+[log superaccessors] [context] ++ t12494.scala / term C
+[log superaccessors] [context] ++ t12494.scala / Template(value <local C>)
+[log superaccessors] [context] ++ t12494.scala / Template(value <local C>)
+[log superaccessors] [context] ++ t12494.scala / term <init>
+[log superaccessors] [context] ++ t12494.scala / term <init>
+[log superaccessors] [context] ++ t12494.scala / type C2
+[log superaccessors] [context] ++ t12494.scala / type C2
+[log superaccessors] [context] ++ t12494.scala / Template(value <local C2>)
+[log superaccessors] [context] ++ t12494.scala / Template(value <local C2>)
+[log superaccessors] [context] ++ t12494.scala / term <init>
+[log superaccessors] [context] ++ t12494.scala / term <init>
+[log superaccessors] [context] ++ t12494.scala / term f
+[log superaccessors] [context] ++ t12494.scala / term f
+[log superaccessors] [context] ++ t12494.scala / term test
+[log superaccessors] [context] ++ t12494.scala / term test
+[log superaccessors] In trait Base, renaming g -> Base$$g
+[log superaccessors] Expanded 'g' to 'Base$$g' in trait Base
+[log superaccessors] In trait Base, renaming h -> Base$$h
+[log superaccessors] Expanded 'h' to 'Base$$h' in trait Base
+[log superaccessors] In trait Base, renaming p -> Base$$p
+[log superaccessors] Expanded 'p' to 'Base$$p' in trait Base
+[log superaccessors] [context] ++ t12494.scala / type Base
+[log superaccessors] [context] ++ t12494.scala / type Base
+[log superaccessors] [context] ++ t12494.scala / Template(value <local Base>)
+[log superaccessors] [context] ++ t12494.scala / Template(value <local Base>)
+[log superaccessors] [context] ++ t12494.scala / term f
+[log superaccessors] [context] ++ t12494.scala / term f
+[log superaccessors] [context] ++ t12494.scala / term g
+[log superaccessors] [context] ++ t12494.scala / term g
+[log superaccessors] [context] ++ t12494.scala / term h
+[log superaccessors] [context] ++ t12494.scala / term h
+[log superaccessors] [context] ++ t12494.scala / term p
+[log superaccessors] [context] ++ t12494.scala / term p
+[log superaccessors] [context] ++ t12494.scala / term Base
+[log superaccessors] [context] ++ t12494.scala / term Base
+[log superaccessors] [context] ++ t12494.scala / Template(value <local Base>)
+[log superaccessors] [context] ++ t12494.scala / Template(value <local Base>)
+[log superaccessors] [context] ++ t12494.scala / term <init>
+[log superaccessors] [context] ++ t12494.scala / term <init>
+[log superaccessors] [context] ++ t12494.scala / type Child
+[log superaccessors] [context] ++ t12494.scala / type Child
+[log superaccessors] [context] ++ t12494.scala / Template(value <local Child>)
+[log superaccessors] [context] ++ t12494.scala / Template(value <local Child>)
+[log superaccessors] [context] ++ t12494.scala / term <init>
+[log superaccessors] [context] ++ t12494.scala / term <init>
+[log superaccessors] [context] ++ t12494.scala / term f
+[log superaccessors] [context] ++ t12494.scala / term f
+[log superaccessors] [context] ++ t12494.scala / term g
+[log superaccessors] [context] ++ t12494.scala / term g
+[log superaccessors] [context] ++ t12494.scala / term h
+[log superaccessors] [context] ++ t12494.scala / term h
+[log superaccessors] [context] ++ t12494.scala / term p
+[log superaccessors] [context] ++ t12494.scala / term p
+[running phase extmethods on t12494.scala]
+[running phase pickler on t12494.scala]
+[running phase refchecks on t12494.scala]
+t12494.scala:9: error: weaker access privileges in overriding
+<method> <deferred> protected[trait C] def f: scala.this.Int (defined in trait C)
+  override should at least be protected[C];
+ found   : scala.this.Int
+ required: scala.this.Int
+        protected[C] def f: Int = 42  // no, limitation
+                         ^
+t12494.scala:28: error: weaker access privileges in overriding
+<method> <deferred> protected[trait C] def f: scala.this.Int (defined in trait C)
+  override should at least be protected[C];
+ found   : scala.this.Int
+ required: scala.this.Int
+          protected[C] def f: Int = 42   // no
+                           ^
+t12494.scala:47: error: class Child needs to be abstract.
+Missing implementations for 3 members of trait Base.
+  <method> <deferred> <expandedname> private[trait Base] def g: scala.this.Int = ???
+  <method> <deferred> <expandedname> private[trait Base] def h: scala.this.Int = ???
+  <method> <deferred> <expandedname> private[trait Base] def p: scala.this.Int = ???
+
+  class Child extends Base {
+        ^
+t12494.scala:50: error: method g overrides nothing
+    override private[Base] def g: Int = 42     // ok, companion
+                               ^
+t12494.scala:51: error: method h overrides nothing
+    override protected[Base] def h: Int = 42   // ok, private[C] widens to protected[C]
+                                 ^
+t12494.scala:52: error: method p overrides nothing
+    override protected def p: Int = 42         // error, protected only overrides protected
+                           ^
+6 errors

--- a/test/files/neg/t12494.scala
+++ b/test/files/neg/t12494.scala
@@ -1,0 +1,54 @@
+// scalac: -Ylog:superaccessors -Ydebug
+object X {
+  def m: Int = {
+    trait C {
+      protected[C] def f: Int
+    }
+    object C {
+      class C2 extends C {
+        protected[C] def f: Int = 42  // no, limitation
+        def test = f
+      }
+    }
+    new C.C2().test
+  }
+}
+object Y {
+  def n: Int = {
+    trait C {
+      protected[C] def f: Int
+    }
+    class X { private def x = 17 }
+    locally {
+      object X {
+        val y = 27
+      }
+      object C {
+        class C2 extends C {
+          protected[C] def f: Int = 42   // no
+          def test = f + X.y
+        }
+      }
+      new C.C2().test
+    }
+  }
+}
+
+// other combinations
+// mangling qualified privates says:
+// Expanded 'g' to 'Base$$g' in trait Base
+trait Base {
+  protected[Base] def f: Int
+  private[Base] def g: Int
+  private[Base] def h: Int
+  private[Base] def p: Int
+}
+object Base {
+  class Child extends Base {
+    override protected[Base] def f: Int = 42   // ok, companion
+    // was: overrides nothing (because of name mangling)
+    override private[Base] def g: Int = 42     // ok, companion
+    override protected[Base] def h: Int = 42   // ok, private[C] widens to protected[C]
+    override protected def p: Int = 42         // error, protected only overrides protected
+  }
+}

--- a/test/files/neg/t4762.check
+++ b/test/files/neg/t4762.check
@@ -1,7 +1,7 @@
-t4762.scala:17: warning: private[this] value x in class B shadows mutable x inherited from class A.  Changes to x will not be visible within class B - you may want to give them distinct names.
+t4762.scala:17: warning: private[this] value x in class B shadows mutable x inherited from class A. Changes to x will not be visible within class B; you may want to give them distinct names.
     /* (99,99) */  (this.x, this.y),
                          ^
-t4762.scala:50: warning: private[this] value x in class Derived shadows mutable x inherited from class Base.  Changes to x will not be visible within class Derived - you may want to give them distinct names.
+t4762.scala:50: warning: private[this] value x in class Derived shadows mutable x inherited from class Base. Changes to x will not be visible within class Derived; you may want to give them distinct names.
   class Derived( x : Int ) extends Base( x ) { override def toString = x.toString }
                                                                        ^
 t4762.scala:13: error: weaker access privileges in overriding

--- a/test/files/neg/t8525.check
+++ b/test/files/neg/t8525.check
@@ -4,7 +4,7 @@ t8525.scala:9: warning: adapted the argument list to the expected 2-tuple: add a
  after adaptation: X.f((3, 4): (Int, Int))
   def g = f(3, 4)       // adapted
            ^
-t8525.scala:11: warning: private[this] value name in class X shadows mutable name inherited from class Named.  Changes to name will not be visible within class X - you may want to give them distinct names.
+t8525.scala:11: warning: private[this] value name in class X shadows mutable name inherited from class Named. Changes to name will not be visible within class X; you may want to give them distinct names.
   override def toString = name // shadowing mutable var name
                           ^
 t8525.scala:10: warning: side-effecting nullary methods are discouraged: suggest defining as `def u()` instead

--- a/test/files/neg/t8610.check
+++ b/test/files/neg/t8610.check
@@ -7,7 +7,7 @@ t8610.scala:9: warning: adapted the argument list to the expected 2-tuple: add a
  after adaptation: X.f((3, 4): (Int, Int))
   def g = f(3, 4)       // adapted
            ^
-t8610.scala:11: warning: private[this] value name in class X shadows mutable name inherited from class Named.  Changes to name will not be visible within class X - you may want to give them distinct names.
+t8610.scala:11: warning: private[this] value name in class X shadows mutable name inherited from class Named. Changes to name will not be visible within class X; you may want to give them distinct names.
   override def toString = name // shadowing mutable var name
                           ^
 t8610.scala:10: warning: side-effecting nullary methods are discouraged: suggest defining as `def u()` instead

--- a/test/files/run/t12494.scala
+++ b/test/files/run/t12494.scala
@@ -1,0 +1,24 @@
+
+trait Base {
+  protected[Base] def f: Int
+}
+object Base {
+  class Child extends Base {
+    protected[Base] def f: Int = 42
+    def test = f
+  }
+}
+
+object Test extends App {
+  assert(new Base.Child().test == 42)
+}
+
+/*
+was:
+t12494.scala:7: error: weaker access privileges in overriding
+protected[trait Base] def f: Int (defined in trait Base)
+  override should at least be protected[Base]
+    protected[Base] def f: Int = 42
+                        ^
+1 error
+*/


### PR DESCRIPTION
Fixes scala/bug#12494

This is for the static module case, not for local companions.