### PR TITLE
Fix null-pointer regression in `Vector#prependedAll` and `Vector#appendedAll`

### DIFF
--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -193,13 +193,15 @@ sealed abstract class Vector[+A] private[immutable] (private[immutable] final va
   override def prepended[B >: A](elem: B): Vector[B] = super.prepended(elem)
   override def prependedAll[B >: A](prefix: collection.IterableOnce[B]): Vector[B] = {
     val k = prefix.knownSize
-    if(k == 0) this
+    if (k == 0) this
+    else if (k < 0) super.prependedAll(prefix)
     else prependedAll0(prefix, k)
   }
 
   override final def appendedAll[B >: A](suffix: collection.IterableOnce[B]): Vector[B] = {
     val k = suffix.knownSize
-    if(k == 0) this
+    if (k == 0) this
+    else if (k < 0) super.appendedAll(suffix)
     else appendedAll0(suffix, k)
   }
 

--- a/test/junit/scala/collection/immutable/VectorTest.scala
+++ b/test/junit/scala/collection/immutable/VectorTest.scala
@@ -13,6 +13,19 @@ import scala.reflect.{ClassTag, classTag}
 class VectorTest {
   import VectorUtils.validateDebug
 
+
+  @Test
+  def t12564(): Unit = {
+    val vector1 = Vector.fill(1000)(0)
+    // Some prepending, manifesting the bug seems to require 2 separate prepends
+    val vector2 = List.fill(25)(1) ++: 2 +: vector1
+    // Now append for fun and profit
+    val vector3 = vector2 ++ List.fill(40)(3)
+    // Any iteration will do although might hit NullPointerException in different place
+    val vector4 = vector3.collect { case n => n }
+    assert(vector3 == vector4)
+  }
+
   @Test
   def hasCorrectDropAndTakeMethods(): Unit = {
     val v = Vector(0) ++ Vector(1 to 64: _*)


### PR DESCRIPTION
Also make a corresponding fix to `appendedAll`. This isn't exercised by the test case though.

Fixes scala/bug#12564