### PR TITLE
Tweak doc for ordering of SeqMap

### DIFF
--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -92,13 +92,11 @@ trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]
   @`inline` final override def -- (keys: IterableOnce[K]): C = removedAll(keys)
 
   /** Creates a new map obtained by updating this map with a given key/value pair.
-    *  @param    key the key
-    *  @param    value the value
-    *  @tparam   V1 the type of the added value
-    *  @return   A new map with the new key/value mapping added to this map.
-    *
-    *    @inheritdoc
-    */
+   *  @param    key the key
+   *  @param    value the value
+   *  @tparam   V1 the type of the added value
+   *  @return   A new map with the new key/value mapping added to this map.
+   */
   def updated[V1 >: V](key: K, value: V1): CC[K, V1]
 
   /**

--- a/src/library/scala/collection/immutable/SeqMap.scala
+++ b/src/library/scala/collection/immutable/SeqMap.scala
@@ -16,12 +16,14 @@ package immutable
 
 import scala.collection.mutable.{Builder, ReusableBuilder}
 
-/** A generic trait for ordered immutable maps. Concrete classes have to provide
- *  functionality for the abstract methods in `SeqMap`.
+/** A base trait for ordered, immutable maps.
  *
- *  Methods that return a new map, such as [[removed]] and [[updated]], must preserve ordering.
+ *  Note that the [[equals]] method for [[SeqMap]] compares key-value pairs
+ *  without regard to ordering.
  *
- *  Note that when checking for equality, [[SeqMap]] does not take ordering into account.
+ *  All behavior is defined in terms of the abstract methods in `SeqMap`.
+ *  It is sufficient for concrete subclasses to implement those methods.
+ *  Methods that return a new map, in particular [[removed]] and [[updated]], must preserve ordering.
  *
  *  @tparam K      the type of the keys contained in this linked map.
  *  @tparam V      the type of the values associated with the keys in this linked map.

--- a/src/library/scala/collection/immutable/SeqMap.scala
+++ b/src/library/scala/collection/immutable/SeqMap.scala
@@ -16,19 +16,19 @@ package immutable
 
 import scala.collection.mutable.{Builder, ReusableBuilder}
 
-/**
-  * A generic trait for ordered immutable maps. Concrete classes have to provide
-  * functionality for the abstract methods in `SeqMap`.
-  *
-  * Note that when checking for equality [[SeqMap]] does not take into account
-  * ordering.
-  *
-  * @tparam K      the type of the keys contained in this linked map.
-  * @tparam V      the type of the values associated with the keys in this linked map.
-  *
-  * @define coll immutable seq map
-  * @define Coll `immutable.SeqMap`
-  */
+/** A generic trait for ordered immutable maps. Concrete classes have to provide
+ *  functionality for the abstract methods in `SeqMap`.
+ *
+ *  Methods that return a new map, such as [[removed]] and [[updated]], must preserve ordering.
+ *
+ *  Note that when checking for equality, [[SeqMap]] does not take ordering into account.
+ *
+ *  @tparam K      the type of the keys contained in this linked map.
+ *  @tparam V      the type of the values associated with the keys in this linked map.
+ *
+ *  @define coll immutable seq map
+ *  @define Coll `immutable.SeqMap`
+ */
 
 trait SeqMap[K, +V]
   extends Map[K, V]


### PR DESCRIPTION
Maintain order! and fix doc glitch
```
 A new map with the new key/value mapping added to this map. <invalid inheritdoc annotation>
```

Fixes https://github.com/scala/bug/issues/11719