### PR TITLE
fix small oversight in sbt-header config

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -693,7 +693,8 @@ lazy val junit = project.in(file("test") / "junit")
     libraryDependencies ++= Seq(junitDep, junitInterfaceDep, jolDep),
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),
     (Compile / unmanagedSourceDirectories) := Nil,
-    (Test / unmanagedSourceDirectories) := List(baseDirectory.value)
+    (Test / unmanagedSourceDirectories) := List(baseDirectory.value),
+    Test / headerSources := Nil,
   )
 
 lazy val scalacheck = project.in(file("test") / "scalacheck")


### PR DESCRIPTION
after this change, `headerCreateAll` makes no changes. we don't bother with headers in the test/junit directory.