### PR TITLE
Make unused-import warnings easier to silence (support filtering by `origin=`)

### DIFF
--- a/test/files/neg/t12326.check
+++ b/test/files/neg/t12326.check
@@ -1,0 +1,6 @@
+t12326.scala:5: warning: Unused import
+import scala.collection.mutable._
+                                ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/t12326.scala
+++ b/test/files/neg/t12326.scala
@@ -1,0 +1,9 @@
+// scalac: -Werror -Wunused:imports -Wconf:site=p.T:s
+
+package p
+
+import scala.collection.mutable._
+
+trait T {
+  import scala.concurrent.ExecutionContext.Implicits._
+}

--- a/test/files/neg/t12326b.check
+++ b/test/files/neg/t12326b.check
@@ -1,0 +1,6 @@
+t12326b.scala:5: warning: Unused import
+import scala.collection.mutable.{ListBuffer, Map, Set}
+                                 ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/t12326b.scala
+++ b/test/files/neg/t12326b.scala
@@ -1,0 +1,9 @@
+// scalac: -Werror -Wunused:imports -Wconf:site=p.T:s,origin=scala.collection.mutable.Map:s,origin=scala.collection.mutable.Set:s
+
+package p
+
+import scala.collection.mutable.{ListBuffer, Map, Set}
+
+trait T {
+  import scala.concurrent.ExecutionContext.Implicits._
+}

--- a/test/files/neg/t12326c.check
+++ b/test/files/neg/t12326c.check
@@ -1,0 +1,6 @@
+t12326c.scala:8: warning: Unused import
+  import scala.concurrent.ExecutionContext.Implicits._
+                                                     ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/t12326c.scala
+++ b/test/files/neg/t12326c.scala
@@ -1,0 +1,9 @@
+// scalac: -Werror -Wunused:imports -Wconf:origin=scala.collection.mutable.*:s
+
+package p
+
+import scala.collection.mutable.{ListBuffer, Map, Set}
+
+trait T {
+  import scala.concurrent.ExecutionContext.Implicits._
+}

--- a/test/files/pos/t12326.scala
+++ b/test/files/pos/t12326.scala
@@ -1,0 +1,7 @@
+// scalac: -Werror -Wunused:imports -Wconf:origin=scala.collection.mutable._:s,origin=scala.concurrent.ExecutionContext.Implicits._:s
+
+import scala.collection.mutable._
+
+trait T {
+  import scala.concurrent.ExecutionContext.Implicits._
+}

--- a/test/files/pos/t12326b.scala
+++ b/test/files/pos/t12326b.scala
@@ -1,0 +1,8 @@
+// scalac: -Werror -Wunused:imports
+
+import annotation._
+
+@nowarn("origin=scala.concurrent.ExecutionContext.Implicits._")
+trait T {
+  import scala.concurrent.ExecutionContext.Implicits._
+}


### PR DESCRIPTION
This allows nowarn by regex matching the fully-qualified selector string. For `import a.{b, _}`, match `a.b` or `a._`.

Fixes scala/bug#12326