### PR TITLE
Revert "Partest uses -release 8"

### DIFF
--- a/src/partest/scala/tools/partest/nest/Runner.scala
+++ b/src/partest/scala/tools/partest/nest/Runner.scala
@@ -453,15 +453,10 @@ class Runner(val testInfo: TestInfo, val suiteRunner: AbstractRunner) {
   }
 
   // all sources in a round may contribute flags via // scalac: -flags
-  // if a javaVersion isn't specified, require the minimum viable using -release 8 to avoid gotcha in CI.
   def flagsForCompilation(sources: List[File]): List[String] = {
-    import scala.util.Properties.isJavaAtLeast
-    var perFile = toolArgsFor(sources)("scalac")
-    if (parentFile.getParentFile.getName == "macro-annot")
-      perFile ::= "-Ymacro-annotations"
-    if (isJavaAtLeast(9) && !perFile.exists(_.startsWith("-release")) && toolArgsFor(sources)("javaVersion", split = false).isEmpty)
-      perFile :::= List("-release", "8")
-    perFile
+    val perFile = toolArgsFor(sources)("scalac")
+    if (parentFile.getParentFile.getName == "macro-annot") "-Ymacro-annotations" :: perFile
+    else perFile
   }
 
   // inspect sources for tool args

--- a/test/files/neg/choices.check
+++ b/test/files/neg/choices.check
@@ -1,10 +1,3 @@
-#partest java9+
-error: Usage: -Yresolve-term-conflict:<strategy> where <strategy> choices are package, object, error (default: error).
-error: bad option: '-Yresolve-term-conflict'
-error: bad options: -release 8 -Yresolve-term-conflict
-error: flags file may only contain compiler options, found: -Yresolve-term-conflict
-4 errors
-#partest java8
 error: Usage: -Yresolve-term-conflict:<strategy> where <strategy> choices are package, object, error (default: error).
 error: bad option: '-Yresolve-term-conflict'
 error: bad options: -Yresolve-term-conflict

--- a/test/files/neg/partestInvalidFlag.check
+++ b/test/files/neg/partestInvalidFlag.check
@@ -1,9 +1,3 @@
-#partest java9+
-error: bad option: '-badCompilerFlag'
-error: bad options: -release 8 -badCompilerFlag notAFlag -opt:badChoice
-error: flags file may only contain compiler options, found: -badCompilerFlag notAFlag -opt:badChoice
-3 errors
-#partest java8
 error: bad option: '-badCompilerFlag'
 error: bad options: -badCompilerFlag notAFlag -opt:badChoice
 error: flags file may only contain compiler options, found: -badCompilerFlag notAFlag -opt:badChoice


### PR DESCRIPTION
Reverts scala/scala#10056 for now, because it leads to failing builds on JDKs > 8.

For example, `qsc -opt:inline:'**' -Wopt -Werror -release 8 ../test/files/pos/t3420.scala` fails with https://github.com/scala/bug/issues/12612

```
error: java.lang.IndexOutOfBoundsException
	at scala.tools.asm.tree.InsnList.get(InsnList.java:94)
```

It works without the `-release` flag.

Maybe we can try again later, but IIRC using the `-release` flag puts `ct.sym` on the classpath instead of the actual JDK jars, which could be undesired for our test coverage.