### PR TITLE
-Wunused:synthetics is first class

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -608,9 +608,7 @@ trait TypeDiagnostics extends splain.SplainDiagnostics {
           case nme.CONSTRUCTOR => sym.owner.companion.isCaseClass
           case nme.copy        => sym.owner.typeSignature.member(nme.copy).isSynthetic
         }
-      def defaultGetterOK = sym.isDefaultGetter && !privateSyntheticDefault
-      def contextBoundOK = sym.isImplicit && settings.warnUnusedSynthetics
-      contextBoundOK || defaultGetterOK
+      sym.isParameter || sym.isParamAccessor || sym.isDefaultGetter && !privateSyntheticDefault
     }
     def isUnusedTerm(m: Symbol): Boolean = (
       m.isTerm
@@ -745,7 +743,10 @@ trait TypeDiagnostics extends splain.SplainDiagnostics {
           ||
             p.isImplicit && cond(p.tpe.typeSymbol) { case SameTypeClass | SubTypeClass | DummyImplicitClass => true }
         )
-        def warningIsOnFor(s: Symbol) = if (s.isImplicit) settings.warnUnusedImplicits else settings.warnUnusedExplicits
+        def warningIsOnFor(s: Symbol) =
+          if (!s.isImplicit) settings.warnUnusedExplicits
+          else if (!s.isSynthetic) settings.warnUnusedImplicits
+          else settings.warnUnusedSynthetics
         def warnable(s: Symbol) = (
           warningIsOnFor(s)
             && !isImplementation(s.owner)

--- a/test/files/neg/t12591.check
+++ b/test/files/neg/t12591.check
@@ -1,0 +1,6 @@
+t12591.scala:5: warning: evidence parameter evidence$1 of type Context[A] in method g is never used
+  def g[A: Context] = f
+           ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/t12591.scala
+++ b/test/files/neg/t12591.scala
@@ -1,0 +1,7 @@
+// scalac: -Werror -Wunused:synthetics
+trait Context[A]
+
+object Example {
+  def g[A: Context] = f
+  def f = 42
+}


### PR DESCRIPTION
Always collect synthetic parameter, then check lint option when filtering.

Fixes scala/bug#12591