### PR TITLE
Remove stray unzip from Properties converter

### DIFF
--- a/src/library/scala/collection/convert/JavaCollectionWrappers.scala
+++ b/src/library/scala/collection/convert/JavaCollectionWrappers.scala
@@ -486,7 +486,6 @@ private[collection] object JavaCollectionWrappers extends Serializable {
       with StrictOptimizedMapOps[String, String, mutable.Map, mutable.Map[String, String]]
       with StrictOptimizedIterableOps[(String, String), mutable.Iterable, mutable.Map[String, String]]
       with Serializable {
-    unzip
 
     override def size = underlying.size
     override def isEmpty: Boolean = underlying.isEmpty

--- a/test/junit/scala/collection/CollectionConversionsTest.scala
+++ b/test/junit/scala/collection/CollectionConversionsTest.scala
@@ -75,5 +75,16 @@ class CollectionConversionsTest {
     }
     assertEquals(1, x)
   }
+  @Test def `t11976 head-scratcher`: Unit = {
+    import scala.jdk.CollectionConverters._
+    val myProps = new java.util.Properties
+    myProps.put("a", "A")
+    var x = 0
+    myProps.asScala.partition { case (key, value) =>
+      x += 1
+      true
+    }
+    assertEquals(1, x)
+  }
 }
 


### PR DESCRIPTION
Noticed by `-Wnonunit-statement`.

The author may remember if it's needed for something, or is just stray debug code.