### PR TITLE
Improve concurrent behavior of Java `ConcurrentMap` wrapper

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -36,6 +36,9 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[MissingClassProblem]("scala.runtime.PStatics"),  // private[scala]
     ProblemFilters.exclude[MissingClassProblem]("scala.runtime.PStatics$"), // private[scala]
 
+    // internal to wrappers
+    ProblemFilters.exclude[NewMixinForwarderProblem]("scala.collection.convert.JavaCollectionWrappers#JMapWrapperLike.getOrElseUpdate"),
+    ProblemFilters.exclude[NewMixinForwarderProblem]("scala.collection.convert.JavaCollectionWrappers#JMapWrapperLike.updateWith"),
   )
 
   override val buildSettings = Seq(

--- a/src/library/scala/collection/convert/JavaCollectionWrappers.scala
+++ b/src/library/scala/collection/convert/JavaCollectionWrappers.scala
@@ -332,6 +332,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
       else
         None
     }
+    override def getOrElseUpdate(key: K, op: => V): V = underlying.computeIfAbsent(key, _ => op)
 
     def addOne(kv: (K, V)): this.type = { underlying.put(kv._1, kv._2); this }
     def subtractOne(key: K): this.type = { underlying remove key; this }
@@ -353,6 +354,10 @@ private[collection] object JavaCollectionWrappers extends Serializable {
       }
 
     override def update(k: K, v: V): Unit = underlying.put(k, v)
+
+    override def updateWith(key: K)(remappingFunction: Option[V] => Option[V]): Option[V] = Option {
+      underlying.compute(key, (_, v) => remappingFunction(Option(v)).getOrElse(null.asInstanceOf[V]))
+    }
 
     // support Some(null) if currently bound to null
     override def remove(k: K): Option[V] = {
@@ -434,6 +439,8 @@ private[collection] object JavaCollectionWrappers extends Serializable {
 
     override def get(k: K) = Option(underlying get k)
 
+    override def getOrElseUpdate(key: K, op: => V): V = underlying.computeIfAbsent(key, _ => op)
+
     override def isEmpty: Boolean = underlying.isEmpty
     override def knownSize: Int = if (underlying.isEmpty) 0 else super.knownSize
     override def empty = new JConcurrentMapWrapper(new juc.ConcurrentHashMap[K, V])
@@ -454,7 +461,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
       }
 
     override def updateWith(key: K)(remappingFunction: Option[V] => Option[V]): Option[V] = Option {
-      underlying.compute(key, (_: K, v: V) => remappingFunction(Option(v)).getOrElse(null.asInstanceOf[V]))
+      underlying.compute(key, (_, v) => remappingFunction(Option(v)).getOrElse(null.asInstanceOf[V]))
     }
   }
 

--- a/src/library/scala/collection/convert/JavaCollectionWrappers.scala
+++ b/src/library/scala/collection/convert/JavaCollectionWrappers.scala
@@ -452,6 +452,10 @@ private[collection] object JavaCollectionWrappers extends Serializable {
         case _ if isEmpty => None
         case _ => Try(last).toOption
       }
+
+    override def updateWith(key: K)(remappingFunction: Option[V] => Option[V]): Option[V] = Option {
+      underlying.compute(key, (_: K, v: V) => remappingFunction(Option(v)).getOrElse(null.asInstanceOf[V]))
+    }
   }
 
   @SerialVersionUID(3L)


### PR DESCRIPTION
Improve the atomicity of `updateWith` by calling `compute` on the Java `ConcurrentMap`.

Similarly, `getOrElseUpdate` calls `computeIfAbsent`.

Note that `null` values are not supported.

The 2.13.8 version of `concurrentMap.asScala.getOrElseUpdate` calls `underlying.putIfAbsent`, which NPEs on `null`; the new version calls `underlying.computeIfAbsent`, which ignores a null computed value.

Code which relies on the new behavior will throw an exception when used with a previous version of the library.

Fixes scala/bug#12586