### PR TITLE
expand GitHub Actions matrix (add Ubuntu, more JDKs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,13 @@ defaults:
 
 jobs:
   build_and_test:
-    name: Windows
-    runs-on: windows-latest
+    name: Test
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - java: 8
-          - java: 17
+        os: [ubuntu-latest, windows-latest]
+        java: [8, 11, 17]
+    runs-on: ${{matrix.os}}
     steps:
       - run: git config --global core.autocrlf false
       - name: Checkout


### PR DESCRIPTION
(resubmission of #9941)

on every _merged_ PR, run the full 8/11/17 and Linux/Windows matrix (six entries)

we don't merge a huge quantity of PRs, so I think the cost/benefit here is probably good

it also constitutes progress on relying more on GitHub Actions and less on Travis-CI and Jenkins. for full context on that, see scala/scala-dev#751