### PR TITLE
Fix 2.13.7 `releaseFence` regression affecting GraalVM compatibility

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -750,7 +750,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
 
       for (m <- normMembers) {
         if (!needsSpecialization(fullEnv, m)) {
-          if (m.isValue && !m.isMutable && !m.isMethod && !m.isDeferred && !m.isLazy) {
+          if (m.isValue && !m.isMutable && !m.isMethod && !m.isDeferred && !m.isLazy && !m.isParamAccessor) {
             // non-specialized `val` fields are made mutable (in Constructors) and assigned from the
             // constructors of specialized subclasses. See PR scala/scala#9704.
             clazz.primaryConstructor.updateAttachment(ConstructorNeedsFence)

--- a/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
@@ -393,7 +393,7 @@ class BytecodeTest extends BytecodeTesting {
   @Test
   def nonSpecializedValFence(): Unit = {
     def code(u1: String) =
-      s"""abstract class Speck[@specialized(Int) T](t: T) {
+      s"""abstract class Speck[@specialized(Int) T](t: T, sm: String, val sn: String) {
          |  val a = t
          |  $u1
          |  lazy val u2 = "?"


### PR DESCRIPTION
Don't emit `releaseFence` for class params of specialized classes  

Non-specialized val fields in a specialized class are made non-final
because of the way specialization is encoded. A `releaseFence` call
is added to the constructor to ensure safe publication.

The releaseFence call is not necessary for class parameters as those
remain final.

Follow-up for #9704, fixes scala/bug#12500