### PR TITLE
Hygienic `StringContext` under `-Xsource:3`

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1504,9 +1504,10 @@ self =>
       }
       if (in.token == STRINGLIT) partsBuf += literal()
 
-      // Documenting that it is intentional that the ident is not rooted for purposes of virtualization
-      //val t1 = atPos(o2p(start)) { Select(Select (Ident(nme.ROOTPKG), nme.scala_), nme.StringContextName) }
-      val t1 = atPos(o2p(start)) { Ident(nme.StringContextName) }
+      // Scala 2 allowed uprooted Ident for purposes of virtualization
+      val t1 =
+        if (currentRun.isScala3) atPos(o2p(start)) { Select(Select(Ident(nme.ROOTPKG), nme.scala_), nme.StringContextName) }
+        else atPos(o2p(start)) { Ident(nme.StringContextName) }
       val t2 = atPos(start) { Apply(t1, partsBuf.toList) } updateAttachment InterpolatedString
       t2 setPos t2.pos.makeTransparent
       val t3 = Select(t2, interpolator) setPos t2.pos

--- a/test/files/run/interpolator-hygiene.scala
+++ b/test/files/run/interpolator-hygiene.scala
@@ -1,0 +1,31 @@
+// scalac: -Xsource:3
+class C {
+  class X(parts: Any*) {
+    def s(args: Any*) = "hello, work"
+  }
+  object StringContext {
+    def apply(parts: Any*) = new X(parts: _*)
+  }
+  def name = "Scala3"
+  def test = s"hello, $name"
+}
+class D {
+  import D.*
+  class StringContext(parts: Any*) {
+    def x(args: Any*) = "hello, work"
+  }
+  object StringContext {
+    def apply(parts: Any*) = new StringContext(parts: _*)
+  }
+  def name = "Scala3"
+  def test = x"hello, $name"
+}
+object D {
+  implicit class x(val sc: StringContext) extends AnyVal {
+    def x(args: Any*) = "hello, world"
+  }
+}
+object Test extends App {
+  assert(new C().test == "hello, Scala3")
+  assert(new D().test == "hello, world")
+}


### PR DESCRIPTION
Desugaring of interpolation under `-Xsource:3` uses `_root_.scala.StringContext`.

Test runs under Scala 3 without any special flags.