### PR TITLE
Ignore conversion to type with inaccessible member

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1342,9 +1342,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           case EmptyTree  => qual
           case coercion   =>
             if (settings.logImplicitConv)
-              context.echo(qual.pos,
-                "applied implicit conversion from %s to %s = %s".format(
-                  qual.tpe, searchTemplate, coercion.symbol.defString))
+              context.echo(qual.pos, s"applied implicit conversion from ${qual.tpe} to ${searchTemplate} = ${coercion.symbol.defString}")
 
             typedQualifier(atPos(qual.pos)(new ApplyImplicitView(coercion, List(qual))))
         }

--- a/test/files/pos/t11787.scala
+++ b/test/files/pos/t11787.scala
@@ -1,0 +1,10 @@
+
+object syntax {
+  implicit class Ops1(x: String) { private[syntax] def bar: Int = 1 }
+  implicit class Ops2(x: String) { def bar: Int = 2 }
+}
+
+object test {
+  import syntax._
+  val result = "foo".bar
+}


### PR DESCRIPTION
Fixes scala/bug#11787

Spec already says inaccessible `e.m` doesn't stop search, so extend that to targets of conversions.
