### PR TITLE
[bug#12473] Throw on unsigned type in `NumericRange#reverse`

### DIFF
--- a/src/library/scala/collection/immutable/NumericRange.scala
+++ b/src/library/scala/collection/immutable/NumericRange.scala
@@ -153,7 +153,13 @@ sealed class NumericRange[T](
   override def splitAt(n: Int): (NumericRange[T], NumericRange[T]) = (take(n), drop(n))
 
   override def reverse: NumericRange[T] =
-    if (isEmpty) this else new NumericRange.Inclusive(last, start, -step)
+    if (isEmpty) this
+    else {
+      val newStep = -step
+      if (num.sign(newStep) == num.sign(step)) {
+        throw new ArithmeticException("number type is unsigned, and .reverse requires a negative step")
+      } else new NumericRange.Inclusive(last, start, newStep)
+    }
 
   import NumericRange.defaultOrdering
 

--- a/test/junit/scala/runtime/RichCharTest.scala
+++ b/test/junit/scala/runtime/RichCharTest.scala
@@ -1,0 +1,20 @@
+package scala.runtime
+
+import org.junit.Test
+
+import scala.collection.immutable.NumericRange
+import scala.tools.testkit.AssertUtil.assertThrows
+
+class RichCharTest {
+  @Test
+  def rangeReverse(): Unit = {
+    def check(range: NumericRange[Char]): Unit =
+      assertThrows[ArithmeticException](range.reverse,
+                                        s => Seq("unsigned", "reverse", "negative step").forall(s.contains))
+
+    check('a' until 'z')
+    check('a' until 'z' by 2.toChar)
+    check('a' to 'z')
+    check('a' to 'z' by 2.toChar)
+  }
+}


### PR DESCRIPTION
stopgap for scala/bug#12473