### PR TITLE
Fix `-Yimports` support for package objects

### DIFF
--- a/test/files/pos/t12554.scala
+++ b/test/files/pos/t12554.scala
@@ -1,0 +1,7 @@
+// scalac: -Yimports:java.lang,scala,scala.Predef,scala.util.chaining
+
+class C {
+  def f = 42.tap(println)
+}
+
+// was: error: bad preamble import scala.util.chaining

--- a/test/files/pos/t12554b/p_1.scala
+++ b/test/files/pos/t12554b/p_1.scala
@@ -1,0 +1,18 @@
+
+package p {
+  object X
+}
+
+package object q {
+  object Y
+}
+
+package q {
+  class C
+}
+
+package object r {
+  object Z {
+    def greeting = "hello, world"
+  }
+}

--- a/test/files/pos/t12554b/s_2.scala
+++ b/test/files/pos/t12554b/s_2.scala
@@ -1,0 +1,9 @@
+
+// scalac: -Yimports:java.lang,scala,scala.Predef,p,q,r.Z
+
+object Test extends App {
+  println(X)
+  println(Y)
+  println(new C)
+  println(greeting)
+}


### PR DESCRIPTION
If user specifies `-Yimports:p.q` where `package object p { object q }`, the package object must now be forced early.

Fixes scala/bug#12554