### PR TITLE
Use fake dir entry in classpath for test

### DIFF
--- a/test/files/pos/t9370/sample_2.scala
+++ b/test/files/pos/t9370/sample_2.scala
@@ -1,5 +1,5 @@
 
-// scalac: -Xplugin:/tmp -Xplugin:. -Xplugin-require:timebomb -Ystop-after:parser
+// scalac: -Xplugin:/tmp-fake -Xplugin:. -Xplugin-require:timebomb -Ystop-after:parser
 //
 package sample
 


### PR DESCRIPTION
The test is to look into second entry if necessary.
The first entry need not be a real directory.
In particular, the test currently fails if someone copied
a plugin file to /tmp.