### PR TITLE
Issue warnings in silent mode

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -582,7 +582,7 @@ trait Infer extends Checkable {
         }
       }
       val targs = solvedTypes(tvars, tparams, varianceInTypes(formals), upper = false, lubDepth(formals) max lubDepth(argtpes))
-      if (settings.warnInferAny && context.reportErrors && !fn.isEmpty) {
+      if (settings.warnInferAny && !fn.isEmpty) {
         // Can warn about inferring Any/AnyVal/Object as long as they don't appear
         // explicitly anywhere amongst the formal, argument, result, or expected type.
         // ...or lower bound of a type param, since they're asking for it.

--- a/test/files/neg/t12441.check
+++ b/test/files/neg/t12441.check
@@ -1,0 +1,21 @@
+t12441.scala:7: warning: a type was inferred to be `Any`; this may indicate a programming error.
+  def g = Option.empty[String].contains(1234)
+                               ^
+t12441.scala:8: warning: a type was inferred to be `Any`; this may indicate a programming error.
+  def h() = k(Option.empty[String].contains(1234))
+                                   ^
+t12441.scala:10: warning: adaptation of an empty argument list by inserting () is deprecated: this is unlikely to be what you want
+        signature: SetOps.apply(elem: A): Boolean
+  given arguments: <none>
+ after adaptation: SetOps((): Unit)
+  def s0 = List(1, 2, 3).toSet()  // adapt mistaken arg () to apply and infer AnyVal
+                              ^
+t12441.scala:10: warning: a type was inferred to be `AnyVal`; this may indicate a programming error.
+  def s0 = List(1, 2, 3).toSet()  // adapt mistaken arg () to apply and infer AnyVal
+                         ^
+t12441.scala:14: warning: a type was inferred to be `Any`; this may indicate a programming error.
+  def peskier = p == (42, List(17, ""))
+                          ^
+error: No warnings can be incurred under -Werror.
+5 warnings
+1 error

--- a/test/files/neg/t12441.scala
+++ b/test/files/neg/t12441.scala
@@ -1,0 +1,15 @@
+
+// scalac: -Xlint -Werror
+
+trait T {
+  def k(u: => Unit): Unit = u
+  def f: Any = Option.empty[String].contains(1234)
+  def g = Option.empty[String].contains(1234)
+  def h() = k(Option.empty[String].contains(1234))
+
+  def s0 = List(1, 2, 3).toSet()  // adapt mistaken arg () to apply and infer AnyVal
+
+  val p = (42, 27)
+  def pesky = p == (42, 17)
+  def peskier = p == (42, List(17, ""))
+}

--- a/test/files/neg/t8035-removed.check
+++ b/test/files/neg/t8035-removed.check
@@ -13,11 +13,14 @@ t8035-removed.scala:11: error: adaptation of an empty argument list by inserting
   given arguments: <none>
   sdf.format()
             ^
+t8035-removed.scala:4: warning: a type was inferred to be `AnyVal`; this may indicate a programming error.
+  List(1,2,3).toSet()
+              ^
 t8035-removed.scala:14: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
         signature: List.::[B >: A](elem: B): List[B]
   given arguments: 42, 27
  after adaptation: List.::((42, 27): (Int, Int))
   Nil.::(42, 27)      // yeswarn
         ^
-1 warning
+2 warnings
 3 errors

--- a/test/files/neg/warn-inferred-any.check
+++ b/test/files/neg/warn-inferred-any.check
@@ -1,6 +1,9 @@
 warn-inferred-any.scala:10: warning: a type was inferred to be `Any`; this may indicate a programming error.
   { List(1, 2, 3) contains "a" }  // only this warns
                   ^
+warn-inferred-any.scala:17: warning: a type was inferred to be `AnyVal`; this may indicate a programming error.
+  { 1 to 5 contains 5L }          // should warn: scala.Predef.intWrapper(1).to(5).contains[AnyVal](5L)
+           ^
 warn-inferred-any.scala:18: warning: a type was inferred to be `AnyVal`; this may indicate a programming error.
   { 1L to 5L contains 5 }         // warn
              ^
@@ -14,5 +17,5 @@ warn-inferred-any.scala:37: warning: a type was inferred to be `Object`; this ma
   cs.contains(new C2)             // warns
      ^
 error: No warnings can be incurred under -Werror.
-5 warnings
+6 warnings
 1 error


### PR DESCRIPTION
Fixes scala/bug#12441

This enables Any check in silent mode. The intuition was don't issue warnings about erroneous trees that will be rejiggered.