### PR TITLE
[REVISIT] Lint check for override handles varargs

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -734,7 +734,7 @@ trait TypeDiagnostics extends splain.SplainDiagnostics {
       if (settings.warnUnusedParams) {
         def isImplementation(m: Symbol): Boolean = {
           def classOf(s: Symbol): Symbol = if (s.isClass || s == NoSymbol) s else classOf(s.owner)
-          val opc = new overridingPairs.PairsCursor(classOf(m))
+          val opc = new overridingPairs.EarlyPairsCursor(classOf(m))
           opc.iterator.exists(pair => pair.low == m)
         }
         import PartialFunction._

--- a/src/partest/scala/tools/partest/nest/Runner.scala
+++ b/src/partest/scala/tools/partest/nest/Runner.scala
@@ -117,6 +117,7 @@ class Runner(val testInfo: TestInfo, val suiteRunner: AbstractRunner) {
     )
 
     pushTranscript(args mkString " ")
+    suiteRunner.verbose(files.mkString("% javac compiling ", " ", ""))
     if (runCommand(args, logFile)) genPass() else {
       genFail("java compilation failed")
     }

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4852,7 +4852,6 @@ trait Types
       case mt1 @ MethodType(params1, res1) =>
         tp2 match {
           case mt2 @ MethodType(params2, res2) =>
-            // sameLength(params1, params2) was used directly as pre-screening optimization (now done by matchesQuantified -- is that ok, performance-wise?)
             mt1.isImplicit == mt2.isImplicit &&
             matchingParams(params1, params2) &&
             matchesQuantified(params1, params2, res1, res2)

--- a/test/files/neg/t12594.check
+++ b/test/files/neg/t12594.check
@@ -1,0 +1,11 @@
+child_2.scala:4: warning: parameter value values in method takeMany is never used
+  def takeMany(values: String*): Unit = println()
+               ^
+child_2.scala:3: error: class Child needs to be abstract.
+Missing implementation for member of trait Parent_1:
+  def takeMany(x$1: Integer*): Unit = ??? // Integer* does not match String* in `def takeMany(values: String*): Unit`
+
+class Child extends Parent_1 {
+      ^
+1 warning
+1 error

--- a/test/files/neg/t12594/Parent_1.java
+++ b/test/files/neg/t12594/Parent_1.java
@@ -1,0 +1,4 @@
+
+public interface Parent_1 {
+	void takeMany(Integer... values);
+}

--- a/test/files/neg/t12594/child_2.scala
+++ b/test/files/neg/t12594/child_2.scala
@@ -1,0 +1,5 @@
+// scalac: -Werror -Wunused
+
+class Child extends Parent_1 {
+  def takeMany(values: String*): Unit = println()
+}

--- a/test/files/pos/t12594/Parent_1.java
+++ b/test/files/pos/t12594/Parent_1.java
@@ -1,0 +1,6 @@
+
+public interface Parent_1 {
+	void takeMany(String... values);
+	<A> void takePoly(A... values);
+	void takeOne(String value);
+}

--- a/test/files/pos/t12594/child_2.scala
+++ b/test/files/pos/t12594/child_2.scala
@@ -1,0 +1,7 @@
+// scalac: -Werror -Wunused
+
+class Child extends Parent_1 {
+  def takeMany(values: String*): Unit = println()
+  def takePoly[A](values: A*): Unit = println()
+  def takeOne(value: String): Unit = println()
+}

--- a/test/files/pos/t12594/test.scala
+++ b/test/files/pos/t12594/test.scala
@@ -1,0 +1,63 @@
+// scalac: -Werror -Wunused
+
+import java.nio.file.Path
+import java.nio.file.FileSystem
+import java.net.URI
+import java.nio.file.LinkOption
+import java.nio.file.{WatchKey, WatchService}
+import java.nio.file.WatchEvent.{Kind, Modifier}
+
+class FooPath extends Path {
+
+  override def getFileSystem(): FileSystem = default[FileSystem]
+
+  override def isAbsolute(): Boolean = maybe
+
+  override def getRoot(): Path = somePath
+
+  override def getFileName(): Path = somePath
+
+  override def getParent(): Path = somePath
+
+  override def getNameCount(): Int = number
+
+  override def getName(x$1: Int): Path = somePath
+
+  override def subpath(x$1: Int, x$2: Int): Path = somePath
+
+  override def startsWith(x$1: Path): Boolean = maybe
+
+  override def endsWith(x$1: Path): Boolean = maybe
+
+  override def normalize(): Path = somePath
+
+  override def resolve(x$1: Path): Path = somePath
+
+  override def relativize(x$1: Path): Path = somePath
+
+  override def toUri(): URI = default[URI]
+
+  override def toAbsolutePath(): Path = somePath
+
+  override def toRealPath(x$1: LinkOption*): Path = somePath
+
+  override def register(x$1: WatchService, x$2: Array[Kind[_ <: Object]], x$3: Modifier*): WatchKey = someKey
+
+  override def compareTo(x$1: Path): Int = number
+
+  def someKey: WatchKey = default[WatchKey]
+  def somePath: Path = default[Path]
+  def maybe: Boolean = false
+  def number: Int = 42
+  def default[A]: A = null.asInstanceOf[A]
+
+  // default methods
+  override def endsWith(x$1: String): Boolean = ??? // String does not match java.nio.file.Path in `override def endsWith(x$1: java.nio.file.Path): Boolean`
+  override def iterator(): java.util.Iterator[java.nio.file.Path] = ???
+  override def register(x$1: java.nio.file.WatchService, x$2: java.nio.file.WatchEvent.Kind[_]*): java.nio.file.WatchKey = ???
+  override def resolve(x$1: String): java.nio.file.Path = ??? // String does not match java.nio.file.Path in `override def resolve(x$1: java.nio.file.Path): java.nio.file.Path`
+  override def resolveSibling(x$1: String): java.nio.file.Path = ???
+  override def resolveSibling(x$1: java.nio.file.Path): java.nio.file.Path = ???
+  override def startsWith(x$1: String): Boolean = ??? // String does not match java.nio.file.Path in `override def startsWith(x$1: java.nio.file.Path): Boolean`
+  override def toFile(): java.io.File = ???
+}


### PR DESCRIPTION
The check for unused params doesn't warn if a signature
is inherited by override; but varargs types do not align
at typer, so do extra work to notice Scala `A*` in override
of Java `A...`. Some code duplication is incurred.

Fixes scala/bug#12594