### PR TITLE
JQuery 3.6.0 (was 3.5.1)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@
  *
  * What you see below is very much work-in-progress. The following features are implemented:
  *   - Compiling all classses for the compiler and library ("compile" in the respective subprojects)
- *   - Running JUnit ("junit/test"), ScalaCheck ("scalacheck/test"), and partest ("test/it:test") tests
+ *   - Running JUnit ("junit/test"), ScalaCheck ("scalacheck/test"), and partest ("test/IntegrationTest/test") tests
  *   - Creating build/quick with all compiled classes and launcher scripts ("dist/mkQuick")
  *   - Creating build/pack with all JARs and launcher scripts ("dist/mkPack")
  *   - Building all scaladoc sets ("doc")
@@ -1143,7 +1143,7 @@ def generateServiceProviderResources(services: (String, String)*): Setting[_] =
 
 // Add tab completion to partest
 commands += Command("partest")(_ => PartestUtil.partestParser((ThisBuild / baseDirectory).value, (ThisBuild / baseDirectory).value / "test")) { (state, parsed) =>
-  ("test/it:testOnly -- " + parsed) :: state
+  ("test/IntegrationTest/testOnly -- " + parsed) :: state
 }
 
 // Watch the test files also so ~partest triggers on test case changes

--- a/project/ScaladocSettings.scala
+++ b/project/ScaladocSettings.scala
@@ -15,8 +15,8 @@ object ScaladocSettings {
       s.get(artifact.key).isDefined && s.get(moduleID.key).exists(_.organization == "org.webjars")
     val dest = (resourceManaged.value / "webjars").getAbsoluteFile
     IO.createDirectory(dest)
-    val classpathes = (Compile / dependencyClasspath).value
-    val files: Seq[File] = classpathes.filter(isWebjar).flatMap { classpathEntry =>
+    val classpaths = (Compile / dependencyClasspath).value
+    val files: Seq[File] = classpaths.filter(isWebjar).flatMap { classpathEntry =>
       val jarFile = classpathEntry.data
       IO.unzip(jarFile, dest)
     }

--- a/project/ScaladocSettings.scala
+++ b/project/ScaladocSettings.scala
@@ -7,7 +7,7 @@ object ScaladocSettings {
 
   // when this changes, the integrity check in HtmlFactory.scala also needs updating
   val webjarResources = Seq(
-    "org.webjars" % "jquery" % "3.5.1"
+    "org.webjars" % "jquery" % "3.6.0"
   )
 
   def extractResourcesFromWebjar = Def.task {

--- a/spec/_layouts/default.yml
+++ b/spec/_layouts/default.yml
@@ -16,7 +16,7 @@
     }
   });
   </script>
-  <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.2/styles/default.min.css">
   <!-- need to use include to see value of page.chapter variable -->
   <style type="text/css">

--- a/spec/_layouts/toc.yml
+++ b/spec/_layouts/toc.yml
@@ -6,7 +6,7 @@
   <link rel="icon" type="image/png" href="public/favicon.ico">
   <link rel="shortcut icon" type="image/png" href="public/favicon.ico">
 
-  <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
   <title>{{ page.title }} | Scala {{ site.thisScalaVersion }}</title>
 
   <link rel="stylesheet" type="text/css" href="public/stylesheets/screen.css">

--- a/src/intellij/scala.ipr.SAMPLE
+++ b/src/intellij/scala.ipr.SAMPLE
@@ -296,7 +296,7 @@
         <root url="jar://$USER_HOME$/.ivy2/cache/com.googlecode.java-diff-utils/diffutils/jars/diffutils-1.3.0.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/test-interface/jars/test-interface-1.0.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/junit/junit/jars/junit-4.12.jar!/" />
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.webjars/jquery/jars/jquery-3.5.1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.webjars/jquery/jars/jquery-3.6.0.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.hamcrest/hamcrest-core/jars/hamcrest-core-1.3.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.openjdk.jol/jol-core/jars/jol-core-0.13.jar!/" />
       </CLASSES>
@@ -323,7 +323,7 @@
         <root url="jar://$USER_HOME$/.ivy2/cache/junit/junit/jars/junit-4.12.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/com.googlecode.java-diff-utils/diffutils/jars/diffutils-1.3.0.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/test-interface/jars/test-interface-1.0.jar!/" />
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.webjars/jquery/jars/jquery-3.5.1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.webjars/jquery/jars/jquery-3.6.0.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.hamcrest/hamcrest-core/jars/hamcrest-core-1.3.jar!/" />
       </CLASSES>
       <JAVADOC />
@@ -506,7 +506,7 @@
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-9.2.0-scala-1.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-xml_2.12/bundles/scala-xml_2.12-1.0.6.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/test-interface/jars/test-interface-1.0.jar!/" />
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.webjars/jquery/jars/jquery-3.5.1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.webjars/jquery/jars/jquery-3.6.0.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scalacheck/scalacheck_2.12/jars/scalacheck_2.12-1.14.3.jar!/" />
       </CLASSES>
       <JAVADOC />
@@ -518,7 +518,7 @@
         <root url="jar://$USER_HOME$/.ivy2/cache/org.apache.ant/ant-launcher/jars/ant-launcher-1.9.4.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-asm/bundles/scala-asm-9.2.0-scala-1.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang.modules/scala-xml_2.12/bundles/scala-xml_2.12-1.0.6.jar!/" />
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.webjars/jquery/jars/jquery-3.5.1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.webjars/jquery/jars/jquery-3.6.0.jar!/" />
       </CLASSES>
       <JAVADOC />
       <SOURCES />
@@ -558,7 +558,7 @@
         <root url="jar://$USER_HOME$/.ivy2/cache/com.googlecode.java-diff-utils/diffutils/jars/diffutils-1.3.0.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/junit/junit/jars/junit-4.12.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-sbt/test-interface/jars/test-interface-1.0.jar!/" />
-        <root url="jar://$USER_HOME$/.ivy2/cache/org.webjars/jquery/jars/jquery-3.5.1.jar!/" />
+        <root url="jar://$USER_HOME$/.ivy2/cache/org.webjars/jquery/jars/jquery-3.6.0.jar!/" />
         <root url="jar://$USER_HOME$/.ivy2/cache/org.hamcrest/hamcrest-core/jars/hamcrest-core-1.3.jar!/" />
       </CLASSES>
       <JAVADOC />

--- a/src/scaladoc/scala/tools/nsc/doc/html/HtmlFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/HtmlFactory.scala
@@ -95,7 +95,7 @@ class HtmlFactory(val universe: doc.Universe, val reporter: Reporter) {
   )
 
   final def webjarResources = List(
-    ("jquery.min.js", "9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=")
+    ("jquery.min.js", "/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=")
   )
 
   /** Generates the Scaladoc site for a model into the site root.


### PR DESCRIPTION
replaces #9855, which the Steward submitted, but a human touch was needed

https://blog.jquery.com/2021/03/02/jquery-3-6-0-released/ makes it seem like a pretty safe upgrade, knock on wood

our last upgrade was #8963