### PR TITLE
Improve helpfulness of missing-method errors

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -534,21 +534,21 @@ abstract class RefChecks extends Transform {
 
       // Verifying a concrete class has nothing unimplemented.
       if (clazz.isConcreteClass && !typesOnly) {
-        val abstractErrors = new ListBuffer[String]
-        def abstractErrorMessage =
-          // a little formatting polish
-          if (abstractErrors.size <= 2) abstractErrors mkString " "
-          else abstractErrors.tail.mkString(abstractErrors.head + "\n", "\n", "")
+        val abstractErrors = ListBuffer.empty[String]
+        def abstractErrorMessage = abstractErrors.mkString(if (abstractErrors.size <= 2) " " else "\n")
 
-        def abstractClassError(mustBeMixin: Boolean, msg: String): Unit = {
-          def prelude = (
+        def mustBeMixin(msg: String): Unit = addError(mustBeMixin = true, msg, supplement = "")
+        def abstractClassError(msg: String): Unit = addError(mustBeMixin = false, msg, supplement = "")
+        def abstractClassErrorStubs(msg: String, stubs: String): Unit = addError(mustBeMixin = false, msg, supplement = stubs)
+        def addError(mustBeMixin: Boolean, msg: String, supplement: String): Unit = {
+          def prelude =
             if (clazz.isAnonymousClass || clazz.isModuleClass) "object creation impossible."
             else if (mustBeMixin) s"$clazz needs to be a mixin."
             else s"$clazz needs to be abstract."
-          )
 
-          if (abstractErrors.isEmpty) abstractErrors ++= List(prelude, msg)
-          else abstractErrors += msg
+          if (abstractErrors.isEmpty) abstractErrors += prelude
+          abstractErrors += msg
+          if (!supplement.isEmpty) abstractErrors += supplement
         }
 
         def javaErasedOverridingSym(sym: Symbol): Symbol =
@@ -563,43 +563,34 @@ abstract class RefChecks extends Transform {
               exitingErasure(tp1 matches tp2)
             })
 
-        def ignoreDeferred(member: Symbol) = (
+        def ignoreDeferred(member: Symbol) =
           (member.isAbstractType && !member.isFBounded) || (
             // the test requires exitingErasure so shouldn't be
             // done if the compiler has no erasure phase available
                member.isJavaDefined
             && (currentRun.erasurePhase == NoPhase || javaErasedOverridingSym(member) != NoSymbol)
           )
-        )
 
         // 2. Check that only abstract classes have deferred members
         def checkNoAbstractMembers(): Unit = {
           // Avoid spurious duplicates: first gather any missing members.
-          def memberList = clazz.info.nonPrivateMembersAdmitting(VBRIDGE)
-          var missing: List[Symbol] = Nil
-          var rest: List[Symbol] = Nil
-          memberList.reverseIterator.foreach {
-            case m if m.isDeferred && !ignoreDeferred(m) =>
-              missing ::= m
-            case m if m.isAbstractOverride && m.isIncompleteIn(clazz) =>
-              rest ::= m
-            case _ => // No more
+          val (missing, rest): (List[Symbol], Iterator[Symbol]) = {
+            val memberList = clazz.info.nonPrivateMembersAdmitting(VBRIDGE)
+            val (missing0, rest0) = memberList.iterator.partition(m => m.isDeferred & !ignoreDeferred(m))
+            (missing0.toList, rest0)
           }
-          // Group missing members by the name of the underlying symbol,
-          // to consolidate getters and setters.
-          val grouped = missing groupBy (_.name.getterName)
-          val missingMethods = grouped.toList flatMap {
-            case (name, syms) =>
-              if (syms exists (_.isSetter)) syms filterNot (_.isGetter)
-              else syms
+          // Group missing members by the name of the underlying symbol, to consolidate getters and setters.
+          val grouped = missing.groupBy(_.name.getterName)
+          val missingMethods = grouped.toList.flatMap {
+            case (_, syms) if syms.exists(_.isSetter) => syms.filterNot(_.isGetter)
+            case (_, syms)                            => syms
           }
-
           def stubImplementations: List[String] = {
             // Grouping missing methods by the declaring class
             val regrouped = missingMethods.groupBy(_.owner).toList
             def membersStrings(members: List[Symbol]) = {
-              members foreach fullyInitializeSymbol
-              members.sortBy(_.name) map (m => m.defStringSeenAs(clazz.tpe_* memberType m) + " = ???")
+              members.foreach(fullyInitializeSymbol)
+              members.sortBy(_.name).map(m => s"${m.defStringSeenAs(clazz.tpe_* memberType m)} = ???")
             }
 
             if (regrouped.tail.isEmpty)
@@ -609,15 +600,6 @@ abstract class RefChecks extends Transform {
                 ("// Members declared in " + owner.fullName) +: membersStrings(members) :+ ""
             }).init
           }
-
-          // If there are numerous missing methods, we presume they are aware of it and
-          // give them a nicely formatted set of method signatures for implementing.
-          if (missingMethods.size > 1) {
-            abstractClassError(false, s"Missing implementations for ${missingMethods.size} members. Stub implementations follow:")
-            abstractErrors += stubImplementations.map("  " + _ + "\n").mkString("", "", "")
-            return
-          }
-
           def diagnose(member: Symbol): String = {
             val underlying = analyzer.underlyingSymbol(member) // TODO: don't use this method
 
@@ -629,12 +611,11 @@ abstract class RefChecks extends Transform {
             if (groupedAccessors.exists(_.isSetter) || (member.isGetter && !isMultiple && member.setterIn(member.owner).exists)) {
               // If both getter and setter are missing, squelch the setter error.
               if (member.isSetter && isMultiple) null
-              else {
-                if (member.isSetter) "\n(Note that an abstract var requires a setter in addition to the getter)"
-                else if (member.isGetter && !isMultiple) "\n(Note that an abstract var requires a getter in addition to the setter)"
-                else "\n(Note that variables need to be initialized to be defined)"
-              }
-            } else if (underlying.isMethod) {
+              else if (member.isSetter) "\n(Note that an abstract var requires a setter in addition to the getter)"
+              else if (member.isGetter && !isMultiple) "\n(Note that an abstract var requires a getter in addition to the setter)"
+              else "\n(Note that variables need to be initialized to be defined)"
+            }
+            else if (underlying.isMethod) {
               // Highlight any member that nearly matches: same name and arity,
               // but differs in one param or param list.
               val abstractParamLists = underlying.paramLists
@@ -646,15 +627,17 @@ abstract class RefChecks extends Transform {
                 sumSize(m.paramLists, 0) == sumSize(abstractParamLists, 0) &&
                 sameLength(m.tpe.typeParams, underlying.tpe.typeParams)
               }
-
               matchingArity match {
                 // So far so good: only one candidate method
                 case Scope(concrete) =>
-                  val aplIter = abstractParamLists .iterator.flatten
-                  val cplIter = concrete.paramLists.iterator.flatten
+                  val concreteParamLists = concrete.paramLists
+                  val aplIter = abstractParamLists.iterator.flatten
+                  val cplIter = concreteParamLists.iterator.flatten
                   def mismatch(apl: Symbol, cpl: Symbol): Option[(Type, Type)] =
                     if (apl.tpe.asSeenFrom(clazz.tpe, underlying.owner) =:= cpl.tpe) None else Some(apl.tpe -> cpl.tpe)
-
+                  def missingImplicit = abstractParamLists.zip(concreteParamLists).exists {
+                    case (abss, konkrete) => abss.headOption.exists(_.isImplicit) && !konkrete.headOption.exists(_.isImplicit)
+                  }
                   val mismatches = mapFilter2(aplIter, cplIter)(mismatch).take(2).toList
                   mismatches match {
                     // Only one mismatched parameter: say something useful.
@@ -666,8 +649,7 @@ abstract class RefChecks extends Transform {
                       val addendum = (
                         if (abstractSym == concreteSym) {
                           // TODO: what is the optimal way to test for a raw type at this point?
-                          // Compilation has already failed so we shouldn't have to worry overmuch
-                          // about forcing types.
+                          // Compilation has already failed so we shouldn't have to worry overmuch about forcing types.
                           if (underlying.isJavaDefined && pa.typeArgs.isEmpty && abstractSym.typeParams.nonEmpty)
                             s". To implement this raw type, use ${rawToExistential(pa)}"
                           else if (pa.prefix =:= pc.prefix)
@@ -675,19 +657,12 @@ abstract class RefChecks extends Transform {
                           else
                             ": their prefixes (i.e., enclosing instances) differ"
                         }
-                        else if (abstractSym isSubClass concreteSym)
-                          subclassMsg(abstractSym, concreteSym)
-                        else if (concreteSym isSubClass abstractSym)
-                          subclassMsg(concreteSym, abstractSym)
+                        else if (abstractSym.isSubClass(concreteSym)) subclassMsg(abstractSym, concreteSym)
+                        else if (concreteSym.isSubClass(abstractSym)) subclassMsg(concreteSym, abstractSym)
                         else ""
                       )
                       s"\n(Note that $pa does not match $pc$addendum)"
-                    case Nil => // other overriding gotchas
-                      val missingImplicit = abstractParamLists.zip(concrete.paramLists).exists {
-                        case (abss, konkrete) => abss.headOption.exists(_.isImplicit) && !konkrete.headOption.exists(_.isImplicit)
-                      }
-                      val msg = if (missingImplicit) "\n(overriding member must declare implicit parameter list)" else ""
-                      msg
+                    case Nil if missingImplicit => "\n(overriding member must declare implicit parameter list)" // other overriding gotchas
                     case _ => ""
                   }
                 case _ => ""
@@ -695,22 +670,30 @@ abstract class RefChecks extends Transform {
             }
             else ""
           }
-          for (member <- missing ; msg = diagnose(member) ; if msg != null) {
-            val addendum = if (msg.isEmpty) msg else " " + msg
-            val from = if (member.owner != clazz) s" // inherited from ${member.owner}" else ""
-            abstractClassError(false, s"Missing implementation for:\n  ${infoString0(member, false)}$from$addendum")
+          // The outcomes are
+          // - 1 method in current class
+          // If there are numerous missing methods, we presume they are aware of it and
+          // give them a nicely formatted set of method signatures for implementing.
+          if (missingMethods.size > 1) {
+            val stubs = stubImplementations.map("  " + _ + "\n").mkString("", "", "")
+            abstractClassErrorStubs(s"Missing implementations for ${missingMethods.size} members. Stub implementations follow:", stubs)
           }
-
-          // Check the remainder for invalid absoverride.
-          rest.foreach { member =>
-            val other = member.superSymbolIn(clazz)
-            val explanation =
-              if (other != NoSymbol) " and overrides incomplete superclass member\n" + infoString(other)
-              else ", but no concrete implementation could be found in a base class"
-
-            abstractClassError(true, s"${infoString(member)} is marked `abstract` and `override`$explanation")
+          else {
+            for (member <- missing ; msg = diagnose(member) if msg != null) {
+              val addendum = if (msg.isEmpty) msg else " " + msg
+              val from = if (member.owner != clazz) s" // inherited from ${member.owner}" else ""
+              abstractClassError(s"Missing implementation for:\n  ${infoString0(member, false)}$from$addendum")
+            }
+            // Check the remainder for invalid absoverride.
+            for (member <- rest if member.isAbstractOverride && member.isIncompleteIn(clazz)) {
+              val explanation = member.superSymbolIn(clazz) match {
+                case NoSymbol => ", but no concrete implementation could be found in a base class"
+                case other    => " and overrides incomplete superclass member\n" + infoString(other)
+              }
+              mustBeMixin(s"${infoString(member)} is marked `abstract` and `override`$explanation")
+            }
           }
-        }
+        } // end checkNoAbstractMembers
 
         // 3. Check that concrete classes do not have deferred definitions
         // that are not implemented in a subclass.
@@ -724,10 +707,9 @@ abstract class RefChecks extends Transform {
           for (decl <- bc.info.decls) {
             if (decl.isDeferred && !ignoreDeferred(decl)) {
               val impl = decl.matchingSymbol(clazz.thisType, admit = VBRIDGE)
-              if (impl == NoSymbol || (decl.owner isSubClass impl.owner)) {
-                abstractClassError(false, s"No implementation found in a subclass for deferred declaration\n" +
+              if (impl == NoSymbol || decl.owner.isSubClass(impl.owner))
+                abstractClassError(s"No implementation found in a subclass for deferred declaration\n" +
                                           s"${infoString(decl)}${analyzer.abstractVarMessage(decl)}")
-              }
             }
           }
           if (bc.superClass hasFlag ABSTRACT)

--- a/test/files/neg/abstract-class-2.check
+++ b/test/files/neg/abstract-class-2.check
@@ -1,6 +1,7 @@
-abstract-class-2.scala:11: error: object creation impossible. Missing implementation for:
-  def f(x: P2.this.p.S1): Int // inherited from trait S2
-(Note that P.this.p.S1 does not match P2.this.S1: their prefixes (i.e., enclosing instances) differ)
+abstract-class-2.scala:11: error: object creation impossible.
+Missing implementation for member of trait S2:
+  def f(x: P2.this.p.S1): Int = ??? // P.this.p.S1 does not match P2.this.S1: their prefixes (i.e., enclosing instances) differ
+
   object O2 extends S2 {
          ^
 1 error

--- a/test/files/neg/abstract-class-error.check
+++ b/test/files/neg/abstract-class-error.check
@@ -1,6 +1,7 @@
-S.scala:1: error: class S needs to be abstract. Missing implementation for:
-  def g(y: Int, z: java.util.List): Int // inherited from class J
-(Note that java.util.List does not match java.util.List[String]. To implement this raw type, use java.util.List[_])
+S.scala:1: error: class S needs to be abstract.
+Missing implementation for member of class J:
+  def g(y: Int, z: java.util.List[_]): Int = ??? // implements `def g(y: Int, z: java.util.List): Int`; java.util.List does not match java.util.List[String]. To implement this raw type, use java.util.List[_]
+
 class S extends J {
       ^
 1 error

--- a/test/files/neg/abstract-concrete-methods.check
+++ b/test/files/neg/abstract-concrete-methods.check
@@ -1,6 +1,7 @@
-abstract-concrete-methods.scala:7: error: class Outer2 needs to be abstract. Missing implementation for:
-  def score(i: Outer2#Inner): Double // inherited from trait Outer
-(Note that This#Inner does not match Outer2#Inner: class Inner in class Outer2 is a subclass of trait Inner in trait Outer, but method parameter types must match exactly.)
+abstract-concrete-methods.scala:7: error: class Outer2 needs to be abstract.
+Missing implementation for member of trait Outer:
+  def score(i: Outer2#Inner): Double = ??? // This#Inner does not match Outer2#Inner: class Inner in class Outer2 is a subclass of trait Inner in trait Outer, but method parameter types must match exactly.
+
 class Outer2 extends Outer[Outer2] {
       ^
 1 error

--- a/test/files/neg/abstract-report.check
+++ b/test/files/neg/abstract-report.check
@@ -10,6 +10,6 @@ Missing implementations for 6 members. Stub implementations follow:
   protected def newSpecificBuilder: scala.collection.mutable.Builder[String,List[String]] = ???
   def toIterable: Iterable[String] = ???
 
-class Unimplemented extends scala.collection.IterableOps[String, List, List[String]] { }
+class Unimplemented extends scala.collection.IterableOps[String, List, List[String]]
       ^
 1 error

--- a/test/files/neg/abstract-report.check
+++ b/test/files/neg/abstract-report.check
@@ -1,5 +1,5 @@
 abstract-report.scala:1: error: class Unimplemented needs to be abstract.
-Missing implementations for 6 members. Stub implementations follow:
+Missing implementations for 6 members.
   // Members declared in scala.collection.IterableOnce
   def iterator: Iterator[String] = ???
 

--- a/test/files/neg/abstract-report.scala
+++ b/test/files/neg/abstract-report.scala
@@ -1,1 +1,1 @@
-class Unimplemented extends scala.collection.IterableOps[String, List, List[String]] { }
+class Unimplemented extends scala.collection.IterableOps[String, List, List[String]]

--- a/test/files/neg/abstract-report2.check
+++ b/test/files/neg/abstract-report2.check
@@ -1,5 +1,5 @@
 abstract-report2.scala:3: error: class Foo needs to be abstract.
-Missing implementations for 13 members. Stub implementations follow:
+Missing implementations for 13 members of trait Collection.
   def add(x$1: Int): Boolean = ???
   def addAll(x$1: java.util.Collection[_ <: Int]): Boolean = ???
   def clear(): Unit = ???
@@ -17,7 +17,7 @@ Missing implementations for 13 members. Stub implementations follow:
 class Foo extends Collection[Int]
       ^
 abstract-report2.scala:5: error: class Bar needs to be abstract.
-Missing implementations for 13 members. Stub implementations follow:
+Missing implementations for 13 members of trait Collection.
   def add(x$1: List[_ <: String]): Boolean = ???
   def addAll(x$1: java.util.Collection[_ <: List[_ <: String]]): Boolean = ???
   def clear(): Unit = ???
@@ -35,7 +35,7 @@ Missing implementations for 13 members. Stub implementations follow:
 class Bar extends Collection[List[_ <: String]]
       ^
 abstract-report2.scala:7: error: class Baz needs to be abstract.
-Missing implementations for 13 members. Stub implementations follow:
+Missing implementations for 13 members of trait Collection.
   def add(x$1: T): Boolean = ???
   def addAll(x$1: java.util.Collection[_ <: T]): Boolean = ???
   def clear(): Unit = ???
@@ -53,7 +53,7 @@ Missing implementations for 13 members. Stub implementations follow:
 class Baz[T] extends Collection[T]
       ^
 abstract-report2.scala:21: error: class Dingus needs to be abstract.
-Missing implementations for 7 members. Stub implementations follow:
+Missing implementations for 7 members.
   // Members declared in scala.collection.IterableOnce
   def iterator: Iterator[(Set[Int], String)] = ???
 
@@ -69,4 +69,10 @@ Missing implementations for 7 members. Stub implementations follow:
 
 class Dingus extends Bippy[String, Set[Int], List[Int]]
       ^
-4 errors
+abstract-report2.scala:23: error: class JustOne needs to be abstract.
+Missing implementation for member of trait Collection:
+  def toArray[T](x$1: Array[T with Object]): Array[T with Object] = ???
+
+class JustOne extends Collection[Int] {
+      ^
+5 errors

--- a/test/files/neg/abstract-report2.scala
+++ b/test/files/neg/abstract-report2.scala
@@ -19,3 +19,25 @@ trait Symbolic {
 trait Bippy[T1, T2, T3] extends collection.IterableOps[(T2, String), List, List[(T2, String)]] with Xyz[T3]
 
 class Dingus extends Bippy[String, Set[Int], List[Int]]
+
+class JustOne extends Collection[Int] {
+  def add(x$1: Int): Boolean = ???
+  def addAll(x$1: java.util.Collection[_ <: Int]): Boolean = ???
+  def clear(): Unit = ???
+  def contains(x$1: Object): Boolean = ???
+  def containsAll(x$1: java.util.Collection[_]): Boolean = ???
+  def isEmpty(): Boolean = ???
+  def iterator(): java.util.Iterator[Int] = ???
+  def remove(x$1: Object): Boolean = ???
+  def removeAll(x$1: java.util.Collection[_]): Boolean = ???
+  def retainAll(x$1: java.util.Collection[_]): Boolean = ???
+  def size(): Int = ???
+  //def toArray[T](x$1: Array[T with Object]): Array[T with Object] = ???
+  def toArray(): Array[Object] = ???
+}
+/* was:
+test/files/neg/abstract-report2.scala:23: error: class JustOne needs to be abstract. Missing implementation for:
+  def toArray[T](x$1: Array[T with Object]): Array[T with Object] // inherited from trait Collection
+(Note that Array[T with Object] does not match java.util.function.IntFunction[Array[T with Object]])
+class JustOne extends Collection[Int] {
+ */

--- a/test/files/neg/abstract-vars.check
+++ b/test/files/neg/abstract-vars.check
@@ -1,26 +1,31 @@
-abstract-vars.scala:5: error: class Fail1 needs to be abstract. Missing implementation for:
-  def x: Int
-(Note that variables need to be initialized to be defined)
+abstract-vars.scala:5: error: class Fail1 needs to be abstract.
+Missing implementation:
+  def x: Int = ??? // variables need to be initialized to be defined
+
 class Fail1 extends A {
       ^
-abstract-vars.scala:9: error: class Fail2 needs to be abstract. Missing implementation for:
-  def x: Int // inherited from class A
-(Note that variables need to be initialized to be defined)
+abstract-vars.scala:9: error: class Fail2 needs to be abstract.
+Missing implementation for member of class A:
+  def x: Int = ??? // variables need to be initialized to be defined
+
 class Fail2 extends A { }
       ^
-abstract-vars.scala:11: error: class Fail3 needs to be abstract. Missing implementation for:
-  def x_=(x$1: Int): Unit // inherited from class A
-(Note that an abstract var requires a setter in addition to the getter)
+abstract-vars.scala:11: error: class Fail3 needs to be abstract.
+Missing implementation for member of class A:
+  def x_=(x$1: Int): Unit = ??? // an abstract var requires a setter in addition to the getter
+
 class Fail3 extends A {
       ^
-abstract-vars.scala:14: error: class Fail4 needs to be abstract. Missing implementation for:
-  def x_=(x$1: Int): Unit // inherited from class A
-(Note that an abstract var requires a setter in addition to the getter)
+abstract-vars.scala:14: error: class Fail4 needs to be abstract.
+Missing implementation for member of class A:
+  def x_=(x$1: Int): Unit = ??? // an abstract var requires a setter in addition to the getter
+
 class Fail4 extends A {
       ^
-abstract-vars.scala:18: error: class Fail5 needs to be abstract. Missing implementation for:
-  def x: Int // inherited from class A
-(Note that an abstract var requires a getter in addition to the setter)
+abstract-vars.scala:18: error: class Fail5 needs to be abstract.
+Missing implementation for member of class A:
+  def x: Int = ??? // an abstract var requires a getter in addition to the setter
+
 class Fail5 extends A {
       ^
 5 errors

--- a/test/files/neg/accesses2.check
+++ b/test/files/neg/accesses2.check
@@ -3,8 +3,10 @@ private[package p2] def f2(): Int (defined in class A)
   override should not be private
     private def f2(): Int = 1
                 ^
-accesses2.scala:5: error: class B1 needs to be abstract. Missing implementation for:
-  private[package p2] def f2(): Int // inherited from class A
+accesses2.scala:5: error: class B1 needs to be abstract.
+Missing implementation for member of class A:
+  private[package p2] def f2(): Int = ???
+
   class B1 extends A {
         ^
 accesses2.scala:9: error: weaker access privileges in overriding

--- a/test/files/neg/logImplicits.check
+++ b/test/files/neg/logImplicits.check
@@ -13,8 +13,10 @@ logImplicits.scala:21: applied implicit conversion from Int(1) to ?{def -> : ?} 
 logImplicits.scala:21: applied implicit conversion from (Int, Int) to ?{def + : ?} = final implicit def any2stringadd[A](self: A): any2stringadd[A]
   def f = (1 -> 2) + "c"
              ^
-logImplicits.scala:24: error: class Un needs to be abstract. Missing implementation for:
-  def unimplemented: Int
+logImplicits.scala:24: error: class Un needs to be abstract.
+Missing implementation:
+  def unimplemented: Int = ???
+
 class Un {
       ^
 1 error

--- a/test/files/neg/raw-types-stubs.check
+++ b/test/files/neg/raw-types-stubs.check
@@ -1,6 +1,6 @@
 S_3.scala:1: error: class Sub needs to be abstract.
-Missing implementations for 2 members. Stub implementations follow:
-  def raw(x$1: M_1[_ <: String]): Unit = ???
+Missing implementations for 2 members of class Raw_2.
+  def raw(x$1: M_1[_ <: String]): Unit = ??? // implements `def raw(x$1: M_1): Unit`
   def raw(x$1: Object): Unit = ???
 
 class Sub extends Raw_2 { }

--- a/test/files/neg/t0345.check
+++ b/test/files/neg/t0345.check
@@ -1,5 +1,7 @@
-t0345.scala:2: error: object creation impossible. Missing implementation for:
-  def cons(a: Nothing): Unit // inherited from trait Lizt
+t0345.scala:2: error: object creation impossible.
+Missing implementation for member of trait Lizt:
+  def cons(a: Nothing): Unit = ???
+
     val empty = new Lizt[Nothing] {
                     ^
 1 error

--- a/test/files/neg/t10260.check
+++ b/test/files/neg/t10260.check
@@ -1,21 +1,25 @@
-Test.scala:1: error: class IAImpl needs to be abstract. Missing implementation for:
-  def foo(a: A): Unit // inherited from trait IA
-(Note that A does not match A[_]. To implement this raw type, use A[T] forSome { type T <: A[T] })
+Test.scala:1: error: class IAImpl needs to be abstract.
+Missing implementation for member of trait IA:
+  def foo(a: A[T] forSome { type T <: A[T] }): Unit = ??? // implements `def foo(a: A): Unit`; A does not match A[_]. To implement this raw type, use A[T] forSome { type T <: A[T] }
+
 class IAImpl extends IA { def foo(a: A[_]) = ??? }
       ^
-Test.scala:2: error: class IBImpl needs to be abstract. Missing implementation for:
-  def foo(a: B): Unit // inherited from trait IB
-(Note that B does not match B[_, _]. To implement this raw type, use B[T,R] forSome { type T; type R <: java.util.List[_ >: T] })
+Test.scala:2: error: class IBImpl needs to be abstract.
+Missing implementation for member of trait IB:
+  def foo(a: B[T,R] forSome { type T; type R <: java.util.List[_ >: T] }): Unit = ??? // implements `def foo(a: B): Unit`; B does not match B[_, _]. To implement this raw type, use B[T,R] forSome { type T; type R <: java.util.List[_ >: T] }
+
 class IBImpl extends IB { def foo(a: B[_,_]) = ??? }
       ^
-Test.scala:3: error: class ICImpl needs to be abstract. Missing implementation for:
-  def foo(a: Int, b: C, c: String): C // inherited from trait IC
-(Note that C does not match C[_]. To implement this raw type, use C[_ <: String])
+Test.scala:3: error: class ICImpl needs to be abstract.
+Missing implementation for member of trait IC:
+  def foo(a: Int, b: C[_ <: String], c: String): C[_ <: String] = ??? // implements `def foo(a: Int, b: C, c: String): C`; C does not match C[_]. To implement this raw type, use C[_ <: String]
+
 class ICImpl extends IC { def foo(a: Int, b: C[_], c: String) = ??? }
       ^
-Test.scala:4: error: class IDImpl needs to be abstract. Missing implementation for:
-  def foo(a: D): Unit // inherited from trait ID
-(Note that D does not match D[_ <: String]. To implement this raw type, use D[_])
+Test.scala:4: error: class IDImpl needs to be abstract.
+Missing implementation for member of trait ID:
+  def foo(a: D[_]): Unit = ??? // implements `def foo(a: D): Unit`; D does not match D[_ <: String]. To implement this raw type, use D[_]
+
 class IDImpl extends ID { def foo(a: D[_ <: String]) = ??? }
       ^
 4 errors

--- a/test/files/neg/t2213.check
+++ b/test/files/neg/t2213.check
@@ -1,5 +1,5 @@
 t2213.scala:9: error: class C needs to be abstract.
-Missing implementations for 4 members. Stub implementations follow:
+Missing implementations for 4 members of class A.
   def f: Int = ???
   def g: Int = ???
   val x: Int = ???
@@ -8,7 +8,7 @@ Missing implementations for 4 members. Stub implementations follow:
 class C extends A {}
       ^
 t2213.scala:11: error: object creation impossible.
-Missing implementations for 4 members. Stub implementations follow:
+Missing implementations for 4 members of class A.
   def f: Int = ???
   def g: Int = ???
   val x: Int = ???

--- a/test/files/neg/t3854.check
+++ b/test/files/neg/t3854.check
@@ -1,6 +1,7 @@
-t3854.scala:1: error: class Bar needs to be abstract. Missing implementation for:
-  def foo[G[_]](implicit n: N[G,F]): X[F] // inherited from trait Foo
-(Note that N[G,F] does not match M[G])
+t3854.scala:1: error: class Bar needs to be abstract.
+Missing implementation for member of trait Foo:
+  def foo[G[_]](implicit n: N[G,F]): X[F] = ??? // N[G,F] does not match M[G]
+
 class Bar[F[_]] extends Foo[F] {
       ^
 1 error

--- a/test/files/neg/t4431.check
+++ b/test/files/neg/t4431.check
@@ -1,4 +1,5 @@
-t4431.scala:5: error: class BB needs to be abstract. No implementation found in a subclass for deferred declaration
+t4431.scala:5: error: class BB needs to be abstract.
+No implementation found in a subclass for deferred declaration
 def f(): Unit
   class BB extends B { def f (): Unit }
         ^

--- a/test/files/neg/t521.check
+++ b/test/files/neg/t521.check
@@ -1,13 +1,17 @@
-t521.scala:10: error: class PlainFile needs to be abstract. Missing implementation for:
-  def path: String // inherited from class AbstractFile
+t521.scala:10: error: class PlainFile needs to be abstract.
+Missing implementation for member of class AbstractFile:
+  def path: String = ???
+
 class PlainFile(val file : File) extends AbstractFile {}
       ^
 t521.scala:13: error: `override` modifier required to override concrete member:
 val file: java.io.File (defined in class PlainFile)
 final class ZipArchive(val file : File, archive : ZipFile) extends PlainFile(file) {
                            ^
-t521.scala:13: error: class ZipArchive needs to be abstract. Missing implementation for:
-  def path: String // inherited from class AbstractFile
+t521.scala:13: error: class ZipArchive needs to be abstract.
+Missing implementation for member of class AbstractFile:
+  def path: String = ???
+
 final class ZipArchive(val file : File, archive : ZipFile) extends PlainFile(file) {
             ^
 t521.scala:15: error: stable, immutable value required to override:

--- a/test/files/neg/t6013.check
+++ b/test/files/neg/t6013.check
@@ -1,8 +1,10 @@
-DerivedScala.scala:4: error: class C needs to be abstract. No implementation found in a subclass for deferred declaration
+DerivedScala.scala:4: error: class C needs to be abstract.
+No implementation found in a subclass for deferred declaration
 def foo: Int (defined in class B)
 class C extends B
       ^
-DerivedScala.scala:7: error: class DerivedScala needs to be abstract. No implementation found in a subclass for deferred declaration
+DerivedScala.scala:7: error: class DerivedScala needs to be abstract.
+No implementation found in a subclass for deferred declaration
 def foo(): Boolean (defined in class Abstract)
 class DerivedScala extends Abstract
       ^

--- a/test/files/neg/t856.check
+++ b/test/files/neg/t856.check
@@ -1,5 +1,5 @@
 t856.scala:3: error: class ComplexRect needs to be abstract.
-Missing implementations for 2 members. Stub implementations follow:
+Missing implementations for 2 members.
   // Members declared in scala.Equals
   def canEqual(that: Any): Boolean = ???
 

--- a/test/files/neg/t9138.check
+++ b/test/files/neg/t9138.check
@@ -1,20 +1,25 @@
-t9138.scala:9: error: class D needs to be abstract. Missing implementation for:
-  def f(t: B)(s: String): B // inherited from class C
-(Note that String does not match Int)
+t9138.scala:9: error: class D needs to be abstract.
+Missing implementation for member of class C:
+  def f(t: B)(s: String): B = ??? // String does not match Int
+
 class D extends C[B] {
       ^
-t9138.scala:19: error: object creation impossible. Missing implementation for:
-  def foo(a: String)(b: Int): Nothing // inherited from trait Base
+t9138.scala:19: error: object creation impossible.
+Missing implementation for member of trait Base:
+  def foo(a: String)(b: Int): Nothing = ???
+
 object Derived extends Base[String] {
        ^
-t9138.scala:29: error: class DDD needs to be abstract. Missing implementation for:
-  def f(t: B, s: String): B // inherited from class CCC
-(Note that T does not match Int)
+t9138.scala:29: error: class DDD needs to be abstract.
+Missing implementation for member of class CCC:
+  def f(t: B, s: String): B = ??? // T does not match Int
+
 class DDD extends CCC[B] {
       ^
-t9138.scala:43: error: object creation impossible. Missing implementation for:
-  def create(conditionalParams: ImplementingParamTrait)(implicit d: Double): Int // inherited from trait Model
-(overriding member must declare implicit parameter list)
+t9138.scala:43: error: object creation impossible.
+Missing implementation for member of trait Model:
+  def create(conditionalParams: ImplementingParamTrait)(implicit d: Double): Int = ??? // overriding member must declare implicit parameter list
+
 object Obj extends Model[ImplementingParamTrait] {
        ^
 4 errors


### PR DESCRIPTION
Always print the missing methods in stub form, with the template in the header, and with diagnostic text as a line comment.

```
scala> class C extends Runnable
             ^
       error: class C needs to be abstract.
       Missing implementation for member of trait Runnable:
         def run(): Unit = ???

scala> class C extends Runnable with java.io.Closeable
             ^
       error: class C needs to be abstract.
       Missing implementations for 2 members.
         // Members declared in java.io.Closeable
         def close(): Unit = ???

         // Members declared in java.lang.Runnable
         def run(): Unit = ???

scala> trait T { var n: Int }
trait T

scala> class C extends T { def n = 42 }
             ^
       error: class C needs to be abstract.
       Missing implementation for member of trait T:
         def n_=(x$1: Int): Unit = ??? // an abstract var requires a setter in addition to the getter

scala>
```

Fixes scala/bug#12487