### PR TITLE
Deprecate IterableOnceOps.fold

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -500,7 +500,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     *  @tparam A2  the element type of the second resulting collection
     *  @param f    the 'split function' mapping the elements of this array to an [[scala.util.Either]]
     *
-    *  @return     a pair of arrays: the first one made of those values returned by `f` that were wrapped in [[scala.util.Left]], 
+    *  @return     a pair of arrays: the first one made of those values returned by `f` that were wrapped in [[scala.util.Left]],
     *              and the second one made of those wrapped in [[scala.util.Right]]. */
   def partitionMap[A1: ClassTag, A2: ClassTag](f: A => Either[A1, A2]): (Array[A1], Array[A2]) = {
     val res1 = ArrayBuilder.make[A1]
@@ -914,6 +914,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     *  @param op      a binary operator that must be associative.
     *  @return        the result of applying the fold operator `op` between all the elements, or `z` if this array is empty.
     */
+  @deprecated("Use foldLeft or foldRight instead", "2.13.9")
   def fold[A1 >: A](z: A1)(op: (A1, A1) => A1): A1 = foldLeft(z)(op)
 
   /** Builds a new array by applying a function to all elements of this array.

--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -605,7 +605,7 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
   /** Counts the number of elements in the $coll which satisfy a predicate.
     *
     *  $willNotTerminateInf
-    * 
+    *
     *  @param p     the predicate  used to test elements.
     *  @return      the number of elements satisfying the predicate `p`.
     */
@@ -694,6 +694,7 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
     *  @param op      a binary operator that must be associative.
     *  @return        the result of applying the fold operator `op` between all the elements and `z`, or `z` if this $coll is empty.
     */
+  @deprecated("Use foldLeft or foldRight instead", "2.13.9")
   def fold[A1 >: A](z: A1)(op: (A1, A1) => A1): A1 = foldLeft(z)(op)
 
   /** Reduces the elements of this $coll using the specified associative binary operator.

--- a/src/library/scala/collection/StringOps.scala
+++ b/src/library/scala/collection/StringOps.scala
@@ -1113,6 +1113,7 @@ final class StringOps(private val s: String) extends AnyVal {
     *  @param op      a binary operator that must be associative.
     *  @return        the result of applying the fold operator `op` between all the chars and `z`, or `z` if this string is empty.
     */
+  @deprecated("Use foldLeft or foldRight instead", "2.13.9")
   @`inline` def fold[A1 >: Char](z: A1)(op: (A1, A1) => A1): A1 = foldLeft(z)(op)
 
   /** Selects the first char of this string.

--- a/test/files/run/iterableonce-fold-deprecation.check
+++ b/test/files/run/iterableonce-fold-deprecation.check
@@ -1,0 +1,21 @@
+iterableonce-fold-deprecation.scala:10: warning: method fold in trait IterableOnceOps is deprecated (since 2.13.9): Use foldLeft or foldRight instead
+    new LowerCaseString("Foo").fold(' ')((_, _) => ' ')
+                               ^
+iterableonce-fold-deprecation.scala:11: warning: method fold in trait IterableOnceOps is deprecated (since 2.13.9): Use foldLeft or foldRight instead
+    Iterator.empty[Int].fold(0)(_ + _)
+                        ^
+iterableonce-fold-deprecation.scala:13: warning: method fold in trait IterableOnceOps is deprecated (since 2.13.9): Use foldLeft or foldRight instead
+    List(1, 3, 5).fold(0)(_ + _)
+                  ^
+iterableonce-fold-deprecation.scala:14: warning: method fold in trait IterableOnceOps is deprecated (since 2.13.9): Use foldLeft or foldRight instead
+    BitSet(1, 3, 5).fold(0)(_ + _)
+                    ^
+iterableonce-fold-deprecation.scala:15: warning: method fold in trait IterableOnceOps is deprecated (since 2.13.9): Use foldLeft or foldRight instead
+    Map(1 -> 'a', 3 -> 'b', 5 -> 'c').fold(0 -> 'z')((_, _) => 10 -> 'x')
+                                      ^
+iterableonce-fold-deprecation.scala:17: warning: method fold in class ArrayOps is deprecated (since 2.13.9): Use foldLeft or foldRight instead
+    Array(1, 3, 5).fold(0)(_ + _)
+                   ^
+iterableonce-fold-deprecation.scala:18: warning: method fold in class StringOps is deprecated (since 2.13.9): Use foldLeft or foldRight instead
+    "Foo".fold(' ')((_, _) => ' ')
+          ^

--- a/test/files/run/iterableonce-fold-deprecation.scala
+++ b/test/files/run/iterableonce-fold-deprecation.scala
@@ -1,0 +1,43 @@
+// scalac: -deprecation
+//
+//
+//
+// scala pr #9972
+object Test {
+  import scala.collection.immutable.BitSet
+
+  def main(args: Array[String]): Unit = {
+    new LowerCaseString("Foo").fold(' ')((_, _) => ' ')
+    Iterator.empty[Int].fold(0)(_ + _)
+
+    List(1, 3, 5).fold(0)(_ + _)
+    BitSet(1, 3, 5).fold(0)(_ + _)
+    Map(1 -> 'a', 3 -> 'b', 5 -> 'c').fold(0 -> 'z')((_, _) => 10 -> 'x')
+
+    Array(1, 3, 5).fold(0)(_ + _)
+    "Foo".fold(' ')((_, _) => ' ')
+
+    // Ensure Option.fold is not deprecated
+    Option(10).fold(ifEmpty = 1)(x => (x * 3) + 5)
+  }
+}
+
+final case class LowerCaseString(source: String) extends IterableOnce[Char] with scala.collection.IterableOnceOps[Char, Iterable, String] {
+  override def iterator: Iterator[Char] = source.iterator.map(_.toLower)
+
+  override def scanLeft[B](z: B)(op: (B, Char) => B): Iterable[B] = ???
+  override def filter(p: Char => Boolean): String = ???
+  override def filterNot(pred: Char => Boolean): String = ???
+  override def take(n: Int): String = ???
+  override def takeWhile(p: Char => Boolean): String = ???
+  override def drop(n: Int): String = ???
+  override def dropWhile(p: Char => Boolean): String = ???
+  override def slice(from: Int, until: Int): String = ???
+  override def map[B](f: Char => B): Iterable[B] = ???
+  override def flatMap[B](f: Char => IterableOnce[B]): Iterable[B] = ???
+  override def flatten[B](implicit asIterable: Char => IterableOnce[B]): Iterable[B] = ???
+  override def collect[B](pf: PartialFunction[Char,B]): Iterable[B] = ???
+  override def zipWithIndex: Iterable[(Char, Int)] = ???
+  override def span(p: Char => Boolean): (String, String) = ???
+  override def tapEach[U](f: Char => U): String = ???
+}

--- a/test/junit/scala/collection/ArrayOpsTest.scala
+++ b/test/junit/scala/collection/ArrayOpsTest.scala
@@ -38,15 +38,15 @@ class ArrayOpsTest {
     val a = Array(1,2,3)
     assertEquals(6, a.foldLeft(0){ (a, b) => a+b })
     assertEquals(6, a.foldRight(0){ (a, b) => a+b })
-    assertEquals(6, a.fold(0){ (a, b) => a+b })
+    assertEquals(6, a.fold(0){ (a, b) => a+b } : @annotation.nowarn)
     val b = Array[Int]()
     assertEquals(0, b.foldLeft(0){ (a, b) => a+b })
     assertEquals(0, b.foldRight(0){ (a, b) => a+b })
-    assertEquals(0, b.fold(0){ (a, b) => a+b })
+    assertEquals(0, b.fold(0){ (a, b) => a+b } : @annotation.nowarn)
     val c = Array(1)
     assertEquals(3, c.foldLeft(2){ (a, b) => a+b })
     assertEquals(3, c.foldRight(2){ (a, b) => a+b })
-    assertEquals(3, c.fold(2){ (a, b) => a+b })
+    assertEquals(3, c.fold(2){ (a, b) => a+b } : @annotation.nowarn)
   }
 
   @Test


### PR DESCRIPTION
IMHO, there is no need for `fold` now that the parallel collections are on their own module and that trying to abstract over both sequential and parallel collections is not really recommended _(and probably not common either)_.

Also, personally, I have seen a couple of newcomers being confused about it and cryptic error messages due to type inference; usually, because they are trying to `fold` some `IterableOnce[A]` into some type `B`, as you can do with `foldLeft` but since `fold` does not allow arbitrary types _(for obvious reasons)_ the compiler infers `Any` _(or something worse)_.