### PR TITLE
Avoid spurious "illegal trait super target" error

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Mixin.scala
+++ b/src/compiler/scala/tools/nsc/transform/Mixin.scala
@@ -103,10 +103,9 @@ abstract class Mixin extends Transform with ast.TreeDSL with AccessorSynthesis {
    *  @param acc        The symbol statically referred to by the superaccessor in the trait
    *  @param mixinClass The mixin class that produced the superaccessor
    */
-  private def rebindSuper(base: Symbol, acc: Symbol, mixinClass: Symbol): Symbol = {
-    val site = base.thisType
-
+  private def rebindSuper(base: Symbol, acc: Symbol, mixinClass: Symbol): Symbol =
     exitingSpecialize {
+      val site = base.thisType
       // the specialized version T$sp of a trait T will have a super accessor that has the same alias
       // as the super accessor in trait T; we must rebind super
       // from the vantage point of the original trait T, not the specialized T$sp
@@ -138,7 +137,6 @@ abstract class Mixin extends Transform with ast.TreeDSL with AccessorSynthesis {
 
       sym
     }
-  }
 
 // --------- type transformation -----------------------------------------------
 

--- a/test/files/pos/t12520.scala
+++ b/test/files/pos/t12520.scala
@@ -1,0 +1,16 @@
+class Outcome
+trait TestSuite {
+  protected trait NoArgTest extends (() => Outcome)
+  protected def withFixture(test: NoArgTest): Outcome = test()
+}
+
+trait TestSuiteMixin { this: TestSuite =>
+  protected def withFixture(test: NoArgTest): Outcome
+}
+
+trait TimeLimitedTests extends TestSuiteMixin { this: TestSuite =>
+  abstract override def withFixture(test: NoArgTest): Outcome = super.withFixture(test)
+}
+
+trait AnyFunSuiteLike extends TestSuite
+abstract class Test[C] extends AnyFunSuiteLike with TimeLimitedTests


### PR DESCRIPTION
Time travelling is a risky venture

Fixes scala/bug#12520

Follow-up for https://github.com/scala/scala/pull/7641