### PR TITLE
[backport] Make `-target` support JDK 8 through 19 (and deprecate 5 through 7)

### DIFF
--- a/project/ScalaOptionParser.scala
+++ b/project/ScalaOptionParser.scala
@@ -106,7 +106,7 @@ object ScalaOptionParser {
     "-Ymacro-expand" -> List("discard", "none"),
     "-Yresolve-term-conflict" -> List("error", "object", "package"),
     "-g" -> List("line", "none", "notailcails", "source", "vars"),
-    "-target" -> List("jvm-1.5", "jvm-1.6", "jvm-1.7", "jvm-1.8"))
+    "-target" -> targetSettingNames)
   private def multiChoiceSettingNames = Map[String, List[String]](
     "-Xlint" -> List("adapted-args", "nullary-unit", "inaccessible", "nullary-override", "infer-any", "missing-interpolator", "doc-detached", "private-shadow", "type-parameter-shadow", "poly-implicit-overload", "option-implicit", "delayedinit-select", "by-name-right-associative", "package-object-classes", "unsound-match", "stars-align"),
     "-language" -> List("help", "_", "dynamics", "postfixOps", "reflectiveCalls", "implicitConversions", "higherKinds", "existentials", "experimental.macros"),
@@ -126,4 +126,5 @@ object ScalaOptionParser {
   private def scaladocPathSettingNames = List("-doc-root-content", "-diagrams-dot-path")
   private def scaladocMultiStringSettingNames = List("-doc-external-doc")
 
+  private val targetSettingNames = (5 to 18).flatMap(v => s"$v" :: s"jvm-1.$v" :: s"jvm-$v" :: s"1.$v" :: Nil).toList
 }

--- a/src/compiler/scala/tools/ant/Scalac.scala
+++ b/src/compiler/scala/tools/ant/Scalac.scala
@@ -23,6 +23,7 @@ import org.apache.tools.ant.util.facade.{FacadeTaskHelper, ImplementationSpecifi
 import scala.tools.nsc.{Global, Settings, CompilerCommand}
 import scala.tools.nsc.io.{Path => SPath}
 import scala.tools.nsc.reporters.{ ConsoleReporter, Reporter }
+import scala.tools.nsc.settings.StandardScalaSettings
 
 /** An Ant task to compile with the new Scala compiler (NSC).
  *
@@ -99,7 +100,7 @@ class Scalac extends ScalaMatchingTask with ScalacShared {
 
   /** Defines valid values for the `target` property. */
   object Target extends PermissibleValue {
-    val values = List("jvm-1.5", "jvm-1.6", "jvm-1.7", "jvm-1.8")
+    val values = StandardScalaSettings.AllPermissibleTargetValues
   }
 
   /** Defines valid values for the `deprecation` and `unchecked` properties. */

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -33,6 +33,7 @@ import scala.tools.nsc.io.{AbstractFile, SourceReader}
 import scala.tools.nsc.plugins.Plugins
 import scala.tools.nsc.profile.Profiler
 import scala.tools.nsc.reporters.{FilteringReporter, MakeFilteringForwardingReporter, Reporter}
+import scala.tools.nsc.settings.StandardScalaSettings
 import scala.tools.nsc.symtab.classfile.Pickler
 import scala.tools.nsc.symtab.{Flags, SymbolTable, SymbolTrackers}
 import scala.tools.nsc.transform._
@@ -1368,10 +1369,15 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
       settings.userSetSettings filter (_.isDeprecated) foreach { s =>
         runReporting.deprecationWarning(NoPosition, s.name + " is deprecated: " + s.deprecationMessage.get, "", "", "")
       }
-      val supportedTarget = "jvm-1.8"
-      if (settings.target.value != supportedTarget) {
-        runReporting.deprecationWarning(NoPosition, settings.target.name + ":" + settings.target.value + " is deprecated and has no effect, setting to " + supportedTarget, "2.12.0", site = "", origin = "")
-        settings.target.value = supportedTarget
+      if (!StandardScalaSettings.SupportedTargetVersions.contains(settings.target.value)) {
+        runReporting.deprecationWarning(
+          NoPosition,
+          settings.target.name + ":" + settings.target.value + " is deprecated and has no effect, setting to " + StandardScalaSettings.DefaultTargetVersion,
+          since = "2.12.16",
+          site = "",
+          origin = ""
+        )
+        settings.target.value = StandardScalaSettings.DefaultTargetVersion
       }
       settings.conflictWarning.foreach(runReporting.warning(NoPosition, _, WarningCategory.Other, site = ""))
     }

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
@@ -77,8 +77,19 @@ abstract class BackendUtils extends PerRunInit {
   private[this] lazy val classesOfSideEffectFreeConstructors: LazyVar[Set[String]] = perRunLazy(this)(sideEffectFreeConstructors.get.map(_._1))
 
   lazy val classfileVersion: LazyVar[Int] = perRunLazy(this)(compilerSettings.target match {
-    case "jvm-1.8" => asm.Opcodes.V1_8
-  })
+      case "8"  => asm.Opcodes.V1_8
+      case "9"  => asm.Opcodes.V9
+      case "10" => asm.Opcodes.V10
+      case "11" => asm.Opcodes.V11
+      case "12" => asm.Opcodes.V12
+      case "13" => asm.Opcodes.V13
+      case "14" => asm.Opcodes.V14
+      case "15" => asm.Opcodes.V15
+      case "16" => asm.Opcodes.V16
+      case "17" => asm.Opcodes.V17
+      case "18" => asm.Opcodes.V18
+      // to be continued...
+    })
 
 
   lazy val majorVersion: LazyVar[Int] = perRunLazy(this)(classfileVersion.get & 0xFF)

--- a/test/files/neg/deprecated-target.check
+++ b/test/files/neg/deprecated-target.check
@@ -1,4 +1,4 @@
-warning: -target is deprecated: -target:jvm-1.7 is deprecated, forcing use of jvm-1.8
+warning: -target is deprecated: -target:7 is deprecated, forcing use of 8
 error: No warnings can be incurred under -Xfatal-warnings.
 one warning found
 one error found

--- a/test/junit/scala/tools/nsc/settings/TargetTest.scala
+++ b/test/junit/scala/tools/nsc/settings/TargetTest.scala
@@ -1,0 +1,95 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.tools.nsc
+package settings
+
+import org.junit.{Assert, Test}, Assert.{assertEquals, assertFalse, assertTrue, fail}
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.collection.mutable.ListBuffer
+
+@RunWith(classOf[JUnit4])
+class TargetTest {
+
+  @Test def testSettingTargetSetting(): Unit = {
+    def check(in: String, expect: String) = {
+      val settings = new Settings(err => fail(s"Error output: $err"))
+      val (ok, _) = settings.processArgumentString(in)
+      assertTrue(ok)
+      assertEquals(expect, settings.target.value)
+    }
+    def checkDeprecated(in: String, expect: String) = {
+      val messages = ListBuffer.empty[String]
+      val settings = new Settings(messages.append(_))
+      val (ok, _) = settings.processArgumentString(in)
+      assertTrue(ok)
+      assertTrue(messages.isEmpty)
+      assertTrue(settings.target.deprecationMessage.exists(_.contains("is deprecated, forcing use of")))
+      assertEquals(expect, settings.target.value)
+    }
+    def checkFail(in: String) = {
+      val messages = ListBuffer.empty[String]
+      val settings = new Settings(messages.append(_))
+      val (ok, _) = settings.processArgumentString(in)
+      assertFalse(ok)
+      assertTrue(messages.nonEmpty)
+      assertEquals(2, messages.size)   // bad choice + bad option
+      assertTrue(messages.exists(_.startsWith("bad option")))
+    }
+
+    checkDeprecated("-target:jvm-1.5", "8")
+    checkDeprecated("-target:1.5", "8")
+
+    checkDeprecated("-target:jvm-1.6", "8")
+    checkDeprecated("-target:6", "8")
+
+    checkDeprecated("-target:jvm-1.7", "8")
+    checkDeprecated("-target:jvm-7", "8")
+
+    check("-target:jvm-1.8", "8")
+    check("-target:1.8", "8")
+    check("-target:jvm-8", "8")
+    check("-target:8", "8")
+
+    check("-target:jvm-9", "9")
+    check("-target:9", "9")
+    // it's not Java 1.9, you reprobates!
+
+    check("-target:jvm-10", "10")
+    check("-target:10", "10")
+
+    check("-target:jvm-11", "11")
+    check("-target:11", "11")
+
+    check("-target:jvm-12", "12")
+    check("-target:12", "12")
+
+    // (scene missing)
+
+    check("-target:jvm-16", "16")
+    check("-target:16", "16")
+
+    check("-target:jvm-17", "17")
+    check("-target:17", "17")
+
+    check("-target:jvm-18", "18")
+    check("-target:18", "18")
+
+    checkFail("-target:jvm-19")   // not yet...
+    checkFail("-target:jvm-3000") // not in our lifetime
+    checkFail("-target:msil")     // really?
+
+  }
+
+}


### PR DESCRIPTION
Even though [scala >= 2.12.15 supports jvm >=8](https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html). It is not possible to use it as a target. This adds `jvm-11`, `jvm-17` and `jvm-18` alongside `jvm-1.8` as supported target values.