### PR TITLE
optimize mutable.TreeSet#{max, min}

### DIFF
--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -150,7 +150,7 @@ final class TreeSet[A] private[immutable] (private[immutable] val tree: RB.Tree[
   override def init = new TreeSet(RB.delete(tree, lastKey))
 
   override def min[A1 >: A](implicit ord: Ordering[A1]): A = {
-    if ((ord eq ordering) && nonEmpty) {
+    if ((ord == ordering) && nonEmpty) {
       head
     } else {
       super.min(ord)
@@ -158,7 +158,7 @@ final class TreeSet[A] private[immutable] (private[immutable] val tree: RB.Tree[
   }
 
   override def max[A1 >: A](implicit ord: Ordering[A1]): A = {
-    if ((ord eq ordering) && nonEmpty) {
+    if ((ord == ordering) && nonEmpty) {
       last
     } else {
       super.max(ord)

--- a/src/library/scala/collection/mutable/TreeSet.scala
+++ b/src/library/scala/collection/mutable/TreeSet.scala
@@ -104,6 +104,13 @@ sealed class TreeSet[A] private (tree: RB.Tree[A, Null])(implicit val ordering: 
   override def last = RB.maxKey(tree).get
   override def lastOption = RB.maxKey(tree)
 
+
+  override def min[B >: A](implicit cmp: Ordering[B]): A =
+    if ((cmp == ordering) && nonEmpty) head else super.min(cmp)
+
+  override def max[B >: A](implicit cmp: Ordering[B]): A =
+    if ((cmp == ordering) && nonEmpty) last else super.max(cmp)
+
   override def foreach[U](f: A => U): Unit = RB.foreachKey(tree, f)
   override def clear(): Unit = RB.clear(tree)
 

--- a/test/junit/scala/collection/mutable/TreeSetTest.scala
+++ b/test/junit/scala/collection/mutable/TreeSetTest.scala
@@ -1,6 +1,6 @@
 package scala.collection.mutable
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert._
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -52,4 +52,35 @@ class TreeSetTest {
       assertEquals(expected, src filter set)
     }
   }
+
+  @Test
+  def min(): Unit = {
+    val nonEmptySet = mutable.TreeSet(2, 4, -1, 3)
+    assertEquals(-1, nonEmptySet.min)
+    assertEquals(4, nonEmptySet.min(implicitly[Ordering[Int]].reverse))
+
+    try {
+      TreeSet.empty[Int].min
+      fail("expect UnsupportedOperationException")
+    } catch {
+      case e: UnsupportedOperationException =>
+        assertEquals("empty.min", e.getMessage)
+    }
+  }
+
+  @Test
+  def max(): Unit = {
+    val nonEmptySet = mutable.TreeSet(2, 4, -1, 3)
+    assertEquals(4, nonEmptySet.max)
+    assertEquals(-1, nonEmptySet.max(implicitly[Ordering[Int]].reverse))
+
+    try {
+      mutable.TreeSet.empty[Int].max
+      fail("expect UnsupportedOperationException")
+    } catch {
+      case e: UnsupportedOperationException =>
+        assertEquals("empty.max", e.getMessage)
+    }
+  }
+
 }


### PR DESCRIPTION
Additional fix of mutable.TreeSet for https://github.com/scala/bug/issues/11598