### PR TITLE
Deal with Object/Any impedence mismatch under -Ypickle-write-java

### DIFF
--- a/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
+++ b/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
@@ -399,6 +399,12 @@ abstract class UnPickler {
         ThisType(sym)
       }
 
+      def fixJavaObjectType(typeRef: Type): Type = {
+        if (classRoot.isJava && typeRef =:= definitions.ObjectTpe) {
+          definitions.ObjectTpeJava
+        } else typeRef
+      }
+
       // We're stuck with the order types are pickled in, but with judicious use
       // of named parameters we can recapture a declarative flavor in a few cases.
       // But it's still a rat's nest of ad-hockery.
@@ -409,7 +415,7 @@ abstract class UnPickler {
         case SINGLEtpe                 => SingleType(readTypeRef(), readSymbolRef().filter(_.isStable)) // scala/bug#7596 account for overloading
         case SUPERtpe                  => SuperType(readTypeRef(), readTypeRef())
         case CONSTANTtpe               => ConstantType(readConstantRef())
-        case TYPEREFtpe                => TypeRef(readTypeRef(), readSymbolRef(), readTypes())
+        case TYPEREFtpe                => fixJavaObjectType(TypeRef(readTypeRef(), readSymbolRef(), readTypes()))
         case TYPEBOUNDStpe             => TypeBounds(readTypeRef(), readTypeRef())
         case REFINEDtpe | CLASSINFOtpe => CompoundType(readSymbolRef(), readTypes())
         case METHODtpe                 => MethodTypeRef(readTypeRef(), readSymbols())


### PR DESCRIPTION
-Ypickle-write-java can generate Scala pickles for Java files.
Unpickler needs to deal with the special case for Object/Any,
as we do when using Java sources of javac compiled .class files
as inputs.

Fixes scala/bug#12512