### PR TITLE
Improve error position and recovery for bad dollar

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -1047,7 +1047,9 @@ trait Scanners extends ScannersCommon {
           getInterpolatedIdentRest()
         } else {
           val expectations = "$$, $\", $identifier or ${expression}"
-          syntaxError(s"invalid string interpolation $$$ch, expected: $expectations")
+          syntaxError(charOffset - 2, s"invalid string interpolation $$$ch, expected: $expectations")
+          putChar('$')
+          getStringPart(multiLine, seenEscapedQuote)  // consume rest of interpolation, taking $ as literal
         }
       } else {
         val isUnclosedLiteral = (ch == SU || (!multiLine && (ch == CR || ch == LF)))

--- a/test/files/neg/f-interp-pos.check
+++ b/test/files/neg/f-interp-pos.check
@@ -1,0 +1,4 @@
+f-interp-pos.scala:5: error: invalid string interpolation $<, expected: $$, $", $identifier or ${expression}
+  def oops = f"$s%s $<s"
+                    ^
+1 error

--- a/test/files/neg/f-interp-pos.scala
+++ b/test/files/neg/f-interp-pos.scala
@@ -1,0 +1,6 @@
+
+trait T {
+  def s = { println("SSS") ; "hello" }
+  def ok = String.format("%s, %<s", s)
+  def oops = f"$s%s $<s"
+}


### PR DESCRIPTION
Bad dollar in string interpolation should error at the dollar, then consume it as a literal so that lexing can continue.

Backports the commit from https://github.com/lampepfl/dotty/pull/13367