### PR TITLE
Only check accessible extension for non-empty refinement

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -752,7 +752,8 @@ trait Implicits extends splain.SplainData {
                     val lastArg = as.head
                     as.tail.isEmpty && {
                       lastArg match {
-                        case RefinedType(_, syms) => syms.reverseIterator.exists(x => context.isAccessible(restpe.nonPrivateMember(x.name), restpe))
+                        case RefinedType(_, syms) if !syms.isEmpty =>
+                          syms.reverseIterator.exists(x => context.isAccessible(restpe.nonPrivateMember(x.name), restpe))
                         case _ => true
                       }
                     } && loop(restpe, lastArg)

--- a/test/files/pos/t11787b.scala
+++ b/test/files/pos/t11787b.scala
@@ -1,0 +1,4 @@
+
+class C {
+  def f = (Array(1), Array("foo")).zipped
+}


### PR DESCRIPTION
Followup to #9999, fixing a regression uncovered by the community build