### PR TITLE
Fix bug where `-Vtype-diffs` sometimes lost error type information

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/splain/SplainFormatting.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/splain/SplainFormatting.scala
@@ -434,8 +434,11 @@ trait SplainFormatting extends SplainFormatters {
 
   def formatDiffImpl(found: Type, req: Type, top: Boolean): Formatted = {
     val (left, right) = dealias(found) -> dealias(req)
-    if (left =:= right) formatType(left, top)
-    else if (left.typeSymbol == right.typeSymbol) formatDiffInfix(left, right, top)
+
+    val normalized = Seq(left, right).map(_.normalize).distinct
+    if (normalized.size == 1) return formatType(normalized.head, top)
+
+    if (left.typeSymbol == right.typeSymbol) formatDiffInfix(left, right, top)
     else formatDiffSpecial(left, right, top).getOrElse(formatDiffSimple(left, right))
   }
 

--- a/test/files/run/splain.check
+++ b/test/files/run/splain.check
@@ -11,6 +11,10 @@ newSource1.scala:6: error: type mismatch;
   FoundReq.L|FoundReq.R
   f(new L)
     ^
+newSource1.scala:5: error: type mismatch;
+  () => scala.Unit|Runnable
+  f(3.0, () => println("doesn't work"))
+            ^
 newSource1.scala:7: error: implicit error;
 !I e: Bounds.F[Bounds.Arg]
   implicitly[F[Arg]]

--- a/test/files/run/splain.scala
+++ b/test/files/run/splain.scala
@@ -34,6 +34,15 @@ object FoundReq
 }
   """
 
+  final val foundReqSingleAbstractMethod = """
+object FoundReq extends App {
+  def f(x: AnyVal, f: Runnable) = 1
+  def f(x: Double, f: Runnable) = 2
+
+  f(3.0, () => println("doesn't work"))
+}
+  """
+
   def bounds: String = """
 object Bounds
 {
@@ -227,6 +236,7 @@ object a {
 
     run(chain)
     run(foundReq)
+    run(foundReqSingleAbstractMethod)
     run(bounds)
     run(longAnnotationMessage)
     run(longInfix)


### PR DESCRIPTION
Fix for scala/bug#12561