### PR TITLE
Java default is never mismatched missing method

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -595,7 +595,8 @@ abstract class RefChecks extends Transform {
                 m.name == underlying.name &&
                 sameLength(m.paramLists, abstractParamLists) &&
                 sumSize(m.paramLists, 0) == sumSize(abstractParamLists, 0) &&
-                sameLength(m.tpe.typeParams, underlying.tpe.typeParams)
+                sameLength(m.tpe.typeParams, underlying.tpe.typeParams) &&
+                !(m.isJavaDefined && m.hasFlag(JAVA_DEFAULTMETHOD))
               }
               matchingArity match {
                 // So far so good: only one candidate method
@@ -618,8 +619,6 @@ abstract class RefChecks extends Transform {
                         s": ${c1.fullLocationString} is a subclass of ${c2.fullLocationString}, but method parameter types must match exactly."
                       val addendum = (
                         if (abstractSym == concreteSym) {
-                          // TODO: what is the optimal way to test for a raw type at this point?
-                          // Compilation has already failed so we shouldn't have to worry overmuch about forcing types.
                           if (underlying.isJavaDefined && pa.typeArgs.isEmpty && abstractSym.typeParams.nonEmpty)
                             s". To implement this raw type, use ${rawToExistential(pa)}"
                           else if (pa.prefix =:= pc.prefix)

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -662,10 +662,11 @@ abstract class RefChecks extends Transform {
                 val diagnostic = diagnose(m, accessors)
                 if (diagnostic == null) null
                 else {
-                  val s0 = infoString0(m, showLocation = false)
+                  val s0a = infoString0(m, showLocation = false)
                   fullyInitializeSymbol(m)
+                  val s0b = m.defString
                   val s1 = m.defStringSeenAs(clazz.tpe_*.memberType(m))
-                  val implMsg = if (s0 != s1) s"implements `$s0`" else ""
+                  val implMsg = if (s1 != s0a) s"implements `$s0a`" else if (s1 != s0b) s"implements `$s0b`" else ""
                   val spacer  = if (diagnostic.nonEmpty && implMsg.nonEmpty) "; " else ""
                   val comment = if (diagnostic.nonEmpty || implMsg.nonEmpty) s" // $implMsg$spacer$diagnostic" else ""
                   s"$s1 = ???$comment"

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -617,7 +617,12 @@ abstract class RefChecks extends Transform {
                       val concreteSym = pc.typeSymbol
                       def subclassMsg(c1: Symbol, c2: Symbol) =
                         s": ${c1.fullLocationString} is a subclass of ${c2.fullLocationString}, but method parameter types must match exactly."
-                      val addendum = (
+                      def wrongSig = {
+                        val m = concrete
+                        fullyInitializeSymbol(m)
+                        m.defStringSeenAs(clazz.tpe_*.memberType(m))
+                      }
+                      val addendum =
                         if (abstractSym == concreteSym) {
                           if (underlying.isJavaDefined && pa.typeArgs.isEmpty && abstractSym.typeParams.nonEmpty)
                             s". To implement this raw type, use ${rawToExistential(pa)}"
@@ -628,8 +633,7 @@ abstract class RefChecks extends Transform {
                         }
                         else if (abstractSym.isSubClass(concreteSym)) subclassMsg(abstractSym, concreteSym)
                         else if (concreteSym.isSubClass(abstractSym)) subclassMsg(concreteSym, abstractSym)
-                        else ""
-                      )
+                        else s" in `$wrongSig`"
                       s"$pa does not match $pc$addendum"
                     case Nil if missingImplicit => "overriding member must declare implicit parameter list" // other overriding gotchas
                     case _ => ""

--- a/test/files/jvm/scala-concurrent-tck.scala
+++ b/test/files/jvm/scala-concurrent-tck.scala
@@ -145,7 +145,7 @@ class FutureCallbacks extends TestBase {
   test("testOnFailure")(testOnFailure())
   test("testOnFailureWhenSpecialThrowable")(testOnFailureWhenSpecialThrowable(5, new Error))
   // testOnFailureWhenSpecialThrowable(6, new scala.util.control.ControlThrowable { })
-  //TODO: this test is currently problematic, because NonFatal does not match InterruptedException
+  //TODO: this test is currently problematic, because NonFatal does not catch InterruptedException
   //testOnFailureWhenSpecialThrowable(7, new InterruptedException)
   test("testThatNestedCallbacksDoNotYieldStackOverflow")(testThatNestedCallbacksDoNotYieldStackOverflow())
   test("testOnFailureWhenTimeoutException")(testOnFailureWhenTimeoutException())

--- a/test/files/neg/abstract-class-2.check
+++ b/test/files/neg/abstract-class-2.check
@@ -1,6 +1,6 @@
 abstract-class-2.scala:11: error: object creation impossible.
 Missing implementation for member of trait S2:
-  def f(x: P2.this.p.S1): Int = ??? // P.this.p.S1 does not match P2.this.S1: their prefixes (i.e., enclosing instances) differ
+  def f(x: P2.this.p.S1): Int = ??? // implements `def f(x: P.this.p.S1): Int`; P.this.p.S1 does not match P2.this.S1: their prefixes (i.e., enclosing instances) differ
 
   object O2 extends S2 {
          ^

--- a/test/files/neg/abstract-concrete-methods.check
+++ b/test/files/neg/abstract-concrete-methods.check
@@ -1,6 +1,6 @@
 abstract-concrete-methods.scala:7: error: class Outer2 needs to be abstract.
 Missing implementation for member of trait Outer:
-  def score(i: Outer2#Inner): Double = ??? // This#Inner does not match Outer2#Inner: class Inner in class Outer2 is a subclass of trait Inner in trait Outer, but method parameter types must match exactly.
+  def score(i: Outer2#Inner): Double = ??? // implements `def score(i: This#Inner): Double`; This#Inner does not match Outer2#Inner: class Inner in class Outer2 is a subclass of trait Inner in trait Outer, but method parameter types must match exactly.
 
 class Outer2 extends Outer[Outer2] {
       ^

--- a/test/files/neg/abstract-report.check
+++ b/test/files/neg/abstract-report.check
@@ -1,14 +1,14 @@
 abstract-report.scala:1: error: class Unimplemented needs to be abstract.
 Missing implementations for 6 members.
   // Members declared in scala.collection.IterableOnce
-  def iterator: Iterator[String] = ???
+  def iterator: Iterator[String] = ??? // implements `def iterator: Iterator[A]`
 
   // Members declared in scala.collection.IterableOps
-  protected def coll: List[String] = ???
-  protected def fromSpecific(coll: scala.collection.IterableOnce[String]): List[String] = ???
-  def iterableFactory: scala.collection.IterableFactory[List] = ???
-  protected def newSpecificBuilder: scala.collection.mutable.Builder[String,List[String]] = ???
-  def toIterable: Iterable[String] = ???
+  protected def coll: List[String] = ??? // implements `protected def coll: C`
+  protected def fromSpecific(coll: scala.collection.IterableOnce[String]): List[String] = ??? // implements `protected def fromSpecific(coll: scala.collection.IterableOnce[A @scala.annotation.unchecked.uncheckedVariance]): C`
+  def iterableFactory: scala.collection.IterableFactory[List] = ??? // implements `def iterableFactory: scala.collection.IterableFactory[CC]`
+  protected def newSpecificBuilder: scala.collection.mutable.Builder[String,List[String]] = ??? // implements `protected def newSpecificBuilder: scala.collection.mutable.Builder[A @scala.annotation.unchecked.uncheckedVariance,C]`
+  def toIterable: Iterable[String] = ??? // implements `def toIterable: Iterable[A]`
 
 class Unimplemented extends scala.collection.IterableOps[String, List, List[String]]
       ^

--- a/test/files/neg/abstract-report2.check
+++ b/test/files/neg/abstract-report2.check
@@ -1,12 +1,12 @@
 abstract-report2.scala:3: error: class Foo needs to be abstract.
 Missing implementations for 13 members of trait Collection.
-  def add(x$1: Int): Boolean = ???
-  def addAll(x$1: java.util.Collection[_ <: Int]): Boolean = ???
+  def add(x$1: Int): Boolean = ??? // implements `def add(x$1: E): Boolean`
+  def addAll(x$1: java.util.Collection[_ <: Int]): Boolean = ??? // implements `def addAll(x$1: java.util.Collection[_ <: E]): Boolean`
   def clear(): Unit = ???
   def contains(x$1: Object): Boolean = ???
   def containsAll(x$1: java.util.Collection[_]): Boolean = ???
   def isEmpty(): Boolean = ???
-  def iterator(): java.util.Iterator[Int] = ???
+  def iterator(): java.util.Iterator[Int] = ??? // implements `def iterator(): java.util.Iterator[E]`
   def remove(x$1: Object): Boolean = ???
   def removeAll(x$1: java.util.Collection[_]): Boolean = ???
   def retainAll(x$1: java.util.Collection[_]): Boolean = ???
@@ -18,13 +18,13 @@ class Foo extends Collection[Int]
       ^
 abstract-report2.scala:5: error: class Bar needs to be abstract.
 Missing implementations for 13 members of trait Collection.
-  def add(x$1: List[_ <: String]): Boolean = ???
-  def addAll(x$1: java.util.Collection[_ <: List[_ <: String]]): Boolean = ???
+  def add(x$1: List[_ <: String]): Boolean = ??? // implements `def add(x$1: E): Boolean`
+  def addAll(x$1: java.util.Collection[_ <: List[_ <: String]]): Boolean = ??? // implements `def addAll(x$1: java.util.Collection[_ <: E]): Boolean`
   def clear(): Unit = ???
   def contains(x$1: Object): Boolean = ???
   def containsAll(x$1: java.util.Collection[_]): Boolean = ???
   def isEmpty(): Boolean = ???
-  def iterator(): java.util.Iterator[List[_ <: String]] = ???
+  def iterator(): java.util.Iterator[List[_ <: String]] = ??? // implements `def iterator(): java.util.Iterator[E]`
   def remove(x$1: Object): Boolean = ???
   def removeAll(x$1: java.util.Collection[_]): Boolean = ???
   def retainAll(x$1: java.util.Collection[_]): Boolean = ???
@@ -36,13 +36,13 @@ class Bar extends Collection[List[_ <: String]]
       ^
 abstract-report2.scala:7: error: class Baz needs to be abstract.
 Missing implementations for 13 members of trait Collection.
-  def add(x$1: T): Boolean = ???
-  def addAll(x$1: java.util.Collection[_ <: T]): Boolean = ???
+  def add(x$1: T): Boolean = ??? // implements `def add(x$1: E): Boolean`
+  def addAll(x$1: java.util.Collection[_ <: T]): Boolean = ??? // implements `def addAll(x$1: java.util.Collection[_ <: E]): Boolean`
   def clear(): Unit = ???
   def contains(x$1: Object): Boolean = ???
   def containsAll(x$1: java.util.Collection[_]): Boolean = ???
   def isEmpty(): Boolean = ???
-  def iterator(): java.util.Iterator[T] = ???
+  def iterator(): java.util.Iterator[T] = ??? // implements `def iterator(): java.util.Iterator[E]`
   def remove(x$1: Object): Boolean = ???
   def removeAll(x$1: java.util.Collection[_]): Boolean = ???
   def retainAll(x$1: java.util.Collection[_]): Boolean = ???
@@ -55,17 +55,17 @@ class Baz[T] extends Collection[T]
 abstract-report2.scala:21: error: class Dingus needs to be abstract.
 Missing implementations for 7 members.
   // Members declared in scala.collection.IterableOnce
-  def iterator: Iterator[(Set[Int], String)] = ???
+  def iterator: Iterator[(Set[Int], String)] = ??? // implements `def iterator: Iterator[A]`
 
   // Members declared in scala.collection.IterableOps
-  protected def coll: List[(Set[Int], String)] = ???
-  protected def fromSpecific(coll: scala.collection.IterableOnce[(Set[Int], String)]): List[(Set[Int], String)] = ???
-  def iterableFactory: scala.collection.IterableFactory[List] = ???
-  protected def newSpecificBuilder: scala.collection.mutable.Builder[(Set[Int], String),List[(Set[Int], String)]] = ???
-  def toIterable: Iterable[(Set[Int], String)] = ???
+  protected def coll: List[(Set[Int], String)] = ??? // implements `protected def coll: C`
+  protected def fromSpecific(coll: scala.collection.IterableOnce[(Set[Int], String)]): List[(Set[Int], String)] = ??? // implements `protected def fromSpecific(coll: scala.collection.IterableOnce[A @scala.annotation.unchecked.uncheckedVariance]): C`
+  def iterableFactory: scala.collection.IterableFactory[List] = ??? // implements `def iterableFactory: scala.collection.IterableFactory[CC]`
+  protected def newSpecificBuilder: scala.collection.mutable.Builder[(Set[Int], String),List[(Set[Int], String)]] = ??? // implements `protected def newSpecificBuilder: scala.collection.mutable.Builder[A @scala.annotation.unchecked.uncheckedVariance,C]`
+  def toIterable: Iterable[(Set[Int], String)] = ??? // implements `def toIterable: Iterable[A]`
 
   // Members declared in Xyz
-  def foo(x: List[Int]): Boolean = ???
+  def foo(x: List[Int]): Boolean = ??? // implements `def foo(x: T): Boolean`
 
 class Dingus extends Bippy[String, Set[Int], List[Int]]
       ^

--- a/test/files/neg/t0345.check
+++ b/test/files/neg/t0345.check
@@ -1,6 +1,6 @@
 t0345.scala:2: error: object creation impossible.
 Missing implementation for member of trait Lizt:
-  def cons(a: Nothing): Unit = ???
+  def cons(a: Nothing): Unit = ??? // implements `def cons(a: A): Unit`
 
     val empty = new Lizt[Nothing] {
                     ^

--- a/test/files/neg/t3854.check
+++ b/test/files/neg/t3854.check
@@ -1,6 +1,6 @@
 t3854.scala:1: error: class Bar needs to be abstract.
 Missing implementation for member of trait Foo:
-  def foo[G[_]](implicit n: N[G,F]): X[F] = ??? // N[G,F] does not match M[G]
+  def foo[G[_]](implicit n: N[G,F]): X[F] = ??? // N[G,F] does not match M[G] in `def foo[G[_[_], _]](implicit M: M[G]): X[[α]G[F,α]]`
 
 class Bar[F[_]] extends Foo[F] {
       ^

--- a/test/files/neg/t856.check
+++ b/test/files/neg/t856.check
@@ -4,7 +4,7 @@ Missing implementations for 2 members.
   def canEqual(that: Any): Boolean = ???
 
   // Members declared in scala.Product2
-  def _2: Double = ???
+  def _2: Double = ??? // implements `def _2: T2`
 
 class ComplexRect(val _1:Double, _2:Double) extends Complex {
       ^

--- a/test/files/neg/t9138.check
+++ b/test/files/neg/t9138.check
@@ -1,6 +1,6 @@
 t9138.scala:9: error: class D needs to be abstract.
 Missing implementation for member of class C:
-  def f(t: B)(s: String): B = ??? // String does not match Int
+  def f(t: B)(s: String): B = ??? // String does not match Int in `def f(b: B)(i: Int): B`
 
 class D extends C[B] {
       ^
@@ -12,7 +12,7 @@ object Derived extends Base[String] {
        ^
 t9138.scala:29: error: class DDD needs to be abstract.
 Missing implementation for member of class CCC:
-  def f(t: B, s: String): B = ??? // T does not match Int
+  def f(t: B, s: String): B = ??? // T does not match Int in `def f(b: Int, i: String): Int`
 
 class DDD extends CCC[B] {
       ^

--- a/test/files/neg/t9138.check
+++ b/test/files/neg/t9138.check
@@ -1,24 +1,24 @@
 t9138.scala:9: error: class D needs to be abstract.
 Missing implementation for member of class C:
-  def f(t: B)(s: String): B = ??? // String does not match Int in `def f(b: B)(i: Int): B`
+  def f(t: B)(s: String): B = ??? // implements `def f(t: T)(s: String): T`; String does not match Int in `def f(b: B)(i: Int): B`
 
 class D extends C[B] {
       ^
 t9138.scala:19: error: object creation impossible.
 Missing implementation for member of trait Base:
-  def foo(a: String)(b: Int): Nothing = ???
+  def foo(a: String)(b: Int): Nothing = ??? // implements `def foo(a: A)(b: Int): Nothing`
 
 object Derived extends Base[String] {
        ^
 t9138.scala:29: error: class DDD needs to be abstract.
 Missing implementation for member of class CCC:
-  def f(t: B, s: String): B = ??? // T does not match Int in `def f(b: Int, i: String): Int`
+  def f(t: B, s: String): B = ??? // implements `def f(t: T, s: String): T`; T does not match Int in `def f(b: Int, i: String): Int`
 
 class DDD extends CCC[B] {
       ^
 t9138.scala:43: error: object creation impossible.
 Missing implementation for member of trait Model:
-  def create(conditionalParams: ImplementingParamTrait)(implicit d: Double): Int = ??? // overriding member must declare implicit parameter list
+  def create(conditionalParams: ImplementingParamTrait)(implicit d: Double): Int = ??? // implements `def create(conditionalParams: P)(implicit d: Double): Int`; overriding member must declare implicit parameter list
 
 object Obj extends Model[ImplementingParamTrait] {
        ^


### PR DESCRIPTION
When looking for method implementations that are off-by-one from a missing method, exclude Java default methods (because they are not written in Scala). 

The salutary side effect is that Java default methods added to JDK after JDK 8 don't generate advice in check files.

It is not inconceivable that the user added a default method but got the signature wrong. If that user leverages their lightbend subscription to get this advice back, the check file can be filtered on `#partest jdk8`. Note that the example at https://github.com/scala/scala/pull/9827#issuecomment-1034202547 was deemed confusing.