### PR TITLE
Avoid crash on message with missing type params

### DIFF
--- a/src/compiler/scala/reflect/macros/compiler/Validators.scala
+++ b/src/compiler/scala/reflect/macros/compiler/Validators.scala
@@ -54,15 +54,15 @@ trait Validators {
       // we only check strict correspondence between value parameterss
       // type parameters of macro defs and macro impls don't have to coincide with each other
       if (aparamss.sizeCompare(rparamss) != 0) MacroImplParamssMismatchError()
-      foreach2(aparamss, rparamss)((aparams, rparams) => {
+      foreach2(aparamss, rparamss) { (aparams, rparams) =>
         if (aparams.sizeCompare(rparams) < 0) MacroImplMissingParamsError(aparams, rparams)
         if (rparams.sizeCompare(aparams) < 0) MacroImplExtraParamsError(aparams, rparams)
-      })
+      }
 
       try {
-        // cannot fuse this map2 and the map2 above because if aparamss.flatten != rparamss.flatten
+        // cannot fuse this foreach2 and the foreach2 above because if aparamss.flatten != rparamss.flatten
         // then `atpeToRtpe` is going to fail with an unsound substitution
-        map2(aparamss.flatten, rparamss.flatten)((aparam, rparam) => {
+        foreach2(aparamss.flatten, rparamss.flatten) { (aparam, rparam) =>
           if (aparam.name != rparam.name && !rparam.isSynthetic) MacroImplParamNameMismatchError(aparam, rparam)
           if (isRepeated(aparam) ^ isRepeated(rparam)) MacroImplVarargMismatchError(aparam, rparam)
           val aparamtpe = aparam.tpe match {
@@ -70,7 +70,7 @@ trait Validators {
             case tpe => tpe
           }
           checkMacroImplParamTypeMismatch(atpeToRtpe(aparamtpe), rparam)
-        })
+        }
 
         checkMacroImplResultTypeMismatch(atpeToRtpe(aret), rret)
 

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -1224,16 +1224,16 @@ trait ContextErrors extends splain.SplainErrors {
           kindErrors.toList.mkString("\n", ", ", ""))
       }
 
-      private[scala] def NotWithinBoundsErrorMessage(prefix: String, targs: List[Type], tparams: List[Symbol], explaintypes: Boolean) = {
+      private[scala] def NotWithinBoundsErrorMessage(prefix: String, targs: List[Type], tparams: List[Symbol], explaintypes: Boolean): String = {
         if (explaintypes) {
-          val bounds = tparams map (tp => tp.info.instantiateTypeParams(tparams, targs).bounds)
+          val bounds = tparams.map(_.info.instantiateTypeParams(tparams, targs).bounds)
           foreach2(targs, bounds)((targ, bound) => explainTypes(bound.lo, targ))
           foreach2(targs, bounds)((targ, bound) => explainTypes(targ, bound.hi))
         }
+        def bracketed(items: List[_]) = items.mkString("[", ",", "]")
+        val bounds = tparams.headOption.map(h => s"${h.owner}'s type parameter bounds ${bracketed(tparams.map(_.defString))}").getOrElse("empty type parameter list")
 
-        prefix + "type arguments " + targs.mkString("[", ",", "]") +
-        " do not conform to " + tparams.head.owner + "'s type parameter bounds " +
-        (tparams map (_.defString)).mkString("[", ",", "]")
+        s"${prefix}type arguments ${bracketed(targs)} do not conform to ${bounds}"
       }
 
       def NotWithinBounds(tree: Tree, prefix: String, targs: List[Type],

--- a/test/files/neg/t10700-message.check
+++ b/test/files/neg/t10700-message.check
@@ -1,0 +1,4 @@
+usage_2.scala:3: error: test type arguments [Int] do not conform to empty type parameter list
+  println(scala.testing.Macros.m[Int])
+                                ^
+1 error

--- a/test/files/neg/t10700-message/macros_1.scala
+++ b/test/files/neg/t10700-message/macros_1.scala
@@ -1,0 +1,26 @@
+
+package scala
+package testing
+
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox.Context
+
+object Macros {
+  def m[A]: String = macro Impls.mImpl[A]
+}
+
+object Impls {
+  def mImpl[A : c.WeakTypeTag](c: Context): c.Expr[String] = {
+    import c._
+    val g = universe.asInstanceOf[scala.tools.nsc.Global]
+    import g.typer.infer.InferErrorGen._
+    val t = implicitly[c.WeakTypeTag[A]].tpe.asInstanceOf[g.analyzer.global.Type]
+    val msg = NotWithinBoundsErrorMessage(prefix = "test ", targs = List(t), tparams = Nil, explaintypes = false)
+    abort(macroApplication.pos, msg)
+    Expr[String] {
+      import universe._
+      Literal(Constant(msg))
+    }
+  }
+}
+// was: java.util.NoSuchElementException: head of empty list

--- a/test/files/neg/t10700-message/usage_2.scala
+++ b/test/files/neg/t10700-message/usage_2.scala
@@ -1,0 +1,4 @@
+
+object usage extends App {
+  println(scala.testing.Macros.m[Int])
+}


### PR DESCRIPTION
Mitigates scala/bug#10700

Just avoid crashing if the incoming type params are empty. The extant test cases error before generating the message.

Note that macros don't check type args if no type params on impl method.

Also follow up previous `foreach2` opt with another.