### PR TITLE
Fix a tree shape in untypecheck-ing extractors

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/Trees.scala
+++ b/src/compiler/scala/tools/nsc/ast/Trees.scala
@@ -110,6 +110,7 @@ trait Trees extends scala.reflect.internal.Trees { self: Global =>
   object treeInfo extends {
     val global: Trees.this.type = self
   } with TreeInfo
+  import treeInfo._
 
   // --- additional cases in operations ----------------------------------
 
@@ -324,10 +325,9 @@ trait Trees extends scala.reflect.internal.Trees { self: Global =>
                 transform(fn)
               case EmptyTree =>
                 tree
-              // The typer does not accept UnApply. Replace it to Apply, which can be retyped.
-              case UnApply(Apply(Select(prefix, termNames.unapply | termNames.unapplySeq),
-                                 List(Ident(termNames.SELECTOR_DUMMY))), args) =>
-                Apply(prefix, transformTrees(args))
+              // The typer does not accept UnApply. Replace it with Apply, which can be retyped.
+              case UnApply(Unapplied(Applied(Select(fun, nme.unapply | nme.unapplySeq), _, _)), args) =>
+                Apply(transform(fun), transformTrees(args))
               case _ =>
                 val dupl = tree.duplicate
                 // Typically the resetAttrs transformer cleans both symbols and types.

--- a/test/files/run/t12577/A_1.scala
+++ b/test/files/run/t12577/A_1.scala
@@ -1,0 +1,7 @@
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox.Context
+
+object A {
+  def foo[A, B](pf: PartialFunction[A, B]): PartialFunction[A, B] = macro impl
+  def impl(c: Context)(pf: c.Tree): c.Tree = c.untypecheck(pf)
+}

--- a/test/files/run/t12577/B_2.scala
+++ b/test/files/run/t12577/B_2.scala
@@ -1,0 +1,10 @@
+trait X
+class B[T](val i: Int)
+object B {
+  def unapply[T](b: B[T]): Option[Int] = Some(b.i)
+}
+object Test {
+  def main(args: Array[String]): Unit = {
+    A.foo[B[X], Int] { case B(x) => x }
+  }
+}


### PR DESCRIPTION
First, use Applied to match on TypeApply nodes too, and then just ignore it's
type arguments.  This fixes the test case.

Then reuse the Unapplied utility for matching the use of SELECTOR_DUMMY.

I also picked up running transform on `fun` from Jason's branch.

Fixes https://github.com/scala/bug/issues/12577