### PR TITLE
Correctly handle overloads in mixed compilation with Java inner classes (fixing 2.12.16 regression)

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5051,7 +5051,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       // so, when we can't find a member in the class scope, check the companion
       def inCompanionForJavaStatic(cls: Symbol, name: Name): Symbol =
         if (!(context.unit.isJava && cls.isClass)) NoSymbol else {
-          context.javaFindMember(cls.typeOfThis, name, _ => true)._2
+          context.javaFindMember(cls.typeOfThis, name, _.isStaticMember)._2
         }
 
       /* Attribute a selection where `tree` is `qual.name`.

--- a/test/files/pos/t12605/A.scala
+++ b/test/files/pos/t12605/A.scala
@@ -1,0 +1,13 @@
+class A {
+  val c = new C()
+
+  val t1 = new c.T1()
+  c.t(new t1.A())
+
+  val t2 = new c.T2()
+  c.t(new t2.A())
+
+  // https://github.com/scala/bug/issues/12606
+  // val u = new c.U()
+  // c.u(new c.U.A())
+}

--- a/test/files/pos/t12605/C.java
+++ b/test/files/pos/t12605/C.java
@@ -1,0 +1,11 @@
+public class C {
+  public class T1 { public class A {} }
+  public void t(T1.A a) {}
+
+  public class T2 { public class A {} }
+  public void t(T2.A a) {}
+
+  // https://github.com/scala/bug/issues/12606, requires Java 16+
+  // public class U { public static class A {} }
+  // public void u(U.A a) {}
+}


### PR DESCRIPTION
In Java code, `A.B` can refer to a static or non-static member `B`. The Scala compiler models a selection of a static member as a selection from the companion object `A`.

If the selection `A.B` (select from object `A`) doesn't yield a result, `handleMissing` creates a `SelectFromTypeTree` in a second try.

Another special handling for Java is that `A.B` may refer to a static member `B` defined in a parent of `A`. This is done by
`inCompanionForJavaStatic` in `typedSelect`. This lookup should only find static members (fixed by this PR).

Before this PR, `A.B` for a non-static member B succeeded through `inCompanionForJavaStatic`, which means the qualifier `A` remained a reference to the synthetic companion object `A`. This means that the we obtained the a type `A.B` instead of `A#B`.

After this PR, the `inCompanionForJavaStatic` lookup fails and we go to `handleMissing`, which changes the resulting tree into a `SelectFromTypeTree` (select from class A).

Fixes https://github.com/scala/bug/issues/12605.