### PR TITLE
loosen unicode directional character check

### DIFF
--- a/src/reflect/scala/reflect/internal/Chars.scala
+++ b/src/reflect/scala/reflect/internal/Chars.scala
@@ -105,9 +105,7 @@ trait Chars {
   }
 
   def isBiDiCharacter(c: Char): Boolean = (c: @switch) match {
-    case '\u061c' |
-         '\u200e' | '\u200f' |
-         '\u202a' | '\u202b' | '\u202c' | '\u202d' | '\u202e' |
+    case '\u202a' | '\u202b' | '\u202c' | '\u202d' | '\u202e' |
          '\u2066' | '\u2067' | '\u2068' | '\u2069' => true
     case _ => false
   }

--- a/test/files/neg/t12478.check
+++ b/test/files/neg/t12478.check
@@ -19,13 +19,13 @@ t12478.scala:9: error: found unicode bidirectional character '\u202e'; use a uni
 t12478.scala:11: error: found unicode bidirectional character '\u202e'; use a unicode escape instead
   // comm‮tne
           ^
-t12478.scala:13: error: found unicode bidirectional character '\u202e'; use a unicode escape instead
+t12478.scala:16: error: found unicode bidirectional character '\u202e'; use a unicode escape instead
   """te‮tx"""
         ^
-t12478.scala:14: error: found unicode bidirectional character '\u202e'; use a unicode escape instead
+t12478.scala:17: error: found unicode bidirectional character '\u202e'; use a unicode escape instead
   raw"""te‮tx"""
            ^
-t12478.scala:16: error: found unicode bidirectional character '\u202e'; use a unicode escape instead
+t12478.scala:19: error: found unicode bidirectional character '\u202e'; use a unicode escape instead
   val u202e = '‮'
                 ^
 10 errors found

--- a/test/files/neg/t12478.scala
+++ b/test/files/neg/t12478.scala
@@ -10,6 +10,9 @@ object Test {
 
   // comm‮tne
 
+  // comment with direction indicator that isn't a threat:
+  //  - From the Latin "coævus": com- ‎("equal") in combination with aevum ‎(aevum, "age").
+
   """te‮tx"""
   raw"""te‮tx"""
 


### PR DESCRIPTION
as per discussion on #10017, we were flagging too many characters. a false positive came up in the community build; I modified the test case to include it.