### PR TITLE
[WIP] Move unused lints after refchecks, handle java varargs

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
@@ -116,13 +116,8 @@ trait Analyzer extends AnyRef
           val typer = newTyper(rootContext(unit))
           unit.body = typer.typed(unit.body)
           // interactive typed may finish by throwing a `TyperResult`
-          if (!settings.Youtline) {
+          if (!settings.Youtline)
             for (workItem <- unit.toCheck) workItem()
-            if (!settings.isScaladoc && settings.warnUnusedImport)
-              warnUnusedImports(unit)
-            if (!settings.isScaladoc && settings.warnUnused.isSetByUser)
-              new checkUnused(typer).apply(unit)
-          }
         }
         finally {
           runReporting.reportSuspendedMessages(unit)

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1228,9 +1228,9 @@ abstract class RefChecks extends Transform {
           }
           tree1
         }
-      case Import(_, _)                                                                       => EmptyTree
-      case DefDef(mods, _, _, _, _, _) if (mods hasFlag MACRO) || (tree.symbol hasFlag MACRO) => EmptyTree
-      case _                                                                                  => transform(tree)
+      case Import(_, _)                                                       => EmptyTree
+      case DefDef(mods, _, _, _, _, _) if mods.isMacro || tree.symbol.isMacro => EmptyTree
+      case _                                                                  => transform(tree)
     }
 
     /* Check whether argument types conform to bounds of type parameters */

--- a/test/files/neg/t10296-warn.check
+++ b/test/files/neg/t10296-warn.check
@@ -1,5 +1,5 @@
-Unused_2.scala:9: warning: private method unusedMacro in object Unused is never used
-  private def unusedMacro(): Unit = macro UnusedMacro.usedMacroImpl
+Unused_2.scala:13: warning: private method fixme macro defs are eliminated at refchecks in object Unused is never used
+  private def `fixme macro defs are eliminated at refchecks` = println("Restore macro warnings")
               ^
 error: No warnings can be incurred under -Werror.
 1 warning

--- a/test/files/neg/t10296-warn/Unused_2.scala
+++ b/test/files/neg/t10296-warn/Unused_2.scala
@@ -9,4 +9,6 @@ object Unused {
   private def unusedMacro(): Unit = macro UnusedMacro.usedMacroImpl
 
   def f() = usedMacro()
+
+  private def `fixme macro defs are eliminated at refchecks` = println("Restore macro warnings")
 }

--- a/test/files/neg/t12594.check
+++ b/test/files/neg/t12594.check
@@ -1,0 +1,7 @@
+child_2.scala:3: error: class Child needs to be abstract.
+Missing implementation for member of trait Parent_1:
+  def takeMany(x$1: Integer*): Unit = ??? // Integer* does not match String* in `def takeMany(values: String*): Unit`
+
+class Child extends Parent_1 {
+      ^
+1 error

--- a/test/files/neg/t12594/Parent_1.java
+++ b/test/files/neg/t12594/Parent_1.java
@@ -1,0 +1,4 @@
+
+public interface Parent_1 {
+	void takeMany(Integer... values);
+}

--- a/test/files/neg/t12594/child_2.scala
+++ b/test/files/neg/t12594/child_2.scala
@@ -1,0 +1,5 @@
+// scalac: -Werror -Wunused
+
+class Child extends Parent_1 {
+  def takeMany(values: String*): Unit = println()   // error in RefChecks without linting
+}

--- a/test/files/neg/t6446-additional.check
+++ b/test/files/neg/t6446-additional.check
@@ -8,20 +8,21 @@ superaccessors   5  add super accessors in traits and nested classes
     extmethods   6  add extension methods for inline classes
        pickler   7  serialize symbol tables
      refchecks   8  reference/override checking, translate nested objects
-        patmat   9  translate match expressions
-       uncurry  10  uncurry, translate function values to anonymous classes
-        fields  11  synthesize accessors and fields, add bitmaps for lazy vals
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-    lambdalift  17  move nested functions to top level
-  constructors  18  move field definitions into constructors
-       flatten  19  eliminate inner classes
-         mixin  20  mixin composition
-       cleanup  21  platform-specific cleanups, generate reflective calls
-    delambdafy  22  remove lambdas
-           jvm  23  generate JVM bytecode
-       ploogin  24  A sample phase that does so many things it's kind of hard...
-      terminal  25  the last phase during a compilation run
+         lints   9  check for common errors
+        patmat  10  translate match expressions
+       uncurry  11  uncurry, translate function values to anonymous classes
+        fields  12  synthesize accessors and fields, add bitmaps for lazy vals
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+    lambdalift  18  move nested functions to top level
+  constructors  19  move field definitions into constructors
+       flatten  20  eliminate inner classes
+         mixin  21  mixin composition
+       cleanup  22  platform-specific cleanups, generate reflective calls
+    delambdafy  23  remove lambdas
+           jvm  24  generate JVM bytecode
+       ploogin  25  A sample phase that does so many things it's kind of hard...
+      terminal  26  the last phase during a compilation run

--- a/test/files/neg/t6446-missing.check
+++ b/test/files/neg/t6446-missing.check
@@ -9,19 +9,20 @@ superaccessors   5  add super accessors in traits and nested classes
     extmethods   6  add extension methods for inline classes
        pickler   7  serialize symbol tables
      refchecks   8  reference/override checking, translate nested objects
-        patmat   9  translate match expressions
-       uncurry  10  uncurry, translate function values to anonymous classes
-        fields  11  synthesize accessors and fields, add bitmaps for lazy vals
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-    lambdalift  17  move nested functions to top level
-  constructors  18  move field definitions into constructors
-       flatten  19  eliminate inner classes
-         mixin  20  mixin composition
-       cleanup  21  platform-specific cleanups, generate reflective calls
-    delambdafy  22  remove lambdas
-           jvm  23  generate JVM bytecode
-      terminal  24  the last phase during a compilation run
+         lints   9  check for common errors
+        patmat  10  translate match expressions
+       uncurry  11  uncurry, translate function values to anonymous classes
+        fields  12  synthesize accessors and fields, add bitmaps for lazy vals
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+    lambdalift  18  move nested functions to top level
+  constructors  19  move field definitions into constructors
+       flatten  20  eliminate inner classes
+         mixin  21  mixin composition
+       cleanup  22  platform-specific cleanups, generate reflective calls
+    delambdafy  23  remove lambdas
+           jvm  24  generate JVM bytecode
+      terminal  25  the last phase during a compilation run

--- a/test/files/neg/t6446-show-phases.check
+++ b/test/files/neg/t6446-show-phases.check
@@ -8,19 +8,20 @@ superaccessors   5  add super accessors in traits and nested classes
     extmethods   6  add extension methods for inline classes
        pickler   7  serialize symbol tables
      refchecks   8  reference/override checking, translate nested objects
-        patmat   9  translate match expressions
-       uncurry  10  uncurry, translate function values to anonymous classes
-        fields  11  synthesize accessors and fields, add bitmaps for lazy vals
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-    lambdalift  17  move nested functions to top level
-  constructors  18  move field definitions into constructors
-       flatten  19  eliminate inner classes
-         mixin  20  mixin composition
-       cleanup  21  platform-specific cleanups, generate reflective calls
-    delambdafy  22  remove lambdas
-           jvm  23  generate JVM bytecode
-      terminal  24  the last phase during a compilation run
+         lints   9  check for common errors
+        patmat  10  translate match expressions
+       uncurry  11  uncurry, translate function values to anonymous classes
+        fields  12  synthesize accessors and fields, add bitmaps for lazy vals
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+    lambdalift  18  move nested functions to top level
+  constructors  19  move field definitions into constructors
+       flatten  20  eliminate inner classes
+         mixin  21  mixin composition
+       cleanup  22  platform-specific cleanups, generate reflective calls
+    delambdafy  23  remove lambdas
+           jvm  24  generate JVM bytecode
+      terminal  25  the last phase during a compilation run

--- a/test/files/neg/t7494-no-options.check
+++ b/test/files/neg/t7494-no-options.check
@@ -9,20 +9,21 @@ superaccessors   5  add super accessors in traits and nested classes
     extmethods   6  add extension methods for inline classes
        pickler   7  serialize symbol tables
      refchecks   8  reference/override checking, translate nested objects
-        patmat   9  translate match expressions
-       uncurry  10  uncurry, translate function values to anonymous classes
-        fields  11  synthesize accessors and fields, add bitmaps for lazy vals
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-    lambdalift  17  move nested functions to top level
-  constructors  18  move field definitions into constructors
-       flatten  19  eliminate inner classes
-         mixin  20  mixin composition
-       cleanup  21  platform-specific cleanups, generate reflective calls
-    delambdafy  22  remove lambdas
-           jvm  23  generate JVM bytecode
-       ploogin  24  A sample phase that does so many things it's kind of hard...
-      terminal  25  the last phase during a compilation run
+         lints   9  check for common errors
+        patmat  10  translate match expressions
+       uncurry  11  uncurry, translate function values to anonymous classes
+        fields  12  synthesize accessors and fields, add bitmaps for lazy vals
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+    lambdalift  18  move nested functions to top level
+  constructors  19  move field definitions into constructors
+       flatten  20  eliminate inner classes
+         mixin  21  mixin composition
+       cleanup  22  platform-specific cleanups, generate reflective calls
+    delambdafy  23  remove lambdas
+           jvm  24  generate JVM bytecode
+       ploogin  25  A sample phase that does so many things it's kind of hard...
+      terminal  26  the last phase during a compilation run

--- a/test/files/neg/t7860.scala
+++ b/test/files/neg/t7860.scala
@@ -1,4 +1,4 @@
-// scalac: -Xfatal-warnings -Ywarn-unused:privates
+// scalac: -Werror -Wunused:privates
 //
 
 class Test

--- a/test/files/pos/t12594/Parent_1.java
+++ b/test/files/pos/t12594/Parent_1.java
@@ -1,0 +1,6 @@
+
+public interface Parent_1 {
+	void takeMany(String... values);
+	<A> void takePoly(A... values);
+	void takeOne(String value);
+}

--- a/test/files/pos/t12594/child_2.scala
+++ b/test/files/pos/t12594/child_2.scala
@@ -1,0 +1,7 @@
+// scalac: -Werror -Wunused
+
+class Child extends Parent_1 {
+  def takeMany(values: String*): Unit = println()
+  def takePoly[A](values: A*): Unit = println()
+  def takeOne(value: String): Unit = println()
+}

--- a/test/files/pos/t12594/test.scala
+++ b/test/files/pos/t12594/test.scala
@@ -1,0 +1,63 @@
+// scalac: -Werror -Wunused
+
+import java.nio.file.Path
+import java.nio.file.FileSystem
+import java.net.URI
+import java.nio.file.LinkOption
+import java.nio.file.{WatchKey, WatchService}
+import java.nio.file.WatchEvent.{Kind, Modifier}
+
+class FooPath extends Path {
+
+  override def getFileSystem(): FileSystem = default[FileSystem]
+
+  override def isAbsolute(): Boolean = maybe
+
+  override def getRoot(): Path = somePath
+
+  override def getFileName(): Path = somePath
+
+  override def getParent(): Path = somePath
+
+  override def getNameCount(): Int = number
+
+  override def getName(x$1: Int): Path = somePath
+
+  override def subpath(x$1: Int, x$2: Int): Path = somePath
+
+  override def startsWith(x$1: Path): Boolean = maybe
+
+  override def endsWith(x$1: Path): Boolean = maybe
+
+  override def normalize(): Path = somePath
+
+  override def resolve(x$1: Path): Path = somePath
+
+  override def relativize(x$1: Path): Path = somePath
+
+  override def toUri(): URI = default[URI]
+
+  override def toAbsolutePath(): Path = somePath
+
+  override def toRealPath(x$1: LinkOption*): Path = somePath
+
+  override def register(x$1: WatchService, x$2: Array[Kind[_ <: Object]], x$3: Modifier*): WatchKey = someKey
+
+  override def compareTo(x$1: Path): Int = number
+
+  def someKey: WatchKey = default[WatchKey]
+  def somePath: Path = default[Path]
+  def maybe: Boolean = false
+  def number: Int = 42
+  def default[A]: A = null.asInstanceOf[A]
+
+  // default methods
+  override def endsWith(x$1: String): Boolean = ??? // String does not match java.nio.file.Path in `override def endsWith(x$1: java.nio.file.Path): Boolean`
+  override def iterator(): java.util.Iterator[java.nio.file.Path] = ???
+  override def register(x$1: java.nio.file.WatchService, x$2: java.nio.file.WatchEvent.Kind[_]*): java.nio.file.WatchKey = ???
+  override def resolve(x$1: String): java.nio.file.Path = ??? // String does not match java.nio.file.Path in `override def resolve(x$1: java.nio.file.Path): java.nio.file.Path`
+  override def resolveSibling(x$1: String): java.nio.file.Path = ???
+  override def resolveSibling(x$1: java.nio.file.Path): java.nio.file.Path = ???
+  override def startsWith(x$1: String): Boolean = ??? // String does not match java.nio.file.Path in `override def startsWith(x$1: java.nio.file.Path): Boolean`
+  override def toFile(): java.io.File = ???
+}

--- a/test/files/run/names-defaults.check
+++ b/test/files/run/names-defaults.check
@@ -10,6 +10,12 @@ names-defaults.scala:369: warning: the parameter name s is deprecated: use x ins
 names-defaults.scala:371: warning: the parameter name x is deprecated: use s instead
   println(deprNam2.g(x = "sljkfd"))
                        ^
+names-defaults.scala:269: warning: multiline expressions might require enclosing parentheses; a value can be silently discarded when Unit is expected
+    spawn(b = { val ttt = 1; ttt }, a = 0)
+                             ^
+names-defaults.scala:269: warning: a pure expression does nothing in statement position
+    spawn(b = { val ttt = 1; ttt }, a = 0)
+                             ^
 names-defaults.scala:35: warning: local var var2 in value <local Test> is never used
     var var2 = 0
         ^
@@ -22,12 +28,6 @@ names-defaults.scala:280: warning: local val v in method foo is never used
 names-defaults.scala:280: warning: local val u in method foo is never used
   class A2489x2 { def foo(): Unit = { val v = 10; def bar(a: Int = 1, b: Int = 2) = a; bar(); val u = 0 } }
                                                                                                   ^
-names-defaults.scala:269: warning: multiline expressions might require enclosing parentheses; a value can be silently discarded when Unit is expected
-    spawn(b = { val ttt = 1; ttt }, a = 0)
-                             ^
-names-defaults.scala:269: warning: a pure expression does nothing in statement position
-    spawn(b = { val ttt = 1; ttt }, a = 0)
-                             ^
 1: @
 get: $
 get: 2

--- a/test/files/run/programmatic-main.check
+++ b/test/files/run/programmatic-main.check
@@ -8,19 +8,20 @@ superaccessors   5  add super accessors in traits and nested classes
     extmethods   6  add extension methods for inline classes
        pickler   7  serialize symbol tables
      refchecks   8  reference/override checking, translate nested objects
-        patmat   9  translate match expressions
-       uncurry  10  uncurry, translate function values to anonymous classes
-        fields  11  synthesize accessors and fields, add bitmaps for lazy vals
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-    lambdalift  17  move nested functions to top level
-  constructors  18  move field definitions into constructors
-       flatten  19  eliminate inner classes
-         mixin  20  mixin composition
-       cleanup  21  platform-specific cleanups, generate reflective calls
-    delambdafy  22  remove lambdas
-           jvm  23  generate JVM bytecode
-      terminal  24  the last phase during a compilation run
+         lints   9  check for common errors
+        patmat  10  translate match expressions
+       uncurry  11  uncurry, translate function values to anonymous classes
+        fields  12  synthesize accessors and fields, add bitmaps for lazy vals
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+    lambdalift  18  move nested functions to top level
+  constructors  19  move field definitions into constructors
+       flatten  20  eliminate inner classes
+         mixin  21  mixin composition
+       cleanup  22  platform-specific cleanups, generate reflective calls
+    delambdafy  23  remove lambdas
+           jvm  24  generate JVM bytecode
+      terminal  25  the last phase during a compilation run


### PR DESCRIPTION
After refchecks, bridges for java varargs are in place, so in theory it's easier to check whether a method implements an interface. However, locating the bridge is not much easier than looking for the override in the alternative PR.

After refchecks, macro defs have been eliminated, so it's no longer possible to lint them by inspection.

It's also necessary to ignore `$extension` methods, which are also not quite trivial to detect.

Having a `lints` phase makes it convenient to `-Vdebug -Vlog:lints`.

Fixes scala/bug#12594