### PR TITLE
Fix stability of existential types

### DIFF
--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -909,14 +909,13 @@ trait Definitions extends api.StandardDefinitions {
      */
     @tailrec
     final def isStable(tp: Type): Boolean = tp match {
-      case _: SingletonType                             => true
-      case NoPrefix                                     => true
+      case NoPrefix | _: SingletonType                  => true
       case TypeRef(_, NothingClass | SingletonClass, _) => true
-      case TypeRef(_, sym, _) if sym.isAbstractType     => tp.upperBound.typeSymbol isSubClass SingletonClass
+      case TypeRef(_, sym, _) if sym.isAbstractType     => tp.upperBound.typeSymbol.isSubClass(SingletonClass)
       case TypeRef(pre, sym, _) if sym.isModuleClass    => isStable(pre)
-      case TypeRef(_, _, _)                             => val normalize = tp.normalize; (normalize ne tp) && isStable(normalize)
+      case _: TypeRef                                   => val norm = tp.normalize; (norm ne tp) && isStable(norm)
       case TypeVar(origin, _)                           => isStable(origin)
-      case AnnotatedType(_, atp)                        => isStable(atp)    // Really?
+      case ExistentialType(qs, underlying)              => isStable(deriveTypeWithWildcards(qs)(underlying))
       case _: SimpleTypeProxy                           => isStable(tp.underlying)
       case _                                            => false
     }

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -2939,6 +2939,8 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
 
     override def isPackageObject    = isModule && (rawname == nme.PACKAGE)
 
+    override def isExistentiallyBound = this hasFlag EXISTENTIAL
+
     // The name in comments is what it is being disambiguated from.
     // TODO - rescue CAPTURED from BYNAMEPARAM so we can see all the names.
     override def resolveOverloadedFlag(flag: Long) = flag match {

--- a/test/files/neg/t12514.check
+++ b/test/files/neg/t12514.check
@@ -1,0 +1,4 @@
+t12514.scala:10: error: t.type forSome { val t: Test.T } is not a legal prefix for a constructor
+  val y = new (t.type forSome { val t: T })#Y {}
+                                            ^
+1 error

--- a/test/files/neg/t12514.scala
+++ b/test/files/neg/t12514.scala
@@ -1,0 +1,11 @@
+import scala.language.existentials
+
+object Test {
+  trait T {
+    trait Y {
+      def x = 0
+    }
+  }
+
+  val y = new (t.type forSome { val t: T })#Y {}
+}


### PR DESCRIPTION
 - Replace existential qualifiers with wildcards for stability check
 - Term symbols can also be existentially bound

Fixes scala/bug#12514