### PR TITLE
Avoid potential cycle under `-Ypickle-write-java`

### DIFF
--- a/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
+++ b/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
@@ -399,10 +399,10 @@ abstract class UnPickler {
         ThisType(sym)
       }
 
-      def fixJavaObjectType(typeRef: Type): Type = {
-        if (classRoot.isJava && typeRef =:= definitions.ObjectTpe) {
+      def mkTypeRef(pre: Type, sym: Symbol, args: List[Type]): Type = {
+        if (classRoot.isJava && (sym == definitions.ObjectClass)) {
           definitions.ObjectTpeJava
-        } else typeRef
+        } else TypeRef(pre, sym, args)
       }
 
       // We're stuck with the order types are pickled in, but with judicious use
@@ -415,7 +415,7 @@ abstract class UnPickler {
         case SINGLEtpe                 => SingleType(readTypeRef(), readSymbolRef().filter(_.isStable)) // scala/bug#7596 account for overloading
         case SUPERtpe                  => SuperType(readTypeRef(), readTypeRef())
         case CONSTANTtpe               => ConstantType(readConstantRef())
-        case TYPEREFtpe                => fixJavaObjectType(TypeRef(readTypeRef(), readSymbolRef(), readTypes()))
+        case TYPEREFtpe                => mkTypeRef(readTypeRef(), readSymbolRef(), readTypes())
         case TYPEBOUNDStpe             => TypeBounds(readTypeRef(), readTypeRef())
         case REFINEDtpe | CLASSINFOtpe => CompoundType(readSymbolRef(), readTypes())
         case METHODtpe                 => MethodTypeRef(readTypeRef(), readSymbols())


### PR DESCRIPTION
Followup for #9826 that fixes a `StackOverflowException` it introduces by using `=:=` to check if we're dealing with
a `java.lang.Object` reference. I don't have a test case for the SOE itself. An existing test (`testPickleWriteJava`) covers the functionality of #9826.