### PR TITLE
Avoid crash when super accessor requires Java interface as direct parent

### DIFF
--- a/test/files/neg/t12523.check
+++ b/test/files/neg/t12523.check
@@ -1,0 +1,4 @@
+Test.scala:1: error: Unable to implement a super accessor, A needs to be directly extended by class C.
+class C extends B {
+      ^
+1 error

--- a/test/files/neg/t12523/A.java
+++ b/test/files/neg/t12523/A.java
@@ -1,0 +1,5 @@
+public interface A {
+    default int foo() {
+        return 41;
+    }
+}

--- a/test/files/neg/t12523/B.java
+++ b/test/files/neg/t12523/B.java
@@ -1,0 +1,3 @@
+public interface B extends A {
+    int bar();
+}

--- a/test/files/neg/t12523/Test.scala
+++ b/test/files/neg/t12523/Test.scala
@@ -1,0 +1,15 @@
+class C extends B {
+  override def bar(): Int = 1
+
+  override def foo(): Int = {
+    val f: () => Int = super.foo
+    f()
+  }
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+   var c = new C()
+   assert(c.foo() + c.bar() == 42)
+  }
+}

--- a/test/files/run/t12523/A.java
+++ b/test/files/run/t12523/A.java
@@ -1,0 +1,5 @@
+public interface A {
+    default int foo() {
+        return 41;
+    }
+}

--- a/test/files/run/t12523/B.java
+++ b/test/files/run/t12523/B.java
@@ -1,0 +1,3 @@
+public interface B extends A {
+    int bar();
+}

--- a/test/files/run/t12523/Test.scala
+++ b/test/files/run/t12523/Test.scala
@@ -1,0 +1,15 @@
+class C extends B with A {
+  override def bar(): Int = 1
+
+  override def foo(): Int = {
+    val f: () => Int = super.foo
+    f()
+  }
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+   var c = new C()
+   assert(c.foo() + c.bar() == 42)
+  }
+}


### PR DESCRIPTION
`A.super.foo` requires `A` to be a direct parent if it's a Java-defined
interface. If such a super call is generated in a super accessor,
issue an error.

This was already done for super accessors generated during mixin, but
not for super accessors created in superaccessors.

Fixes https://github.com/scala/bug/issues/12523