### PR TITLE
Avoid sys.props

### DIFF
--- a/project/genprod.scala
+++ b/project/genprod.scala
@@ -100,14 +100,15 @@ zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz */
 object FunctionZero extends Function(0) {
   override def genprodString  = "\n// genprod generated these sources at: " + java.time.Instant.now()
   override def covariantSpecs = "@specialized(Specializable.Primitives) "
-  override def descriptiveComment = "  " + functionNTemplate.format("javaVersion", "anonfun0",
-"""
- *    val javaVersion = () => sys.props("java.version")
+  override def descriptiveComment = "  " + functionNTemplate.format("greeting", "anonfun0",
+raw"""
+ *    val name = "world"
+ *    val greeting = () => s"hello, $$name"
  *
  *    val anonfun0 = new Function0[String] {
- *      def apply(): String = sys.props("java.version")
+ *      def apply(): String = s"hello, $$name"
  *    }
- *    assert(javaVersion() == anonfun0())
+ *    assert(greeting() == anonfun0())
  * """)
   override def moreMethods = ""
 }
@@ -207,8 +208,10 @@ class Function(val i: Int) extends Group("Function") with Arity {
   def descriptiveComment  = ""
   def functionNTemplate =
 """
- *  In the following example, the definition of %s is a
- *  shorthand for the anonymous class definition %s:
+ *  In the following example, the definition of `%s` is
+ *  shorthand, conceptually, for the anonymous class definition
+ *  `%s`, although the implementation details of how the
+ *  function value is constructed may differ:
  *
  *  {{{
  *  object Main extends App {%s}

--- a/src/library/scala/Function0.scala
+++ b/src/library/scala/Function0.scala
@@ -11,24 +11,27 @@
  */
 
 // GENERATED CODE: DO NOT EDIT.
-// genprod generated these sources at: 2020-02-01T04:13:22.795Z
+// genprod generated these sources at: 2022-01-17T20:47:12.170348200Z
 
 package scala
 
 
 /** A function of 0 parameters.
  *  
- *  In the following example, the definition of javaVersion is a
- *  shorthand for the anonymous class definition anonfun0:
+ *  In the following example, the definition of `greeting` is
+ *  shorthand, conceptually, for the anonymous class definition
+ *  `anonfun0`, although the implementation details of how the
+ *  function value is constructed may differ:
  *
  *  {{{
  *  object Main extends App {
- *    val javaVersion = () => sys.props("java.version")
+ *    val name = "world"
+ *    val greeting = () => s"hello, $name"
  *
  *    val anonfun0 = new Function0[String] {
- *      def apply(): String = sys.props("java.version")
+ *      def apply(): String = s"hello, $name"
  *    }
- *    assert(javaVersion() == anonfun0())
+ *    assert(greeting() == anonfun0())
  * }
  *  }}}
  */

--- a/src/library/scala/Function1.scala
+++ b/src/library/scala/Function1.scala
@@ -45,8 +45,10 @@ object Function1 {
 
 /** A function of 1 parameter.
  *  
- *  In the following example, the definition of succ is a
- *  shorthand for the anonymous class definition anonfun1:
+ *  In the following example, the definition of `succ` is
+ *  shorthand, conceptually, for the anonymous class definition
+ *  `anonfun1`, although the implementation details of how the
+ *  function value is constructed may differ:
  *
  *  {{{
  *  object Main extends App {

--- a/src/library/scala/Function2.scala
+++ b/src/library/scala/Function2.scala
@@ -17,8 +17,10 @@ package scala
 
 /** A function of 2 parameters.
  *  
- *  In the following example, the definition of max is a
- *  shorthand for the anonymous class definition anonfun2:
+ *  In the following example, the definition of `max` is
+ *  shorthand, conceptually, for the anonymous class definition
+ *  `anonfun2`, although the implementation details of how the
+ *  function value is constructed may differ:
  *
  *  {{{
  *  object Main extends App {

--- a/src/reflect/scala/reflect/io/ZipArchive.scala
+++ b/src/reflect/scala/reflect/io/ZipArchive.scala
@@ -14,6 +14,7 @@ package scala
 package reflect
 package io
 
+import java.lang.Boolean.{getBoolean => booleanProperty}
 import java.net.URL
 import java.io.{ByteArrayInputStream, FilterInputStream, IOException, InputStream}
 import java.io.{File => JFile}
@@ -34,7 +35,7 @@ import ZipArchive._
  *  ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''
  */
 object ZipArchive {
-  private[io] val closeZipFile = sys.props.get("scala.classpath.closeZip").map(_.toBoolean).getOrElse(false)
+  private[io] val closeZipFile = booleanProperty("scala.classpath.closeZip")
 
   private[io] final val RootEntry = "/"
 


### PR DESCRIPTION
Per https://github.com/scala/scala/pull/5830 and there's no great reason to use it.

In particular, avoiding the paulp promotion in function docs, which should commit less to implementation details.

The other usage of `sys.props` fell between cracks of the linked PR that spring.