### PR TITLE
Deprecations suppress deprecations

### DIFF
--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -89,7 +89,7 @@ trait Reporting extends internal.Reporting { self: ast.Positions with Compilatio
           source <- suppressions.keysIterator.toList
           sups   <- suppressions.remove(source)
           sup    <- sups.reverse
-        } if (!sup.used) issueWarning(Message.Plain(sup.annotPos, "@nowarn annotation does not suppress any warnings", WarningCategory.UnusedNowarn, ""))
+        } if (!sup.used && !sup.synthetic) issueWarning(Message.Plain(sup.annotPos, "@nowarn annotation does not suppress any warnings", WarningCategory.UnusedNowarn, ""))
     }
 
     def reportSuspendedMessages(unit: CompilationUnit): Unit = {
@@ -629,7 +629,7 @@ object Reporting {
     }
   }
 
-  case class Suppression(annotPos: Position, filters: List[MessageFilter], start: Int, end: Int) {
+  case class Suppression(annotPos: Position, filters: List[MessageFilter], start: Int, end: Int, synthetic: Boolean = false) {
     private[this] var _used = false
     def used: Boolean = _used
     def markUsed(): Unit = { _used = true }

--- a/src/compiler/scala/tools/nsc/ast/TreeGen.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeGen.scala
@@ -174,7 +174,7 @@ abstract class TreeGen extends scala.reflect.internal.TreeGen with TreeDSL {
    */
   def convertToTypeName(tree: Tree): Option[RefTree] = tree match {
     case Select(qual, name) => Some(Select(qual, name.toTypeName))
-    case Ident(name)        => Some(Ident(name.toTypeName))
+    case Ident(name)        => Some(Ident(name.toTypeName).copyAttrs(tree))
     case _                  => None
   }
 

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -104,7 +104,7 @@ trait ScannersCommon {
   }
 
   def createKeywordArray(keywords: Seq[(Name, Token)], defaultToken: Token): (Token, Array[Token]) = {
-    val names = keywords sortBy (_._1.start) map { case (k, v) => (k.start, v) }
+    val names = keywords.sortBy(_._1.start).map { case (k, v) => (k.start, v) }
     val low   = names.head._1
     val high  = names.last._1
     val arr   = Array.fill(high - low + 1)(defaultToken)
@@ -1515,7 +1515,7 @@ trait Scanners extends ScannersCommon {
     nme.HASHkw      -> HASH,
     nme.ATkw        -> AT,
     nme.MACROkw     -> IDENTIFIER,
-    nme.THENkw      -> IDENTIFIER)
+    )
 
   private var kwOffset: Offset = -1
   private val kwArray: Array[Token] = {
@@ -1528,7 +1528,7 @@ trait Scanners extends ScannersCommon {
 
   final val softModifierNames = Set(nme.open, nme.infix)
 
-  final val scala3Keywords = Set(nme.`enum`, nme.`export`, nme.`given`)
+  final val scala3Keywords = Set(nme.`enum`, nme.`export`, nme.`given`, nme.`then`)
 
 // Token representation ----------------------------------------------------
 

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -209,7 +209,6 @@ trait StdNames {
     final val RETURNkw: TermName    = kw("return")
     final val SEALEDkw: TermName    = kw("sealed")
     final val SUPERkw: TermName     = kw("super")
-    final val THENkw: TermName      = kw("then")
     final val THISkw: TermName      = kw("this")
     final val THROWkw: TermName     = kw("throw")
     final val TRAITkw: TermName     = kw("trait")
@@ -680,6 +679,7 @@ trait StdNames {
     val `enum`: NameType          = nameType("enum")
     val `export`: NameType        = nameType("export")
     val `given`: NameType         = nameType("given")
+    val `then`: NameType          = nameType("then")
 
     // Scala 3 soft keywords
     val infix: NameType           = nameType("infix")

--- a/test/files/neg/t5715.check
+++ b/test/files/neg/t5715.check
@@ -1,0 +1,15 @@
+t5715.scala:16: warning: then is a reserved word (since 2.10.0); usage as an identifier is deprecated
+  val y = new then                    // keyword and deprecated ref
+              ^
+t5715.scala:19: warning: then is a reserved word (since 2.10.0); usage as an identifier is deprecated
+  object then                         // keyword
+         ^
+t5715.scala:12: warning: class then in package example is deprecated (since 0.1): that was then
+  val u = new `then`                  // backticked but deprecated ref
+              ^
+t5715.scala:16: warning: class then in package example is deprecated (since 0.1): that was then
+  val y = new then                    // keyword and deprecated ref
+              ^
+error: No warnings can be incurred under -Werror.
+4 warnings
+1 error

--- a/test/files/neg/t5715.check
+++ b/test/files/neg/t5715.check
@@ -1,7 +1,4 @@
-t5715.scala:16: warning: then is a reserved word (since 2.10.0); usage as an identifier is deprecated
-  val y = new then                    // keyword and deprecated ref
-              ^
-t5715.scala:19: warning: then is a reserved word (since 2.10.0); usage as an identifier is deprecated
+t5715.scala:19: warning: Wrap `then` in backticks to use it as an identifier, it will become a keyword in Scala 3.
   object then                         // keyword
          ^
 t5715.scala:12: warning: class then in package example is deprecated (since 0.1): that was then
@@ -11,5 +8,5 @@ t5715.scala:16: warning: class then in package example is deprecated (since 0.1)
   val y = new then                    // keyword and deprecated ref
               ^
 error: No warnings can be incurred under -Werror.
-4 warnings
+3 warnings
 1 error

--- a/test/files/neg/t5715.scala
+++ b/test/files/neg/t5715.scala
@@ -1,0 +1,20 @@
+
+// scalac: -Xlint -Werror
+
+package example
+
+@deprecated("that was then", "0.1")
+class then                            // suppressed
+
+object X {
+  @deprecated("this is now", "0.5")
+  val t = new then                    // suppressed
+  val u = new `then`                  // backticked but deprecated ref
+}
+
+object Y {
+  val y = new then                    // keyword and deprecated ref
+}
+object Z {
+  object then                         // keyword
+}


### PR DESCRIPTION
Any deprecation warning is suppressed if an enclosing definition is deprecated. This is now also true for deprecated syntax.

Fixes scala/bug#5715