### PR TITLE
Make `-release` more useful, deprecate `-target`, align with Scala 3

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/PostProcessorFrontendAccess.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/PostProcessorFrontendAccess.scala
@@ -186,7 +186,7 @@ object PostProcessorFrontendAccess {
 
       @inline def debug: Boolean = s.isDebug
 
-      val target: String = s.target.value
+      val target: String = s.targetValue
 
       private val singleOutDir = s.outputDirs.getSingleOutput
       // the call to `outputDirFor` should be frontendSynch'd, but we assume that the setting is not mutated during the backend

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -82,15 +82,6 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
       domain  = languageFeatures
     ) withAbbreviation "--language"
   }
-  val release = StringSetting("-release", "release", "Compile for a specific version of the Java platform. Supported targets: 8, 9, ..., 17, 18", "").withPostSetHook { (value: StringSetting) =>
-    if (value.value != "" && !scala.util.Properties.isJavaAtLeast("9")) {
-      errorFn.apply("-release is only supported on Java 9 and higher")
-    } else {
-      // TODO validate numeric value
-      // TODO validate release <= java.specification.version
-    }
-  } withAbbreviation "--release"
-  def releaseValue: Option[String] = Option(release.value).filter(_ != "")
 
   /**
    * -X "Advanced" settings

--- a/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
@@ -14,11 +14,10 @@ package scala.tools.nsc
 package settings
 
 import scala.tools.util.PathResolver.Defaults
+import scala.util.Properties.{isJavaAtLeast, javaSpecVersion}
 
 /** Settings which aren't behind a -V, -W, -X, -Y, or -P option.
  *  When possible, the val and the option have identical names.
- *  The abstract settings are commented as to why they are as yet
- *  implemented in MutableSettings rather than mutation-generically.
  */
 trait StandardScalaSettings { _: MutableSettings =>
 
@@ -52,7 +51,26 @@ trait StandardScalaSettings { _: MutableSettings =>
   val nowarn =         BooleanSetting ("-nowarn", "Generate no warnings.") withAbbreviation "--no-warnings" withPostSetHook { s => if (s) maxwarns.value = 0 }
   val optimise:        BooleanSetting // depends on post hook which mutates other settings
   val print =          BooleanSetting ("-print", "Print program with Scala-specific features removed.") withAbbreviation "--print"
-  val target =         ChoiceSetting  ("-target", "target", "Target platform for object files.", AllTargetVersions, "8") withPreSetHook normalizeTarget _ withAbbreviation "--target"
+  val release =
+    ChoiceSetting("-release", "release", "Compile for a version of the Java API and target class file.", AllTargetVersions, normalizeTarget(javaSpecVersion))
+      .withPostSetHook { setting =>
+        val current = setting.value.toInt
+        if (!isJavaAtLeast("9") && current > 8) errorFn.apply("-release is only supported on JVM 9 and higher")
+        if (target.valueSetByUser.map(_.toInt > current).getOrElse(false)) errorFn("-release cannot be less than -target")
+        //target.value = setting.value  // this would trigger deprecation
+      }
+      .withAbbreviation("--release")
+      .withAbbreviation("-java-output-version")
+  def releaseValue: Option[String] = release.valueSetByUser
+  val target =
+    ChoiceSetting("-target", "target", "Target platform for object files.", AllTargetVersions, "8")
+      .withPreSetHook(normalizeTarget)
+      .withPostSetHook { setting =>
+        if (releaseValue.map(_.toInt < setting.value.toInt).getOrElse(false)) errorFn("-release cannot be less than -target")
+      }
+      .withAbbreviation("--target")
+      .withDeprecationMessage("Use -release instead to compile against the correct platform API.")
+  def targetValue: String = target.valueSetByUser.orElse(releaseValue).getOrElse(target.value)
   val unchecked =      BooleanSetting ("-unchecked", "Enable additional warnings where generated code depends on assumptions. See also -Wconf.") withAbbreviation "--unchecked" withPostSetHook { s =>
     if (s.value) Wconf.tryToSet(List(s"cat=unchecked:w"))
     else Wconf.tryToSet(List(s"cat=unchecked:s"))
@@ -66,8 +84,14 @@ trait StandardScalaSettings { _: MutableSettings =>
   // Support passe prefixes of -target values:
   //   - `jvm-` (from back when we also had `msil`)
   //   - `1.` (from back when Java 2 was a possibility)
-  // `-target:1.jvm-13` is ridiculous, though.
-  private[this] def normalizeTarget(in: String): String = in.stripPrefix("jvm-").stripPrefix("1.")
+  private def normalizeTarget(in: String): String = {
+    val jvmish = raw"jvm-(\d*)".r
+    in match {
+      case "1.8" | "jvm-1.8" => "8"
+      case jvmish(n) => n
+      case n => n
+    }
+  }
 }
 
 object StandardScalaSettings {

--- a/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
@@ -60,7 +60,7 @@ trait StandardScalaSettings { _: MutableSettings =>
         //target.value = setting.value  // this would trigger deprecation
       }
       .withAbbreviation("--release")
-      .withAbbreviation("-java-output-version")
+      // .withAbbreviation("-java-output-version")
   def releaseValue: Option[String] = release.valueSetByUser
   val target =
     ChoiceSetting("-target", "target", "Target platform for object files.", AllTargetVersions, "8")
@@ -69,9 +69,9 @@ trait StandardScalaSettings { _: MutableSettings =>
         if (releaseValue.map(_.toInt < setting.value.toInt).getOrElse(false)) errorFn("-release cannot be less than -target")
       }
       .withAbbreviation("--target")
-      .withAbbreviation("--Xtarget")
-      .withAbbreviation("-Xtarget")
-      .withAbbreviation("-Xunchecked-java-output-version")
+      // .withAbbreviation("--Xtarget")
+      // .withAbbreviation("-Xtarget")
+      // .withAbbreviation("-Xunchecked-java-output-version")
       .withDeprecationMessage("Use -release instead to compile against the correct platform API.")
   def targetValue: String = releaseValue.getOrElse(target.value)
   val unchecked =      BooleanSetting ("-unchecked", "Enable additional warnings where generated code depends on assumptions. See also -Wconf.") withAbbreviation "--unchecked" withPostSetHook { s =>

--- a/test/files/neg/t12543.check
+++ b/test/files/neg/t12543.check
@@ -1,0 +1,4 @@
+t12543.scala:10: error: value of is not a member of object java.util.List
+    val ss = java.util.List.of("Hello", who)
+                            ^
+1 error

--- a/test/files/neg/t12543.scala
+++ b/test/files/neg/t12543.scala
@@ -1,0 +1,17 @@
+
+// scalac: -Werror -release 8
+
+import scala.jdk.CollectionConverters._
+//import jdk.CollectionConverters._  // scala/bug/issues/12566
+import sun._
+
+object HelloWorld {
+  def main(args: Array[String]) = {
+    val ss = java.util.List.of("Hello", who)
+    println(ss.asScala.mkString("", ", ", "!"))
+  }
+}
+
+object sun {
+  val who = "world"
+}


### PR DESCRIPTION
## Why `-release`?

Use `-release` to specify the minimum JVM version that your code requires. This can be version 8 or higher, but is typically an LTS (Long Term Support) version such as `-release 8`, `-release 11`, or `-release 17`.

The compiler will compile your code with the Java standard library for the specified version, and it will output class files for that version (that is, that can only even be classloaded by that JVM version or higher).

Using `-release` allows you to decouple the JVM version on which your code is _built_ from the minimum JVM version on which it _runs_. For example, you might specify `-release 8` so your users are free to use 8, but you yourself can use 11 or 17 at build time (locally, or in CI).

## What has changed?

`-release` already existed in earlier Scala versions, but it only controlled the Java standard library version, not the bytecode version (which was controlled by `-target`).

The old `-target` option is now deprecated, because `-release` now includes `-target`'s behavior.

`-java-output-version` is now supported as an alias for `-release`.

## Motivation

Improves ergonomics and avoids accidental misuse, since now only `-release` is needed, whereas before two flags were needed.

Aligns `-release`s behavior on Scala 2 with its behavior on Scala 3.

Fixes scala/bug#12543.