### PR TITLE
Doc for combinations includes different words

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -1599,30 +1599,53 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     */
   def sliding(size: Int, step: Int = 1): Iterator[Array[A]] = mutable.ArraySeq.make(xs).sliding(size, step).map(_.toArray[A])
 
-  /** Iterates over combinations.  A _combination_ of length `n` is a subsequence of
-    *  the original array, with the elements taken in order.  Thus, `Array("x", "y")` and `Array("y", "y")`
-    *  are both length-2 combinations of `Array("x", "y", "y")`, but `Array("y", "x")` is not.  If there is
-    *  more than one way to generate the same subsequence, only one will be returned.
-    *
-    *  For example, `Array("x", "y", "y", "y")` has three different ways to generate `Array("x", "y")` depending on
-    *  whether the first, second, or third `"y"` is selected.  However, since all are
-    *  identical, only one will be chosen.  Which of the three will be taken is an
-    *  implementation detail that is not defined.
-    *
-    *  @return   An Iterator which traverses the possible n-element combinations of this array.
-    *  @example  {{{
-    *  Array("a", "b", "b", "b", "c").combinations(2) == Iterator(Array(a, b), Array(a, c), Array(b, b), Array(b, c))
-    *  }}}
-    */
+  /** Iterates over combinations of elements.
+   *
+   *  A '''combination''' of length `n` is a sequence of `n` elements selected in order of their first index in this sequence.
+   *
+   *  For example, `"xyx"` has two combinations of length 2. The `x` is selected first: `"xx"`, `"xy"`.
+   *  The sequence `"yx"` is not returned as a combination because it is subsumed by `"xy"`.
+   *
+   *  If there is more than one way to generate the same combination, only one will be returned.
+   *
+   *  For example, the result `"xy"` arbitrarily selected one of the `x` elements.
+   *
+   *  As a further illustration, `"xyxx"` has three different ways to generate `"xy"` because there are three elements `x`
+   *  to choose from. Moreover, there are three unordered pairs `"xx"` but only one is returned.
+   *
+   *  It is not specified which of these equal combinations is returned. It is an implementation detail
+   *  that should not be relied on. For example, the combination `"xx"` does not necessarily contain
+   *  the first `x` in this sequence. This behavior is observable if the elements compare equal
+   *  but are not identical.
+   *
+   *  As a consequence, `"xyx".combinations(3).next()` is `"xxy"`: the combination does not reflect the order
+   *  of the original sequence, but the order in which elements were selected, by "first index";
+   *  the order of each `x` element is also arbitrary.
+   *
+   *  @return   An Iterator which traverses the n-element combinations of this array
+   *  @example {{{
+   *    Array('a', 'b', 'b', 'b', 'c').combinations(2).map(runtime.ScalaRunTime.stringOf).foreach(println)
+   *    // Array(a, b)
+   *    // Array(a, c)
+   *    // Array(b, b)
+   *    // Array(b, c)
+   *    Array('b', 'a', 'b').combinations(2).map(runtime.ScalaRunTime.stringOf).foreach(println)
+   *    // Array(b, b)
+   *    // Array(b, a)
+   *  }}}
+   */
   def combinations(n: Int): Iterator[Array[A]] = mutable.ArraySeq.make(xs).combinations(n).map(_.toArray[A])
 
-  /** Iterates over distinct permutations.
-    *
-    *  @return   An Iterator which traverses the distinct permutations of this array.
-    *  @example {{{
-    *  Array("a", "b", "b").permutations == Iterator(Array(a, b, b), Array(b, a, b), Array(b, b, a))
-    *  }}}
-    */
+  /** Iterates over distinct permutations of elements.
+   *
+   *  @return   An Iterator which traverses the distinct permutations of this array.
+   *  @example {{{
+   *    Array('a', 'b', 'b').permutations.map(runtime.ScalaRunTime.stringOf).foreach(println)
+   *    // Array(a, b, b)
+   *    // Array(b, a, b)
+   *    // Array(b, b, a)
+   *  }}}
+   */
   def permutations: Iterator[Array[A]] = mutable.ArraySeq.make(xs).permutations.map(_.toArray[A])
 
   // we have another overload here, so we need to duplicate this method

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -528,35 +528,59 @@ trait SeqOps[+A, +CC[_], +C] extends Any
   @deprecated("Use .reverseIterator.map(f).to(...) instead of .reverseMap(f)", "2.13.0")
   def reverseMap[B](f: A => B): CC[B] = iterableFactory.from(new View.Map(View.fromIteratorProvider(() => reverseIterator), f))
 
-  /** Iterates over distinct permutations.
-    *
-    *  $willForceEvaluation
-    *
-    *  @return   An Iterator which traverses the distinct permutations of this $coll.
-    *  @example  `"abb".permutations = Iterator(abb, bab, bba)`
-    */
+  /** Iterates over distinct permutations of elements.
+   *
+   *  $willForceEvaluation
+   *
+   *  @return   An Iterator which traverses the distinct permutations of this $coll.
+   *  @example {{{
+   *    Seq('a', 'b', 'b').permutations.foreach(println)
+   *    // List(a, b, b)
+   *    // List(b, a, b)
+   *    // List(b, b, a)
+   *  }}}
+   */
   def permutations: Iterator[C] =
     if (isEmpty) Iterator.single(coll)
     else new PermutationsItr
 
-  /** Iterates over combinations.  A _combination_ of length `n` is a subsequence of
-    *  the original sequence, with the elements taken in order of their first occurrence.  Thus, `"yy"` and `"yx"`
-    *  are both length-2 combinations of `"yxy"`, but `"xy"` is not.  If there is
-    *  more than one way to generate the same subsequence, only one will be returned.
-    *
-    *  For example, `"yxyy"` has three different ways to generate `"yx"` depending on
-    *  whether the first, second, or third `"y"` is selected.  However, since all are
-    *  identical, only one will be chosen.  Which of the three will be taken is an
-    *  implementation detail that is not defined.
-    *
-    *  $willForceEvaluation
-    *
-    *  @return   An Iterator which traverses the possible n-element combinations of this $coll.
-    *  @example {{{
-    *    "abbbc".combinations(2) = Iterator(ab, ac, bb, bc)
-    *    "bab".combinations(2) = Iterator(bb, ba)
-    *  }}}
-    */
+  /** Iterates over combinations of elements.
+   *
+   *  A '''combination''' of length `n` is a sequence of `n` elements selected in order of their first index in this sequence.
+   *
+   *  For example, `"xyx"` has two combinations of length 2. The `x` is selected first: `"xx"`, `"xy"`.
+   *  The sequence `"yx"` is not returned as a combination because it is subsumed by `"xy"`.
+   *
+   *  If there is more than one way to generate the same combination, only one will be returned.
+   *
+   *  For example, the result `"xy"` arbitrarily selected one of the `x` elements.
+   *
+   *  As a further illustration, `"xyxx"` has three different ways to generate `"xy"` because there are three elements `x`
+   *  to choose from. Moreover, there are three unordered pairs `"xx"` but only one is returned.
+   *
+   *  It is not specified which of these equal combinations is returned. It is an implementation detail
+   *  that should not be relied on. For example, the combination `"xx"` does not necessarily contain
+   *  the first `x` in this sequence. This behavior is observable if the elements compare equal
+   *  but are not identical.
+   *
+   *  As a consequence, `"xyx".combinations(3).next()` is `"xxy"`: the combination does not reflect the order
+   *  of the original sequence, but the order in which elements were selected, by "first index";
+   *  the order of each `x` element is also arbitrary.
+   *
+   *  $willForceEvaluation
+   *
+   *  @return   An Iterator which traverses the n-element combinations of this $coll.
+   *  @example {{{
+   *    Seq('a', 'b', 'b', 'b', 'c').combinations(2).foreach(println)
+   *    // List(a, b)
+   *    // List(a, c)
+   *    // List(b, b)
+   *    // List(b, c)
+   *    Seq('b', 'a', 'b').combinations(2).foreach(println)
+   *    // List(b, b)
+   *    // List(b, a)
+   *  }}}
+   */
   def combinations(n: Int): Iterator[C] =
     if (n < 0 || n > size) Iterator.empty
     else new CombinationsItr(n)

--- a/src/library/scala/collection/StringOps.scala
+++ b/src/library/scala/collection/StringOps.scala
@@ -1593,31 +1593,55 @@ final class StringOps(private val s: String) extends AnyVal {
     */
   def sliding(size: Int, step: Int = 1): Iterator[String] = new WrappedString(s).sliding(size, step).map(_.unwrap)
 
-  /** Iterates over combinations.  A _combination_ of length `n` is a subsequence of
-    *  the original string, with the chars taken in order of their first occurrence.  Thus, `"yy"` and `"yx"`
-    *  are both length-2 combinations of `"yxy"`, but `"xy"` is not.  If there is
-    *  more than one way to generate the same subsequence, only one will be returned.
-    *
-    *  For example, `"yxyy"` has three different ways to generate `"yx"` depending on
-    *  whether the first, second, or third `"y"` is selected.  However, since all are
-    *  identical, only one will be chosen.  Which of the three will be taken is an
-    *  implementation detail that is not defined.
-    *
-    *  @return   An Iterator which traverses the possible n-element combinations of this string.
-    *  @example {{{
-    *    "abbbc".combinations(2) = Iterator(ab, ac, bb, bc)
-    *    "bab".combinations(2) = Iterator(bb, ba)
-    *  }}}
-    *  @note     $unicodeunaware
-    */
+  /** Iterates over combinations of elements.
+   *
+   *  A '''combination''' of length `n` is a sequence of `n` elements selected in order of their first index in this sequence.
+   *
+   *  For example, `"xyx"` has two combinations of length 2. The `x` is selected first: `"xx"`, `"xy"`.
+   *  The sequence `"yx"` is not returned as a combination because it is subsumed by `"xy"`.
+   *
+   *  If there is more than one way to generate the same combination, only one will be returned.
+   *
+   *  For example, the result `"xy"` arbitrarily selected one of the `x` elements.
+   *
+   *  As a further illustration, `"xyxx"` has three different ways to generate `"xy"` because there are three elements `x`
+   *  to choose from. Moreover, there are three unordered pairs `"xx"` but only one is returned.
+   *
+   *  It is not specified which of these equal combinations is returned. It is an implementation detail
+   *  that should not be relied on. For example, the combination `"xx"` does not necessarily contain
+   *  the first `x` in this sequence. This behavior is observable if the elements compare equal
+   *  but are not identical.
+   *
+   *  As a consequence, `"xyx".combinations(3).next()` is `"xxy"`: the combination does not reflect the order
+   *  of the original sequence, but the order in which elements were selected, by "first index";
+   *  the order of each `x` element is also arbitrary.
+   *
+   *  @return   An Iterator which traverses the n-element combinations of this string.
+   *  @example {{{
+   *    "abbbc".combinations(2).foreach(println)
+   *    // ab
+   *    // ac
+   *    // bb
+   *    // bc
+   *    "bab".combinations(2).foreach(println)
+   *    // bb
+   *    // ba
+   *  }}}
+   *  @note     $unicodeunaware
+   */
   def combinations(n: Int): Iterator[String] = new WrappedString(s).combinations(n).map(_.unwrap)
 
-  /** Iterates over distinct permutations.
-    *
-    *  @return   An Iterator which traverses the distinct permutations of this string.
-    *  @example  `"abb".permutations = Iterator(abb, bab, bba)`
-    *  @note     $unicodeunaware
-    */
+  /** Iterates over distinct permutations of elements.
+   *
+   *  @return   An Iterator which traverses the distinct permutations of this string.
+   *  @example {{{
+   *    "abb".permutations.foreach(println)
+   *    // abb
+   *    // bab
+   *    // bba
+   *  }}}
+   *  @note     $unicodeunaware
+   */
   def permutations: Iterator[String] = new WrappedString(s).permutations.map(_.unwrap)
 }
 


### PR DESCRIPTION
Fixes scala/bug#12540

Explains the status quo in a way even I can understand, at least until I forget what I meant.

The main text is cut/pasted and not specialized, but just uses "String notation", which is convenient because compact.

The examples are specialized and runnable, following other example blocks in collections. To answer the question on the recent PR, the examples look like worksheet style, with comments to show output.

At the last minute, added a line to address the intuition on the ticket, about why isn't the combination taking n elements of a sequence of length n just the sequence itself?

