### PR TITLE
Use StrictOptimizedSetOps in immutable.Set[1,2,3,4]

### DIFF
--- a/test/benchmarks/src/main/scala/scala/collection/immutable/SetBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/SetBenchmark.scala
@@ -26,4 +26,9 @@ class SetBenchmark {
   @Benchmark def set4AddElement(bh: Blackhole): Unit = {
     bh.consume(base + "e")
   }
+
+  // benchmark for the optimized concat method
+  @Benchmark def set4Concat(bh: Blackhole): Unit = {
+    bh.consume(base concat base)
+  }
 }


### PR DESCRIPTION
Using StrictOptimizedSetOps adds a single optimization to these sets: concat will not lead to the creation of a new set if the added elements are already in the set.

See also https://contributors.scala-lang.org/t/why-do-immutable-set1-2-3-4-not-implement-strictoptimizedsetops/5741