### PR TITLE
Make Scala-3-style implicit resolution explicitly opt-in rather than bundled in `-Xsource:3`

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1168,6 +1168,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
 
     // We hit these checks regularly. They shouldn't change inside the same run, so cache the comparisons here.
     val isScala3 = settings.isScala3
+    val isScala3ImplicitResolution = settings.Yscala3ImplicitResolution
 
     // used in sbt
     def uncheckedWarnings: List[(Position, String)]   = reporting.uncheckedWarnings

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -275,6 +275,7 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
   val YpickleWrite = StringSetting("-Ypickle-write", "directory|jar", "destination for generated .sig files containing type signatures.", "", None).internalOnly()
   val YpickleWriteApiOnly = BooleanSetting("-Ypickle-write-api-only", "Exclude private members (other than those material to subclass compilation, such as private trait vals) from generated .sig files containing type signatures.").internalOnly()
   val YtrackDependencies = BooleanSetting("-Ytrack-dependencies", "Record references to in unit.depends. Deprecated feature that supports SBT 0.13 with incOptions.withNameHashing(false) only.", default = true)
+  val Yscala3ImplicitResolution = BooleanSetting("-Yscala3-implicit-resolution", "Use Scala-3-style downwards comparisons for implicit search and overloading resolution (see https://github.com/scala/bug/issues/12437).", default = false)
 
   sealed abstract class CachePolicy(val name: String, val help: String)
   object CachePolicy {

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -903,9 +903,9 @@ trait Infer extends Checkable {
         isAsSpecificValueType(rtpe1, tpe2, undef1 ::: tparams1, undef2)
       case _                         =>
         tpe2 match {
-          case PolyType(tparams2, rtpe2) => isAsSpecificValueType(tpe1, rtpe2, undef1, undef2 ::: tparams2)
-          case _ if !currentRun.isScala3 => existentialAbstraction(undef1, tpe1) <:< existentialAbstraction(undef2, tpe2)
-          case _                         =>
+          case PolyType(tparams2, rtpe2)                   => isAsSpecificValueType(tpe1, rtpe2, undef1, undef2 ::: tparams2)
+          case _ if !currentRun.isScala3ImplicitResolution => existentialAbstraction(undef1, tpe1) <:< existentialAbstraction(undef2, tpe2)
+          case _                                           =>
             // Backport of fix for https://github.com/scala/bug/issues/2509
             // from Dotty https://github.com/lampepfl/dotty/commit/89540268e6c49fb92b9ca61249e46bb59981bf5a
             //

--- a/test/files/neg/t2509-2.scala
+++ b/test/files/neg/t2509-2.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:3.0
+// scalac: -Yscala3-implicit-resolution
 class A
 class B extends A
 class C extends B

--- a/test/files/neg/t2509-3.scala
+++ b/test/files/neg/t2509-3.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:3.0
+// scalac: -Yscala3-implicit-resolution
 class A
 class B extends A
 

--- a/test/files/neg/t2509-7b.scala
+++ b/test/files/neg/t2509-7b.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:3.0
+// scalac: -Yscala3-implicit-resolution
 class Both[-A, +B]
 
 trait Factory[A] {

--- a/test/files/pos/t2509-5.scala
+++ b/test/files/pos/t2509-5.scala
@@ -1,5 +1,5 @@
 // See https://github.com/lampepfl/dotty/issues/2974
-// scalac: -Xsource:3.0
+// scalac: -Yscala3-implicit-resolution
 
 trait Foo[-T]
 

--- a/test/files/pos/t2509-6.scala
+++ b/test/files/pos/t2509-6.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:3.0
+// scalac: -Yscala3-implicit-resolution
 class A
 class B extends A
 

--- a/test/files/pos/t2509-7a.scala
+++ b/test/files/pos/t2509-7a.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:3.0
+// scalac: -Yscala3-implicit-resolution
 
 class Both[-A, +B]
 

--- a/test/files/run/t2509-1.scala
+++ b/test/files/run/t2509-1.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:3.0
+// scalac: -Yscala3-implicit-resolution
 import scala.language.implicitConversions
 
 class A

--- a/test/files/run/t2509-4.scala
+++ b/test/files/run/t2509-4.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:3.0
+// scalac: -Yscala3-implicit-resolution
 import scala.language.implicitConversions
 
 class A

--- a/test/files/run/t7768.scala
+++ b/test/files/run/t7768.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:3.0
+// scalac: -Yscala3-implicit-resolution
 class A
 class B extends A
 class C extends B

--- a/test/junit/scala/tools/nsc/typechecker/InferencerTest.scala
+++ b/test/junit/scala/tools/nsc/typechecker/InferencerTest.scala
@@ -6,7 +6,6 @@ import org.junit.{After, Before, Test}
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import scala.tools.nsc.settings.ScalaVersion
 import scala.tools.testkit.BytecodeTesting
 
 class A
@@ -26,18 +25,19 @@ trait ZwC[-T] extends Z[T] with C
 class InferencerTests extends BytecodeTesting {
   import compiler.global._, analyzer._
 
-  var storedXsource: ScalaVersion = null
+  var storedYscala3ImplicitResolution: Boolean = false
   @Before
-  def storeXsource(): Unit = {
-    storedXsource = settings.source.value
+  def storeYscala3ImplicitResolution(): Unit = {
+    storedYscala3ImplicitResolution = settings.Yscala3ImplicitResolution.value
   }
   @After
-  def restoreXsource(): Unit = {
-    settings.source.value = storedXsource
+  def restoreYscala3ImplicitResolution(): Unit = {
+    settings.Yscala3ImplicitResolution.value = storedYscala3ImplicitResolution
   }
 
   @Test
   def isAsSpecificScala2(): Unit = {
+    settings.Yscala3ImplicitResolution.value = false
     val run = new global.Run
 
     enteringPhase(run.typerPhase) {
@@ -103,7 +103,7 @@ class InferencerTests extends BytecodeTesting {
 
   @Test
   def isAsSpecificScala3(): Unit = {
-    settings.source.value = ScalaVersion("3.0")
+    settings.Yscala3ImplicitResolution.value = true
 
     val run = new global.Run
 


### PR DESCRIPTION
# Motivation

Using `-Xsource:3` to enable some Scala 3 syntax and behavior breaks implicit resolution in certain cases, as described in bug report https://github.com/scala/bug/issues/12437. Most notably it makes Scala.js unions not work. This PR disables Scala-3-style implicit resolution when `-Xsource:3` is used (because it is currently broken) while making it possible to opt in to use it with a newly introduced flag `-Yscala3-implicit-resolution`.

# Usage

If you use `-Xsource:3` and are impacted by https://github.com/scala/bug/issues/12437 then do not add `-Yscala3-implicit-resolution` to the Scala compiler options. It will disable Scala-3-style implicit resolution while still preserving other Scala 3 behavior in your Scala 2 code.

If you use `-Xsource:3` currently but are not impacted by https://github.com/scala/bug/issues/12437, add `-Yscala3-implicit-resolution` to the Scala compiler options to preserve the Scala 2.13.8 behavior of `-Xsource:3` flag. Note that even if you are not currently impacted by the bug you may be in the future so the recommendation is **not to** use `-Yscala3-implicit-resolution` unless your code doesn't compile without it (because Scala-3-style implicit resolution is partially broken).

If you don't use `-Xsource:3` currently you probably don't want to enable Scala-3-style implicit resolution without using `-Xsource:3` so there's no action required for you.
