### PR TITLE
Remove `.git` suffix from scm.url in POM file

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -186,7 +186,7 @@ lazy val commonSettings = instanceSettings ++ clearSourceAndResourceDirectories 
   pomExtra := {
     <scm>
       <connection>scm:git:git://github.com/scala/scala.git</connection>
-      <url>https://github.com/scala/scala.git</url>
+      <url>https://github.com/scala/scala</url>
     </scm>
       <issueManagement>
         <system>GitHub</system>


### PR DESCRIPTION
This removes the `.git` suffix from the `url.scm` element in the POM file generated by sbt.
This helps Scala Steward to link to release notes and version diffs for future Scala releases.
GitHub also redirects https://github.com/scala/scala.git to https://github.com/scala/scala
which indicates that the latter is the canonical URL of this repo.