### PR TITLE
doc: fix -release versions

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -82,7 +82,7 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
       domain  = languageFeatures
     ) withAbbreviation "--language"
   }
-  val release = StringSetting("-release", "release", "Compile for a specific version of the Java platform. Supported targets: 6, 7, 8, 9", "").withPostSetHook { (value: StringSetting) =>
+  val release = StringSetting("-release", "release", "Compile for a specific version of the Java platform. Supported targets: 8, 9, ..., 17, 18", "").withPostSetHook { (value: StringSetting) =>
     if (value.value != "" && !scala.util.Properties.isJavaAtLeast("9")) {
       errorFn.apply("-release is only supported on Java 9 and higher")
     } else {


### PR DESCRIPTION
it would be nice if `-release 7` and lower actually failed fast, but regardless, I believe this change is mergeable on its own