### PR TITLE
Avoid NoSuchElementException for lastOption

### DIFF
--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -248,7 +248,16 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
     *  @return  the last element of this $coll$ if it is nonempty,
     *           `None` if it is empty.
     */
-  def lastOption: Option[A] = if (isEmpty) None else Some(last)
+  def lastOption: Option[A] = {
+    val it = iterator
+    if (!it.hasNext) {
+      None
+    } else {
+      var lst = it.next()
+      while (it.hasNext) lst = it.next()
+      Some(lst)
+    }
+  }
 
   /** A view over the elements of this collection. */
   def view: View[A] = View.fromIteratorProvider(() => iterator)

--- a/test/files/run/view-headoption.check
+++ b/test/files/run/view-headoption.check
@@ -7,8 +7,6 @@ f2: 5
 fail
 success
 fail
-success
-fail
 fail
 success
 fail


### PR DESCRIPTION
when i use concurrent data structure, Iterable#lastOption maybe throw NoSuchElementException

<img width="984" alt="image" src="https://user-images.githubusercontent.com/12369652/162116394-f288a591-b7aa-459f-93b2-6b7f443de873.png">
