### PR TITLE
[backport] Allow ? as a wildcard even without -Xsource:3

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -704,7 +704,7 @@ self =>
     def isRawIdent = in.token == IDENTIFIER
 
     def isWildcardType = in.token == USCORE || isScala3WildcardType
-    def isScala3WildcardType = currentRun.isScala3 && isRawIdent && in.name == raw.QMARK
+    def isScala3WildcardType = isRawIdent && in.name == raw.QMARK
 
     def isIdent = in.token == IDENTIFIER || in.token == BACKQUOTED_IDENT
     def isMacro = in.token == IDENTIFIER && in.name == nme.MACROkw

--- a/test/files/pos/wildcards-present.scala
+++ b/test/files/pos/wildcards-present.scala
@@ -1,5 +1,3 @@
-// scalac: -Xsource:3
-//
 object Test {
   val xs: List[?] = List(1, 2, 3)
   val ys: Map[? <: AnyRef, ? >: Null] = Map()
@@ -9,8 +7,7 @@ object Test {
     case _ => x
   }
 
-  // Only allowed in Scala 3 under -source 3.0-migration
-  type ? = Int
+  type `?` = Int
 
   val xs2: List[`?`] = List(1)
   val xs3: List[Int] = xs2


### PR DESCRIPTION
This backports #9990 to Scala 2.12 as discussed in that PR.