### PR TITLE
Add `-Yprint-trees:diff` to make `-Vprint` show diffs between phases

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,7 +23,7 @@ libraryDependencies ++= Seq(
   "org.eclipse.jgit" % "org.eclipse.jgit" % "4.11.9.201909030838-r",
   "org.slf4j" % "slf4j-nop" % "1.7.36",
   "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",
-  )
+)
 
 Global / concurrentRestrictions := Seq(
   Tags.limitAll(1) // workaround for https://github.com/sbt/sbt/issues/2970

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -207,20 +207,28 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
     infolevel = InfoLevel.Verbose
 
     def showUnit(unit: CompilationUnit): Unit = {
-      print(" // " + unit.source)
+      print(s" // ${unit.source}")
       if (unit.body == null) println(": tree is null")
       else {
-        val source = util.stringFromWriter(w => newTreePrinter(w) print unit.body)
+        val source = util.stringFromWriter(w => newTreePrinter(w).print(unit.body))
 
         // treePrinter show unit.body
         if (lastPrintedSource == source)
-          println(": tree is unchanged since " + lastPrintedPhase)
+          println(s": tree is unchanged since $lastPrintedPhase")
         else {
-          lastPrintedPhase = phase.prev // since we're running inside "exitingPhase"
+          println()
+          if (settings.showTreeDiff) {
+            import scala.jdk.CollectionConverters._
+            import com.github.difflib.{DiffUtils, UnifiedDiffUtils}
+            val diff = DiffUtils.diff(lastPrintedSource.linesIterator.toList.asJava, source.linesIterator.toList.asJava)
+            val unified = UnifiedDiffUtils.generateUnifiedDiff(lastPrintedPhase.name, phase.prev.name, lastPrintedSource.linesIterator.toList.asJava, diff, 1).asScala
+            unified.foreach(println)
+          }
+          else
+            println(source)
+          println()
+          lastPrintedPhase  = phase.prev // since we're running inside "exitingPhase"
           lastPrintedSource = source
-          println("")
-          println(source)
-          println("")
         }
       }
     }

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -227,15 +227,16 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
       name = "-Yprint-trees",
       helpArg = "style",
       descr = "How to print trees when -Vprint is enabled.",
-      choices = List("text", "compact", "format", "text+format"),
+      choices = List("text", "compact", "format", "text+format", "diff"),
       default = "text"
     ).withPostSetHook(pt => pt.value match {
-      case "text"        =>
       case "compact"     => XshowtreesCompact.value = true
       case "format"      => Xshowtrees.value = true
       case "text+format" => XshowtreesStringified.value = true
+      case _             =>
     })
 
+  def showTreeDiff: Boolean = YprintTrees.value == "diff"
   val Xshowtrees      = BooleanSetting    ("-Yshow-trees", "(Requires -Vprint:) Print detailed ASTs in formatted form.").internalOnly()
   val XshowtreesCompact
                       = BooleanSetting    ("-Yshow-trees-compact", "(Requires -Vprint:) Print detailed ASTs in compact form.").internalOnly()

--- a/src/partest/scala/tools/partest/nest/FileManager.scala
+++ b/src/partest/scala/tools/partest/nest/FileManager.scala
@@ -75,10 +75,11 @@ object FileManager {
    */
   def compareContents(original: Seq[String], revised: Seq[String], originalName: String = "a", revisedName: String = "b"): String = {
     import scala.jdk.CollectionConverters._
+    import com.github.difflib.{DiffUtils, UnifiedDiffUtils}
 
-    val diff = difflib.DiffUtils.diff(original.asJava, revised.asJava)
+    val diff = DiffUtils.diff(original.asJava, revised.asJava)
     if (diff.getDeltas.isEmpty) ""
-    else difflib.DiffUtils.generateUnifiedDiff(originalName, revisedName, original.asJava, diff, 1).asScala.mkString("\n")
+    else UnifiedDiffUtils.generateUnifiedDiff(originalName, revisedName, original.asJava, diff, 1).asScala.mkString("\n")
   }
 
   def withTempFile[A](outFile: File, fileBase: String, lines: Seq[String])(body: File => A): A = {

--- a/src/tastytest/scala/tools/tastytest/Diff.scala
+++ b/src/tastytest/scala/tools/tastytest/Diff.scala
@@ -1,20 +1,21 @@
 package scala.tools.tastytest
 
 import scala.jdk.CollectionConverters._
+import com.github.difflib.{DiffUtils, UnifiedDiffUtils}
 
 object Diff {
   def splitIntoLines(string: String): Seq[String] =
-    string.trim.replace("\r\n", "\n").split("\n").toSeq
+    string.trim.linesIterator.toSeq
 
   def compareContents(output: String, check: String): String =
     compareContents(splitIntoLines(output), splitIntoLines(check))
 
   def compareContents(output: Seq[String], check: Seq[String]): String = {
-    val diff = difflib.DiffUtils.diff(check.asJava, output.asJava)
+    val diff = DiffUtils.diff(check.asJava, output.asJava)
     if (diff.getDeltas.isEmpty)
       ""
     else
-      difflib.DiffUtils
+      UnifiedDiffUtils
         .generateUnifiedDiff(
           "check",
           "output",
@@ -22,7 +23,7 @@ object Diff {
           diff,
           1
         )
-        .toArray()
+        .asScala
         .mkString("\n")
   }
 }

--- a/test/junit/scala/tools/nsc/FileUtils.scala
+++ b/test/junit/scala/tools/nsc/FileUtils.scala
@@ -3,7 +3,7 @@ package scala.tools.nsc
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
 
-import difflib.DiffUtils
+import com.github.difflib.{DiffUtils, UnifiedDiffUtils}
 
 import scala.jdk.CollectionConverters._
 import scala.reflect.io.PlainNioFile
@@ -118,7 +118,7 @@ object FileUtils {
     val lines1 = lines(text1)
     val lines2 = lines(text2)
     val patch = DiffUtils.diff(lines1, lines2)
-    val value = DiffUtils.generateUnifiedDiff(path1.toString, path2.toString, lines1, patch, 10)
+    val value = UnifiedDiffUtils.generateUnifiedDiff(path1.toString, path2.toString, lines1, patch, 10)
     val diffToString = value.asScala.mkString("\n")
     diffToString
   }


### PR DESCRIPTION
When printing compiler ASTs with `-Yprint`, enable printing just the `diff` by `-Yprint-trees:diff`.

That is useful when you don't need to see the whole tree, but you want to see when some feature is introduced into the tree, or observe only the changes at a phase.

Now `-Yprint-trees:help` reports
```
Usage: -Yprint-trees:<style> where <style> choices are text, compact, format, text+format, diff (default: text).
```
What do those words mean? `compact` is `Tree` DSL style. `format` is less compact. `text` means sourcelike. `text+format` just outputs both styles. `diff` is just a text-based diff of the `text` style.

This PR also upgrades to the `difflib` the seems to have usurped the version from 2011.

We ought to embrace our differences. Vive la différence.