### PR TITLE
Use normal mixed-in Product.productIterator

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
@@ -24,7 +24,6 @@ import symtab.Flags._
  *    def productArity: Int
  *    def productElement(n: Int): Any
  *    def productPrefix: String
- *    ~def productIterator: Iterator[Any]~
  *
  *  Selectively added to case classes/objects, unless a non-default
  *  implementation already exists:
@@ -114,13 +113,6 @@ trait SyntheticMethods extends ast.TreeDSL {
         (m0 ne meth) && !m0.isDeferred && !m0.isSynthetic && (m0.owner != AnyValClass) && (typeInClazz(m0) matches typeInClazz(meth))
       }
     }
-    /*
-    def productIteratorMethod =
-      createMethod(nme.productIterator, iteratorOfType(AnyTpe))(_ =>
-        Select(Super(This(tpnme.EMPTY), tpnme.EMPTY), definitions.Product_iterator))
-        //gen.mkRuntimeCall(nme.typedProductIterator, List(AnyTpe), List(mkThis))
-      )
-     */
 
     def perElementMethod(name: Name, returnType: Type)(caseFn: Symbol => Tree): Tree = 
       createSwitchMethod(name, accessors.indices, returnType)(idx => caseFn(accessors(idx)))
@@ -267,7 +259,6 @@ trait SyntheticMethods extends ast.TreeDSL {
         Product_productPrefix -> (() => constantNullary(nme.productPrefix, clazz.name.decode)),
         Product_productArity -> (() => constantNullary(nme.productArity, arity)),
         Product_productElement -> (() => perElementMethod(nme.productElement, AnyTpe)(mkThisSelect)),
-        //Product_iterator -> (() => productIteratorMethod),
         Product_canEqual -> (() => canEqualMethod)
       )
     }

--- a/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
@@ -24,7 +24,7 @@ import symtab.Flags._
  *    def productArity: Int
  *    def productElement(n: Int): Any
  *    def productPrefix: String
- *    def productIterator: Iterator[Any]
+ *    ~def productIterator: Iterator[Any]~
  *
  *  Selectively added to case classes/objects, unless a non-default
  *  implementation already exists:
@@ -114,11 +114,13 @@ trait SyntheticMethods extends ast.TreeDSL {
         (m0 ne meth) && !m0.isDeferred && !m0.isSynthetic && (m0.owner != AnyValClass) && (typeInClazz(m0) matches typeInClazz(meth))
       }
     }
-    def productIteratorMethod = {
+    /*
+    def productIteratorMethod =
       createMethod(nme.productIterator, iteratorOfType(AnyTpe))(_ =>
-        gen.mkMethodCall(ScalaRunTimeModule, nme.typedProductIterator, List(AnyTpe), List(mkThis))
+        Select(Super(This(tpnme.EMPTY), tpnme.EMPTY), definitions.Product_iterator))
+        //gen.mkRuntimeCall(nme.typedProductIterator, List(AnyTpe), List(mkThis))
       )
-    }
+     */
 
     def perElementMethod(name: Name, returnType: Type)(caseFn: Symbol => Tree): Tree = 
       createSwitchMethod(name, accessors.indices, returnType)(idx => caseFn(accessors(idx)))
@@ -265,7 +267,7 @@ trait SyntheticMethods extends ast.TreeDSL {
         Product_productPrefix -> (() => constantNullary(nme.productPrefix, clazz.name.decode)),
         Product_productArity -> (() => constantNullary(nme.productArity, arity)),
         Product_productElement -> (() => perElementMethod(nme.productElement, AnyTpe)(mkThisSelect)),
-        Product_iterator -> (() => productIteratorMethod),
+        //Product_iterator -> (() => productIteratorMethod),
         Product_canEqual -> (() => canEqualMethod)
       )
     }

--- a/test/files/run/idempotency-case-classes.check
+++ b/test/files/run/idempotency-case-classes.check
@@ -20,7 +20,6 @@ C(2,3)
       case 1 => C.this.y
       case _ => scala.runtime.Statics.ioobe[Any](x$1)
     };
-    override <synthetic> def productIterator: Iterator[Any] = scala.runtime.ScalaRunTime.typedProductIterator[Any](C.this);
     <synthetic> def canEqual(x$1: Any): Boolean = x$1.$isInstanceOf[C]();
     override <synthetic> def productElementName(x$1: Int): String = x$1 match {
       case 0 => "x"

--- a/test/files/scalap/caseClass.check
+++ b/test/files/scalap/caseClass.check
@@ -6,7 +6,6 @@ case class CaseClass[A <: scala.Seq[scala.Int]](i: A, s: scala.Predef.String) ex
   override def productPrefix: java.lang.String = { /* compiled code */ }
   def productArity: scala.Int = { /* compiled code */ }
   def productElement(x$1: scala.Int): scala.Any = { /* compiled code */ }
-  override def productIterator: scala.collection.Iterator[scala.Any] = { /* compiled code */ }
   def canEqual(x$1: scala.Any): scala.Boolean = { /* compiled code */ }
   override def productElementName(x$1: scala.Int): java.lang.String = { /* compiled code */ }
   override def hashCode(): scala.Int = { /* compiled code */ }

--- a/test/files/scalap/caseObject.check
+++ b/test/files/scalap/caseObject.check
@@ -3,7 +3,6 @@ case object CaseObject extends scala.AnyRef with scala.Product with scala.Serial
   override def productPrefix: java.lang.String = { /* compiled code */ }
   def productArity: scala.Int = { /* compiled code */ }
   def productElement(x$1: scala.Int): scala.Any = { /* compiled code */ }
-  override def productIterator: scala.collection.Iterator[scala.Any] = { /* compiled code */ }
   def canEqual(x$1: scala.Any): scala.Boolean = { /* compiled code */ }
   override def hashCode(): scala.Int = { /* compiled code */ }
   override def toString(): java.lang.String = { /* compiled code */ }

--- a/test/scaladoc/run/implicits-chaining.scala
+++ b/test/scaladoc/run/implicits-chaining.scala
@@ -1,6 +1,6 @@
 import scala.tools.nsc.doc.model._
 import scala.tools.partest.ScaladocModelTest
-import language._
+import org.junit.Assert.{assertEquals, assertTrue}
 
 object Test extends ScaladocModelTest {
 
@@ -23,43 +23,43 @@ object Test extends ScaladocModelTest {
     val A = base._class("A")
 
     conv = A._conversion(base.qualifiedName + ".convertToZ")
-    assert(conv.members.length == 2)
-    assert(conv.constraints.length == 1)
+    assertEquals(3, conv.members.length)
+    assertEquals(1, conv.constraints.length)
 
 //// class B ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     val B = base._class("B")
 
     conv = B._conversion(base.qualifiedName + ".convertToZ")
-    assert(conv.members.length == 2)
-    assert(conv.constraints.length == 0)
+    assertEquals(3, conv.members.length)
+    assertEquals(0, conv.constraints.length)
 
 //// class C ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     val C = base._class("C")
 
-    assert(C._conversions(base.qualifiedName + ".convertToZ").isEmpty)
+    assertTrue(C._conversions(base.qualifiedName + ".convertToZ").isEmpty)
 
 //// class D ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     val D = base._class("D")
 
     conv = D._conversion(base.qualifiedName + ".convertToZ")
-    assert(conv.members.length == 2)
-    assert(conv.constraints.length == 0)
+    assertEquals(3, conv.members.length)
+    assertEquals(0, conv.constraints.length)
 
 //// class E ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     val E = base._class("E")
 
     conv = E._conversion(base.qualifiedName + ".convertToZ")
-    assert(conv.members.length == 2)
-    assert(conv.constraints.length == 0)
+    assertEquals(3, conv.members.length)
+    assertEquals(0, conv.constraints.length)
 
 //// class F ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     val F = base._class("F")
 
-    assert(F._conversions(base.qualifiedName + ".convertToZ").isEmpty)
+    assertTrue(F._conversions(base.qualifiedName + ".convertToZ").isEmpty)
   }
 }


### PR DESCRIPTION
Omit generating the method and acquire the usual
trait implementation. This follows Scala 3.

(The special runtime support was added as an experiment
and never removed when the experiment ended.)