### PR TITLE
Improve error reporting on context bounds (correct position, improved messaging)

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2600,8 +2600,10 @@ self =>
             contextBoundBuf += atPos(in.skipToken())(makeFunctionTypeTree(List(Ident(pname)), typ()))
           }
           while (in.token == COLON) {
-            contextBoundBuf += atPos(in.skipToken()) {
-              AppliedTypeTree(typ(), List(Ident(pname)))
+            in.nextToken()
+            val colonBound = typ()
+            contextBoundBuf += atPos(colonBound.pos) {
+              AppliedTypeTree(colonBound, List(Ident(pname)))
             }
           }
         }

--- a/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
@@ -154,11 +154,11 @@ abstract class TreeBuilder {
     if (contextBounds.isEmpty) vparamss
     else {
       val mods = Modifiers(if (owner.isTypeName) PARAMACCESSOR | LOCAL | PRIVATE else PARAM)
-      def makeEvidenceParam(tpt: Tree) = ValDef(mods | IMPLICIT | SYNTHETIC, freshTermName(nme.EVIDENCE_PARAM_PREFIX), tpt, EmptyTree)
-      val evidenceParams = contextBounds map makeEvidenceParam
+      def makeEvidenceParam(tpt: Tree) = atPos(tpt.pos)(ValDef(mods | IMPLICIT | SYNTHETIC, freshTermName(nme.EVIDENCE_PARAM_PREFIX), tpt, EmptyTree))
+      val evidenceParams = contextBounds.map(makeEvidenceParam)
 
-      val vparamssLast = if(vparamss.nonEmpty) vparamss.last else Nil
-      if(vparamssLast.nonEmpty && vparamssLast.head.mods.hasFlag(IMPLICIT))
+      val vparamssLast = if (vparamss.nonEmpty) vparamss.last else Nil
+      if (vparamssLast.nonEmpty && vparamssLast.head.mods.hasFlag(IMPLICIT))
         vparamss.init ::: List(evidenceParams ::: vparamssLast)
       else
         vparamss ::: List(evidenceParams)

--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -751,8 +751,14 @@ trait TypeDiagnostics extends splain.SplainDiagnostics {
             && !isImplementation(s.owner)
             && !isConvention(s)
           )
-        for (s <- unusedPrivates.unusedParams if warnable(s))
-          emitUnusedWarning(s.pos, s"parameter $s in ${if (s.owner.isAnonymousFunction) "anonymous function" else s.owner} is never used", WarningCategory.UnusedParams, s)
+        for (s <- unusedPrivates.unusedParams if warnable(s)) {
+          val what =
+            if (s.name.startsWith(nme.EVIDENCE_PARAM_PREFIX)) s"evidence parameter ${s.name} of type ${s.tpe}"
+            else s"parameter ${s/*.name*/}"
+          val where =
+            if (s.owner.isAnonymousFunction) "anonymous function" else s.owner
+          emitUnusedWarning(s.pos, s"$what in $where is never used", WarningCategory.UnusedParams, s)
+        }
       }
     }
     def apply(unit: CompilationUnit): Unit = if (warningsEnabled && !unit.isJava && !typer.context.reporter.hasErrors) {

--- a/test/files/neg/classmanifests_new_deprecations.check
+++ b/test/files/neg/classmanifests_new_deprecations.check
@@ -1,6 +1,6 @@
 classmanifests_new_deprecations.scala:4: warning: type ClassManifest in package reflect is deprecated (since 2.10.0): use scala.reflect.ClassTag instead
   def rcm1[T: scala.reflect.ClassManifest] = ???
-            ^
+                            ^
 classmanifests_new_deprecations.scala:5: warning: type ClassManifest in package reflect is deprecated (since 2.10.0): use scala.reflect.ClassTag instead
   def rcm2[T](implicit evidence$1: scala.reflect.ClassManifest[T]) = ???
                                                  ^

--- a/test/files/neg/warn-unused-params.check
+++ b/test/files/neg/warn-unused-params.check
@@ -31,12 +31,12 @@ warn-unused-params.scala:97: warning: parameter value i in anonymous function is
 warn-unused-params.scala:101: warning: parameter value ctx in method f is never used
   def f[A](implicit ctx: Context[A]) = answer
                     ^
-warn-unused-params.scala:102: warning: parameter value evidence$1 in method g is never used
+warn-unused-params.scala:102: warning: evidence parameter evidence$1 of type Context[A] in method g is never used
   def g[A: Context] = answer
-      ^
-warn-unused-params.scala:104: warning: parameter value evidence$2 in class Bound is never used
+           ^
+warn-unused-params.scala:104: warning: evidence parameter evidence$2 of type Context[A] in class Bound is never used
 class Bound[A: Context]
-             ^
+               ^
 error: No warnings can be incurred under -Werror.
 13 warnings
 1 error


### PR DESCRIPTION
The caret will point to the bound.

Supersedes https://github.com/scala/scala/pull/10014 which kindly calls it "probably" a bug, but there may be further tweaking of types. I think the correct position suffices, but implicit not found will say `evidence parameter evidence$1`, so this PR risks the redundancy.