### PR TITLE
upgrade tasty reader tests for Scala 3.1.1

### DIFF
--- a/project/DottySupport.scala
+++ b/project/DottySupport.scala
@@ -12,7 +12,7 @@ import sbt.librarymanagement.{
   * Settings to support validation of TastyUnpickler against the release of dotty with the matching TASTy version
   */
 object TastySupport {
-  val supportedTASTyRelease = "3.1.0" // TASTy version 28.1-0
+  val supportedTASTyRelease = "3.1.1-RC2" // TASTy version 28.1-0
   val scala3Compiler = "org.scala-lang" % "scala3-compiler_3" % supportedTASTyRelease
   val scala3Library = "org.scala-lang" % "scala3-library_3" % supportedTASTyRelease
 

--- a/test/tasty/neg-move-macros/src-3/MacroCompat.scala
+++ b/test/tasty/neg-move-macros/src-3/MacroCompat.scala
@@ -6,10 +6,8 @@ import scala.annotation.experimental
 
 object MacroCompat {
 
-  @experimental
   implicit def pos: Position = macro Macros.posImpl // implemented in test/tasty/run/pre/tastytest/package.scala
 
-  @experimental
   implicit inline def pos: Position = ${ Macros3.posImpl }
 
   def testCase(test: => Any)(using Position): String =

--- a/test/tasty/pos/src-3/tastytest/AnythingIsPossible.scala
+++ b/test/tasty/pos/src-3/tastytest/AnythingIsPossible.scala
@@ -15,7 +15,7 @@ object AnythingIsPossible {
 
   type IntSpecial = Int @unchecked
 
-  class Match extends Box((0: @unchecked) match {
+  class Match extends Box((0: Int @unchecked) match {
     case n if n > 50    => "big"
     case 26 | 24        => "26 | 24"
     case a @ _ if a > 0 => "small"

--- a/test/tasty/run/src-3/tastytest/AnythingIsPossible.scala
+++ b/test/tasty/run/src-3/tastytest/AnythingIsPossible.scala
@@ -15,7 +15,7 @@ object AnythingIsPossible {
 
   type IntSpecial = Int @unchecked
 
-  class Match extends Box((0: @unchecked) match {
+  class Match extends Box((0: Int @unchecked) match {
     case n if n > 50    => "big"
     case 26 | 24        => "26 | 24"
     case a @ _ if a > 0 => "small"

--- a/test/tasty/run/src-3/tastytest/InlineCompat.scala
+++ b/test/tasty/run/src-3/tastytest/InlineCompat.scala
@@ -8,10 +8,8 @@ import scala.annotation.experimental
 
 object InlineCompat {
 
-  @experimental
   def foo(code: String): String = macro InlineCompatScala2Macro.foo
 
-  @experimental
   inline def foo(inline code: String): String = code // inline method, not macro
 
 }

--- a/test/tasty/run/src-3/tastytest/InlineCompat2.scala
+++ b/test/tasty/run/src-3/tastytest/InlineCompat2.scala
@@ -8,10 +8,8 @@ import scala.annotation.experimental
 
 object InlineCompat2 {
 
-  @experimental
   def foo(code: String): String = macro InnerScala2MacroImpl.fooImpl
 
-  @experimental
   inline def foo(inline code: String): String = code // inline method, not macro
 
   object InnerScala2MacroImpl {

--- a/test/tasty/run/src-3/tastytest/MacroCompat.scala
+++ b/test/tasty/run/src-3/tastytest/MacroCompat.scala
@@ -6,30 +6,20 @@ import scala.annotation.experimental
 
 object MacroCompat {
 
-  @experimental
   implicit def pos: Position = macro Position.posImpl
-
-  @experimental
   implicit inline def pos: Position = ${ Macros3.posImpl }
 
-  @experimental
   def constInt[T](x: T): Int = macro Macros.constIntImpl[T]
-
-  @experimental
   inline def constInt[T](x: T): Int = ${ Macros3.constIntImpl[T]('x) }
 
   object Bundles {
-    @experimental
-    def mono: Int = macro MacroImpl.mono
 
-    @experimental
+    def mono: Int = macro MacroImpl.mono
     inline def mono: Int = ${ Macros3.monoImpl }
 
-    @experimental
     def poly[T]: String = macro MacroImpl.poly[T]
-
-    @experimental
     inline def poly[T]: String = ${ Macros3.polyImpl[T] }
+
   }
 
   def testCase(test: => Any)(implicit pos: Position): (String, Position) =


### PR DESCRIPTION
Scala 3.1.1 lets the dual Scala 2/3 macros be defined together without the experimental annotation, so this PR just upgrades the Scala 3 version used for compiling test cases to TASTy