### PR TITLE
Refrain from adding ctor to class from ct.sym

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -549,7 +549,8 @@ abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
       val needsConstructor = (
            !sawPrivateConstructor
         && !(instanceScope containsName nme.CONSTRUCTOR)
-        && ((sflags & INTERFACE) == 0 || (sflags | JAVA_ANNOTATION) != 0)
+        && ((sflags & INTERFACE) == 0 || (sflags & JAVA_ANNOTATION) != 0)
+        && !file.name.endsWith(".sig")
       )
       if (needsConstructor)
         instanceScope enter clazz.newClassConstructor(NoPosition)

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -548,9 +548,8 @@ abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
       0 until u2() foreach (_ => parseMethod())
       val needsConstructor = (
            !sawPrivateConstructor
-        && !(instanceScope containsName nme.CONSTRUCTOR)
-        && ((sflags & INTERFACE) == 0 || (sflags & JAVA_ANNOTATION) != 0)
-        && !file.name.endsWith(".sig")
+        && !instanceScope.containsName(nme.CONSTRUCTOR)
+        && ((sflags & (INTERFACE|JAVA_ANNOTATION)) == (INTERFACE|JAVA_ANNOTATION))
       )
       if (needsConstructor)
         instanceScope enter clazz.newClassConstructor(NoPosition)

--- a/test/files/neg/t12565.check
+++ b/test/files/neg/t12565.check
@@ -1,0 +1,4 @@
+t12565.scala:5: error: java.time.Instant does not have a constructor
+  def f = new java.time.Instant
+          ^
+1 error

--- a/test/files/neg/t12565.scala
+++ b/test/files/neg/t12565.scala
@@ -1,0 +1,9 @@
+// scalac: -Werror --release 8
+// javaVersion: 9+
+
+class C {
+  def f = new java.time.Instant
+}
+object Test extends App {
+  println(new C().f)
+}


### PR DESCRIPTION
Fixes scala/bug#12565

Tweak test for java annotation flag when parsing class file.

Previously, spurious constructors were added. Noticed when parsing `.sig` entry from `ct.sym`, which exposes only public API.