### PR TITLE
Prefer StandardCharsets

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -16,7 +16,7 @@ package nsc
 
 import java.io.{Closeable, FileNotFoundException, IOException}
 import java.net.URL
-import java.nio.charset._
+import java.nio.charset.{Charset, CharsetDecoder, IllegalCharsetNameException, StandardCharsets, UnsupportedCharsetException}, StandardCharsets.UTF_8
 
 import scala.annotation.{nowarn, tailrec}
 import scala.collection.{immutable, mutable}
@@ -1476,7 +1476,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
           case pathString =>
             import java.nio.file._
             val path = Paths.get(pathString)
-            Files.write(path, argsFile.getBytes(StandardCharsets.UTF_8))
+            Files.write(path, argsFile.getBytes(UTF_8))
             reporter.echo(s"Compiler arguments written to: $path")
         }
       }

--- a/src/compiler/scala/tools/nsc/PickleExtractor.scala
+++ b/src/compiler/scala/tools/nsc/PickleExtractor.scala
@@ -12,6 +12,7 @@
 
 package scala.tools.nsc
 
+import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor, _}
 
@@ -92,12 +93,12 @@ object PickleExtractor {
       input.visibleAnnotations.asScala.foreach { node =>
         if (node.desc == "Lscala/reflect/ScalaSignature;") {
           val Array("bytes", data: String) = node.values.toArray(): @unchecked
-          val bytes = data.getBytes(java.nio.charset.StandardCharsets.UTF_8)
+          val bytes = data.getBytes(UTF_8)
           val len = ByteCodecs.decode(bytes)
           pickleData = bytes.take(len)
         } else if (node.desc == "Lscala/reflect/ScalaLongSignature;") {
           val Array("bytes", data: java.util.Collection[String @unchecked]) = node.values.toArray(): @unchecked
-          val encoded = data.asScala.toArray flatMap (_.getBytes(java.nio.charset.StandardCharsets.UTF_8))
+          val encoded = data.asScala.toArray.flatMap(_.getBytes(UTF_8))
           val len = ByteCodecs.decode(encoded)
           pickleData = encoded.take(len)
         }

--- a/src/compiler/scala/tools/nsc/PipelineMain.scala
+++ b/src/compiler/scala/tools/nsc/PipelineMain.scala
@@ -14,6 +14,7 @@ package scala.tools.nsc
 
 import java.io.File
 import java.lang.Thread.UncaughtExceptionHandler
+import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.{Files, Path, Paths}
 import java.util.concurrent.ConcurrentHashMap
 import java.util.{Collections, Locale}
@@ -101,7 +102,7 @@ class PipelineMainClass(argFiles: Seq[Path], pipelineSettings: PipelineMain.Pipe
     }
     builder.append("}\n")
     val path = logDir.resolve("projects.dot")
-    Files.write(path, builder.toString.getBytes(java.nio.charset.StandardCharsets.UTF_8))
+    Files.write(path, builder.toString.getBytes(UTF_8))
     reporterEcho("Wrote project dependency graph to: " + path.toAbsolutePath)
   }
 
@@ -348,7 +349,7 @@ class PipelineMainClass(argFiles: Seq[Path], pipelineSettings: PipelineMain.Pipe
     projects.iterator.flatMap(projectEvents).addString(sb, ",\n")
     trace.append("]}")
     val traceFile = logDir.resolve(s"build-${label}.trace")
-    Files.write(traceFile, trace.toString.getBytes())
+    Files.write(traceFile, trace.toString.getBytes(UTF_8))
     reporterEcho("Chrome trace written to " + traceFile.toAbsolutePath)
   }
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/ClassfileWriters.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/ClassfileWriters.scala
@@ -15,7 +15,7 @@ package scala.tools.nsc.backend.jvm
 import java.io.{DataOutputStream, IOException}
 import java.nio.ByteBuffer
 import java.nio.channels.{ClosedByInterruptException, FileChannel}
-import java.nio.charset.StandardCharsets
+import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file._
 import java.nio.file.attribute.FileAttribute
 import java.util
@@ -133,7 +133,7 @@ abstract class ClassfileWriters {
       override def writeClass(className: InternalName, bytes: Array[Byte], sourceFile: AbstractFile): Unit = {
         basic.writeClass(className, bytes, sourceFile)
         asmp.foreach { writer =>
-          val asmBytes = AsmUtils.textify(AsmUtils.readClass(bytes)).getBytes(StandardCharsets.UTF_8)
+          val asmBytes = AsmUtils.textify(AsmUtils.readClass(bytes)).getBytes(UTF_8)
           writer.writeFile(classRelativePath(className, ".asm"), asmBytes)
         }
         dump.foreach { writer =>

--- a/src/compiler/scala/tools/nsc/fsc/CompileSocket.scala
+++ b/src/compiler/scala/tools/nsc/fsc/CompileSocket.scala
@@ -139,7 +139,7 @@ class CompileSocket extends CompileOutputCommon {
     val file = portFile(port)
     // 128 bits of delicious randomness, suitable for printing with println over a socket,
     // and storage in a file -- see getPassword
-    val secretDigits = new BigInteger(128, new SecureRandom()).toString.getBytes("UTF-8")
+    val secretDigits = new BigInteger(128, new SecureRandom()).toString.getBytes(java.nio.charset.StandardCharsets.UTF_8)
 
     try OwnerOnlyChmod.chmodFileAndWrite(file.jfile.toPath, secretDigits)
     catch chmodFailHandler(s"Cannot create file: ${file}")

--- a/src/compiler/scala/tools/nsc/fsc/CompileSocket.scala
+++ b/src/compiler/scala/tools/nsc/fsc/CompileSocket.scala
@@ -13,6 +13,7 @@
 package scala.tools.nsc.fsc
 
 import java.math.BigInteger
+import java.nio.charset.StandardCharsets.UTF_8
 import java.security.SecureRandom
 
 import scala.annotation.tailrec
@@ -139,7 +140,7 @@ class CompileSocket extends CompileOutputCommon {
     val file = portFile(port)
     // 128 bits of delicious randomness, suitable for printing with println over a socket,
     // and storage in a file -- see getPassword
-    val secretDigits = new BigInteger(128, new SecureRandom()).toString.getBytes(java.nio.charset.StandardCharsets.UTF_8)
+    val secretDigits = new BigInteger(128, new SecureRandom()).toString.getBytes(UTF_8)
 
     try OwnerOnlyChmod.chmodFileAndWrite(file.jfile.toPath, secretDigits)
     catch chmodFailHandler(s"Cannot create file: ${file}")

--- a/src/library/scala/io/Codec.scala
+++ b/src/library/scala/io/Codec.scala
@@ -13,7 +13,8 @@
 package scala
 package io
 
-import java.nio.charset.{ Charset, CharsetDecoder, CharsetEncoder, CharacterCodingException, CodingErrorAction => Action }
+import java.nio.charset.{CharacterCodingException, Charset, CharsetDecoder, CharsetEncoder, CodingErrorAction => Action}
+import java.nio.charset.StandardCharsets.{ISO_8859_1, UTF_8}
 import scala.annotation.migration
 import scala.language.implicitConversions
 
@@ -81,8 +82,8 @@ trait LowPriorityCodecImplicits {
 }
 
 object Codec extends LowPriorityCodecImplicits {
-  final val ISO8859: Codec = new Codec(Charset forName "ISO-8859-1")
-  final val UTF8: Codec    = new Codec(Charset forName "UTF-8")
+  final val ISO8859: Codec = Codec(ISO_8859_1)
+  final val UTF8: Codec    = Codec(UTF_8)
 
   /** Optimistically these two possible defaults will be the same thing.
    *  In practice this is not necessarily true, and in fact Sun classifies

--- a/src/reflect/scala/reflect/internal/util/FileUtils.scala
+++ b/src/reflect/scala/reflect/internal/util/FileUtils.scala
@@ -14,7 +14,7 @@ package scala.reflect.internal.util
 
 import java.io.{BufferedWriter, IOException, OutputStreamWriter, Writer}
 import java.nio.CharBuffer
-import java.nio.charset.{Charset, CharsetEncoder, StandardCharsets}
+import java.nio.charset.{Charset, CharsetEncoder, StandardCharsets}, StandardCharsets.UTF_8
 import java.nio.file.{Files, OpenOption, Path}
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.atomic.AtomicBoolean
@@ -25,7 +25,7 @@ import scala.concurrent.{Await, Promise}
 import scala.util.{Failure, Success}
 
 object FileUtils {
-  def newAsyncBufferedWriter(path: Path, charset: Charset = StandardCharsets.UTF_8, options: Array[OpenOption] = NO_OPTIONS, threadsafe: Boolean = false): LineWriter = {
+  def newAsyncBufferedWriter(path: Path, charset: Charset = UTF_8, options: Array[OpenOption] = NO_OPTIONS, threadsafe: Boolean = false): LineWriter = {
     val encoder: CharsetEncoder = charset.newEncoder
     val writer = new OutputStreamWriter(Files.newOutputStream(path, options: _*), encoder)
     newAsyncBufferedWriter(new BufferedWriter(writer), threadsafe)

--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -20,15 +20,16 @@ import scala.ref.WeakReference
 import scala.collection.mutable.WeakHashMap
 import scala.collection.immutable.ArraySeq
 
+import java.io.IOException
 import java.lang.{ Class => jClass, Package => jPackage }
+import java.lang.annotation.{ Annotation => jAnnotation }
+import java.lang.ref.{ WeakReference => jWeakReference }
 import java.lang.reflect.{
   Method => jMethod, Constructor => jConstructor, Field => jField,
   Member => jMember, Type => jType, TypeVariable => jTypeVariable,
   Parameter => jParameter, GenericDeclaration, GenericArrayType,
   ParameterizedType, WildcardType, AnnotatedElement }
-import java.lang.annotation.{ Annotation => jAnnotation }
-import java.io.IOException
-import java.lang.ref.{ WeakReference => jWeakReference }
+import java.nio.charset.StandardCharsets.UTF_8
 
 import scala.reflect.internal.{ JavaAccFlags, MissingRequirementError }
 import internal.pickling.ByteCodecs
@@ -669,7 +670,7 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
         loadBytes[String]("scala.reflect.ScalaSignature") match {
           case Some(ssig) =>
             info(s"unpickling Scala $clazz and $module, owner = ${clazz.owner}")
-            val bytes = ssig.getBytes(java.nio.charset.StandardCharsets.UTF_8)
+            val bytes = ssig.getBytes(UTF_8)
             val len = ByteCodecs.decode(bytes)
             assignAssociatedFile(clazz, module, jclazz)
             unpickler.unpickle(bytes take len, 0, clazz, module, jclazz.getName)
@@ -678,7 +679,7 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
             loadBytes[Array[String]]("scala.reflect.ScalaLongSignature") match {
               case Some(slsig) =>
                 info(s"unpickling Scala $clazz and $module with long Scala signature")
-                val encoded = slsig flatMap (_.getBytes(java.nio.charset.StandardCharsets.UTF_8))
+                val encoded = slsig.flatMap(_.getBytes(UTF_8))
                 val len = ByteCodecs.decode(encoded)
                 val decoded = encoded.take(len)
                 assignAssociatedFile(clazz, module, jclazz)

--- a/src/testkit/scala/tools/testkit/VirtualCompilerTesting.scala
+++ b/src/testkit/scala/tools/testkit/VirtualCompilerTesting.scala
@@ -14,7 +14,7 @@ package scala.tools.testkit
 
 import java.io.OutputStreamWriter
 import java.net.URI
-import java.nio.charset.StandardCharsets
+import java.nio.charset.StandardCharsets.UTF_8
 import java.util.Locale
 
 import javax.tools._
@@ -38,7 +38,7 @@ class VirtualCompiler {
 
   /** A javac file manager that places classfiles in `output`. */
   lazy val fileManager: JavaFileManager = {
-    val dflt = javac.getStandardFileManager(null, Locale.ENGLISH, StandardCharsets.UTF_8)
+    val dflt = javac.getStandardFileManager(null, Locale.ENGLISH, UTF_8)
     new VirtualFileManager(output, dflt)
   }
 


### PR DESCRIPTION
Fixes scala/bug#6407

Resuscitates a classic soc just before the 10-year statute of limitations runs out.

https://github.com/scala/scala/pull/1359

The functional change in xml was done at

https://github.com/scala/scala-xml/pull/122

where they asked for `scala.migration`, or I guess it's `scala.annotation.migration` to make sure no one knows about it or can use it without an import.

Also audited `getBytes()`, of which there is a stray in `PipelineMain` but skipped because the other usage there is conforming.
