### PR TITLE
Make fields for locals captured in traits non-final

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/AccessorSynthesis.scala
+++ b/src/compiler/scala/tools/nsc/transform/AccessorSynthesis.scala
@@ -94,7 +94,9 @@ trait AccessorSynthesis extends Transform with ast.TreeDSL {
 
       protected def setterBody(setter: Symbol, getter: Symbol): Tree = {
         assert(getter.hasFlag(PARAMACCESSOR), s"missing implementation for non-paramaccessor $setter in $clazz")
-
+        // scala-dev#408: fields for locals captured in a trait are non-final. The lambdalift phase adds the
+        // ConstructorNeedsFence attachment to the primary constructor of the class to ensure safe publication.
+        setter.accessed.setFlag(MUTABLE)
         Assign(fieldAccess(setter), Ident(setter.firstParam))
       }
 

--- a/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
@@ -411,4 +411,21 @@ class BytecodeTest extends BytecodeTesting {
           assertInvoke(c, "scala/runtime/Statics", "releaseFence")
     }
   }
+
+  @Test
+  def t12340(): Unit = {
+    val code =
+      """class C {
+        |  def foo(param: String) = {
+        |    trait T {
+        |      def bar = param
+        |    }
+        |    (new T {}).bar
+        |  }
+        |}""".stripMargin
+    val List(_, cAnon, _) = compileClasses(code)
+    // field for caputred param is not final
+    assertEquals(Opcodes.ACC_PRIVATE, cAnon.fields.asScala.find(_.name.startsWith("param")).get.access)
+    assertInvoke(getMethod(cAnon, "<init>"), "scala/runtime/Statics", "releaseFence")
+  }
 }


### PR DESCRIPTION
Other fields synthesized in subclasses of traits are already non-final.
This is required because these fields are assigned in trait setters.
The JVM enforces this for classfiles with version > 52, i.e., JDK 9+.

To ensure safe publication, the constuctor calls `releaseFence`.

Fixes https://github.com/scala/bug/issues/12340. Follow-up for https://github.com/scala/scala/pull/7028.