### PR TITLE
Fix some sorting methods to operate correctly on slices

### DIFF
--- a/src/library/scala/util/Sorting.scala
+++ b/src/library/scala/util/Sorting.scala
@@ -213,20 +213,20 @@ object Sorting {
   }
 
   // Why would you even do this?
-  private def booleanSort(a: Array[Boolean]): Unit = {
-    var i = 0
+  private def booleanSort(a: Array[Boolean], from: Int, until: Int): Unit = {
+    var i = from
     var n = 0
-    while (i < a.length) {
+    while (i < until) {
       if (!a(i)) n += 1
       i += 1
     }
     i = 0
     while (i < n) {
-      a(i) = false
+      a(from + i) = false
       i += 1
     }
-    while (i < a.length) {
-      a(i) = true
+    while (from + i < until) {
+      a(from + i) = true
       i += 1
     }
   }
@@ -238,14 +238,14 @@ object Sorting {
       // Note that runtime matches are covariant, so could actually be any Array[T] s.t. T is not primitive (even boxed value classes)
       if (a.length > 1 && (ord eq null)) throw new NullPointerException("Ordering")
       java.util.Arrays.sort(a, from, until, ord)
-    case a: Array[Int]     => if (ord eq Ordering.Int) java.util.Arrays.sort(a) else mergeSort[Int](a, from, until, ord)
+    case a: Array[Int]     => if (ord eq Ordering.Int) java.util.Arrays.sort(a, from, until) else mergeSort[Int](a, from, until, ord)
     case a: Array[Double]  => mergeSort[Double](a, from, until, ord)  // Because not all NaNs are identical, stability is meaningful!
-    case a: Array[Long]    => if (ord eq Ordering.Long) java.util.Arrays.sort(a) else mergeSort[Long](a, from, until, ord)
+    case a: Array[Long]    => if (ord eq Ordering.Long) java.util.Arrays.sort(a, from, until) else mergeSort[Long](a, from, until, ord)
     case a: Array[Float]   => mergeSort[Float](a, from, until, ord)   // Because not all NaNs are identical, stability is meaningful!
-    case a: Array[Char]    => if (ord eq Ordering.Char) java.util.Arrays.sort(a) else mergeSort[Char](a, from, until, ord)
-    case a: Array[Byte]    => if (ord eq Ordering.Byte) java.util.Arrays.sort(a) else mergeSort[Byte](a, from, until, ord)
-    case a: Array[Short]   => if (ord eq Ordering.Short) java.util.Arrays.sort(a) else mergeSort[Short](a, from, until, ord)
-    case a: Array[Boolean] => if (ord eq Ordering.Boolean) booleanSort(a) else mergeSort[Boolean](a, from, until, ord)
+    case a: Array[Char]    => if (ord eq Ordering.Char) java.util.Arrays.sort(a, from, until) else mergeSort[Char](a, from, until, ord)
+    case a: Array[Byte]    => if (ord eq Ordering.Byte) java.util.Arrays.sort(a, from, until) else mergeSort[Byte](a, from, until, ord)
+    case a: Array[Short]   => if (ord eq Ordering.Short) java.util.Arrays.sort(a, from, until) else mergeSort[Short](a, from, until, ord)
+    case a: Array[Boolean] => if (ord eq Ordering.Boolean) booleanSort(a, from, until) else mergeSort[Boolean](a, from, until, ord)
     // Array[Unit] is matched as an Array[AnyRef] due to covariance in runtime matching.  Not worth catching it as a special case.
     case null => throw new NullPointerException
   }

--- a/test/junit/scala/util/SortingTest.scala
+++ b/test/junit/scala/util/SortingTest.scala
@@ -15,6 +15,8 @@ class SortingTest {
     { var i = 1; while (i < a.length) { if (a(i).i > a(i-1).i || (a(i).i == a(i-1).i && a(i).j < a(i-1).j)) return false; i += 1 }; true }
   
   def isSorted(a: Array[N]): Boolean = { var i = 1; while (i < a.length) { if (a(i).i < a(i-1).i) return false; i += 1 }; true }
+
+  def isSorted(a: Array[Int], from: Int, until: Int): Boolean = { var i = from + 1; while (i < until) { if (a(i) < a(i-1)) return false; i += 1 }; true }
   
   def isAntisorted(a: Array[N]): Boolean = { var i = 1; while (i < a.length) { if (a(i).i > a(i-1).i) return false; i += 1 }; true }
   
@@ -34,10 +36,14 @@ class SortingTest {
     val sxs = { val temp = xs.clone; Sorting.stableSort(temp); temp }
     val rxs = { val temp = xs.clone; Sorting.stableSort(temp)(backwardsN); temp }
     val sys = Sorting.stableSort(ys.clone.toIndexedSeq, (i: Int) => xs(i))
+
+    val xxs = Array.fill(size)(rng.nextInt(variety))
+    Sorting.stableSort(xxs, xxs.length / 2, xxs.length)
     
     assertTrue("Quicksort should be in order", isSorted(qxs))
     assertTrue("Quicksort should be in reverse order", isAntisorted(pxs))
     assertTrue("Stable sort should be sorted and stable", isStable(sxs))
+    assertTrue("Stable sort should only sort slice provided", isSorted(xxs, xxs.length / 2 , xxs.length))
     assertTrue("Stable sort should be reverse sorted but stable", isAntistable(rxs))
     assertTrue("Stable sorting by proxy should produce sorted stable list", isStable(sys.map(i => xs(i))))
     assertTrue("Quicksort should produce canonical ordering", (qxs zip zs).forall{ case (a,b) => a.i == b.i })

--- a/test/junit/scala/util/SortingTest.scala
+++ b/test/junit/scala/util/SortingTest.scala
@@ -38,12 +38,17 @@ class SortingTest {
     val sys = Sorting.stableSort(ys.clone.toIndexedSeq, (i: Int) => xs(i))
 
     val xxs = Array.fill(size)(rng.nextInt(variety))
-    Sorting.stableSort(xxs, xxs.length / 2, xxs.length)
+    val sortSliceArray = xxs.clone(); Sorting.stableSort(sortSliceArray, xxs.length / 2, xxs.length)
+    val sliceMin = xxs.slice(xxs.length / 2, xxs.length).minOption.getOrElse(Int.MinValue)
+    val sliceAboveMinCountsEqual = xxs.slice(xxs.length / 2, xxs.length).count(_ >= sliceMin) == sortSliceArray.slice(xxs.length / 2, xxs.length).count(_ >= sliceMin)
+    val firstHalfUnchanged = xxs.slice(0, xxs.length / 2).toSeq == sortSliceArray.slice(0, xxs.length / 2).toSeq
     
     assertTrue("Quicksort should be in order", isSorted(qxs))
     assertTrue("Quicksort should be in reverse order", isAntisorted(pxs))
     assertTrue("Stable sort should be sorted and stable", isStable(sxs))
-    assertTrue("Stable sort should only sort slice provided", isSorted(xxs, xxs.length / 2 , xxs.length))
+    assertTrue("Stable sort on a slice should produce a sorted slice", isSorted(sortSliceArray, xxs.length / 2 , xxs.length))
+    assertTrue("Stable sort should not change values outside the provided range", firstHalfUnchanged)
+    assertTrue("Stable sort on a slice should produce a slice with the same count of elems larger than the slice min", sliceAboveMinCountsEqual)
     assertTrue("Stable sort should be reverse sorted but stable", isAntistable(rxs))
     assertTrue("Stable sorting by proxy should produce sorted stable list", isStable(sys.map(i => xs(i))))
     assertTrue("Quicksort should produce canonical ordering", (qxs zip zs).forall{ case (a,b) => a.i == b.i })
@@ -62,11 +67,13 @@ class SortingTest {
     
     for (size <- sizes) {
       val b = Array.fill(size)(rng.nextBoolean())
+      val sbs = b.clone(); Sorting.stableSort(sbs, sbs.length / 2, sbs.length)
       val bfwd = Sorting.stableSort(b.clone.toIndexedSeq)
       val bbkw = Sorting.stableSort(b.clone.toIndexedSeq, (x: Boolean, y: Boolean) => x && !y)
       assertTrue("All falses should be first", bfwd.dropWhile(_ == false).forall(_ == true))
       assertTrue("All falses should be last when sorted backwards", bbkw.dropWhile(_ == true).forall(_ == false))
       assertTrue("Sorting booleans should preserve the number of trues", b.count(_ == true) == bfwd.count(_ == true))
+      assertTrue("Slice sorting booleans should preserve the number of trues", b.slice(b.length / 2, b.length).count(_ == true) == sbs.slice(b.length / 2, b.length).count(_ == true))
       assertTrue("Backwards sorting booleans should preserve the number of trues", b.count(_ == true) == bbkw.count(_ == true))
       assertTrue("Sorting should not change the sizes of arrays", b.length == bfwd.length && b.length == bbkw.length)
     }


### PR DESCRIPTION
Pull request for the issue: https://github.com/scala/bug/issues/12568

The issue relates to `from` and `to` arguments not being propagated when sorting some type of collections.

Since this is my first PR I apologise for all the obvious things that I've missed, please point them out and I'll fix it promptly :) 
