### PR TITLE
[REVERTED] Partest uses -release 8

### DIFF
--- a/test/files/neg/choices.check
+++ b/test/files/neg/choices.check
@@ -1,3 +1,10 @@
+#partest java9+
+error: Usage: -Yresolve-term-conflict:<strategy> where <strategy> choices are package, object, error (default: error).
+error: bad option: '-Yresolve-term-conflict'
+error: bad options: -release 8 -Yresolve-term-conflict
+error: flags file may only contain compiler options, found: -Yresolve-term-conflict
+4 errors
+#partest java8
 error: Usage: -Yresolve-term-conflict:<strategy> where <strategy> choices are package, object, error (default: error).
 error: bad option: '-Yresolve-term-conflict'
 error: bad options: -Yresolve-term-conflict

--- a/test/files/neg/partestInvalidFlag.check
+++ b/test/files/neg/partestInvalidFlag.check
@@ -1,3 +1,9 @@
+#partest java9+
+error: bad option: '-badCompilerFlag'
+error: bad options: -release 8 -badCompilerFlag notAFlag -opt:badChoice
+error: flags file may only contain compiler options, found: -badCompilerFlag notAFlag -opt:badChoice
+3 errors
+#partest java8
 error: bad option: '-badCompilerFlag'
 error: bad options: -badCompilerFlag notAFlag -opt:badChoice
 error: flags file may only contain compiler options, found: -badCompilerFlag notAFlag -opt:badChoice


### PR DESCRIPTION
If a partest does not specify `javaVersion:` or `scalac: -release N`, then always use `-release 8`.

This avoids the hassle of accidentally committing a test that uses recent API.

A future enhancement would be to infer `javaVersion` from `-release`.

cherry-picked from https://github.com/scala/scala/pull/9893