### PR TITLE
Restore partest crash handler

### DIFF
--- a/src/partest/scala/tools/partest/ConsoleLog.scala
+++ b/src/partest/scala/tools/partest/ConsoleLog.scala
@@ -67,6 +67,7 @@ class ConsoleLog(colorEnabled: Boolean) {
   def printDot(): Unit = printProgress(".")
   def printS(): Unit = printProgress(_warning + "s" +_default)
   def printEx(): Unit  = printProgress(_failure + "X" + _default)
+  def printUnknown(): Unit  = printProgress(_failure + "?" + _default)  // crash or uninit'd
   private def printProgress(icon: String): Unit = synchronized {
     if (dotCount >= DotWidth) {
       outline("\n" + icon)

--- a/src/partest/scala/tools/partest/nest/AbstractRunner.scala
+++ b/src/partest/scala/tools/partest/nest/AbstractRunner.scala
@@ -101,6 +101,7 @@ class AbstractRunner(val config: RunnerSpec.Config, protected final val testSour
     if (terse) {
       if (state.isSkipped) { printS(); Nil }
       else if (state.isOk) { printDot() ; Nil }
+      else if (state.shortStatus(0) == '?') { printUnknown() ; Nil }
       else { printEx() ; statusLine(state, durationMs) :: errInfo }
     } else {
       echo(statusLine(state, durationMs))

--- a/src/partest/scala/tools/partest/nest/DirectCompiler.scala
+++ b/src/partest/scala/tools/partest/nest/DirectCompiler.scala
@@ -151,11 +151,10 @@ class DirectCompiler(val runner: Runner) {
       else runner.genFail(s"compilation failed")
     }
 
-    try {
+    try
       if (suiteRunner.config.optCompilerPath.isEmpty) execCompile()
       else execOtherCompiler()
-    }
-    catch   { case t: Throwable => reportError(t.getMessage) ; runner.genCrash(t) }
-    finally { logWriter.close() }
+    catch runner.crashHandler
+    finally logWriter.close()
   }
 }

--- a/test/files/neg/t7494-multi-right-after.check
+++ b/test/files/neg/t7494-multi-right-after.check
@@ -1,1 +1,1 @@
-error: Multiple phases want to run right after explicitouter; followers: erasure,multi-rafter; created phase-order.dot
+fatal error: Multiple phases want to run right after explicitouter; followers: erasure,multi-rafter; created phase-order.dot

--- a/test/files/neg/t7494-right-after-before.check
+++ b/test/files/neg/t7494-right-after-before.check
@@ -1,1 +1,1 @@
-error: Phase erasure can't follow explicitouter, created phase-order.dot
+fatal error: Phase erasure can't follow explicitouter, created phase-order.dot

--- a/test/files/neg/t7622-cyclic-dependency.check
+++ b/test/files/neg/t7622-cyclic-dependency.check
@@ -1,1 +1,1 @@
-error: Cycle in phase dependencies detected at cyclicdependency2, created phase-cycle.dot
+fatal error: Cycle in phase dependencies detected at cyclicdependency2, created phase-cycle.dot

--- a/test/files/neg/t7622-multi-followers.check
+++ b/test/files/neg/t7622-multi-followers.check
@@ -1,1 +1,1 @@
-error: Multiple phases want to run right after parser; followers: multi1,multi2; created phase-order.dot
+fatal error: Multiple phases want to run right after parser; followers: multi1,multi2; created phase-order.dot


### PR DESCRIPTION
The unused crash handler was refactored out by paulp
in current partest's origin story, and not by more recent
refactorings. A previous tweak to handle Crash as a
TestState did not show or log a stack trace, so the
log would read: "error: null", for example.

The crash handler writes the stack trace to the log.

If there is a check file and the exception is a FatalError
from the compiler, then only the exception message is
logged, so that a neg test can diff it reliably.
If the log file matches the check file, the test passes.
The output will say "fatal error:" to help distinguish
from other errors.

The display of test results in AbstractRunner need not
provide additional output about the crash. The terse
mode icon for a Crash is changed from X to ?.

There is no distinction between an expected Crash
(as DNC or does not compile) and an unexpected error.