### PR TITLE
update doc of `Seq.combinations`.

### DIFF
--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -540,11 +540,11 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     else new PermutationsItr
 
   /** Iterates over combinations.  A _combination_ of length `n` is a subsequence of
-    *  the original sequence, with the elements taken in order.  Thus, `"xy"` and `"yy"`
-    *  are both length-2 combinations of `"xyy"`, but `"yx"` is not.  If there is
+    *  the original sequence, with the elements taken in order of their first occurrence.  Thus, `"yy"` and `"yx"`
+    *  are both length-2 combinations of `"yxy"`, but `"xy"` is not.  If there is
     *  more than one way to generate the same subsequence, only one will be returned.
     *
-    *  For example, `"xyyy"` has three different ways to generate `"xy"` depending on
+    *  For example, `"yxyy"` has three different ways to generate `"yx"` depending on
     *  whether the first, second, or third `"y"` is selected.  However, since all are
     *  identical, only one will be chosen.  Which of the three will be taken is an
     *  implementation detail that is not defined.
@@ -552,7 +552,10 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     *  $willForceEvaluation
     *
     *  @return   An Iterator which traverses the possible n-element combinations of this $coll.
-    *  @example  `"abbbc".combinations(2) = Iterator(ab, ac, bb, bc)`
+    *  @example {{{
+    *    "abbbc".combinations(2) = Iterator(ab, ac, bb, bc)
+    *    "bab".combinations(2) = Iterator(bb, ba)
+    *  }}}
     */
   def combinations(n: Int): Iterator[C] =
     if (n < 0 || n > size) Iterator.empty

--- a/src/library/scala/collection/StringOps.scala
+++ b/src/library/scala/collection/StringOps.scala
@@ -1594,17 +1594,20 @@ final class StringOps(private val s: String) extends AnyVal {
   def sliding(size: Int, step: Int = 1): Iterator[String] = new WrappedString(s).sliding(size, step).map(_.unwrap)
 
   /** Iterates over combinations.  A _combination_ of length `n` is a subsequence of
-    *  the original string, with the chars taken in order.  Thus, `"xy"` and `"yy"`
-    *  are both length-2 combinations of `"xyy"`, but `"yx"` is not.  If there is
+    *  the original string, with the chars taken in order of their first occurrence.  Thus, `"yy"` and `"yx"`
+    *  are both length-2 combinations of `"yxy"`, but `"xy"` is not.  If there is
     *  more than one way to generate the same subsequence, only one will be returned.
     *
-    *  For example, `"xyyy"` has three different ways to generate `"xy"` depending on
+    *  For example, `"yxyy"` has three different ways to generate `"yx"` depending on
     *  whether the first, second, or third `"y"` is selected.  However, since all are
     *  identical, only one will be chosen.  Which of the three will be taken is an
     *  implementation detail that is not defined.
     *
     *  @return   An Iterator which traverses the possible n-element combinations of this string.
-    *  @example  `"abbbc".combinations(2) = Iterator(ab, ac, bb, bc)`
+    *  @example {{{
+    *    "abbbc".combinations(2) = Iterator(ab, ac, bb, bc)
+    *    "bab".combinations(2) = Iterator(bb, ba)
+    *  }}}
     *  @note     $unicodeunaware
     */
   def combinations(n: Int): Iterator[String] = new WrappedString(s).combinations(n).map(_.unwrap)


### PR DESCRIPTION
see also: 
https://stackoverflow.com/questions/71135234/scala-seq-combinations-returns-out-of-order-results
https://users.scala-lang.org/t/whats-the-order-mean-in-seq-combinations/8255


The doc of `Seq.combinations` says
>  A combination of length n is a subsequence of the original sequence, with the elements taken in order. 

`order` here may cause misunderstanding of **alphabetic order**

In fact, the implementation is 
https://github.com/scala/scala/blob/9312709125273760dca2549009ff166f4f5a0c82/src/library/scala/collection/Seq.scala#L610-L677

the `init()` will use the order of firsrt occurence in seq

```scala
scala> val xs = Seq('c', 'b', 'a', 'c', 'd', 'a', 'd', 'd')
val xs: Seq[Char] = List(c, b, a, c, d, a, d, d)

scala> (xs map (e => (e, m.getOrElseUpdate(e, m.size))) sortBy (_._2)).unzip
val res16: (Seq[Char], Seq[Int]) = (List(c, c, b, a, a, d, d, d),List(0, 0, 1, 2, 2, 3, 3, 3))

scala> init(Seq('c', 'b', 'a', 'c', 'd', 'a', 'd', 'd'), 1)
val res11: (scala.collection.IndexedSeq[Char], Array[Int], Array[Int]) = (Vector(c, c, b, a, a, d, d, d),Array(2, 1, 2, 3),Array(1, 0, 0, 0))
```