### PR TITLE
Unary prefix operator must be unbackquoted

### DIFF
--- a/spec/01-lexical-syntax.md
+++ b/spec/01-lexical-syntax.md
@@ -52,7 +52,7 @@ of operator characters.  Second, an identifier can start with an operator
 character followed by an arbitrary sequence of operator characters.
 The preceding two forms are called _plain_ identifiers.  Finally,
 an identifier may also be formed by an arbitrary string between
-back-quotes (host systems may impose some restrictions on which
+backquotes (host systems may impose some restrictions on which
 strings are legal for identifiers).  The identifier then is composed
 of all characters excluding the backquotes themselves.
 

--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -630,8 +630,9 @@ Expressions can be constructed from operands and operators.
 ### Prefix Operations
 
 A prefix operation ´\mathit{op};e´ consists of a prefix operator ´\mathit{op}´, which
-must be one of the identifiers ‘`+`’, ‘`-`’,
-‘`!`’ or ‘`~`’. The expression ´\mathit{op};e´ is
+must be one of the identifiers ‘`+`’, ‘`-`’, ‘`!`’ or ‘`~`’,
+which must not be enclosed in backquotes.
+The expression ´\mathit{op};e´ is
 equivalent to the postfix method application
 `e.unary_´\mathit{op}´`.
 

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -707,7 +707,7 @@ self =>
     def isIdentExcept(except: Name) = isIdent && in.name != except
     def isIdentOf(name: Name)       = isIdent && in.name == name
 
-    def isUnaryOp  = isIdent && raw.isUnary(in.name)
+    def isUnaryOp  = isRawIdent && raw.isUnary(in.name)
     def isRawStar  = isRawIdent && in.name == raw.STAR
     def isRawBar   = isRawIdent && in.name == raw.BAR
     def isRawIdent = in.token == IDENTIFIER

--- a/test/files/neg/unary-unquoted.check
+++ b/test/files/neg/unary-unquoted.check
@@ -1,0 +1,4 @@
+unary-unquoted.scala:7: error: ';' expected but integer literal found.
+  def i = `+` 42      // error not taken as unary prefix operator
+              ^
+1 error

--- a/test/files/neg/unary-unquoted.scala
+++ b/test/files/neg/unary-unquoted.scala
@@ -1,0 +1,8 @@
+
+object Test {
+  def +[T](x: T): String = "x"
+  +[Int](6): String   // OK in scala 2
+}
+class C {
+  def i = `+` 42      // error not taken as unary prefix operator
+}

--- a/test/files/pos/unary-unquoted.scala
+++ b/test/files/pos/unary-unquoted.scala
@@ -1,0 +1,7 @@
+
+object Test {
+  def +[T](x: T): String = "x"
+  `+`[Int](6): String   // Parser can treat + as identifier when backquoted and followed by a type argument
+  `+`(6): String        // Parser can treat + as identifier when backquoted and followed by a value argument
+  +(6): Int             // Parser prioritizes + as unary when possible
+}


### PR DESCRIPTION
Bring the behavior in line with the syntax, and adjust the text for the specification.

Backport from dotty.

https://github.com/lampepfl/dotty/pull/15198