### PR TITLE
Using 'extension' rather than 'pimp' - 2.12.x

### DIFF
--- a/test/files/run/t10283.scala
+++ b/test/files/run/t10283.scala
@@ -4,14 +4,14 @@ trait OpacityTypes {
 }
 
 object OpacityTypes {
-  implicit def orderingT: Ordering[Test.pimp.T] = Test.pimp.orderingT
+  implicit def orderingT: Ordering[Test.extension.T] = Test.extension.orderingT
 }
 
 object Test extends App {
-  val pimp: OpacityTypes = new OpacityTypes {
+  val extension: OpacityTypes = new OpacityTypes {
     override type T = Int
     override def orderingT = Ordering.Int
   }
 
-  implicitly[Ordering[pimp.T]]
+  implicitly[Ordering[extension.T]]
 }


### PR DESCRIPTION
The feature is called "Extension Methods", so no reason to use the term "pimp".

PR for 2.13.x branch: https://github.com/scala/scala/pull/9994 (which is now closed as not needed)