### PR TITLE
Optimize `List()` to `Nil` again (fixing 2.13.4 regression)

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3797,10 +3797,11 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                   case _ =>
                 }
 
-                if (args.isEmpty && canTranslateEmptyListToNil && fun.symbol.isInitialized && currentRun.runDefinitions.isListApply(fun))
-                  atPos(tree.pos)(gen.mkNil setType restpe)
+                if (!isPastTyper && args.isEmpty && canTranslateEmptyListToNil && currentRun.runDefinitions.isListApply(fun))
+                  atPos(tree.pos)(gen.mkNil.setType(restpe))
                 else {
-                  val resTp = ifPatternSkipFormals(if (isPastTyper) restpe else restpe.deconst) // annoying issue with classOf that shouldn't be deconsted after typers (during fields phase)
+                  // annoying issue with classOf that shouldn't be deconsted after typers (during fields phase)
+                  val resTp = ifPatternSkipFormals(if (isPastTyper) restpe else restpe.deconst)
                   constfold(treeCopy.Apply(tree, fun, args2) setType resTp setPos pos2, context.owner)
                 }
               }

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -311,6 +311,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.JavaStringBufferClass
     definitions.JavaCharSequenceClass
     definitions.ListModule
+    definitions.ListModuleAlias
     definitions.NilModule
     definitions.SeqModule
     definitions.Collection_SeqModule

--- a/test/files/jvm/nil-conversion/Foo_1.scala
+++ b/test/files/jvm/nil-conversion/Foo_1.scala
@@ -1,0 +1,13 @@
+// scalac: -opt:none
+class Foo_1 {
+  def foo: List[Int] = List()
+
+  def bar: List[Int] = collection.immutable.List()
+
+  def baz: List[Int] = Foo_1.MyList()
+
+  def boo: List[Int] = List.empty
+}
+object Foo_1 {
+  val MyList = collection.immutable.List
+}

--- a/test/files/jvm/nil-conversion/Test.scala
+++ b/test/files/jvm/nil-conversion/Test.scala
@@ -1,0 +1,39 @@
+// scalac: -opt:none
+import scala.tools.partest.BytecodeTest
+
+import scala.tools.asm
+import asm.Opcodes._
+import asm.tree.{InsnList, AbstractInsnNode, FieldInsnNode, InsnNode}
+import scala.collection.JavaConverters._
+
+object Test extends BytecodeTest {
+
+  val module = "MODULE$" // nme.MODULE_INSTANCE_FIELD.decoded
+
+  def checkModuleLoad(what: String, x: AbstractInsnNode): Unit =
+    x match {
+      case f: FieldInsnNode =>
+        assert(f.name == module)
+        assert(f.owner == what)
+        assert(f.desc == s"L$what;")
+        assert(f.getOpcode == GETSTATIC)
+    }
+  def checkReturn(x: AbstractInsnNode): Unit =
+    x match {
+      case i: InsnNode => assert(i.getOpcode == ARETURN)
+    }
+
+  def show: Unit = {
+    val classNode = loadClassNode("Foo_1")
+    verifyNilConversion(getMethod(classNode, "foo").instructions)
+    verifyNilConversion(getMethod(classNode, "bar").instructions)
+    //verifyNilConversion(getMethod(classNode, "baz").instructions)  // requires extraordinary dispensation
+  }
+
+  def verifyNilConversion(insnList: InsnList): Unit = {
+    val all = insnList.iterator.asScala
+    checkModuleLoad("scala/collection/immutable/Nil$", all.next())
+    checkReturn(all.next())
+    assert(!all.hasNext)
+  }
+}

--- a/test/files/neg/compile-time-only-a.check
+++ b/test/files/neg/compile-time-only-a.check
@@ -64,9 +64,6 @@ compile-time-only-a.scala:60: error: C7
 compile-time-only-a.scala:61: error: C7
   val c707a: List[C7] = ???
              ^
-compile-time-only-a.scala:62: error: C7
-  val c707b = List[C7]()
-                   ^
 compile-time-only-a.scala:63: error: C7
   val c708a: T forSome { type T <: C7 } = ???
                ^
@@ -86,4 +83,4 @@ compile-time-only-a.scala:75: error: placebo
   @placebo def x = (2: @placebo)
                         ^
 1 warning
-28 errors
+27 errors

--- a/test/files/neg/compile-time-only-a.check
+++ b/test/files/neg/compile-time-only-a.check
@@ -65,22 +65,25 @@ compile-time-only-a.scala:61: error: C7
   val c707a: List[C7] = ???
              ^
 compile-time-only-a.scala:63: error: C7
+  val c707c = List.empty[C7]  // not yet eliminated by rewrite to Nil
+                         ^
+compile-time-only-a.scala:64: error: C7
   val c708a: T forSome { type T <: C7 } = ???
                ^
-compile-time-only-a.scala:66: error: C8
+compile-time-only-a.scala:67: error: C8
   val c709: (C8[Int], C8[C7]) = ???
             ^
-compile-time-only-a.scala:67: error: C8
+compile-time-only-a.scala:68: error: C8
   val c710: (C8[_] => C8[_]) = ???
                    ^
-compile-time-only-a.scala:74: error: placebo
+compile-time-only-a.scala:75: error: placebo
 class Test {
       ^
-compile-time-only-a.scala:75: error: placebo
+compile-time-only-a.scala:76: error: placebo
   @placebo def x = (2: @placebo)
                ^
-compile-time-only-a.scala:75: error: placebo
+compile-time-only-a.scala:76: error: placebo
   @placebo def x = (2: @placebo)
                         ^
 1 warning
-27 errors
+28 errors

--- a/test/files/neg/compile-time-only-a.scala
+++ b/test/files/neg/compile-time-only-a.scala
@@ -59,7 +59,8 @@ object Test extends App {
   // val c705: ({ @compileTimeOnly("C7") type C7[T] = List[T] })#C7[_] = ???
   val c706: C7 Either C7 = ???
   val c707a: List[C7] = ???
-  val c707b = List[C7]()
+  val c707b = List[C7]()      // eliminated by rewrite to Nil
+  val c707c = List.empty[C7]  // not yet eliminated by rewrite to Nil
   val c708a: T forSome { type T <: C7 } = ???
   // https://groups.google.com/forum/#!topic/scala-internals/5n07TiCnBZU
   // val c708b: T forSome { @compileTimeOnly("C7") type T } = ???

--- a/test/files/run/badout.check
+++ b/test/files/run/badout.check
@@ -1,0 +1,1 @@
+error: Output dir does not exist: badout-run.obj/bogus

--- a/test/files/run/badout.scala
+++ b/test/files/run/badout.scala
@@ -1,0 +1,13 @@
+
+import scala.tools.partest.DirectTest
+
+object Test extends DirectTest {
+
+  override def code = ""
+
+  private def bogusTemp = s"${testOutput.toString}/bogus" // no need to obfuscate -${System.currentTimeMillis}
+
+  override def extraSettings = s"${super.extraSettings} -Ygen-asmp $bogusTemp"
+
+  override def show() = assert(!compile())
+}

--- a/test/files/run/noInlineUnknownIndy/Test.scala
+++ b/test/files/run/noInlineUnknownIndy/Test.scala
@@ -4,7 +4,7 @@ import scala.jdk.CollectionConverters._
 import scala.tools.asm.tree.{ClassNode, InvokeDynamicInsnNode}
 import scala.tools.asm.{Handle, Opcodes}
 import scala.tools.partest.BytecodeTest.modifyClassFile
-import scala.tools.partest._
+import scala.tools.partest.DirectTest
 
 object Test extends DirectTest {
   override def code = "class T { def foo = A_1.test }"
@@ -21,7 +21,7 @@ object Test extends DirectTest {
       "notAMetaFactoryMethod",
       "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;[Ljava/lang/Object;)Ljava/lang/invoke/CallSite;",
       /* itf = */ false)
-    modifyClassFile(new File(testOutput.toFile, "A_1.class"))((cn: ClassNode) => {
+    modifyClassFile(new File(testOutput.jfile, "A_1.class"))((cn: ClassNode) => {
       val testMethod = cn.methods.iterator.asScala.find(_.name == "test").get
       val indy = testMethod.instructions.iterator.asScala.collect({ case i: InvokeDynamicInsnNode => i }).next()
       indy.bsm = unknownBootstrapMethod

--- a/test/files/run/reify_newimpl_35.check
+++ b/test/files/run/reify_newimpl_35.check
@@ -6,6 +6,6 @@ scala> def foo[T: TypeTag] = reify{List[T]()}
 def foo[T](implicit evidence$1: reflect.runtime.universe.TypeTag[T]): reflect.runtime.universe.Expr[List[T]]
 
 scala> println(foo)
-Expr[List[Nothing]](`package`.List.apply[Nothing]())
+Expr[List[Nothing]](Nil)
 
 scala> :quit

--- a/test/files/run/reify_newimpl_35.scala
+++ b/test/files/run/reify_newimpl_35.scala
@@ -1,5 +1,6 @@
 import scala.tools.partest.ReplTest
 
+// Show that reify sees rewrite to Nil in typer
 object Test extends ReplTest {
   override def extraSettings = "-Xlog-free-types"
   def code = """


### PR DESCRIPTION
Special dealiasing of `scala.List` (once needed by patmat) was removed in 2.13.4, but detection of `List()` for rewrite to `Nil` relied on it and has been broken.

The check for empty `List.apply` now handles `scala.List` and could be made to dealias more generally, see the test, but that is disabled for now as overly liberal.

Also improve error handling if my outputdir for `-Ygen-asmp` doesn't exist. Notice that the setting is not `OutputDir` because that is hardcoded to `-d` only.

Fixes scala/bug#12548
Fixes scala/bug#12549