### PR TITLE
Followup improvements to RefChecks

### DIFF
--- a/src/reflect/scala/reflect/api/TypeTags.scala
+++ b/src/reflect/scala/reflect/api/TypeTags.scala
@@ -15,6 +15,7 @@ package reflect
 package api
 
 import java.io.ObjectStreamException
+import scala.annotation.nowarn
 
 /**
  * A `TypeTag[T]` encapsulates the runtime type representation of some type `T`.
@@ -290,7 +291,7 @@ trait TypeTags { self: Universe =>
 
     def apply[T](mirror1: scala.reflect.api.Mirror[self.type], tpec1: TypeCreator): TypeTag[T] = {
       (mirror1: AnyRef) match {
-        case m: scala.reflect.runtime.JavaMirrors#MirrorImpl
+        case m: scala.reflect.runtime.JavaMirrors#JavaMirror @nowarn("cat=deprecation")
           if cacheMaterializedTypeTags && tpec1.getClass.getName.contains("$typecreator")
             && tpec1.getClass.getDeclaredFields.length == 0 => // excludes type creators that splice in bound types.
 

--- a/test/files/neg/ref-checks.check
+++ b/test/files/neg/ref-checks.check
@@ -1,7 +1,17 @@
-ref-checks.scala:8: error: type arguments [Int] do not conform to trait Chars's type parameter bounds [A <: CharSequence]
+ref-checks.scala:9: error: type arguments [Int] do not conform to trait Chars's type parameter bounds [A <: CharSequence]
   @ann[Chars[Int]] val x = 42
                        ^
-ref-checks.scala:9: error: type arguments [Double] do not conform to trait Chars's type parameter bounds [A <: CharSequence]
+ref-checks.scala:10: error: type arguments [Double] do not conform to trait Chars's type parameter bounds [A <: CharSequence]
   val y: Two[Chars[Long] @uncheckedBounds, Chars[Double]] = null
          ^
-2 errors
+ref-checks.scala:11: error: type arguments [X forSome { type X <: Int }] do not conform to trait Chars's type parameter bounds [A <: CharSequence]
+  def z: Chars[X forSome { type X <: Int }] = null
+         ^
+ref-checks.scala:18: warning: type DeprecatedAlias in object Test is deprecated
+    case _: DeprecatedAlias =>
+            ^
+ref-checks.scala:19: warning: class DeprecatedClass in object Test is deprecated
+    case _: DeprecatedClass =>
+            ^
+2 warnings
+3 errors

--- a/test/files/neg/ref-checks.scala
+++ b/test/files/neg/ref-checks.scala
@@ -1,4 +1,5 @@
-import scala.annotation.StaticAnnotation
+// scalac: -deprecation -Werror
+import scala.annotation.{StaticAnnotation, nowarn}
 import scala.reflect.internal.annotations.uncheckedBounds
 
 object Test {
@@ -7,4 +8,15 @@ object Test {
   class ann[A] extends StaticAnnotation
   @ann[Chars[Int]] val x = 42
   val y: Two[Chars[Long] @uncheckedBounds, Chars[Double]] = null
+  def z: Chars[X forSome { type X <: Int }] = null
+
+  @deprecated type DeprecatedAlias = String
+  @deprecated class DeprecatedClass
+  @nowarn("cat=deprecation") type UndeprecatedAlias = DeprecatedClass
+
+  ("": Any) match {
+    case _: DeprecatedAlias =>
+    case _: DeprecatedClass =>
+    case _: UndeprecatedAlias => // no warning here
+  }
 }


### PR DESCRIPTION
  * Only convert unbound existential types to wildcards.
  * Extend undesired properties check to patterns.

Followup to #9806
Fixes scala/bug#12493