### PR TITLE
Lint unset private[this] vars

### DIFF
--- a/test/files/neg/warn-unused-privates.check
+++ b/test/files/neg/warn-unused-privates.check
@@ -22,54 +22,63 @@ warn-unused-privates.scala:41: warning: private val hummer in class Boppy is nev
 warn-unused-privates.scala:48: warning: private var v1 in trait Accessors is never used
   private var v1: Int = 0 // warn
               ^
-warn-unused-privates.scala:49: warning: private var v2 in trait Accessors is never used
+warn-unused-privates.scala:49: warning: private var v2 in trait Accessors is never updated: consider using immutable val
   private var v2: Int = 0 // warn, never set
               ^
 warn-unused-privates.scala:50: warning: private var v3 in trait Accessors is never used
   private var v3: Int = 0 // warn, never got
               ^
-warn-unused-privates.scala:61: warning: private var s1 in class StableAccessors is never used
+warn-unused-privates.scala:53: warning: private var v5 in trait Accessors is never updated: consider using immutable val
+  private[this] var v5 = 0 // warn, never set
+                    ^
+warn-unused-privates.scala:54: warning: private var v6 in trait Accessors is never used
+  private[this] var v6 = 0 // warn, never got
+                    ^
+warn-unused-privates.scala:67: warning: private var s1 in class StableAccessors is never used
   private var s1: Int = 0 // warn
               ^
-warn-unused-privates.scala:62: warning: private var s2 in class StableAccessors is never updated: consider using immutable val
+warn-unused-privates.scala:68: warning: private var s2 in class StableAccessors is never updated: consider using immutable val
   private var s2: Int = 0 // warn, never set
               ^
-warn-unused-privates.scala:63: warning: private var s3 in class StableAccessors is never used
+warn-unused-privates.scala:69: warning: private var s3 in class StableAccessors is never used
   private var s3: Int = 0 // warn, never got
               ^
-warn-unused-privates.scala:75: warning: private default argument in trait DefaultArgs is never used
+warn-unused-privates.scala:87: warning: private default argument in trait DefaultArgs is never used
   private def bippy(x1: Int, x2: Int = 10, x3: Int = 15): Int = x1 + x2 + x3
                              ^
-warn-unused-privates.scala:75: warning: private default argument in trait DefaultArgs is never used
+warn-unused-privates.scala:87: warning: private default argument in trait DefaultArgs is never used
   private def bippy(x1: Int, x2: Int = 10, x3: Int = 15): Int = x1 + x2 + x3
                                            ^
-warn-unused-privates.scala:108: warning: private object Dongo in object Types is never used
+warn-unused-privates.scala:120: warning: private object Dongo in object Types is never used
   private object Dongo { def f = this } // warn
                  ^
-warn-unused-privates.scala:141: warning: private method x_= in class OtherNames is never used
+warn-unused-privates.scala:153: warning: private method x_= in class OtherNames is never used
   private def x_=(i: Int): Unit = ()
               ^
-warn-unused-privates.scala:142: warning: private method x in class OtherNames is never used
+warn-unused-privates.scala:154: warning: private method x in class OtherNames is never used
   private def x: Int = 42
               ^
-warn-unused-privates.scala:143: warning: private method y_= in class OtherNames is never used
+warn-unused-privates.scala:155: warning: private method y_= in class OtherNames is never used
   private def y_=(i: Int): Unit = ()
               ^
-warn-unused-privates.scala:109: warning: private class Bar1 in object Types is never used
+warn-unused-privates.scala:121: warning: private class Bar1 in object Types is never used
   private class Bar1 // warn
                 ^
-warn-unused-privates.scala:111: warning: private type Alias1 in object Types is never used
+warn-unused-privates.scala:123: warning: private type Alias1 in object Types is never used
   private type Alias1 = String // warn
                ^
-warn-unused-privates.scala:221: warning: private class for your eyes only in object not even using companion privates is never used
+warn-unused-privates.scala:233: warning: private class for your eyes only in object not even using companion privates is never used
   private implicit class `for your eyes only`(i: Int) {  // warn
                          ^
-warn-unused-privates.scala:237: warning: private class D in class nonprivate alias is enclosing is never used
+warn-unused-privates.scala:249: warning: private class D in class nonprivate alias is enclosing is never used
   private class D extends C2   // warn
                 ^
-warn-unused-privates.scala:102: warning: local var x in method f2 is never updated: consider using immutable val
+warn-unused-privates.scala:72: warning: local var s5 in class StableAccessors is never updated: consider using immutable val
+  private[this] var s5 = 0 // warn, never set
+                    ^
+warn-unused-privates.scala:114: warning: local var x in method f2 is never updated: consider using immutable val
     var x = 100 // warn about it being a var
         ^
 error: No warnings can be incurred under -Werror.
-24 warnings
+27 warnings
 1 error

--- a/test/files/neg/warn-unused-privates.scala
+++ b/test/files/neg/warn-unused-privates.scala
@@ -50,10 +50,16 @@ trait Accessors {
   private var v3: Int = 0 // warn, never got
   private var v4: Int = 0 // no warn
 
+  private[this] var v5 = 0 // warn, never set
+  private[this] var v6 = 0 // warn, never got
+  private[this] var v7 = 0 // no warn
+
   def bippy(): Int = {
-    v3 = 5
-    v4 = 6
-    v2 + v4
+    v3 = 3
+    v4 = 4
+    v6 = 6
+    v7 = 7
+    v2 + v4 + v5 + v7
   }
 }
 
@@ -63,10 +69,16 @@ class StableAccessors {
   private var s3: Int = 0 // warn, never got
   private var s4: Int = 0 // no warn
 
+  private[this] var s5 = 0 // warn, never set
+  private[this] var s6 = 0 // no warn, limitation
+  private[this] var s7 = 0 // no warn
+
   def bippy(): Int = {
-    s3 = 5
-    s4 = 6
-    s2 + s4
+    s3 = 3
+    s4 = 4
+    s6 = 6
+    s7 = 7
+    s2 + s4 + s5 + s7
   }
 }
 


### PR DESCRIPTION
`private[this]` vars don't have setters except in traits, where both `isVar` and `isSetter` is true

Fixes scala/bug#12515 but there is still a limitation - no warning on vars without setters which are only updated 