### PR TITLE
[REVISIT SIGNIFICANT INDENTATION] Backport alternative trailing comma

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/MarkupParsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/MarkupParsers.scala
@@ -420,7 +420,7 @@ trait MarkupParsers {
 
     def escapeToScala[A](op: => A, kind: String) = {
       xEmbeddedBlock = false
-      val res = saving[List[Int], A](parser.in.sepRegions, parser.in.sepRegions = _) {
+      val res = saving[Region, A](parser.in.region, parser.in.region = _) {
         parser.in resume LBRACE
         op
       }

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -307,10 +307,10 @@ self =>
      */
     @inline final def lookingAhead[T](body: => T): T = {
       val saved = new ScannerData {} copyFrom in
-      val seps  = in.sepRegions
+      val seps  = in.region
       in.nextToken()
       try body finally {
-        in.sepRegions = seps
+        in.region = seps
         in.copyFrom(saved)
       }
     }
@@ -830,7 +830,7 @@ self =>
       val ts   = ListBuffer.empty[T].addOne(part)
       var done = in.token != separator
       while (!done) {
-        val skippable = separator == COMMA && in.sepRegions.nonEmpty && in.isTrailingComma(in.sepRegions.head)
+        val skippable = separator == COMMA && !in.region.isOutermost && in.isTrailingComma
         if (!skippable) {
           in.nextToken()
           ts += part
@@ -2162,7 +2162,7 @@ self =>
         def isCloseDelim = in.token match {
           case RBRACE => isXML
           case RPAREN => !isXML
-          case COMMA  => !isXML && in.isTrailingComma(RPAREN)
+          case COMMA  => !isXML && in.isTrailingComma
           case _      => false
         }
         def checkWildStar: Tree =

--- a/test/files/neg/quasiquotes-syntax-error-position.check
+++ b/test/files/neg/quasiquotes-syntax-error-position.check
@@ -1,7 +1,7 @@
 quasiquotes-syntax-error-position.scala:5: error: '=' expected but identifier found.
   q"def $a f"
            ^
-quasiquotes-syntax-error-position.scala:6: error: ')' expected but end of quote found.
+quasiquotes-syntax-error-position.scala:6: error: illegal start of simple expression
   q"$a("
        ^
 quasiquotes-syntax-error-position.scala:7: error: '}' expected but end of quote found.
@@ -31,7 +31,7 @@ quasiquotes-syntax-error-position.scala:14: error: ')' expected but end of quote
 quasiquotes-syntax-error-position.scala:15: error: ':' expected but ')' found.
   q"def foo(x)"
              ^
-quasiquotes-syntax-error-position.scala:16: error: ')' expected but ']' found.
+quasiquotes-syntax-error-position.scala:16: error: illegal start of simple expression
   q"$a(])"
        ^
 quasiquotes-syntax-error-position.scala:17: error: in XML literal: '>' expected instead of '$'


### PR DESCRIPTION
Make the coordination between parser and lexer for trailing comma look more like Dotty.
