### PR TITLE
Tooling support: Attachments for infix Apply and postfix Select

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/Trees.scala
+++ b/src/compiler/scala/tools/nsc/ast/Trees.scala
@@ -41,8 +41,6 @@ trait Trees extends scala.reflect.internal.Trees { self: Global =>
   case class InjectDerivedValue(arg: Tree)
        extends SymTree with TermTree
 
-  class PostfixSelect(qual: Tree, name: Name) extends Select(qual, name)
-
   /** emitted by typer, eliminated by refchecks */
   case class TypeTreeWithDeferredRefCheck()(val check: () => TypeTree) extends TypTree
 

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -859,17 +859,18 @@ self =>
         case Parens(args) => mkNamed(args)
         case _            => right :: Nil
       }
+      def mkApply(fun: Tree, args: List[Tree]) = Apply(fun, args).updateAttachment(InfixAttachment)
       if (isExpr) {
         if (treeInfo.isLeftAssoc(op)) {
-          Apply(mkSelection(left), arguments)
+          mkApply(mkSelection(left), arguments)
         } else {
           val x = freshTermName()
           Block(
             List(ValDef(Modifiers(symtab.Flags.SYNTHETIC | symtab.Flags.ARTIFACT), x, TypeTree(), stripParens(left))),
-            Apply(mkSelection(right), List(atPos(left.pos.makeTransparent)(Ident(x)))))
+            mkApply(mkSelection(right), List(atPos(left.pos.makeTransparent)(Ident(x)))))
         }
       } else {
-        Apply(Ident(op.encode), stripParens(left) :: arguments)
+        mkApply(Ident(op.encode), stripParens(left) :: arguments)
       }
     }
 

--- a/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
@@ -57,7 +57,7 @@ abstract class TreeBuilder {
 
   /** Tree for `od op`, start is start0 if od.pos is borked. */
   def makePostfixSelect(start: Int, end: Int, od: Tree, op: Name): Tree = {
-    atPos(r2p(start, end, end + op.length)) { new PostfixSelect(od, op.encode) }
+    atPos(r2p(start, end, end + op.length)) { Select(od, op.encode) }.updateAttachment(PostfixAttachment)
   }
 
   /** Create tree representing a while loop */

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -77,6 +77,11 @@ trait StdAttachments {
    */
   case object BackquotedIdentifierAttachment extends PlainAttachment
 
+  /** Indicates that a selection was postfix (on Select tree) */
+  case object PostfixAttachment extends PlainAttachment
+  /** Indicates that a application was infix (on Apply tree) */
+  case object InfixAttachment extends PlainAttachment
+
   /** A pattern binding exempt from unused warning.
    *
    *  Its host `Ident` has been created from a pattern2 binding, `case x @ p`.

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -53,6 +53,8 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.DelambdafyTarget
     this.JustMethodReference
     this.BackquotedIdentifierAttachment
+    this.PostfixAttachment
+    this.InfixAttachment
     this.NoWarnAttachment
     this.PatVarDefAttachment
     this.ForAttachment

--- a/test/files/run/infixPostfixAttachments.check
+++ b/test/files/run/infixPostfixAttachments.check
@@ -1,0 +1,8 @@
+t1 this.a(0) Set(InfixAttachment)
+t2 this.b(scala.Tuple2.apply[Int, Int](1, 2)).b(scala.Tuple2.apply[Int, Int](1, 2)).c(1, 2) Set(InfixAttachment)
+t2 this.b(scala.Tuple2.apply[Int, Int](1, 2)).b(scala.Tuple2.apply[Int, Int](1, 2)) Set(InfixAttachment)
+t2 this.b(scala.Tuple2.apply[Int, Int](1, 2)) Set(InfixAttachment)
+t4 this.d() Set(InfixAttachment)
+t6 this.d() Set(InfixAttachment)
+t6 this.d Set(PostfixAttachment)
+t8 this.e Set(PostfixAttachment)

--- a/test/files/run/infixPostfixAttachments.scala
+++ b/test/files/run/infixPostfixAttachments.scala
@@ -1,0 +1,37 @@
+import scala.tools.partest._
+
+object Test extends CompilerTest {
+  import global._
+  override def extraSettings = super.extraSettings + " -Yrangepos -Ystop-after:typer"
+
+  override def code =
+    """class C {
+      |  import scala.language.postfixOps
+      |
+      |  def a(x: Any) = this
+      |  def b(x: (Any, Any)) = this
+      |  def c(x: Any, y: Any) = this
+      |  def d() = this
+      |  def e = this
+      |
+      |  def t1 = this a 0
+      |  def t2 = this b (1, 2) b ((1, 2)) c (1, 2)
+      |  def t3 = this.b(1, 2).b((1, 2)).c(1, 2)
+      |  def t4 = this d ()
+      |  def t5 = this.d()
+      |  def t6 = this d
+      |  def t7 = this.d
+      |  def t8 = this e
+      |  def t9 = this.e
+      |}
+      |""".stripMargin
+
+  def check(source: String, unit: CompilationUnit): Unit = unit.body foreach {
+    case dd: DefDef if dd.name.startsWith("t") =>
+      dd.rhs.foreach(t => {
+        if (!t.attachments.isEmpty)
+          println(s"${dd.symbol.name} $t ${t.attachments.all}")
+      })
+    case _ =>
+  }
+}


### PR DESCRIPTION
Mark infix applications and postfix selections with a tree attachment. This can be useful for tooling that builds on the compiler / scala reflection.

A followup, #10063, does the same thing for auto-application.