### PR TITLE
[backport] Avoid retaining refs to previously added items after VectorBuilder.clear

### DIFF
--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -678,6 +678,11 @@ final class VectorBuilder[A]() extends ReusableBuilder[A, Vector[A]] with Vector
   }
 
   def clear(): Unit = {
+    display5 = null
+    display4 = null
+    display3 = null
+    display2 = null
+    display1 = null
     display0 = new Array[AnyRef](32)
     depth = 1
     blockIndex = 0

--- a/test/junit/scala/collection/immutable/VectorTest.scala
+++ b/test/junit/scala/collection/immutable/VectorTest.scala
@@ -5,6 +5,8 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.junit.Test
 
+import scala.tools.testing.AssertUtil._
+
 @RunWith(classOf[JUnit4])
 class VectorTest {
 
@@ -26,5 +28,11 @@ class VectorTest {
     assertEquals(Vector.empty[Int], v takeRight Int.MinValue)
     assertEquals(v, v drop Int.MinValue)
     assertEquals(v, v dropRight Int.MinValue)
+  }
+  @Test def `VectorBuilder.clear retains nothing`: Unit = {
+    val b = new VectorBuilder[Object]()
+    val x = new Object
+    for (_ <- 0 to 16384) b += x
+    assertNotReachable(x, b)(b.clear())
   }
 }

--- a/test/junit/scala/lang/primitives/BoxUnboxTest.scala
+++ b/test/junit/scala/lang/primitives/BoxUnboxTest.scala
@@ -5,6 +5,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
+import scala.annotation.nowarn
 import scala.tools.testing.RunTesting
 
 object BoxUnboxTest {
@@ -12,6 +13,7 @@ object BoxUnboxTest {
 }
 
 @RunWith(classOf[JUnit4])
+@nowarn("msg=comparing values")
 class BoxUnboxTest extends RunTesting {
 
   @Test

--- a/test/junit/scala/reflect/internal/NamesTest.scala
+++ b/test/junit/scala/reflect/internal/NamesTest.scala
@@ -1,11 +1,12 @@
 package scala.reflect.internal
 
-import scala.tools.testing.AssertUtil._
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.junit.Test
 import org.junit.Assert._
+import scala.annotation.nowarn
 import scala.tools.nsc.symtab.SymbolTableForUnitTesting
+import scala.tools.testing.AssertUtil._
 
 @RunWith(classOf[JUnit4])
 class NamesTest {
@@ -33,6 +34,7 @@ class NamesTest {
     assertTrue(h1 != f)
   }
 
+  @nowarn("msg=comparing values")
   @Test
   def termNamesNotEqualsTypeNames() {
     assert(h1 ne h1y)

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/CallGraphTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/CallGraphTest.scala
@@ -13,7 +13,6 @@ import scala.reflect.internal.util.JavaClearable
 import scala.tools.asm.tree._
 import scala.tools.nsc.backend.jvm.BackendReporting._
 import scala.tools.nsc.reporters.StoreReporter
-import scala.tools.testing.AssertUtil._
 import scala.tools.testing.BytecodeTesting
 import scala.tools.testing.BytecodeTesting._
 

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/MethodLevelOptsTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/MethodLevelOptsTest.scala
@@ -11,7 +11,6 @@ import scala.collection.JavaConverters._
 import scala.tools.asm.Opcodes._
 import scala.tools.asm.tree.ClassNode
 import scala.tools.nsc.backend.jvm.AsmUtils._
-import scala.tools.nsc.reporters.StoreReporter
 import scala.tools.partest.ASMConverters._
 import scala.tools.testing.BytecodeTesting
 import scala.tools.testing.BytecodeTesting._

--- a/test/junit/scala/tools/testing/TempDir.scala
+++ b/test/junit/scala/tools/testing/TempDir.scala
@@ -2,7 +2,7 @@ package scala.tools.testing
 
 import java.io.{IOException, File}
 import java.nio.file.{Path, Files}
-import scala.util.{Properties, Try}
+import scala.util.Properties
 import Using.Releasable
 
 object TempDir {


### PR DESCRIPTION
https://github.com/akka/akka/issues/25623
https://github.com/scala/scala/commit/845b0f0ffc59392b3dd59979f89d4f101e598236#diff-59f3462485b74027de4fd5e9febcc81bR627

I compared the code in Vector 2.13.x