### PR TITLE
Align doc and spec for Symbol

### DIFF
--- a/spec/01-lexical-syntax.md
+++ b/spec/01-lexical-syntax.md
@@ -577,16 +577,7 @@ string literal does not start a valid escape sequence.
 symbolLiteral  ::=  ‘'’ plainid
 ```
 
-A symbol literal `'x` is a shorthand for the expression `scala.Symbol("x")` and
-is of the [literal type](03-types.html#literal-types) `'x`.
-`Symbol` is a [case class](05-classes-and-objects.html#case-classes), which is defined as follows.
-
-```scala
-package scala
-final case class Symbol private (name: String) {
-  override def toString: String = "'" + name
-}
-```
+A symbol literal `'x` is deprecated shorthand for the expression `scala.Symbol("x")`.
 
 The `apply` method of `Symbol`'s companion object
 caches weak references to `Symbol`s, thus ensuring that

--- a/spec/03-types.md
+++ b/spec/03-types.md
@@ -131,7 +131,7 @@ determined by evaluating `e == lit`.
 
 Literal types are available for all types for which there is dedicated syntax
 except `Unit`. This includes the numeric types (other than `Byte` and `Short`
-which don't currently have syntax), `Boolean`, `Char`, `String` and `Symbol`.
+which don't currently have syntax), `Boolean`, `Char` and `String`.
 
 ### Stable Types
 A _stable type_ is a singleton type, a literal type,

--- a/src/library/scala/Symbol.scala
+++ b/src/library/scala/Symbol.scala
@@ -14,17 +14,11 @@ package scala
 
 /** This class provides a simple way to get unique objects for equal strings.
  *  Since symbols are interned, they can be compared using reference equality.
- *  Instances of `Symbol` can be created easily with Scala's built-in quote
- *  mechanism.
- *
- *  For instance, the Scala term `'mysym` will
- *  invoke the constructor of the `Symbol` class in the following way:
- *  `Symbol("mysym")`.
  */
 final class Symbol private (val name: String) extends Serializable {
-  /** Converts this symbol to a string.
+  /** A string representation of this symbol.
    */
-  override def toString(): String = "Symbol(" + name + ")"
+  override def toString(): String = s"Symbol($name)"
 
   @throws(classOf[java.io.ObjectStreamException])
   private def readResolve(): Any = Symbol.apply(name)
@@ -40,8 +34,7 @@ object Symbol extends UniquenessCache[String, Symbol] {
 
 /** This is private so it won't appear in the library API, but
   * abstracted to offer some hope of reusability.  */
-private[scala] abstract class UniquenessCache[K, V >: Null]
-{
+private[scala] abstract class UniquenessCache[K, V >: Null] {
   import java.lang.ref.WeakReference
   import java.util.WeakHashMap
   import java.util.concurrent.locks.ReentrantReadWriteLock
@@ -82,10 +75,10 @@ private[scala] abstract class UniquenessCache[K, V >: Null]
       }
       finally wlock.unlock
     }
-
-    val res = cached()
-    if (res == null) updateCache()
-    else res
+    cached() match {
+      case null => updateCache()
+      case res  => res
+    }
   }
   def unapply(other: V): Option[K] = keyFromValue(other)
 }


### PR DESCRIPTION
Arguably, it's not the job of the standard library doc to explain language features, even if library design is language design.

It's interesting to see how the changes around this feature were wrought, that is, fraught or decoupled.

Fixes scala/bug#12507