### PR TITLE
Show parameter type in `-Wunused:params` warnings

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -752,7 +752,7 @@ trait TypeDiagnostics extends splain.SplainDiagnostics {
             && !isConvention(s)
           )
         for (s <- unusedPrivates.unusedParams if warnable(s))
-          emitUnusedWarning(s.pos, s"parameter $s in ${if (s.owner.isAnonymousFunction) "anonymous function" else s.owner} is never used", WarningCategory.UnusedParams, s)
+          emitUnusedWarning(s.pos, s"parameter $s in ${if (s.owner.isAnonymousFunction) "anonymous function" else s.owner} is never used\nType: ${s.tpe.toLongString}", WarningCategory.UnusedParams, s)
       }
     }
     def apply(unit: CompilationUnit): Unit = if (warningsEnabled && !unit.isJava && !typer.context.reporter.hasErrors) {


### PR DESCRIPTION
I recently filed scalameta/metals-feature-requests#270 and learned that the unused parameter warnings in Metals are forwarded from `scalac`.  I realized it would only be a relatively minor change to the compiler, so I'd like to get the ball rolling with this PR.

## Problem

Currently, unused named parameters give the following warning.  The type is not shown, but having the name available makes it easy to figure out which parameter is unused.

```scala
// parameter value arg in method unusedParam is never used
def unusedParam(arg: Int): Unit = { }

// parameter value arg in method unusedParam is never used
def unusedImplicit(implicit arg: Int): Unit = { }
```

However, when using [context bounds](https://www.baeldung.com/scala/view-context-bounds), implicit arguments have auto-generated names like `evidence$1`, making it difficult to identify the steps needed to resolve the warning, especially in cases where there are several type parameters each with their own context bounds.

```scala
object UnusedExample {

  abstract class Foo[T] {
    def foo(arg: T): Unit
  }
  abstract class Bar[T] {
    def bar(arg: T): Unit
  }

  // parameter value evidence$2 in method useFoo is never used
  def unusedFoo[A: Foo: Bar](a: A): Unit = {
    val foo = implicitly[Foo[A]]
    foo.foo(a)
  }
}
```

# Proposed Solution

Warning messages generated by `-Wunused:params` should include both the name AND type of the unused parameter.  For example,

```scala
// parameter value arg in method unusedParam is never used
// Type: Int
def unusedParam(arg: Int): Unit = { }

// parameter value `arg: Int` in method unusedParam is never used
// Type: Int
def unusedImplicit(implicit arg: Int): Unit = { }
```

```scala
object UnusedExample {

  abstract class Foo[T] {
    def foo(arg: T): Unit
  }
  abstract class Bar[T] {
    def bar(arg: T): Unit
  }

  // parameter value evidence$2 in method useFoo is never used
  // Type: Bar[A]
  def unusedFoo[A: Foo: Bar](a: A): Unit = {
    val foo = implicitly[Foo[A]]
    foo.foo(a)
  }
}
```

### Alternatives

Without these more descriptive error messages, the only way to identify the source of an `unused evidence$n` warning is to count up to the `n`th context bound in the method signature.  

In certain cases, the squiggly red/yellow underline will be drawn directly under the unused context bound, making it easy to see which context bound is unused.  However, in some cases it will be drawn under the method name itself (which is probably a bug, although I was not able to reproduce it for my simple example).

## Questions

1. What is the clearest / least intrusive way to present the type information?  I chose to display it on a new line, which may be better for longer type signatures.  Alternatively, the type could appear adjacent to the argument name.  Open to suggestions.
2. For consistency, should the other `-Wunused` warnings be updated to show type information as well?

I'm happy to do the work on this after receiving some guidance on the above.

## Todos

- [ ] once the specific language for the warning(s) has been chosen, update the test cases to reflect the expected warning messages