### PR TITLE
Null type is trivial for warning

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -531,7 +531,7 @@ trait TypeDiagnostics extends splain.SplainDiagnostics {
 
     // so trivial that it never consumes params
     def isTrivial(rhs: Tree): Boolean =
-      rhs.symbol == Predef_??? || rhs.tpe =:= NothingTpe || (rhs match {
+      rhs.symbol == Predef_??? || rhs.tpe == null || rhs.tpe =:= NothingTpe || (rhs match {
         case Literal(_) => true
         case _          => isConstantType(rhs.tpe) || isSingleType(rhs.tpe)
       })


### PR DESCRIPTION
Check that type is non-null before using it. (Take null as trivial RHS.)

Follow up https://github.com/scala/scala/pull/9890#issuecomment-1120942929
