### PR TITLE
[BLOCKED] -Yannotations introduces annotation contexts

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -221,6 +221,7 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
        |
     """
   ))
+  val Yannotations    = MultiStringSetting(name="-Yannotations", arg="package", descr="Custom annotation packages, such as scala.annotation.", helpText=Some("Add annotation package to root contexts."))
   val Yrecursion      = IntSetting        ("-Yrecursion", "Set recursion depth used when locking symbols.", 0, Some((0, Int.MaxValue)), (_: String) => None)
 
   val YprintTrees = ChoiceSetting(

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1890,30 +1890,31 @@ trait Namers extends MethodSynthesis {
      * they were added only in typer, depending on the compilation order, they may
      * or may not be visible.
      */
-    def annotSig(annotations: List[Tree], annotee: Tree, pred: AnnotationInfo => Boolean): List[AnnotationInfo] =
+    def annotSig(annotations: List[Tree], annotee: Tree, pred: AnnotationInfo => Boolean): List[AnnotationInfo] = {
       annotations.filterNot(_ eq null).map { ann =>
         val ctx = typer.context
         // need to be lazy, #1782. enteringTyper to allow inferView in annotation args, scala/bug#5892.
         def computeInfo: AnnotationInfo = enteringTyper {
-          val annotSig = newTyper(ctx.makeNonSilent(ann)).typedAnnotation(ann, Some(annotee))
+          val annotSig = ctx.withinAnnotation(newTyper(ctx.makeNonSilent(ann)).typedAnnotation(ann, Some(annotee)))
           if (pred(annotSig)) annotSig else UnmappableAnnotation // UnmappableAnnotation will be dropped in typedValDef and typedDefDef
         }
         ann match {
           case treeInfo.Applied(Select(New(tpt), _), _, _) =>
             // We can defer typechecking the arguments of annotations. This is important to avoid cycles in
             // checking `hasAnnotation(UncheckedStable)` during typechecking.
-            def computeSymbol = enteringTyper {
+            def computeSymbol = enteringTyper { ctx.withinAnnotation {
               val tptCopy = tpt.duplicate
               val silentTyper  = newTyper(ctx.makeSilent(newtree = tptCopy))
               // Discard errors here, we'll report them in `computeInfo`.
               val tpt1 = silentTyper.typedTypeConstructor(tptCopy)
               tpt1.tpe.finalResultType.typeSymbol
-            }
+            }}
             AnnotationInfo.lazily(computeSymbol, computeInfo)
           case _ =>
             AnnotationInfo.lazily(computeInfo)
         }
       }
+    }
 
     private def annotate(sym: Symbol, annotSigs: List[AnnotationInfo]): Unit = {
       sym setAnnotations annotSigs

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5966,7 +5966,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         case tree: Assign           => typedAssign(tree.lhs, tree.rhs)
         case tree: NamedArg         => typedAssign(tree.lhs, tree.rhs)
         case tree: Super            => typedSuper(tree)
-        case tree: Annotated        => typedAnnotated(tree)
+        case tree: Annotated        => if (!context.inAnnotation) context.withinAnnotation(typedAnnotated(tree)) else typedAnnotated(tree)
         case tree: Return           => typedReturn(tree)
         case tree: Try              => typedTry(tree)
         case tree: Throw            => typedThrow(tree)

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -197,6 +197,8 @@ trait Definitions extends api.StandardDefinitions {
     lazy val ScalaPackageClass    = ScalaPackage.moduleClass.asClass
     lazy val RuntimePackage       = getPackage("scala.runtime")
     lazy val RuntimePackageClass  = RuntimePackage.moduleClass.asClass
+    lazy val AnnotationPackage    = getPackage("scala.annotation")
+    lazy val AnnotationPackageClass = AnnotationPackage.moduleClass.asClass
 
     def javaTypeToValueClass(jtype: Class[_]): Symbol = jtype match {
       case java.lang.Void.TYPE      => UnitClass

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -135,4 +135,6 @@ trait StdAttachments {
   case class ChangeOwnerAttachment(originalOwner: Symbol)
 
   case object InterpolatedString extends PlainAttachment
+
+  case object AnnotationContext extends PlainAttachment
 }

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -73,6 +73,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.NullaryOverrideAdapted
     this.ChangeOwnerAttachment
     this.InterpolatedString
+    this.AnnotationContext
     this.noPrint
     this.typeDebug
     // inaccessible: this.posAssigner
@@ -234,6 +235,8 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.ScalaPackageClass
     definitions.RuntimePackage
     definitions.RuntimePackageClass
+    definitions.AnnotationPackage
+    definitions.AnnotationPackageClass
     definitions.AnyClass
     definitions.AnyRefClass
     definitions.ObjectClass

--- a/test/files/neg/annots-constant-neg.check
+++ b/test/files/neg/annots-constant-neg.check
@@ -65,14 +65,14 @@ Test.scala:63: error: Array constants have to be specified using the `Array(...)
 Test.scala:66: error: annotation argument needs to be a constant; found: java.lang.Integer.TYPE
   @Ann(value = 0, b = java.lang.Integer.TYPE) def u16 = 0 // err
                                         ^
-Test.scala:69: error: Java annotation SuppressWarnings is abstract; cannot be instantiated
+Test.scala:69: error: unknown parameter name: value
+Error occurred in an application involving default arguments.
+  @Ann(value = 0, c = Array(new SuppressWarnings(value = Array("")))) def u17 = 0 // err
+                                                       ^
+Test.scala:69: error: no arguments allowed for nullary constructor SuppressWarnings: (): SuppressWarnings
 Error occurred in an application involving default arguments.
   @Ann(value = 0, c = Array(new SuppressWarnings(value = Array("")))) def u17 = 0 // err
                             ^
-Test.scala:69: error: not found: value value
-Error occurred in an application involving default arguments.
-  @Ann(value = 0, c = Array(new SuppressWarnings(value = Array("")))) def u17 = 0 // err
-                                                 ^
 Test.scala:71: error: annotation argument needs to be a constant; found: new scala.inline()
   @Ann(value = 0, c = Array(new inline)) def u18 = 0 // err
                             ^

--- a/test/files/neg/t11888.check
+++ b/test/files/neg/t11888.check
@@ -1,0 +1,4 @@
+t11888.scala:7: error: not found: type nowarn
+  def f: nowarn  // but only in annotation context
+         ^
+1 error

--- a/test/files/neg/t11888.scala
+++ b/test/files/neg/t11888.scala
@@ -1,0 +1,8 @@
+//scalac: -Yannotations:scala.annotation
+package p
+
+// use nowarn without prefix
+@nowarn
+trait C {
+  def f: nowarn  // but only in annotation context
+}

--- a/test/files/pos/t11888.scala
+++ b/test/files/pos/t11888.scala
@@ -1,0 +1,12 @@
+//scalac: -Yannotations:scala.annotation
+package p
+
+// use nowarn without prefix
+@nowarn
+class C
+
+import collection.AbstractIterator
+
+abstract class ConcatIterator[+A](var current: Iterator[A @unchecked.uncheckedVariance]) extends AbstractIterator[A]
+
+// was: error: not found: type nowarn


### PR DESCRIPTION
Annotation contexts are root contexts that are enabled
for lookups only when typer context mode is `inAnnotation`.
This enables references to `@nowarn`, `@tailrec`, and
`@unchecked.uncheckedVariance` without imports.

`-Yannotations:scala.annotation` would be a nice default
but must be specified.

There is a corresponding ticket for Scala 3 with a similar proposal.

Fixes scala/bug#11888