### PR TITLE
Lift try blocks to methods in value class invocations

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -490,6 +490,11 @@ abstract class UnCurry extends InfoTransform
             else
               super.transform(tree)
 
+          case sel: Select if sel.qualifier.tpe.typeSymbol.isDerivedValueClass =>
+            // `c.f` where `c` is a value class is translated to `C.f$extension(c)` (value class member) or
+            // `new C(c).f()` (universal trait member). In both cases, `try` within `c` needs a lift.
+            withNeedLift(needLift = true) { super.transform(tree) }
+
           case Apply(fn, args) =>
             // Read the param symbols before `transform(fn)`, because UnCurry replaces T* by Seq[T] (see DesugaredParameterType).
             // The call to `transformArgs` below needs `formals` that still have varargs.

--- a/test/files/run/t12550.scala
+++ b/test/files/run/t12550.scala
@@ -1,0 +1,42 @@
+trait T extends Any {
+  def i: Int
+
+  def ti: Int = i
+	def tj(y: Int)(z: Int): Int = i + y + z
+  def tk(c: C): Int = i + c.i
+}
+
+class C(private val x: Int) extends AnyVal with T {
+	def i: Int = x
+	def j(y: Int)(z: Int): Int = x + y + z
+  def k(c: C): Int = x + c.i
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val c = new C(42)
+    assert(t(c) == 42)
+    assert(u(c) == 42)
+    assert(v(c) == 84)
+
+    assert(tt(c) == 42)
+    assert(tu(c) == 42)
+    assert(tv(c) == 84)
+
+    assert(ttt(c) == 42)
+    assert(ttu(c) == 42)
+    assert(ttv(c) == 84)
+  }
+
+  def t(c: C) = (try c catch { case _ :Throwable => c }).i
+  def u(c: C) = (try c catch { case _ :Throwable => c }).j(-1)(1)
+  def v(c: C) = (try c catch { case _ :Throwable => c }).k(try c catch { case _ :Throwable => c })
+
+  def tt(c: C) = (try c catch { case _ :Throwable => c }).ti
+  def tu(c: C) = (try c catch { case _ :Throwable => c }).tj(-1)(1)
+  def tv(c: C) = (try c catch { case _ :Throwable => c }).tk(try c catch { case _ :Throwable => c })
+
+  def ttt(c: T) = (try c catch { case _ :Throwable => c }).ti
+  def ttu(c: T) = (try c catch { case _ :Throwable => c }).tj(-1)(1)
+  def ttv(c: T) = (try c catch { case _ :Throwable => c }).tk(try new C(42) catch { case _ :Throwable => new C(42) })
+}


### PR DESCRIPTION
In `def t = (try c catch { .. }).meth`, it looks like the stack
is empty when loading `c`. But if `c` is a value class, the call is
translated to `C.meth$extension(try c catch { .. })`, so the
`try` expression needs to be lifted to a local method.

Make UnCurry aware of this.

Fixes https://github.com/scala/bug/issues/12550