### PR TITLE
Restore Seq.apply rewrite and partests

### DIFF
--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -495,6 +495,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val NilModule        = requiredModule[scala.collection.immutable.Nil.type]
     @migration("SeqModule now refers to scala.collection.immutable.Seq", "2.13.0")
     lazy val SeqModule        = requiredModule[scala.collection.immutable.Seq.type]
+    lazy val SeqModuleAlias   = getMemberValue(ScalaPackageClass, nme.Seq)
     lazy val Collection_SeqModule       = requiredModule[scala.collection.Seq.type]
 
     // arrays and their members
@@ -1735,10 +1736,9 @@ trait Definitions extends api.StandardDefinitions {
 
       final def isSeqApply(tree: Tree): Boolean = isListApply(tree) || {
         /*
-         *  This is now also used for converting {Seq, List}.apply(a, b, c) to `a :: b :: c :: Nil`
-         *  in Cleanup.
+         * This is now also used for converting {Seq, List}.apply(a, b, c) to `a :: b :: c :: Nil` in CleanUp.
          */
-        def isSeqFactory(sym: Symbol) = sym == SeqModule || sym == Collection_SeqModule
+        def isSeqFactory(sym: Symbol) = sym == SeqModule || sym == SeqModuleAlias || sym == Collection_SeqModule
 
         (tree.symbol == Seq_apply) && (tree match {
           case treeInfo.Applied(core @ Select(qual, _), _, _) =>

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -314,6 +314,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.ListModuleAlias
     definitions.NilModule
     definitions.SeqModule
+    definitions.SeqModuleAlias
     definitions.Collection_SeqModule
     definitions.ArrayModule
     definitions.ArrayModule_overloadedApply

--- a/test/files/instrumented/empty-seq.check
+++ b/test/files/instrumented/empty-seq.check
@@ -1,0 +1,1 @@
+Method call statistics:

--- a/test/files/instrumented/empty-seq.scala
+++ b/test/files/instrumented/empty-seq.scala
@@ -1,0 +1,9 @@
+
+import scala.tools.partest.instrumented.Instrumentation._
+
+object Test extends App {
+  startProfiling()
+  Seq()
+  stopProfiling()
+  printStatistics()
+}

--- a/test/files/run/small-seq-apply.check
+++ b/test/files/run/small-seq-apply.check
@@ -1,0 +1,1 @@
+cost of tracking allocations - cost of Object = 0

--- a/test/files/run/small-seq-apply.scala
+++ b/test/files/run/small-seq-apply.scala
@@ -1,0 +1,47 @@
+
+object Sizes {
+  def list: Int = 24
+  def listBuffer: Int = 32
+
+  def refArray(length:Int): Int = (16 + (length+1) * 4) /8 * 8
+  def wrappedRefArray(length:Int): Int = refArray(length) + 16
+  def wrappedRefArrayIterator: Int = 24
+}
+
+object Test extends scala.tools.testkit.AllocationTest {
+  def main(args: Array[String]): Unit = {
+    smallSeqAllocation
+    //largeSeqAllocation
+  }
+  def smallSeqAllocation: Unit = {
+    exactAllocates(Sizes.list * 1, "collection seq  size 1")(Seq("0"))
+    exactAllocates(Sizes.list * 2, "collection seq  size 2")(Seq("0", "1"))
+    exactAllocates(Sizes.list * 3, "collection seq  size 3")(Seq("0", "1", ""))
+    exactAllocates(Sizes.list * 4, "collection seq  size 4")(Seq("0", "1", "2", "3"))
+    exactAllocates(Sizes.list * 5, "collection seq  size 5")(Seq("0", "1", "2", "3", "4"))
+    exactAllocates(Sizes.list * 6, "collection seq  size 6")(Seq("0", "1", "2", "3", "4", "5"))
+    exactAllocates(Sizes.list * 7, "collection seq  size 7")(Seq("0", "1", "2", "3", "4", "5", "6"))
+  }
+  def largeSeqAllocation: Unit = {
+    exactAllocates(Sizes.list * 10 + Sizes.wrappedRefArray(10) + Sizes.listBuffer + 16, "collection seq size 10")(
+      Seq("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"))
+    exactAllocates(Sizes.list * 20 + Sizes.wrappedRefArray(20) + Sizes.listBuffer + 16, "collection seq size 20")(
+      Seq("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"))
+  }
+}
+
+/*
+restored partest (cf junit) to test outside scala.collection package
+
+cost of tracking allocations - cost of Object = 0
+java.lang.AssertionError: allocating min = 88 allowed = 24 -- collection seq  size 1
+ result = List(0) (class scala.collection.immutable.$colon$colon)
+ allocation 88 (1000 times)
+
+        at org.junit.Assert.fail(Assert.java:89)
+        at scala.tools.testkit.AllocationTest.failTest(AllocationTest.scala:111)
+        at scala.tools.testkit.AllocationTest.exactAllocates(AllocationTest.scala:102)
+        at scala.tools.testkit.AllocationTest.exactAllocates$(AllocationTest.scala:100)
+        at Test$.exactAllocates(small-seq-apply.scala:11)
+        at Test$.smallSeqAllocation(small-seq-apply.scala:17)
+ */


### PR DESCRIPTION
Follow-up to https://github.com/scala/scala/pull/9969
cherry-picked from https://github.com/scala/scala/pull/9991

I see the test from https://github.com/scala/scala/pull/8993 but don't recall where I noticed it.
