### PR TITLE
Fix codegen for MethodHandle.invoke (et al) under JDK 17 `-release`

### DIFF
--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1646,25 +1646,14 @@ trait Definitions extends api.StandardDefinitions {
 
       lazy val PartialManifestClass  = getTypeMember(ReflectPackage, tpnme.ClassManifest)
       lazy val ManifestSymbols = Set[Symbol](PartialManifestClass, FullManifestClass, OptManifestClass)
-      private lazy val PolymorphicSignatureClass = MethodHandleClass.companionModule.info.decl(TypeName("PolymorphicSignature"))
-      private val PolymorphicSignatureName = TypeName("java.lang.invoke.MethodHandle$PolymorphicSignature")
 
       def isPolymorphicSignature(sym: Symbol) = sym != null && sym.isJavaDefined && {
         val owner = sym.safeOwner
         (owner == MethodHandleClass || owner == VarHandleClass) && {
-          def isNativeVarargs = sym.hasAnnotation(NativeAttr) && (sym.paramss match {
+          sym.hasAnnotation(NativeAttr) && (sym.paramss match {
             case List(List(p)) => definitions.isJavaRepeatedParamType(p.info)
             case _ => false
           })
-          def hasPolymorphicSignatureAnnotationLegacyCheck = {
-            if (PolymorphicSignatureClass eq NoSymbol) {
-              // Hack to find the annotation under `scalac -release 8` on JDK 9+, in which the lookup of `PolymorphicSignatureClass` above fails
-              // We fall back to looking for a stub symbol with the expected flattened name.
-              sym.annotations.exists(_.atp.typeSymbolDirect.name == PolymorphicSignatureName)
-            }
-            else sym.hasAnnotation(PolymorphicSignatureClass)
-          }
-          isNativeVarargs || hasPolymorphicSignatureAnnotationLegacyCheck
         }
       }
 


### PR DESCRIPTION
The historical, stripped down version of MethodHandle.class,
stored in ct.sym!/.../MethodHandle.sig, no longer bears
the `@PolymorphicSignature` annotation, and the VM spec
just says to look for:

> A method is signature polymorphic if all of the following are true:
>  • It is declared in the java.lang.invoke.MethodHandle class or the
>    java.lang.invoke.VarHandle class.
>  • It has a single formal parameter of type Object[].
>  • It has the ACC_VARARGS and ACC_NATIVE flags set

Problem:

```
opt/homebrew/bin/cs launch scala:2.13.8 -- -release 11
Welcome to Scala 2.13.8 (OpenJDK 64-Bit Server VM, Java 17.0.1).
Type in expressions for evaluation. Or try :help.

scala> import java.lang.invoke._
import java.lang.invoke._

scala> val lookup = MethodHandles.lookup()
     |
     |     val String_hashCode = lookup.findVirtual(classOf[String], "hashCode", MethodType.methodType(Integer.TYPE))
     |     String_hashCode.invoke("")
java.lang.ClassCastException: Cannot cast [Ljava.lang.Object; to java.lang.String
  at java.base/java.lang.Class.cast(Class.java:3889)
  ... 32 elided
```

Fixed:

```
~/code/scala/build/quick/bin/scala -release 11
Welcome to Scala 2.12.16-20220209-063657-a281f2b (OpenJDK 64-Bit Server VM, Java 17.0.1).
Type in expressions for evaluation. Or try :help.

scala> import java.lang.invoke._; MethodHandles.lookup().findVirtual(classOf[String], "hashCode", MethodType.methodType(Integer.TYPE)).invoke("")
import java.lang.invoke._
res0: Object = 0
```