### PR TITLE
Add `-Wnonunit-statement` to warn about discarded values in statement position

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1617,8 +1617,22 @@ self =>
           val cond = condExpr()
           newLinesOpt()
           val thenp = expr()
-          val elsep = if (in.token == ELSE) { in.nextToken(); expr() }
-          else literalUnit
+          val elsep =
+            if (in.token == ELSE) {
+              in.nextToken()
+              expr()
+            }
+            else {
+              // user asked to silence warnings on unibranch if; also suppresses value discard
+              if (settings.warnNonUnitIf.isSetByUser && !settings.warnNonUnitIf.value) {
+                thenp match {
+                  case Block(_, res) => res.updateAttachment(TypedExpectingUnitAttachment)
+                  case _ => ()
+                }
+                thenp.updateAttachment(TypedExpectingUnitAttachment)
+              }
+              literalUnit
+            }
           If(cond, thenp, elsep)
         }
         parseIf

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -113,6 +113,10 @@ trait Warnings {
     )
   ) withAbbreviation "-Ywarn-macros"
   val warnDeadCode         = BooleanSetting("-Wdead-code", "Warn when dead code is identified.") withAbbreviation "-Ywarn-dead-code"
+  val warnNonUnitIf        = BooleanSetting("-Wnonunit-if", "Warn when if statements are non-Unit expressions, enabled by -Wnonunit-statement.")
+  import scala.language.existentials
+  val warnNonUnitStatement = BooleanSetting("-Wnonunit-statement", "Warn when block statements are non-Unit expressions.")
+    .enablingIfNotSetByUser(warnNonUnitIf :: Nil)
   val warnValueDiscard     = BooleanSetting("-Wvalue-discard", "Warn when non-Unit expression results are unused.") withAbbreviation "-Ywarn-value-discard"
   val warnNumericWiden     = BooleanSetting("-Wnumeric-widen", "Warn when numerics are widened.") withAbbreviation "-Ywarn-numeric-widen"
   val warnOctalLiteral     = BooleanSetting("-Woctal-literal", "Warn on obsolete octal syntax.") withAbbreviation "-Ywarn-octal-literal"

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1788,7 +1788,6 @@ abstract class RefChecks extends Transform {
       )
       // begin checkInterestingResultInStatement
       settings.warnNonUnitStatement.value && checkInterestingShapes(t) && {
-        val msg = "unused value"
         val where = t match {
           case Block(_, res) => res
           case If(_, thenpart, Literal(Constant(()))) =>
@@ -1798,6 +1797,7 @@ abstract class RefChecks extends Transform {
             }
           case _ => t
         }
+        def msg = s"unused value of type ${where.tpe} (add `: Unit` to discard silently)"
         refchecksWarning(where.pos, msg, WarningCategory.OtherPureStatement)
         true
       }

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1770,7 +1770,7 @@ abstract class RefChecks extends Transform {
       // Parser adds suppressing attachment on `if (b) expr` when user has `-Wnonunit-if:false`.
       def checkInterestingShapes(t: Tree): Boolean =
         t match {
-          case If(_, thenpart, elsepart) => checkInterestingShapes(thenpart) | checkInterestingShapes(elsepart) // strict or
+          case If(_, thenpart, elsepart) => checkInterestingShapes(thenpart) || checkInterestingShapes(elsepart) // either or
           //case Block(_, Apply(label, Nil)) if label.symbol != null && nme.isLoopHeaderLabel(label.symbol.name) => false
           case Block(_, res) => checkInterestingShapes(res)
           case Match(_, cases) => cases.exists(k => checkInterestingShapes(k.body))

--- a/src/compiler/scala/tools/nsc/typechecker/StdAttachments.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/StdAttachments.scala
@@ -196,10 +196,6 @@ trait StdAttachments {
    * track of other adapted trees.
    */
   case class OriginalTreeAttachment(original: Tree)
-
-  /** Marks a Typed tree with Unit tpt. */
-  case object TypedExpectingUnitAttachment
-  def explicitlyUnit(tree: Tree): Boolean = tree.hasAttachment[TypedExpectingUnitAttachment.type]
 }
 
 

--- a/src/reflect/scala/reflect/api/Internals.scala
+++ b/src/reflect/scala/reflect/api/Internals.scala
@@ -530,7 +530,7 @@ trait Internals { self: Universe =>
     /** Set symbol's type signature to given type.
      *  @return the symbol itself
      */
-    def setInfo[S <: Symbol](sym: S, tpe: Type): S
+    def setInfo[S <: Symbol](sym: S, tpe: Type): sym.type
 
     /** Set symbol's annotations to given annotations `annots`.
      */

--- a/src/reflect/scala/reflect/internal/ReificationSupport.scala
+++ b/src/reflect/scala/reflect/internal/ReificationSupport.scala
@@ -60,7 +60,7 @@ trait ReificationSupport { self: SymbolTable =>
     def setAnnotations[S <: Symbol](sym: S, annots: List[AnnotationInfo]): S =
       sym.setAnnotations(annots)
 
-    def setInfo[S <: Symbol](sym: S, tpe: Type): S =
+    def setInfo[S <: Symbol](sym: S, tpe: Type): sym.type =
       sym.setInfo(tpe).markAllCompleted()
 
     def mkThis(sym: Symbol): Tree = self.This(sym)

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -145,4 +145,8 @@ trait StdAttachments {
 
   // Use of _root_ is in correct leading position of selection
   case object RootSelection extends PlainAttachment
+
+  /** Marks a Typed tree with Unit tpt. */
+  case object TypedExpectingUnitAttachment
+  def explicitlyUnit(tree: Tree): Boolean = tree.hasAttachment[TypedExpectingUnitAttachment.type]
 }

--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -356,10 +356,12 @@ abstract class TreeInfo {
    *  where the op is an assignment operator.
    */
   def isThisTypeResult(tree: Tree): Boolean = tree match {
-    case Applied(fun @ Select(receiver, op), _, _) =>
+    case Applied(fun @ Select(receiver, op), _, argss) =>
       tree.tpe match {
-        case ThisType(sym) => sym == receiver.symbol
-        case SingleType(_, sym) => sym == receiver.symbol
+        case ThisType(sym) =>
+          sym == receiver.symbol
+        case SingleType(p, sym) =>
+          sym == receiver.symbol || argss.exists(_.exists(sym == _.symbol))
         case _ =>
           def check(sym: Symbol): Boolean =
             (sym == receiver.symbol) || {

--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -363,7 +363,7 @@ abstract class TreeInfo {
         case SingleType(p, sym) =>
           sym == receiver.symbol || argss.exists(_.exists(sym == _.symbol))
         case _ =>
-          def check(sym: Symbol): Boolean =
+          def checkSingle(sym: Symbol): Boolean =
             (sym == receiver.symbol) || {
               receiver match {
                 case Apply(_, _) => Precedence(op.decoded).level == 0         // xs(i) += x
@@ -374,8 +374,8 @@ abstract class TreeInfo {
           @tailrec def loop(mt: Type): Boolean = mt match {
             case MethodType(_, restpe) =>
               restpe match {
-                case ThisType(sym) => check(sym)
-                case SingleType(_, sym) => check(sym)
+                case ThisType(sym) => checkSingle(sym)
+                case SingleType(_, sym) => checkSingle(sym)
                 case _ => loop(restpe)
               }
             case PolyType(_, restpe) => loop(restpe)

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -77,6 +77,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.ChangeOwnerAttachment
     this.InterpolatedString
     this.RootSelection
+    this.TypedExpectingUnitAttachment
     this.noPrint
     this.typeDebug
     // inaccessible: this.posAssigner

--- a/test/files/neg/nonunit-if.check
+++ b/test/files/neg/nonunit-if.check
@@ -4,52 +4,52 @@ nonunit-if.scala:58: warning: discarded non-Unit value of type U
 nonunit-if.scala:62: warning: discarded non-Unit value of type Boolean
       f(a)                  // warn, check is on
        ^
-nonunit-if.scala:13: warning: unused value
+nonunit-if.scala:13: warning: unused value of type scala.concurrent.Future[Int] (add `: Unit` to discard silently)
     improved              // warn
     ^
-nonunit-if.scala:20: warning: unused value
+nonunit-if.scala:20: warning: unused value of type String (add `: Unit` to discard silently)
     new E().toString      // warn
             ^
-nonunit-if.scala:26: warning: unused value
+nonunit-if.scala:26: warning: unused value of type scala.concurrent.Future[Int] (add `: Unit` to discard silently)
   Future(42)              // warn
         ^
-nonunit-if.scala:30: warning: unused value
+nonunit-if.scala:30: warning: unused value of type K (add `: Unit` to discard silently)
   copy()                  // warn
       ^
-nonunit-if.scala:37: warning: unused value
+nonunit-if.scala:37: warning: unused value of type List[Int] (add `: Unit` to discard silently)
   27 +: xs                // warn
      ^
 nonunit-if.scala:44: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
   null                    // warn for purity
   ^
-nonunit-if.scala:58: warning: unused value
+nonunit-if.scala:58: warning: unused value of type U (add `: Unit` to discard silently)
     if (!isEmpty) f(a)      // warn, check is on
                    ^
-nonunit-if.scala:62: warning: unused value
+nonunit-if.scala:62: warning: unused value of type Boolean (add `: Unit` to discard silently)
       f(a)                  // warn, check is on
        ^
-nonunit-if.scala:73: warning: unused value
+nonunit-if.scala:73: warning: unused value of type U (add `: Unit` to discard silently)
     if (!fellback) action(z)  // warn, check is on
                          ^
-nonunit-if.scala:81: warning: unused value
+nonunit-if.scala:81: warning: unused value of type Int (add `: Unit` to discard silently)
       g   // warn, check is on
       ^
-nonunit-if.scala:79: warning: unused value
+nonunit-if.scala:79: warning: unused value of type Int (add `: Unit` to discard silently)
       g   // warn block statement
       ^
-nonunit-if.scala:86: warning: unused value
+nonunit-if.scala:86: warning: unused value of type Int (add `: Unit` to discard silently)
       g   // warn
       ^
-nonunit-if.scala:84: warning: unused value
+nonunit-if.scala:84: warning: unused value of type Int (add `: Unit` to discard silently)
       g   // warn
       ^
-nonunit-if.scala:96: warning: unused value
+nonunit-if.scala:96: warning: unused value of type Int (add `: Unit` to discard silently)
     if (b) {          // warn, at least one branch looks interesting
     ^
-nonunit-if.scala:116: warning: unused value
+nonunit-if.scala:116: warning: unused value of type scala.collection.mutable.LinkedHashSet[A] (add `: Unit` to discard silently)
     set += a     // warn because cannot know whether the `set` was supposed to be consumed or assigned
         ^
-nonunit-if.scala:146: warning: unused value
+nonunit-if.scala:146: warning: unused value of type String (add `: Unit` to discard silently)
     while (it.hasNext) it.next()  // warn
                               ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/nonunit-if.check
+++ b/test/files/neg/nonunit-if.check
@@ -1,0 +1,57 @@
+nonunit-if.scala:58: warning: discarded non-Unit value of type U
+    if (!isEmpty) f(a)      // warn, check is on
+                   ^
+nonunit-if.scala:62: warning: discarded non-Unit value of type Boolean
+      f(a)                  // warn, check is on
+       ^
+nonunit-if.scala:13: warning: unused value
+    improved              // warn
+    ^
+nonunit-if.scala:20: warning: unused value
+    new E().toString      // warn
+            ^
+nonunit-if.scala:26: warning: unused value
+  Future(42)              // warn
+        ^
+nonunit-if.scala:30: warning: unused value
+  copy()                  // warn
+      ^
+nonunit-if.scala:37: warning: unused value
+  27 +: xs                // warn
+     ^
+nonunit-if.scala:44: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+  null                    // warn for purity
+  ^
+nonunit-if.scala:58: warning: unused value
+    if (!isEmpty) f(a)      // warn, check is on
+                   ^
+nonunit-if.scala:62: warning: unused value
+      f(a)                  // warn, check is on
+       ^
+nonunit-if.scala:73: warning: unused value
+    if (!fellback) action(z)  // warn, check is on
+                         ^
+nonunit-if.scala:81: warning: unused value
+      g   // warn, check is on
+      ^
+nonunit-if.scala:79: warning: unused value
+      g   // warn block statement
+      ^
+nonunit-if.scala:86: warning: unused value
+      g   // warn
+      ^
+nonunit-if.scala:84: warning: unused value
+      g   // warn
+      ^
+nonunit-if.scala:96: warning: unused value
+    if (b) {          // warn, at least one branch looks interesting
+    ^
+nonunit-if.scala:116: warning: unused value
+    set += a     // warn because cannot know whether the `set` was supposed to be consumed or assigned
+        ^
+nonunit-if.scala:146: warning: unused value
+    while (it.hasNext) it.next()  // warn
+                              ^
+error: No warnings can be incurred under -Werror.
+18 warnings
+1 error

--- a/test/files/neg/nonunit-if.scala
+++ b/test/files/neg/nonunit-if.scala
@@ -1,0 +1,191 @@
+// scalac: -Werror -Wnonunit-statement -Wnonunit-if:true -Wvalue-discard
+// debug: -Vprint:refchecks -Yprint-trees:format
+import collection.ArrayOps
+import collection.mutable.{ArrayBuilder, LinkedHashSet, ListBuffer}
+import concurrent._
+import scala.reflect.ClassTag
+
+class C {
+  import ExecutionContext.Implicits._
+  def c = {
+    def improved = Future(42)
+    def stale = Future(27)
+    improved              // warn
+    stale
+  }
+}
+class D {
+  def d = {
+    class E
+    new E().toString      // warn
+    new E().toString * 2
+  }
+}
+class F {
+  import ExecutionContext.Implicits._
+  Future(42)              // warn
+}
+// unused template expression uses synthetic method of class
+case class K(s: String) {
+  copy()                  // warn
+}
+// mutations returning this are ok
+class Mutate {
+  val b = ListBuffer.empty[Int]
+  b += 42                 // nowarn, returns this.type
+  val xs = List(42)
+  27 +: xs                // warn
+
+  def f(x: Int): this.type = this
+  def g(): Unit = f(42)   // nowarn
+}
+// some uninteresting expressions may warn for other reasons
+class WhoCares {
+  null                    // warn for purity
+  ???                     // nowarn for impurity
+}
+// explicit Unit ascription to opt out of warning, even for funky applies
+class Absolution {
+  def f(i: Int): Int = i+1
+  import ExecutionContext.Implicits._
+  Future(42): Unit        // nowarn { F(42)(ctx) }: Unit where annot is on F(42)
+  f(42): Unit             // nowarn
+}
+// warn uni-branched unless user disables it with -Wnonunit-if:false
+class Boxed[A](a: A) {
+  def isEmpty = false
+  def foreach[U](f: A => U): Unit =
+    if (!isEmpty) f(a)      // warn, check is on
+  def forall(f: A => Boolean): Unit =
+    if (!isEmpty) {
+      println(".")
+      f(a)                  // warn, check is on
+    }
+  def take(p: A => Boolean): Option[A] = {
+    while (isEmpty || !p(a)) ()
+    Some(a).filter(p)
+  }
+}
+class Unibranch[A, B] {
+  def runWith[U](action: B => U): A => Boolean = { x =>
+    val z = null.asInstanceOf[B]
+    val fellback = false
+    if (!fellback) action(z)  // warn, check is on
+    !fellback
+  }
+  def f(i: Int): Int = {
+    def g = 17
+    if (i < 42) {
+      g   // warn block statement
+      println("uh oh")
+      g   // warn, check is on
+    }
+    while (i < 42) {
+      g   // warn
+      println("uh oh")
+      g   // warn
+    }
+    42
+  }
+}
+class Dibranch {
+  def i: Int = ???
+  def j: Int = ???
+  def f(b: Boolean): Int = {
+    // if-expr might have an uninteresting LUB
+    if (b) {          // warn, at least one branch looks interesting
+      println("true")
+      i
+    }
+    else {
+      println("false")
+      j
+    }
+    42
+  }
+}
+class Next[A] {
+  val all = ListBuffer.empty[A]
+  def f(it: Iterator[A], g: A => A): Unit =
+    while (it.hasNext)
+      all += g(it.next())   // nowarn
+}
+class Setting[A] {
+  def set = LinkedHashSet.empty[A]
+  def f(a: A): Unit = {
+    set += a     // warn because cannot know whether the `set` was supposed to be consumed or assigned
+    println(set)
+  }
+}
+// neither StringBuilder warns, because either append is Java method or returns this.type
+// while loop looks like if branch with block1(block2, jump to label), where block2 typed as non-unit
+class Strung {
+  def iterator = Iterator.empty[String]
+  def addString(b: StringBuilder, start: String, sep: String, end: String): StringBuilder = {
+    val jsb = b.underlying
+    if (start.length != 0) jsb.append(start)
+    val it = iterator
+    if (it.hasNext) {
+      jsb.append(it.next())
+      while (it.hasNext) {
+        jsb.append(sep)
+        jsb.append(it.next())
+      }
+    }
+    if (end.length != 0) jsb.append(end)
+    b
+  }
+  def f(b: java.lang.StringBuilder, it: Iterator[String]): String = {
+    while (it.hasNext) {
+      b.append("\n")
+      b.append(it.next())
+    }
+    b.toString
+  }
+  def g(b: java.lang.StringBuilder, it: Iterator[String]): String = {
+    while (it.hasNext) it.next()  // warn
+    b.toString
+  }
+}
+class J {
+  import java.util.Collections
+  def xs: java.util.List[Int] = ???
+  def f(): Int = {
+    Collections.checkedList[Int](xs, classOf[Int])
+    42
+  }
+}
+class Variant {
+  var bs = ListBuffer.empty[Int]
+  val xs = ListBuffer.empty[Int]
+  private[this] val ys = ListBuffer.empty[Int]
+  private[this] var zs = ListBuffer.empty[Int]
+  def f(i: Int): Unit = {
+    bs.addOne(i)
+    xs.addOne(i)
+    ys.addOne(i)
+    zs.addOne(i)
+    println("done")
+  }
+}
+final class ArrayOops[A](private val xs: Array[A]) extends AnyVal {
+  def other: ArrayOps[A] = ???
+  def transpose[B](implicit asArray: A => Array[B]): Array[Array[B]] = {
+    val aClass = xs.getClass.getComponentType
+    val bb = new ArrayBuilder.ofRef[Array[B]]()(ClassTag[Array[B]](aClass))
+    if (xs.length == 0) bb.result()
+    else {
+      def mkRowBuilder() = ArrayBuilder.make[B](ClassTag[B](aClass.getComponentType))
+      val bs = new ArrayOps(asArray(xs(0))).map((x: B) => mkRowBuilder())
+      for (xs <- other) {
+        var i = 0
+        for (x <- new ArrayOps(asArray(xs))) {
+          bs(i) += x
+          i += 1
+        }
+      }
+      for (b <- new ArrayOps(bs)) bb += b.result()
+      bb.result()
+    }
+  }
+}

--- a/test/files/neg/nonunit-statement.check
+++ b/test/files/neg/nonunit-statement.check
@@ -1,37 +1,37 @@
-nonunit-statement.scala:13: warning: unused value
+nonunit-statement.scala:13: warning: unused value of type scala.concurrent.Future[Int] (add `: Unit` to discard silently)
     improved              // warn
     ^
-nonunit-statement.scala:20: warning: unused value
+nonunit-statement.scala:20: warning: unused value of type String (add `: Unit` to discard silently)
     new E().toString      // warn
             ^
-nonunit-statement.scala:26: warning: unused value
+nonunit-statement.scala:26: warning: unused value of type scala.concurrent.Future[Int] (add `: Unit` to discard silently)
   Future(42)              // warn
         ^
-nonunit-statement.scala:30: warning: unused value
+nonunit-statement.scala:30: warning: unused value of type K (add `: Unit` to discard silently)
   copy()                  // warn
       ^
-nonunit-statement.scala:37: warning: unused value
+nonunit-statement.scala:37: warning: unused value of type List[Int] (add `: Unit` to discard silently)
   27 +: xs                // warn
      ^
 nonunit-statement.scala:44: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
   null                    // warn for purity
   ^
-nonunit-statement.scala:79: warning: unused value
+nonunit-statement.scala:79: warning: unused value of type Int (add `: Unit` to discard silently)
       g   // warn block statement
       ^
-nonunit-statement.scala:86: warning: unused value
+nonunit-statement.scala:86: warning: unused value of type Int (add `: Unit` to discard silently)
       g   // warn
       ^
-nonunit-statement.scala:84: warning: unused value
+nonunit-statement.scala:84: warning: unused value of type Int (add `: Unit` to discard silently)
       g   // warn
       ^
-nonunit-statement.scala:96: warning: unused value
+nonunit-statement.scala:96: warning: unused value of type Int (add `: Unit` to discard silently)
     if (b) {          // warn, at least one branch looks interesting
     ^
-nonunit-statement.scala:116: warning: unused value
+nonunit-statement.scala:116: warning: unused value of type scala.collection.mutable.LinkedHashSet[A] (add `: Unit` to discard silently)
     set += a     // warn because cannot know whether the `set` was supposed to be consumed or assigned
         ^
-nonunit-statement.scala:146: warning: unused value
+nonunit-statement.scala:146: warning: unused value of type String (add `: Unit` to discard silently)
     while (it.hasNext) it.next()  // warn
                               ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/nonunit-statement.check
+++ b/test/files/neg/nonunit-statement.check
@@ -1,0 +1,39 @@
+nonunit-statement.scala:13: warning: unused value
+    improved              // warn
+    ^
+nonunit-statement.scala:20: warning: unused value
+    new E().toString      // warn
+            ^
+nonunit-statement.scala:26: warning: unused value
+  Future(42)              // warn
+        ^
+nonunit-statement.scala:30: warning: unused value
+  copy()                  // warn
+      ^
+nonunit-statement.scala:37: warning: unused value
+  27 +: xs                // warn
+     ^
+nonunit-statement.scala:44: warning: a pure expression does nothing in statement position; multiline expressions may require enclosing parentheses
+  null                    // warn for purity
+  ^
+nonunit-statement.scala:79: warning: unused value
+      g   // warn block statement
+      ^
+nonunit-statement.scala:86: warning: unused value
+      g   // warn
+      ^
+nonunit-statement.scala:84: warning: unused value
+      g   // warn
+      ^
+nonunit-statement.scala:96: warning: unused value
+    if (b) {          // warn, at least one branch looks interesting
+    ^
+nonunit-statement.scala:116: warning: unused value
+    set += a     // warn because cannot know whether the `set` was supposed to be consumed or assigned
+        ^
+nonunit-statement.scala:146: warning: unused value
+    while (it.hasNext) it.next()  // warn
+                              ^
+error: No warnings can be incurred under -Werror.
+12 warnings
+1 error

--- a/test/files/neg/nonunit-statement.scala
+++ b/test/files/neg/nonunit-statement.scala
@@ -189,3 +189,11 @@ final class ArrayOops[A](private val xs: Array[A]) extends AnyVal {
     }
   }
 }
+class Depends {
+  def f[A](a: A): a.type = a
+  def g() = {
+    val d = new Depends
+    f(d)
+    ()
+  }
+}

--- a/test/files/neg/nonunit-statement.scala
+++ b/test/files/neg/nonunit-statement.scala
@@ -1,0 +1,191 @@
+// scalac: -Werror -Wnonunit-statement -Wnonunit-if:false -Wvalue-discard
+// debug: -Vprint:refchecks -Yprint-trees:format
+import collection.ArrayOps
+import collection.mutable.{ArrayBuilder, LinkedHashSet, ListBuffer}
+import concurrent._
+import scala.reflect.ClassTag
+
+class C {
+  import ExecutionContext.Implicits._
+  def c = {
+    def improved = Future(42)
+    def stale = Future(27)
+    improved              // warn
+    stale
+  }
+}
+class D {
+  def d = {
+    class E
+    new E().toString      // warn
+    new E().toString * 2
+  }
+}
+class F {
+  import ExecutionContext.Implicits._
+  Future(42)              // warn
+}
+// unused template expression uses synthetic method of class
+case class K(s: String) {
+  copy()                  // warn
+}
+// mutations returning this are ok
+class Mutate {
+  val b = ListBuffer.empty[Int]
+  b += 42                 // nowarn, returns this.type
+  val xs = List(42)
+  27 +: xs                // warn
+
+  def f(x: Int): this.type = this
+  def g(): Unit = f(42)   // nowarn
+}
+// some uninteresting expressions may warn for other reasons
+class WhoCares {
+  null                    // warn for purity
+  ???                     // nowarn for impurity
+}
+// explicit Unit ascription to opt out of warning, even for funky applies
+class Absolution {
+  def f(i: Int): Int = i+1
+  import ExecutionContext.Implicits._
+  Future(42): Unit        // nowarn { F(42)(ctx) }: Unit where annot is on F(42)
+  f(42): Unit             // nowarn
+}
+// warn uni-branched unless user disables it with -Wnonunit-if:false
+class Boxed[A](a: A) {
+  def isEmpty = false
+  def foreach[U](f: A => U): Unit =
+    if (!isEmpty) f(a)      // nowarn, check is off
+  def forall(f: A => Boolean): Unit =
+    if (!isEmpty) {
+      println(".")
+      f(a)                  // nowarn, check is off
+    }
+  def take(p: A => Boolean): Option[A] = {
+    while (isEmpty || !p(a)) ()
+    Some(a).filter(p)
+  }
+}
+class Unibranch[A, B] {
+  def runWith[U](action: B => U): A => Boolean = { x =>
+    val z = null.asInstanceOf[B]
+    val fellback = false
+    if (!fellback) action(z)  // nowarn, check is off
+    !fellback
+  }
+  def f(i: Int): Int = {
+    def g = 17
+    if (i < 42) {
+      g   // warn block statement
+      println("uh oh")
+      g   // nowarn, check is off
+    }
+    while (i < 42) {
+      g   // warn
+      println("uh oh")
+      g   // warn
+    }
+    42
+  }
+}
+class Dibranch {
+  def i: Int = ???
+  def j: Int = ???
+  def f(b: Boolean): Int = {
+    // if-expr might have an uninteresting LUB
+    if (b) {          // warn, at least one branch looks interesting
+      println("true")
+      i
+    }
+    else {
+      println("false")
+      j
+    }
+    42
+  }
+}
+class Next[A] {
+  val all = ListBuffer.empty[A]
+  def f(it: Iterator[A], g: A => A): Unit =
+    while (it.hasNext)
+      all += g(it.next())   // nowarn
+}
+class Setting[A] {
+  def set = LinkedHashSet.empty[A]
+  def f(a: A): Unit = {
+    set += a     // warn because cannot know whether the `set` was supposed to be consumed or assigned
+    println(set)
+  }
+}
+// neither StringBuilder warns, because either append is Java method or returns this.type
+// while loop looks like if branch with block1(block2, jump to label), where block2 typed as non-unit
+class Strung {
+  def iterator = Iterator.empty[String]
+  def addString(b: StringBuilder, start: String, sep: String, end: String): StringBuilder = {
+    val jsb = b.underlying
+    if (start.length != 0) jsb.append(start)
+    val it = iterator
+    if (it.hasNext) {
+      jsb.append(it.next())
+      while (it.hasNext) {
+        jsb.append(sep)
+        jsb.append(it.next())
+      }
+    }
+    if (end.length != 0) jsb.append(end)
+    b
+  }
+  def f(b: java.lang.StringBuilder, it: Iterator[String]): String = {
+    while (it.hasNext) {
+      b.append("\n")
+      b.append(it.next())
+    }
+    b.toString
+  }
+  def g(b: java.lang.StringBuilder, it: Iterator[String]): String = {
+    while (it.hasNext) it.next()  // warn
+    b.toString
+  }
+}
+class J {
+  import java.util.Collections
+  def xs: java.util.List[Int] = ???
+  def f(): Int = {
+    Collections.checkedList[Int](xs, classOf[Int])
+    42
+  }
+}
+class Variant {
+  var bs = ListBuffer.empty[Int]
+  val xs = ListBuffer.empty[Int]
+  private[this] val ys = ListBuffer.empty[Int]
+  private[this] var zs = ListBuffer.empty[Int]
+  def f(i: Int): Unit = {
+    bs.addOne(i)
+    xs.addOne(i)
+    ys.addOne(i)
+    zs.addOne(i)
+    println("done")
+  }
+}
+final class ArrayOops[A](private val xs: Array[A]) extends AnyVal {
+  def other: ArrayOps[A] = ???
+  def transpose[B](implicit asArray: A => Array[B]): Array[Array[B]] = {
+    val aClass = xs.getClass.getComponentType
+    val bb = new ArrayBuilder.ofRef[Array[B]]()(ClassTag[Array[B]](aClass))
+    if (xs.length == 0) bb.result()
+    else {
+      def mkRowBuilder() = ArrayBuilder.make[B](ClassTag[B](aClass.getComponentType))
+      val bs = new ArrayOps(asArray(xs(0))).map((x: B) => mkRowBuilder())
+      for (xs <- other) {
+        var i = 0
+        for (x <- new ArrayOps(asArray(xs))) {
+          bs(i) += x
+          i += 1
+        }
+      }
+      for (b <- new ArrayOps(bs)) bb += b.result()
+      bb.result()
+    }
+  }
+}

--- a/test/files/neg/value-discard.check
+++ b/test/files/neg/value-discard.check
@@ -1,11 +1,11 @@
 value-discard.scala:6: warning: discarded non-Unit value of type Boolean
-    mutable.Set[String]().remove("")   // expected to warn
+    mutable.Set[String]().remove("")   // warn because suspicious receiver
                                 ^
 value-discard.scala:13: warning: discarded non-Unit value of type scala.collection.mutable.Set[String]
-  def subtract(): Unit = mutable.Set.empty[String].subtractOne("")     // warn
+  def subtract(): Unit = mutable.Set.empty[String].subtractOne("")     // warn because suspicious receiver
                                                               ^
 value-discard.scala:17: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
-    ""                         // warn
+    ""                         // warn pure expr
     ^
 error: No warnings can be incurred under -Werror.
 3 warnings

--- a/test/files/neg/value-discard.scala
+++ b/test/files/neg/value-discard.scala
@@ -1,21 +1,21 @@
-// scalac: -Ywarn-value-discard -Xfatal-warnings
+// scalac: -Wvalue-discard -Werror
 final class UnusedTest {
   import scala.collection.mutable
 
   def remove(): Unit = {
-    mutable.Set[String]().remove("")   // expected to warn
+    mutable.Set[String]().remove("")   // warn because suspicious receiver
   }
 
   def removeAscribed(): Unit = {
-    mutable.Set[String]().remove(""): Unit    // no warn
+    mutable.Set[String]().remove(""): Unit    // nowarn
   }
 
-  def subtract(): Unit = mutable.Set.empty[String].subtractOne("")     // warn
+  def subtract(): Unit = mutable.Set.empty[String].subtractOne("")     // warn because suspicious receiver
 
   def warnings(): Unit = {
     val s: mutable.Set[String] = mutable.Set.empty[String]
-    ""                         // warn
-    "": Unit                   // no warn
-    s.subtractOne("")          // no warn
+    ""                         // warn pure expr
+    "": Unit                   // nowarn
+    s.subtractOne("")          // nowarn
   }
 }

--- a/test/files/neg/virtpatmat_unreach_select.scala
+++ b/test/files/neg/virtpatmat_unreach_select.scala
@@ -1,4 +1,4 @@
-// scalac: -Xfatal-warnings
+// scalac: -Werror
 //
 class Test {
   object severity extends Enumeration

--- a/test/files/pos/skunky-expansion.scala
+++ b/test/files/pos/skunky-expansion.scala
@@ -1,0 +1,31 @@
+// scalac: -Werror -Wnonunit-statement
+//
+import scala.reflect.macros._
+import scala.reflect.api.TypeCreator
+
+abstract trait Encoder[A] extends scala.AnyRef;
+object StringContextOps extends scala.AnyRef {
+  class StringOpsMacros(c: scala.reflect.macros.whitebox.Context) extends scala.AnyRef {
+    def sql_impl(argSeq: StringOpsMacros.this.c.universe.Tree*): AnyRef = {
+      val EncoderType: StringOpsMacros.this.c.universe.Type = StringOpsMacros.this.c.universe.typeOf[Encoder[_]](({
+        val $u: StringOpsMacros.this.c.universe.type = StringOpsMacros.this.c.universe;
+        val $m: $u.Mirror = StringOpsMacros.this.c.universe.rootMirror;
+        $u.TypeTag.apply[Encoder[_]]($m, {
+          final class $typecreator1 extends TypeCreator {
+            def apply[U <: scala.reflect.api.Universe with Singleton]($m$untyped: scala.reflect.api.Mirror[U]): U#Type = {
+              val $u: U = $m$untyped.universe;
+              val $m: $u.Mirror = $m$untyped.asInstanceOf[$u.Mirror];
+              val symdef$EncoderType1: $u.Symbol = $u.internal.reificationSupport.newNestedSymbol($u.internal.reificationSupport.selectTerm($u.internal.reificationSupport.selectType($m.staticModule("StringContextOps").asModule.moduleClass, "StringOpsMacros"), "sql_impl"), $u.TermName.apply("EncoderType"), $u.NoPosition, $u.internal.reificationSupport.FlagsRepr.apply(549755813888L), false);
+              val symdef$_$11: $u.Symbol = $u.internal.reificationSupport.newNestedSymbol(symdef$EncoderType1, $u.TypeName.apply("_$1"), $u.NoPosition, $u.internal.reificationSupport.FlagsRepr.apply(34359738384L), false);
+              $u.internal.reificationSupport.setInfo[$u.Symbol](symdef$EncoderType1, $u.NoType);
+              $u.internal.reificationSupport.setInfo[$u.Symbol](symdef$_$11, $u.internal.reificationSupport.TypeBounds($m.staticClass("scala.Nothing").asType.toTypeConstructor, $m.staticClass("scala.Any").asType.toTypeConstructor));
+              $u.internal.reificationSupport.ExistentialType(scala.collection.immutable.List.apply[$u.Symbol](symdef$_$11), $u.internal.reificationSupport.TypeRef($u.internal.reificationSupport.thisPrefix($m.EmptyPackageClass), $m.staticClass("Encoder"), scala.collection.immutable.List.apply[$u.Type]($u.internal.reificationSupport.TypeRef($u.NoPrefix, symdef$_$11, scala.collection.immutable.Nil))))
+            }
+          };
+          new $typecreator1()
+        })
+      }: StringOpsMacros.this.c.universe.TypeTag[Encoder[_]]));
+      argSeq.head
+    }
+  }
+}

--- a/test/files/pos/skunky.scala
+++ b/test/files/pos/skunky.scala
@@ -1,0 +1,15 @@
+// scalac: -Werror -Wnonunit-statement
+
+import scala.reflect.macros._
+
+trait Encoder[A]
+
+object StringContextOps {
+  class StringOpsMacros(val c: whitebox.Context) {
+    import c.universe._
+    def sql_impl(argSeq: Tree*): Tree = {
+      val EncoderType = typeOf[Encoder[_]]
+      argSeq.head
+    }
+  }
+}


### PR DESCRIPTION
## Summary

New compiler option `-Wnonunit-statement` warns about any interesting expression whose value is ignored because it is followed by another expression.

The new warnings are not included in `-Xlint`; they must be separately enabled with `-Wnonunit-statement`. Users of `-Wnonunit-statement` may also wish to enable a related option, `-Wvalue-discard`.

## Example

```scala
scala> :settings -Wnonunit-statement
scala> Some(3); "hello"
           ^
       warning: unused value
val res0: String = hello
```

## How to silence

The warning can be suppressed at a particular site by explicit ascription: `e: Unit`. This is the same convention used to ignore warnings about "value discard" conversions.

As always, any warning is also suppressible with `@nowarn`.

## Relation to other warnings

This generalizes the current warning for "pure" expressions, which only warns for limited cases where the expression can be proved not to be side-effecting.

`-Wvalue-discard` remains separate. It warns only when a value is discarded because it's the final expression in a block whose expected type is `Unit`, as [specified by the language](https://scala-lang.org/files/archive/spec/2.13/06-expressions.html#value-conversions).

## Details on what warns or doesn't

"Statement position" means statements in templates (i.e., constructors) and statements in blocks (everything in a block except the result expression). If a statement is an expression (and not a definition or assignment), then `-Wnonunit-statement` warns if the type of the expression is not `Unit`. There are heuristic exceptions, such as for methods that return `this.type`, where there is no loss of information. (The method is inherently side-effecting.) There is an additional flag whether to take an `if` statement as side-effecting, so that its result can be ignored.

By default, warns about `if` without `else`. Specify `-Wnonunit-if:false` to turn that off. (That also turns off `-Wvalue-discard` for those cases.)

The heuristic for `this.type`-returning methods intends to accommodate usual idioms updating unstable values.

## Motivation

As requested on Discord!

This is especially useful in pure-functional code where it's unusual for values ever to be intentionally discarded.