### PR TITLE
[REVISIT] Allow deprecating an entire package by deprecating its package object [ci: last-only]

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -269,15 +269,17 @@ abstract class RefChecks extends Transform {
         }
       }
 
-      def infoString(sym: Symbol) = infoString0(sym, sym.owner != clazz)
-      def infoStringWithLocation(sym: Symbol) = infoString0(sym, true)
+      def infoString(sym: Symbol) = infoString0(sym, showLocation = sym.owner != clazz)
+      def infoStringWithLocation(sym: Symbol) = infoString0(sym, showLocation = true)
 
       def infoString0(member: Symbol, showLocation: Boolean) = {
         val location =
           if (!showLocation) ""
-          else member.ownsString match {
-            case ""   => ""
-            case s    => s" (defined in $s)"
+          else {
+            val owner = member.effectiveOwner
+            if (owner.isClass && !owner.isEmptyPrefix)
+              s" (defined in $owner)"
+            else ""
           }
         val macroStr = if (member.isTermMacro) "macro " else ""
 

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1270,7 +1270,7 @@ abstract class RefChecks extends Transform {
         false
     }
 
-    private def checkUndesiredProperties(sym: Symbol, pos: Position): Unit = {
+    private def checkUndesiredProperties(sym: Symbol, pos: Position): Unit = if (sym != NoSymbol) {
       // Issue a deprecation warning if:
       //  - symbol is deprecated and the point of reference is not enclosed in a deprecated member
       //    (or a member with a deprecated companion)

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -2791,19 +2791,13 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       }
     }
 
-    /** String representation of location.
-     */
-    def ownsString: String = {
-      val owns = effectiveOwner
-      if (owns.isClass && !owns.isEmptyPrefix) "" + owns else ""
-    }
-
     /** String representation of location, plus a preposition.  Doesn't do much,
      *  for backward compatibility reasons.
      */
-    def locationString: String = ownsString match {
-      case ""   => ""
-      case s    => " in " + s
+    def locationString: String = {
+      val owner = effectiveOwner
+      if (owner.isClass && !owner.isEmptyPrefix) s" in $owner"
+      else ""
     }
     def fullLocationString: String = toString + locationString
     def signatureString: String    = if (hasRawInfo) infoString(rawInfo) else "<_>"

--- a/test/files/neg/t3115a.check
+++ b/test/files/neg/t3115a.check
@@ -1,7 +1,7 @@
 t3115a.scala:21: warning: method c in class C is deprecated (since 0.1): this is especially useless
     def k = new p.C().c  // deprecated * 2
                       ^
-t3115a.scala:21: warning: class C in package p is deprecated
+t3115a.scala:21: warning: class C in package p is deprecated in package p (since 0.9-RC1): we won't use this package any more
     def k = new p.C().c  // deprecated * 2
                   ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t3115a.check
+++ b/test/files/neg/t3115a.check
@@ -1,0 +1,9 @@
+t3115a.scala:21: warning: method c in class C is deprecated (since 0.1): this is especially useless
+    def k = new p.C().c  // deprecated * 2
+                      ^
+t3115a.scala:21: warning: class C in package p is deprecated
+    def k = new p.C().c  // deprecated * 2
+                  ^
+error: No warnings can be incurred under -Werror.
+2 warnings
+1 error

--- a/test/files/neg/t3115a.scala
+++ b/test/files/neg/t3115a.scala
@@ -1,0 +1,23 @@
+// scalac: -Xlint -Werror
+
+// deprecated package should suppress deprecation warnings in the package
+
+package p {
+  @deprecated("we won't use this package any more", since="0.9-RC1")
+  object `package`
+
+  class C {
+    @deprecated("this is especially useless", since="0.1")
+    def c = 42
+  }
+
+  class D {
+    def d = new C().c   // would be suppressed by deprecating D, should be suppressed by deprecated p
+  }
+}
+
+package q {
+  class K {
+    def k = new p.C().c  // deprecated * 2
+  }
+}

--- a/test/files/neg/t3115b.check
+++ b/test/files/neg/t3115b.check
@@ -1,0 +1,6 @@
+t3115b.scala:17: warning: class C in package p is deprecated
+    def k = new C()    // deprecated
+                ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/t3115b.check
+++ b/test/files/neg/t3115b.check
@@ -1,4 +1,4 @@
-t3115b.scala:17: warning: class C in package p is deprecated
+t3115b.scala:17: warning: class C in package p is deprecated in package p (since 0.9-RC1): we won't use this package any more
     def k = new C()    // deprecated
                 ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t3115b.scala
+++ b/test/files/neg/t3115b.scala
@@ -1,0 +1,20 @@
+// scalac: -Xlint -Werror
+
+// deprecated package should induce deprecation of the package members
+
+package p {
+  @deprecated("we won't use this package any more", since="0.9-RC1")
+  object `package`
+
+  class C {
+    def c = 42
+  }
+}
+
+package q {
+  import p._
+  class K {
+    def k = new C()    // deprecated
+    def n = k.c        // let's not go nuts
+  }
+}

--- a/test/files/neg/t3115c.check
+++ b/test/files/neg/t3115c.check
@@ -1,0 +1,7 @@
+t3115c.scala:4: error: expected start of definition
+package object p {
+^
+t3115c.scala:8: error: expected start of definition
+package q {
+^
+2 errors

--- a/test/files/neg/t3115c.scala
+++ b/test/files/neg/t3115c.scala
@@ -1,0 +1,10 @@
+// scalac: -Xlint -Werror
+
+@deprecated("we won't use this package any more", since="0.9-RC1")
+package object p {
+  def then = 42           // future reserved, but suppressed by available package object
+}
+@deprecated("also defunct", since="0.9-RC1")
+package q {
+  class C
+}

--- a/test/files/neg/t3115d.check
+++ b/test/files/neg/t3115d.check
@@ -1,4 +1,4 @@
-test_2.scala:5: warning: class C in package p is deprecated
+test_2.scala:5: warning: class C in package p is deprecated in package p (since 2.0): this is the old lib
     def f = new p.C
                   ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t3115d.check
+++ b/test/files/neg/t3115d.check
@@ -1,0 +1,6 @@
+test_2.scala:5: warning: class C in package p is deprecated
+    def f = new p.C
+                  ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/t3115d/lib_1.scala
+++ b/test/files/neg/t3115d/lib_1.scala
@@ -1,0 +1,9 @@
+
+// scalac: -Xlint -Werror
+
+package p {
+  @deprecated("this is the old lib", since="2.0")
+  object `package`
+
+  class C
+}

--- a/test/files/neg/t3115d/test_2.scala
+++ b/test/files/neg/t3115d/test_2.scala
@@ -1,0 +1,7 @@
+// scalac: -Xlint -Werror
+
+package q {
+  class Test {
+    def f = new p.C
+  }
+}

--- a/test/files/neg/t3115e.check
+++ b/test/files/neg/t3115e.check
@@ -1,0 +1,9 @@
+t3115e.scala:15: warning: method c in class C is deprecated (since 0.1): this is especially useless
+  def d = new p.q.C().c
+                      ^
+t3115e.scala:15: warning: class C in package q is deprecated in package p (since 0.9-RC1): we won't use this package any more
+  def d = new p.q.C().c
+                  ^
+error: No warnings can be incurred under -Werror.
+2 warnings
+1 error

--- a/test/files/neg/t3115e.scala
+++ b/test/files/neg/t3115e.scala
@@ -1,0 +1,16 @@
+// scalac: -Xlint -Werror
+
+package p {
+  @deprecated("we won't use this package any more", since="0.9-RC1")
+  object `package`
+
+  package q {
+    class C {
+      @deprecated("this is especially useless", since="0.1")
+      def c = 42
+    }
+  }
+}
+class D {
+  def d = new p.q.C().c
+}

--- a/test/files/pos/t3115.scala
+++ b/test/files/pos/t3115.scala
@@ -1,0 +1,12 @@
+// scalac: -Xlint -Werror
+
+package p {
+  @deprecated("we won't use this package any more", since="0.9-RC1")
+  object `package`
+
+  // TODO should suppress, but is not in range; should look up elements by position for semantics
+  @annotation.nowarn
+  class C {
+    def then = 42           // future reserved, but suppressed by available package object
+  }
+}

--- a/test/files/pos/t3115b.scala
+++ b/test/files/pos/t3115b.scala
@@ -1,0 +1,8 @@
+// scalac: -Xlint -Werror
+
+package p {
+  @deprecated("we won't use this package any more", since="0.9-RC1")
+  object `package` {
+    def then = 42           // future reserved, but suppressed by available package object
+  }
+}


### PR DESCRIPTION
Package members are deprecated if the package object of an enclosing package is deprecated.

Fixes https://github.com/scala/bug/issues/3115