### PR TITLE
[backport] Error on source files with Unicode directional formatting characters

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -663,7 +663,12 @@ trait Scanners extends ScannersCommon {
         case ']' =>
           nextChar(); token = RBRACKET
         case SU =>
-          if (isAtEnd) token = EOF
+          if (isAtEnd) {
+            bidiChars.foreach { case (char, offset) =>
+              syntaxError(offset, f"found unicode bidirectional character '\\u$char%04x'; use a unicode escape instead")
+            }
+            token = EOF
+          }
           else {
             syntaxError("illegal character")
             nextChar()

--- a/src/compiler/scala/tools/nsc/util/CharArrayReader.scala
+++ b/src/compiler/scala/tools/nsc/util/CharArrayReader.scala
@@ -13,6 +13,7 @@
 package scala.tools.nsc
 package util
 
+import scala.collection.mutable.ListBuffer
 import scala.reflect.internal.Chars._
 
 trait CharArrayReaderData {
@@ -44,6 +45,8 @@ abstract class CharArrayReader extends CharArrayReaderData { self =>
 
   val buf: Array[Char]
 
+  val bidiChars: ListBuffer[(Int, Int)] = ListBuffer.empty
+
   def decodeUni: Boolean = true
 
   /** An error routine to call on bad unicode escapes \\uxxxx. */
@@ -60,6 +63,8 @@ abstract class CharArrayReader extends CharArrayReaderData { self =>
       val c = buf(charOffset)
       ch = c
       charOffset += 1
+      if (isBiDiCharacter(ch))
+        bidiChars.+=((ch, charOffset))
       if (c == '\\') potentialUnicode()
       if (ch < ' ') {
         skipCR()
@@ -79,6 +84,8 @@ abstract class CharArrayReader extends CharArrayReaderData { self =>
       val c = buf(charOffset)
       ch = c
       charOffset += 1
+      if (isBiDiCharacter(ch))
+        bidiChars.+=((ch, charOffset))
       if (c == '\\') potentialUnicode()
     }
   }

--- a/src/reflect/scala/reflect/internal/Chars.scala
+++ b/src/reflect/scala/reflect/internal/Chars.scala
@@ -103,6 +103,14 @@ trait Chars {
          '|' | '/' | '\\' => true
     case c => isSpecial(c)
   }
+
+  def isBiDiCharacter(c: Char): Boolean = (c: @switch) match {
+    case '\u061c' |
+         '\u200e' | '\u200f' |
+         '\u202a' | '\u202b' | '\u202c' | '\u202d' | '\u202e' |
+         '\u2066' | '\u2067' | '\u2068' | '\u2069' => true
+    case _ => false
+  }
 }
 
 object Chars extends Chars { }

--- a/test/files/neg/t12478.check
+++ b/test/files/neg/t12478.check
@@ -1,0 +1,31 @@
+t12478.scala:3: error: found unicode bidirectional character '\u202e'; use a unicode escape instead
+    accessLevel != "user‮ ⁦// Check if admin⁩ ⁦"
+                         ^
+t12478.scala:3: error: found unicode bidirectional character '\u2066'; use a unicode escape instead
+    accessLevel != "user‮ ⁦// Check if admin⁩ ⁦"
+                           ^
+t12478.scala:3: error: found unicode bidirectional character '\u2069'; use a unicode escape instead
+    accessLevel != "user‮ ⁦// Check if admin⁩ ⁦"
+                                             ^
+t12478.scala:3: error: found unicode bidirectional character '\u2066'; use a unicode escape instead
+    accessLevel != "user‮ ⁦// Check if admin⁩ ⁦"
+                                               ^
+t12478.scala:7: error: found unicode bidirectional character '\u202e'; use a unicode escape instead
+  cl‮ass C
+     ^
+t12478.scala:9: error: found unicode bidirectional character '\u202e'; use a unicode escape instead
+  def a‮cb
+        ^
+t12478.scala:11: error: found unicode bidirectional character '\u202e'; use a unicode escape instead
+  // comm‮tne
+          ^
+t12478.scala:13: error: found unicode bidirectional character '\u202e'; use a unicode escape instead
+  """te‮tx"""
+        ^
+t12478.scala:14: error: found unicode bidirectional character '\u202e'; use a unicode escape instead
+  raw"""te‮tx"""
+           ^
+t12478.scala:16: error: found unicode bidirectional character '\u202e'; use a unicode escape instead
+  val u202e = '‮'
+                ^
+10 errors found

--- a/test/files/neg/t12478.scala
+++ b/test/files/neg/t12478.scala
@@ -1,0 +1,21 @@
+object Test {
+  def isAdmin(accessLevel: String): Boolean =
+    accessLevel != "user‮ ⁦// Check if admin⁩ ⁦"
+
+  def שרה = 0 // no bidi override char, these characters are rtl
+
+  cl‮ass C
+
+  def a‮cb
+
+  // comm‮tne
+
+  """te‮tx"""
+  raw"""te‮tx"""
+
+  val u202e = '‮'
+
+  def main(args: Array[String]): Unit = {
+    println(isAdmin("user"))
+  }
+}

--- a/test/files/run/t12478.check
+++ b/test/files/run/t12478.check
@@ -1,0 +1,3 @@
+ab‮dc‬
+ab‮dc‬
+Sarah

--- a/test/files/run/t12478.scala
+++ b/test/files/run/t12478.scala
@@ -1,0 +1,12 @@
+object Test {
+  val oks = "ab\u202edc\u202c"
+  val okc = '\u202e'
+
+  def שרה = "Sarah"
+
+  def main(args: Array[String]): Unit = {
+    println(oks)
+    println(s"ab${okc}dc\u202c")
+    println(שרה)
+  }
+}


### PR DESCRIPTION
Don't allow characters with unicode property `Bidi_Class` in source files.

Backport of https://github.com/scala/scala/pull/10017