### PR TITLE
minor cleanup: avoid importing language.experimental._

### DIFF
--- a/test/files/pos/t7046-2/Macros_1.scala
+++ b/test/files/pos/t7046-2/Macros_1.scala
@@ -1,7 +1,7 @@
 package p1
 
 import scala.reflect.macros.blackbox._
-import language.experimental._
+import language.experimental.macros
 
 object Macro {
   def impl(c: Context): c.Tree = {

--- a/test/files/pos/t7377/Macro_1.scala
+++ b/test/files/pos/t7377/Macro_1.scala
@@ -1,4 +1,4 @@
-import language.experimental._
+import language.experimental.macros
 import scala.reflect.macros.blackbox.Context
 
 object M {

--- a/test/files/pos/t7987/Macro_1.scala
+++ b/test/files/pos/t7987/Macro_1.scala
@@ -1,4 +1,4 @@
-import scala.language.experimental._
+import scala.language.experimental.macros
 
 object Macro {
   def apply[A](a: A): A = macro impl[A]

--- a/test/files/run/macro-system-properties.check
+++ b/test/files/run/macro-system-properties.check
@@ -1,6 +1,6 @@
 
-scala> import scala.language.experimental._, scala.reflect.macros.blackbox.Context
-import scala.language.experimental._
+scala> import scala.language.experimental.macros, scala.reflect.macros.blackbox.Context
+import scala.language.experimental.macros
 import scala.reflect.macros.blackbox.Context
 
 scala>     object GrabContext {

--- a/test/files/run/macro-system-properties.scala
+++ b/test/files/run/macro-system-properties.scala
@@ -8,7 +8,7 @@ object Test extends ReplTest {
   }
 
   def code = """
-    import scala.language.experimental._, scala.reflect.macros.blackbox.Context
+    import scala.language.experimental.macros, scala.reflect.macros.blackbox.Context
     object GrabContext {
       def lastContext = Option(System.getProperties.get("lastContext").asInstanceOf[reflect.macros.runtime.Context])
       // System.properties lets you stash true globals (unlike statics which are classloader scoped)

--- a/test/junit/scala/tools/nsc/PipelineMainTest.scala
+++ b/test/junit/scala/tools/nsc/PipelineMainTest.scala
@@ -85,7 +85,7 @@ class PipelineMainTest {
     macroProject.withSource("m1/p1/Macro.scala")(
       """
         |package m1.p1
-        |import reflect.macros.blackbox.Context, language.experimental._
+        |import reflect.macros.blackbox.Context, language.experimental.macros
         |object Macro {
         |  def m: Unit = macro impl
         |  def impl(c: Context): c.Tree = {


### PR DESCRIPTION
I noticed this was done over at https://github.com/dotty-staging/scala/tree/sbt-1.5
which is the branch that the Scala 3 community build uses (though I hope to make it just use a tag instead)

I don't know if Scala 3 actually _needs_ these changes (probably it doesn't, or maybe only some past version did?), but I think it's a good minor cleanup regardless, so let's bring it over