### PR TITLE
Prefer type of overridden member when inferring (under `-Xsource:3`)

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1126,9 +1126,10 @@ trait Namers extends MethodSynthesis {
         case ddef: DefDef if tree.symbol.isTermMacro => defnTyper.computeMacroDefType(ddef, pt)
         case _ => defnTyper.computeType(tree.rhs, pt)
       }
-
-      val defnTpe = dropIllegalStarTypes(widenIfNecessary(tree.symbol, rhsTpe, pt))
-      tree.tpt defineType defnTpe setPos tree.pos.focus
+      tree.tpt.defineType {
+        if (currentRun.isScala3 && !pt.isWildcard && pt != NoType && !pt.isErroneous) pt
+        else dropIllegalStarTypes(widenIfNecessary(tree.symbol, rhsTpe, pt))
+      }.setPos(tree.pos.focus)
       tree.tpt.tpe
     }
 

--- a/test/files/pos/t7212.scala
+++ b/test/files/pos/t7212.scala
@@ -1,0 +1,15 @@
+
+// scalac: -Xsource:3
+
+class A {
+  def f: Option[String] = Some("hello, world")
+  def remove(): Unit = ()
+}
+class B extends A {
+  override def f = None
+  override def remove() = ???
+}
+class C extends B {
+  override def f: Option[String] = Some("goodbye, cruel world")
+  override def remove(): Unit = println("removed! (not really)")
+}

--- a/test/files/pos/t7212b/JavaClient.java
+++ b/test/files/pos/t7212b/JavaClient.java
@@ -1,0 +1,6 @@
+
+public class JavaClient extends ScalaThing {
+	public void remove() {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/test/files/pos/t7212b/JavaThing.java
+++ b/test/files/pos/t7212b/JavaThing.java
@@ -1,0 +1,4 @@
+
+public interface JavaThing {
+	default void remove() { throw new UnsupportedOperationException(); }
+}

--- a/test/files/pos/t7212b/ScalaThing.scala
+++ b/test/files/pos/t7212b/ScalaThing.scala
@@ -1,0 +1,6 @@
+
+// scalac: -Xsource:3
+
+class ScalaThing extends JavaThing {
+  override def remove() = ???
+}


### PR DESCRIPTION
Under `-Xsource:3`, adopt the new rule that the type of an override is inferred from the overridden member, and not from the right-hand side of the overriding element, which may narrow the type unexpectedly. The type can be narrowed by supplying an explicit type.

Fixes scala/bug#7212