### PR TITLE
In Scala 3 TASTy reader, restrict access to experimental definitions

### DIFF
--- a/src/compiler/scala/tools/nsc/tasty/bridge/NameOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/NameOps.scala
@@ -54,6 +54,8 @@ trait NameOps { self: TastyUniverse =>
     final val Tuple: String = "Tuple"
     final val Matchable: String = "Matchable"
 
+    val ErasedFunctionN = raw"ErasedFunction(\d+)".r
+    val ErasedContextFunctionN = raw"ErasedContextFunction(\d+)".r
     val ContextFunctionN = raw"ContextFunction(\d+)".r
     val FunctionN        = raw"Function(\d+)".r
 

--- a/src/compiler/scala/tools/nsc/tasty/bridge/SymbolOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/SymbolOps.scala
@@ -117,6 +117,9 @@ trait SymbolOps { self: TastyUniverse =>
     def safeOwner: Symbol = if (sym.owner eq sym) sym else sym.owner
   }
 
+  /** Is this symbol annotated with `scala.annotation.experimental`? */
+  def symIsExperimental(sym: Symbol) = sym.hasAnnotation(defn.ExperimentalAnnotationClass)
+
   /** if isConstructor, make sure it has one non-implicit parameter list */
   def normalizeIfConstructor(termParamss: List[List[Symbol]], isConstructor: Boolean): List[List[Symbol]] =
     if (isConstructor &&

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1286,6 +1286,11 @@ abstract class RefChecks extends Transform {
         if (changed)
           refchecksWarning(pos, s"${sym.fullLocationString} has changed semantics in version ${sym.migrationVersion.get}:\n${sym.migrationMessage.get}", WarningCategory.OtherMigration)
       }
+      if (sym.isExperimental && !currentOwner.ownerChain.exists(x => x.isExperimental)) {
+        val msg =
+          s"${sym.fullLocationString} is marked @experimental and therefore its enclosing scope must be experimental."
+        reporter.error(pos, msg)
+      }
       // See an explanation of compileTimeOnly in its scaladoc at scala.annotation.compileTimeOnly.
       // async/await is expanded after erasure
       if (sym.isCompileTimeOnly && !inAnnotation && !currentOwner.ownerChain.exists(x => x.isCompileTimeOnly)) {

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1316,6 +1316,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val TargetNameAnnotationClass   = getClassIfDefined("scala.annotation.targetName")
     lazy val StaticMethodAnnotationClass = getClassIfDefined("scala.annotation.static")
     lazy val PolyFunctionClass           = getClassIfDefined("scala.PolyFunction")
+    lazy val ExperimentalAnnotationClass = getClassIfDefined("scala.annotation.experimental")
 
     lazy val BeanPropertyAttr           = requiredClass[scala.beans.BeanProperty]
     lazy val BooleanBeanPropertyAttr    = requiredClass[scala.beans.BooleanBeanProperty]

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -934,6 +934,8 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def isCompileTimeOnly       = hasAnnotation(CompileTimeOnlyAttr)
     def compileTimeOnlyMessage  = getAnnotation(CompileTimeOnlyAttr) flatMap (_ stringArg 0)
 
+    def isExperimental = hasAnnotation(ExperimentalAnnotationClass)
+
     /** Is this symbol an accessor method for outer? */
     final def isOuterAccessor = hasFlag(STABLE | ARTIFACT) && (unexpandedName == nme.OUTER)
 

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -443,6 +443,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.TargetNameAnnotationClass
     definitions.StaticMethodAnnotationClass
     definitions.PolyFunctionClass
+    definitions.ExperimentalAnnotationClass
     definitions.BeanPropertyAttr
     definitions.BooleanBeanPropertyAttr
     definitions.CompileTimeOnlyAttr

--- a/src/tastytest/scala/tools/tastytest/SourceKind.scala
+++ b/src/tastytest/scala/tools/tastytest/SourceKind.scala
@@ -9,6 +9,7 @@ object SourceKind {
   case object NoSource  extends SourceKind("")(filter = _ => false)
   case object Scala     extends SourceKind(".scala")()
   case object ScalaFail extends SourceKind("_fail.scala")()
+  case object ScalaPre  extends SourceKind("_pre.scala")()
   case object Check     extends SourceKind(".check")()
   case object SkipCheck extends SourceKind(".skipcheck")()
   case object Java      extends SourceKind(".java")()

--- a/src/tastytest/scala/tools/tastytest/TastyTest.scala
+++ b/src/tastytest/scala/tools/tastytest/TastyTest.scala
@@ -11,6 +11,7 @@ import java.{ util => ju }
 
 import SourceKind._
 import Files._
+import java.io.OutputStream
 
 object TastyTest {
 
@@ -19,6 +20,17 @@ object TastyTest {
   private def log(s: => String): Unit =
     if (verbose) println(s)
 
+  /**Simulates a Scala 2 application that depends on a Scala 3 library, where both may depend on a common prelude
+   * compiled by Scala 2.
+   *
+   * Steps:
+   *  1) compile all Scala files in `pre` with scala 2 to `out`
+   *  2) compile all Scala files in `src-3` with scala 3 to `out`, with `out` as the classpath
+   *  3) compile all Scala files in `src-2` with scala 2 to `out`, with `out` as the classpath
+   *  4) run the main method of all classes in `out/pkgName` that match a file in `src-2`.
+   *     e.g. `out/tastytest/TestFoo.class` should be compiled from a corresponding file
+   *          `src-2/tastytest/TestFoo.scala`.
+   */
   def runSuite(src: String, srcRoot: String, pkgName: String, outDir: Option[String], additionalSettings: Seq[String], additionalDottySettings: Seq[String])(implicit cl: Dotc.ClassLoader): Try[Unit] = for {
     (pre, src2, src3) <- getRunSources(srcRoot/src)
     out               <- outDir.fold(tempDir(pkgName))(dir)
@@ -29,6 +41,14 @@ object TastyTest {
     _                 <- runMainOn(out, testNames:_*)
   } yield ()
 
+  /**Simulates a Scala 2 application that depends on a Scala 3 library, where both may depend on a common prelude
+   * compiled by Scala 2 and Java. In this case the applications are not executed.
+   * Steps:
+   *  1) compile all Java files in `pre` with Java to `out`
+   *  2) compile all Scala files in `pre` with Scala 2 to `out`, with `out` as the classpath
+   *  3) compile all Scala files in `src-3` with scala 3 to `out`, with `out` as the classpath
+   *  4) compile all Scala files in `src-2` with scala 2 to `out`, with `out` as the classpath
+   */
   def posSuite(src: String, srcRoot: String, pkgName: String, outDir: Option[String], additionalSettings: Seq[String], additionalDottySettings: Seq[String])(implicit cl: Dotc.ClassLoader): Try[Unit] = for {
     (pre, src2, src3) <- getRunSources(srcRoot/src, preFilters = Set(Scala, Java))
     _                 =  log(s"Sources to compile under test: ${src2.map(cyan).mkString(", ")}")
@@ -39,6 +59,16 @@ object TastyTest {
     _                 <- scalacPos(out, sourceRoot=srcRoot/src/"src-2", additionalSettings, src2:_*)
   } yield ()
 
+  /**Simulates a Scala 2 application that depends on a Scala 3 library, and is expected to fail compilation.
+   * Steps:
+   *  1) compile all Scala files in `src-3` with scala 3 to `out`
+   *  2) attempt to compile all Scala files in `src-2` with scala 2 to `out`, with `out` as the classpath.
+   *     - If a file matches `FOO_fail.scala`, then it is expected to fail compilation.
+   *     - For each `FOO_fail.scala`, if the file fails compilation, there is expected to be a corresponding `FOO.check` file, containing
+   *       the captured errors, or else a `FOO.skipcheck` file indicating to skip comparing errors.
+   *     - If `FOO_fail.scala` has a corresponding `FOO_pre.scala` file, then that is compiled first to `out`,
+   *       so that `FOO_fail.scala` may depend on its compilation results.
+   */
   def negSuite(src: String, srcRoot: String, pkgName: String, outDir: Option[String], additionalSettings: Seq[String], additionalDottySettings: Seq[String])(implicit cl: Dotc.ClassLoader): Try[Unit] = for {
     (src2, src3)      <- get2And3Sources(srcRoot/src, src2Filters = Set(Scala, Check, SkipCheck))
     out               <- outDir.fold(tempDir(pkgName))(dir)
@@ -46,15 +76,47 @@ object TastyTest {
     _                 <- scalacNeg(out, additionalSettings, src2:_*)
   } yield ()
 
+  /**Simulates a Scala 3 application that depends on a Scala 2 library, where the Scala 2
+   * library directly depends on an upstream Scala 3 library. The Scala 3 application is expected to fail compilation.
+   * Steps:
+   *  1) compile all Scala files in `src-3-upstream` with scala 3 to `out`
+   *  2) compile all Scala files in `src-2-downstream` with scala 2 to `out`, with `out` as the classpath.
+   *  3) attempt to compile all Scala files in `src-3-app` with scala 3 to `out`, with `out` as the classpath,
+   *     following the same steps as `negSuite` to check for errors in compilation.
+   */
+  def negFullCircleSuite(src: String, srcRoot: String, pkgName: String, outDir: Option[String], additionalSettings: Seq[String], additionalDottySettings: Seq[String])(implicit cl: Dotc.ClassLoader): Try[Unit] = for {
+    (src3u, src2d, src3a) <- getFullCircleSources(srcRoot/src, src3appFilters = Set(Scala, Check, SkipCheck))
+    out                   <- outDir.fold(tempDir(pkgName))(dir)
+    _                     <- dotcPos(out, sourceRoot=srcRoot/src/"src-3-upstream", additionalDottySettings, src3u:_*)
+    _                     <- scalacPos(out, sourceRoot=srcRoot/src/"src-2-downstream", additionalSettings, src2d:_*)
+    _                     <- dotcNeg(out, additionalDottySettings, src3a:_*)
+  } yield ()
+
+  /**Same as `negSuite`, but introduces a dependency on a prelude by both the Scala 3 and Scala 2 libraries. In
+   * this case, they depend on binary incompatible versions of the same prelude (e.g. some definitions have moved
+   * between versions). Steps:
+   *  1) compile all Scala files in `pre-A` with scala 2 to `out1`.
+   *  2) compile all Scala files in `pre-B` with scala 2 to `out2`.
+   *  3) compile all Scala files in `src-3` with scala 3 to `out2`, with `out1` as the classpath.
+   *  4) attempt to compile all Scala files in `src-2` with scala 2 to `out2`, with `out2` as the classpath,
+   *     following the same steps as `negSuite` to check for errors in compilation.
+   */
   def negChangePreSuite(src: String, srcRoot: String, pkgName: String, outDirs: Option[(String, String)], additionalSettings: Seq[String], additionalDottySettings: Seq[String])(implicit cl: Dotc.ClassLoader): Try[Unit] = for {
     (preA, preB, src2, src3) <- getMovePreChangeSources(srcRoot/src, src2Filters = Set(Scala, Check, SkipCheck))
     (out1, out2)             <- outDirs.fold(tempDir(pkgName) *> tempDir(pkgName))(p => dir(p._1) *> dir(p._2))
     _                        <- scalacPos(out1, sourceRoot=srcRoot/src/"pre-A", additionalSettings, preA:_*)
-    _                        <- dotcPos(out2, out1, sourceRoot=srcRoot/src/"src-3", additionalDottySettings, src3:_*)
     _                        <- scalacPos(out2, sourceRoot=srcRoot/src/"pre-B", additionalSettings, preB:_*)
+    _                        <- dotcPos(out2, out1, sourceRoot=srcRoot/src/"src-3", additionalDottySettings, src3:_*)
     _                        <- scalacNeg(out2, additionalSettings, src2:_*)
   } yield ()
 
+  /**Same as `negSuite`, but in addition, the Scala 3 library depends on another upstream Scala 3 library,
+   * which is missing from the classpath when compiling the Scala 2 library. Steps:
+   *  1) compile all Scala files in `src-3-A` with scala 3 to `out1`.
+   *  3) compile all Scala files in `src-3-B` with scala 3 to `out2`, with `out1:out2` as the classpath.
+   *  3) attempt to compile all Scala files in `src-2` with scala 2 to `out2`, with `out2` as the classpath,
+   *     following the same steps as `negSuite` to check for errors in compilation.
+   */
   def negSuiteIsolated(src: String, srcRoot: String, pkgName: String, outDirs: Option[(String, String)], additionalSettings: Seq[String], additionalDottySettings: Seq[String])(implicit cl: Dotc.ClassLoader): Try[Unit] = for {
     (src2, src3A, src3B) <- getNegIsolatedSources(srcRoot/src, src2Filters = Set(Scala, Check, SkipCheck))
     (out1, out2)         <- outDirs.fold(tempDir(pkgName) *> tempDir(pkgName))(p => dir(p._1) *> dir(p._2))
@@ -74,39 +136,50 @@ object TastyTest {
   }
 
   private def scalacNeg(out: String, additionalSettings: Seq[String], files: String*): Try[Unit] = {
+    def compile(source: String, writer: OutputStream) =
+      Scalac.scalac(writer, out, "-Ytasty-reader" +: additionalSettings, source)
+    negTestImpl(withCapture(_, compile, identity))(files:_*)
+  }
+
+  private def withCapture(source: String, compile: (String, OutputStream) => Try[Boolean], post: String => String): (String, Try[Boolean]) = {
+    val byteArrayStream = new ByteArrayOutputStream(50)
+    try {
+      val compiled = compile(source, byteArrayStream)
+      (post(byteArrayStream.toString), compiled)
+    } finally byteArrayStream.close()
+  }
+
+  private def negTestImpl(compile: String => (String, Try[Boolean]))(files: String*): Try[Unit] = {
     val errors = mutable.ArrayBuffer.empty[String]
     val unexpectedFail = mutable.ArrayBuffer.empty[String]
-    val failMap = {
+    val failMap: Map[String, (Option[String], Option[String])] = {
       val (sources, rest) = files.partition(ScalaFail.filter)
       sources.map({ s =>
-        val name  = s.stripSuffix(ScalaFail.name)
+        val name = s.stripSuffix(ScalaFail.name)
         val check = Check.fileOf(name)
-        val skip  = SkipCheck.fileOf(name)
-        val found = rest.find(n => n == check || n == skip)
-        s -> found
+        val skip = SkipCheck.fileOf(name)
+        val pre = ScalaPre.fileOf(name)
+        val foundCheck = rest.find(n => n == check || n == skip)
+        val foundPre   = rest.find(_ == pre)
+        s -> (foundCheck, foundPre)
       }).toMap
     }
     if (failMap.isEmpty) {
       printwarnln(s"Warning: there are no source files marked as fail tests. (**/*${ScalaFail.name})")
     }
-    for (source <- files.filter(Scala.filter)) {
-      val buf = new StringBuilder(50)
-      val compiled = {
-        val byteArrayStream = new ByteArrayOutputStream(50)
-        try {
-          if (ScalaFail.filter(source)) {
-            log(s"neg test ${cyan(source.stripSuffix(ScalaFail.name))} started")
+    def negCompile(source: String): Unit = {
+      val (output, compiled) = {
+        if (ScalaFail.filter(source)) {
+          val testName = source.stripSuffix(ScalaFail.name)
+          log(s"neg test ${cyan(testName)} started")
+          failMap(source) match {
+            case (_, Some(pre)) =>
+              log(s"  - compiling pre file...")
+              negCompile(pre)
+            case _ =>
           }
-          val compiled = Console.withErr(byteArrayStream) {
-            Console.withOut(byteArrayStream) {
-              Scalac.scalac(out, "-Ytasty-reader" +: additionalSettings, source)
-            }
-          }
-          byteArrayStream.flush()
-          buf.append(byteArrayStream.toString)
-          compiled
         }
-        finally byteArrayStream.close()
+        compile(source)
       }
       if (compiled.getOrElse(false)) {
         if (failMap.contains(source)) {
@@ -115,13 +188,12 @@ object TastyTest {
         }
       }
       else {
-        val output = buf.toString
         failMap.get(source) match {
           case None =>
             unexpectedFail += source
             System.err.println(output)
             printerrln(s"ERROR: $source did not compile when expected to. Perhaps it should match (**/*${ScalaFail.name})")
-          case Some(Some(checkFile)) if Check.filter(checkFile) =>
+          case Some((Some(checkFile), _)) if Check.filter(checkFile) =>
             processLines(checkFile) { stream =>
               val checkLines  = stream.iterator().asScala.toSeq
               val outputLines = Diff.splitIntoLines(output)
@@ -131,9 +203,9 @@ object TastyTest {
                 printerrln(s"ERROR: $source failed, unexpected output.\n$diff")
               }
             }
-          case Some(Some(skipCheckFile)) =>
+          case Some((Some(skipCheckFile), _)) =>
             printwarnln(s"warning: skipping check on ${skipCheckFile.stripSuffix(SkipCheck.name)}")
-          case Some(None) =>
+          case Some((None, _)) =>
             if (output.nonEmpty) {
               errors += source
               val diff = Diff.compareContents(output, "")
@@ -142,6 +214,9 @@ object TastyTest {
         }
       }
     }
+
+    val sources = files.filter(Scala.filter).filterNot(ScalaPre.filter)
+    sources.foreach(negCompile)
     successWhen(errors.isEmpty && unexpectedFail.isEmpty) {
       if (unexpectedFail.nonEmpty) {
         val str = if (unexpectedFail.size == 1) "file" else "files"
@@ -160,6 +235,21 @@ object TastyTest {
     log(s"compiling sources in ${yellow(sourceRoot)} with dotc.")
     val process = Dotc.dotc(out, classpath, additionalSettings, sources:_*)
     successWhen(process)("dotc failed to compile sources.")
+  }
+
+  private def dotcNeg(out: String, additionalSettings: Seq[String], files: String*)(implicit cl: Dotc.ClassLoader): Try[Unit] = {
+    def compile(source: String, writer: OutputStream) = {
+      Dotc.dotc(writer, out, out, additionalSettings, source)
+    }
+    def scrub(source: String, output: String): String = {
+      output.linesIterator.collect {
+        case header if header.contains(source) =>
+          val filePart = source.split(Files.pathSep).last
+          header.trim.replace(source, filePart)
+        case ok => ok
+      }.mkString(System.lineSeparator())
+    }
+    negTestImpl(src => withCapture(src, compile, scrub(src, _)))(files:_*)
   }
 
   private def getSourceAsName(path: String): String =
@@ -193,6 +283,21 @@ object TastyTest {
       src2 <- getFiles(root/"src-2")
       src3 <- getFiles(root/"src-3")
     } yield (filterByKind(src2Filters, src2:_*), filterByKind(src3Filters, src3:_*))
+  }
+
+  private def getFullCircleSources(root: String, src3upFilters: Set[SourceKind] = Set(Scala),
+    src2downFilters: Set[SourceKind] = Set(Scala),
+    src3appFilters: Set[SourceKind]
+  ): Try[(Seq[String], Seq[String], Seq[String])] = {
+    for {
+      src3up <- getFiles(root/"src-3-upstream")
+      src2down <- getFiles(root/"src-2-downstream")
+      src3app <- getFiles(root/"src-3-app")
+    } yield (
+      filterByKind(src3upFilters, src3up:_*),
+      filterByKind(src2downFilters, src2down:_*),
+      filterByKind(src3appFilters, src3app:_*)
+    )
   }
 
   private def getPreChangeSources(root: String, preAFilters: Set[SourceKind] /*= Set(Scala)*/,

--- a/test/tasty/neg-full-circle/src-2-downstream/ExperimentalDefsPre.scala
+++ b/test/tasty/neg-full-circle/src-2-downstream/ExperimentalDefsPre.scala
@@ -1,0 +1,10 @@
+package downstream
+
+import upstream.ExperimentalClass
+
+@scala.annotation.experimental
+object ExperimentalDefsPre {
+
+  class SubExperimentalNotExperimental extends ExperimentalClass
+
+}

--- a/test/tasty/neg-full-circle/src-3-app/TestExperimentalDefsPre.check
+++ b/test/tasty/neg-full-circle/src-3-app/TestExperimentalDefsPre.check
@@ -1,0 +1,17 @@
+-- Error: TestExperimentalDefsPre_fail.scala:4:10
+4 |  def test = new SubExperimentalNotExperimental
+  |          ^
+  |object ExperimentalDefsPre is marked @experimental and therefore may only be used in an experimental scope.
+-- Error: TestExperimentalDefsPre_fail.scala:4:17
+4 |  def test = new SubExperimentalNotExperimental
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |object ExperimentalDefsPre is marked @experimental and therefore may only be used in an experimental scope.
+-- Error: TestExperimentalDefsPre_fail.scala:6:35
+6 |  class SubSubExperimental extends SubExperimentalNotExperimental
+  |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |object ExperimentalDefsPre is marked @experimental and therefore may only be used in an experimental scope.
+-- Error: TestExperimentalDefsPre_fail.scala:6:8
+6 |  class SubSubExperimental extends SubExperimentalNotExperimental
+  |        ^
+  |extension of experimental class SubExperimentalNotExperimental must have @experimental annotation
+4 errors found

--- a/test/tasty/neg-full-circle/src-3-app/TestExperimentalDefsPre_fail.scala
+++ b/test/tasty/neg-full-circle/src-3-app/TestExperimentalDefsPre_fail.scala
@@ -1,0 +1,6 @@
+import downstream.ExperimentalDefsPre.*
+
+object TestExperimentalDefsPre:
+  def test = new SubExperimentalNotExperimental
+
+  class SubSubExperimental extends SubExperimentalNotExperimental

--- a/test/tasty/neg-full-circle/src-3-upstream/ExperimentalClass.scala
+++ b/test/tasty/neg-full-circle/src-3-upstream/ExperimentalClass.scala
@@ -1,0 +1,6 @@
+package upstream
+
+import scala.annotation.experimental
+
+@experimental
+class ExperimentalClass extends scala.annotation.Annotation

--- a/test/tasty/neg/src-2/ExperimentalDefs.check
+++ b/test/tasty/neg/src-2/ExperimentalDefs.check
@@ -1,0 +1,25 @@
+ExperimentalDefs_fail.scala:10: error: object ExperimentalObj in package tastytest is marked @experimental and therefore its enclosing scope must be experimental.
+  def termRef = ExperimentalObj.foo // error
+                ^
+ExperimentalDefs_fail.scala:11: error: class ExperimentalClass in package tastytest is marked @experimental and therefore its enclosing scope must be experimental.
+  def typeRef = new Box[ExperimentalClass]() // error
+                    ^
+ExperimentalDefs_fail.scala:13: error: class ExperimentalClass in package tastytest is marked @experimental and therefore its enclosing scope must be experimental.
+  class SubExperimental extends ExperimentalClass // error
+                                ^
+ExperimentalDefs_fail.scala:14: error: class ExperimentalClass in package tastytest is marked @experimental and therefore its enclosing scope must be experimental.
+  class SuperExperimental extends Box[ExperimentalClass] // error
+                                  ^
+ExperimentalDefs_fail.scala:15: error: class ExperimentalClass in package tastytest is marked @experimental and therefore its enclosing scope must be experimental.
+  type RefExperimental = Box[ExperimentalClass] // error
+                         ^
+ExperimentalDefs_fail.scala:16: error: class ExperimentalClass in package tastytest is marked @experimental and therefore its enclosing scope must be experimental.
+  type MemberExperimental = { type Ref = ExperimentalClass } // error
+                            ^
+ExperimentalDefs_fail.scala:17: error: class ExperimentalClass in package tastytest is marked @experimental and therefore its enclosing scope must be experimental.
+  type AnnotatedRef = Box[Int] @ExperimentalClass // error
+                                ^
+ExperimentalDefs_fail.scala:19: error: object ExperimentalDefsPre is marked @experimental and therefore its enclosing scope must be experimental.
+  def refSubclassOfExperimental = new SubExperimentalNotExperimental() // error
+                                      ^
+8 errors

--- a/test/tasty/neg/src-2/ExperimentalDefs_fail.scala
+++ b/test/tasty/neg/src-2/ExperimentalDefs_fail.scala
@@ -1,0 +1,28 @@
+import tastytest.ExperimentalObj
+import tastytest.ExperimentalClass
+import scala.annotation.compileTimeOnly
+import ExperimentalDefsPre._
+
+object ExperimentalDefs {
+
+  class Box[T]
+
+  def termRef = ExperimentalObj.foo // error
+  def typeRef = new Box[ExperimentalClass]() // error
+
+  class SubExperimental extends ExperimentalClass // error
+  class SuperExperimental extends Box[ExperimentalClass] // error
+  type RefExperimental = Box[ExperimentalClass] // error
+  type MemberExperimental = { type Ref = ExperimentalClass } // error
+  type AnnotatedRef = Box[Int] @ExperimentalClass // error
+
+  def refSubclassOfExperimental = new SubExperimentalNotExperimental() // error
+
+  @compileTimeOnly("")
+  class OnlyAtCompileTime
+
+  def fixMe1 = List[ExperimentalClass]() // TODO: why is checkUndesiredProperties not called?
+  def fixMe2 = List.apply[ExperimentalClass]() // TODO: why is checkUndesiredProperties not called?
+  def fixMe3 = List[OnlyAtCompileTime]() // TODO: why is checkUndesiredProperties not called?
+  def fixMe4 = List.apply[OnlyAtCompileTime]() // TODO: why is checkUndesiredProperties not called?
+}

--- a/test/tasty/neg/src-2/ExperimentalDefs_pre.scala
+++ b/test/tasty/neg/src-2/ExperimentalDefs_pre.scala
@@ -1,0 +1,9 @@
+import tastytest.ExperimentalObj
+import tastytest.ExperimentalClass
+
+@scala.annotation.experimental
+object ExperimentalDefsPre {
+
+  class SubExperimentalNotExperimental extends ExperimentalClass
+
+}

--- a/test/tasty/neg/src-2/TestSaferExceptions.check
+++ b/test/tasty/neg/src-2/TestSaferExceptions.check
@@ -1,0 +1,4 @@
+TestSaferExceptions_fail.scala:5: error: Unsupported Scala 3 erased context function type in bounds of type mayThrow: erased tastytest.SaferExceptions.CanThrowCapability[E] ?=> A; found in object tastytest.SaferExceptions.
+  def test = SaferExceptions.safeDiv(1, 0) // error
+                             ^
+1 error

--- a/test/tasty/neg/src-2/TestSaferExceptions_fail.scala
+++ b/test/tasty/neg/src-2/TestSaferExceptions_fail.scala
@@ -1,0 +1,7 @@
+package tastytest
+
+object TestSaferExceptions {
+
+  def test = SaferExceptions.safeDiv(1, 0) // error
+
+}

--- a/test/tasty/neg/src-3/ExperimentalClass.scala
+++ b/test/tasty/neg/src-3/ExperimentalClass.scala
@@ -1,0 +1,6 @@
+package tastytest
+
+import scala.annotation.experimental
+
+@experimental
+class ExperimentalClass extends scala.annotation.Annotation

--- a/test/tasty/neg/src-3/ExperimentalObj.scala
+++ b/test/tasty/neg/src-3/ExperimentalObj.scala
@@ -1,0 +1,8 @@
+package tastytest
+
+import scala.annotation.experimental
+
+@experimental
+object ExperimentalObj {
+  def foo = 23
+}

--- a/test/tasty/neg/src-3/SaferExceptions.scala
+++ b/test/tasty/neg/src-3/SaferExceptions.scala
@@ -1,0 +1,21 @@
+package tastytest
+
+import scala.language.experimental.erasedDefinitions
+
+import scala.annotation.experimental
+
+@experimental
+object SaferExceptions {
+
+  class DivByZero extends Exception
+
+  erased class CanThrowCapability[-E <: Exception]
+
+  infix type mayThrow[+A, +E <: Exception] = (erased CanThrowCapability[E]) ?=> A
+
+  def safeDiv(x: Int, y: Int): Int mayThrow DivByZero = {
+    if (y == 0) throw new DivByZero()
+    else x / y
+  }
+
+}

--- a/test/tasty/test/scala/tools/tastytest/TastyTestJUnit.scala
+++ b/test/tasty/test/scala/tools/tastytest/TastyTestJUnit.scala
@@ -27,6 +27,7 @@ class TastyTestJUnit {
     additionalDottySettings = Nil
   ).eval
 
+  /** false positives that should fail, but work when annotations are not read */
   @test def posFalseNoAnnotations(): Unit = TastyTest.posSuite(
     src                     = "pos-false-noannotations",
     srcRoot                 = assertPropIsSet(propSrc),
@@ -59,6 +60,15 @@ class TastyTestJUnit {
     srcRoot                 = assertPropIsSet(propSrc),
     pkgName                 = assertPropIsSet(propPkgName),
     outDirs                 = None,
+    additionalSettings      = Nil,
+    additionalDottySettings = Nil
+  ).eval
+
+  @test def negFullCircle(): Unit = TastyTest.negFullCircleSuite(
+    src                     = "neg-full-circle",
+    srcRoot                 = assertPropIsSet(propSrc),
+    pkgName                 = assertPropIsSet(propPkgName),
+    outDir                  = None,
     additionalSettings      = Nil,
     additionalDottySettings = Nil
   ).eval


### PR DESCRIPTION
experimental definitions are treated like compileTimeOnly.
Test that a scala 3 application can not depend on a scala 2
library that uses experimental definitions.

There is a modification to `RefChecks` to add`@experimental` to `checkUndesiredProperties` - also I seem to have uncovered a bug in `RefChecks` where it will not check `Foo` in `List[Foo]()`.