### PR TITLE
[bug#12464] Fix resizing for `ArrayBuffer` and `PriorityQueue`

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -30,6 +30,12 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.Predef#SeqCharSequence.isEmpty"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.Predef#ArrayCharSequence.isEmpty"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.ArrayCharSequence.isEmpty"),
+
+    // scala/scala#9819
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.mutable.PriorityQueue#ResizableArrayAccess.p_ensureAdditionalSize"), // private[PriorityQueue]
+    ProblemFilters.exclude[MissingClassProblem]("scala.runtime.PStatics"),  // private[scala]
+    ProblemFilters.exclude[MissingClassProblem]("scala.runtime.PStatics$"), // private[scala]
+
   )
 
   override val buildSettings = Seq(

--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -275,6 +275,13 @@ object IterableOnce {
       case src: Iterable[A] => src.copyToArray[B](xs, start, len)
       case src              => src.iterator.copyToArray[B](xs, start, len)
     }
+
+  @inline private[collection] def checkArraySizeWithinVMLimit(size: Int): Unit = {
+    import scala.runtime.PStatics.VM_MaxArraySize
+    if (size > VM_MaxArraySize) {
+      throw new Exception(s"Size of array-backed collection exceeds VM array size limit of ${VM_MaxArraySize}")
+    }
+  }
 }
 
 /** This implementation trait can be mixed into an `IterableOnce` to get the basic methods that are shared between

--- a/src/library/scala/collection/mutable/PriorityQueue.scala
+++ b/src/library/scala/collection/mutable/PriorityQueue.scala
@@ -89,6 +89,7 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
     def p_size0_=(s: Int) = size0 = s
     def p_array = array
     def p_ensureSize(n: Int) = super.ensureSize(n)
+    def p_ensureAdditionalSize(n: Int) = super.ensureAdditionalSize(n)
     def p_swap(a: Int, b: Int): Unit = {
       val h = array(a)
       array(a) = array(b)
@@ -153,7 +154,7 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
     *  @return             this $coll.
     */
   def addOne(elem: A): this.type = {
-    resarr.p_ensureSize(resarr.p_size0 + 1)
+    resarr.p_ensureAdditionalSize(1)
     resarr.p_array(resarr.p_size0) = elem.asInstanceOf[AnyRef]
     fixUp(resarr.p_array, resarr.p_size0)
     resarr.p_size0 += 1
@@ -170,7 +171,7 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
   private def unsafeAdd(elem: A): Unit = {
     // like += but skips fixUp, which breaks the ordering invariant
     // a series of unsafeAdds MUST be followed by heapify
-    resarr.p_ensureSize(resarr.p_size0 + 1)
+    resarr.p_ensureAdditionalSize(1)
     resarr.p_array(resarr.p_size0) = elem.asInstanceOf[AnyRef]
     resarr.p_size0 += 1
   }

--- a/src/library/scala/runtime/PStatics.scala
+++ b/src/library/scala/runtime/PStatics.scala
@@ -1,0 +1,19 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.runtime
+
+// things that should be in `Statics`, but can't be yet for bincompat reasons
+// TODO 3.T: move to `Statics`
+private[scala] object PStatics {
+  final val VM_MaxArraySize = 2147483645 // == `Int.MaxValue - 2`, hotspot limit
+}


### PR DESCRIPTION
Fix `Int` overflows when ensuring the size of an `ArrayBuffer`.

Always use `ensureSize` in `ArrayBuffer.from` to check
against the VM array size limit.

Make sizing behaviour of `ArrayBuffer` consistent.

Partially addresses scala/bug#12464 (still need to address `ArrayDeque`)