### PR TITLE
Uninstate global.treeTpe

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -5291,8 +5291,6 @@ trait Types
     "scala.collection.Iterable",
     "scala.collection.Iterator")
 
-  @deprecated("Use _.tpe", "2.12.12") // used by scala-meta, leave until they remove the dependency.
-  private[scala] val treeTpe = (t: Tree) => t.tpe
   private[scala] val typeContainsTypeVar = { val collector = new FindTypeCollector(_.isInstanceOf[TypeVar]); (tp: Type) => collector.collect(tp).isDefined }
   private[scala] val typeIsSubTypeOfSerializable = (tp: Type) => tp <:< SerializableTpe
 


### PR DESCRIPTION
Bi-annual follow-up to https://github.com/scala/scala/pull/8902
