### PR TITLE
fix build (JDK 17 + bootstrapped + fatal warnings)

### DIFF
--- a/src/compiler/scala/tools/reflect/WrappedProperties.scala
+++ b/src/compiler/scala/tools/reflect/WrappedProperties.scala
@@ -47,6 +47,7 @@ trait WrappedProperties extends PropertiesTrait {
 
 object WrappedProperties {
   object AccessControl extends WrappedProperties {
+    @annotation.nowarn("cat=deprecation") // AccessControlException is deprecated on JDK 17
     def wrap[T](body: => T) = try Some(body) catch { case _: AccessControlException => None }
   }
 }

--- a/src/library/scala/sys/SystemProperties.scala
+++ b/src/library/scala/sys/SystemProperties.scala
@@ -52,6 +52,7 @@ extends mutable.AbstractMap[String, String] {
   def subtractOne (key: String): this.type = { wrapAccess(System.clearProperty(key)) ; this }
   def addOne (kv: (String, String)): this.type = { wrapAccess(System.setProperty(kv._1, kv._2)) ; this }
 
+  @annotation.nowarn("cat=deprecation") // AccessControlException is deprecated on JDK 17
   def wrapAccess[T](body: => T): Option[T] =
     try Some(body) catch { case _: AccessControlException => None }
 }


### PR DESCRIPTION
a little sequel to #9815, which is responsible for newly and rightly emitting these warnings

the failure was seen at e.g. https://app.travis-ci.com/github/scala/scala/jobs/550266267