### PR TITLE
Enable conversion of a function to a trait using an implicit conversion and fully structural types

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3012,7 +3012,10 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               else pt // allow type slack (pos/6221)
           }
 
-          unwrapWrapperTypes(ptNorm baseType FunctionSymbol) match {
+          unwrapWrapperTypes((ptNorm baseType FunctionSymbol) match {
+            case NoType | ErrorType => ptNorm // fallback to known type if no wrapped type
+            case t => t
+          }) match {
             case TypeRef(_, _, args :+ res) => (args, res) // if it's a TypeRef, we know its symbol will be FunctionSymbol
             case _ =>
               val dummyPt = if (pt == ErrorType) ErrorType else NoType

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2672,7 +2672,8 @@ trait Types
       s"$lstr ${sym.decodedName} $rstr"
     }
     private def customToString = sym match {
-      case RepeatedParamClass | JavaRepeatedParamClass => args.head.toString + "*"
+      case RepeatedParamClass | JavaRepeatedParamClass =>
+        args.headOption.map { _.toString }.getOrElse("") + "*"
       case ByNameParamClass if !args.isEmpty           => "=> " + args.head
       case _ if isFunctionTypeDirect(this)             =>
           // Aesthetics: printing Function1 as T => R rather than (T) => R

--- a/test/files/neg/missing-param-type-tuple.check
+++ b/test/files/neg/missing-param-type-tuple.check
@@ -1,31 +1,16 @@
 missing-param-type-tuple.scala:3: error: missing parameter type
-Note: The expected type requires a one-argument function accepting a 2-Tuple.
-      Consider a pattern matching anonymous function, `{ case (a, b) =>  ... }`
   val x: ((Int, Int)) => Int = (a, b) => 0
-                                ^
-missing-param-type-tuple.scala:3: error: missing parameter type
-  val x: ((Int, Int)) => Int = (a, b) => 0
-                                   ^
-missing-param-type-tuple.scala:5: error: missing parameter type
-Note: The expected type requires a one-argument function accepting a 3-Tuple.
-      Consider a pattern matching anonymous function, `{ case (param1, ..., param3) =>  ... }`
-  val y: ((Int, Int, Int)) => Int = (a, b, !!) => 0
-                                     ^
+                                    ^
 missing-param-type-tuple.scala:5: error: missing parameter type
   val y: ((Int, Int, Int)) => Int = (a, b, !!) => 0
-                                        ^
+                                         ^
 missing-param-type-tuple.scala:5: error: missing parameter type
   val y: ((Int, Int, Int)) => Int = (a, b, !!) => 0
-                                           ^
-missing-param-type-tuple.scala:7: error: missing parameter type
-Note: The expected type requires a one-argument function accepting a 3-Tuple.
-      Consider a pattern matching anonymous function, `{ case (param1, ..., param3) =>  ... }`
-  val z: ((Int, Int, Int)) => Int = (a, NotAVariablePatternName, c) => 0
-                                     ^
+                                             ^
 missing-param-type-tuple.scala:7: error: missing parameter type
   val z: ((Int, Int, Int)) => Int = (a, NotAVariablePatternName, c) => 0
-                                        ^
+                                                               ^
 missing-param-type-tuple.scala:7: error: missing parameter type
   val z: ((Int, Int, Int)) => Int = (a, NotAVariablePatternName, c) => 0
-                                                                 ^
-8 errors
+                                                                  ^
+5 errors

--- a/test/files/neg/t556.check
+++ b/test/files/neg/t556.check
@@ -1,7 +1,4 @@
 t556.scala:3: error: missing parameter type
   def g: Int = f((x, y) => x)
-                  ^
-t556.scala:3: error: missing parameter type
-  def g: Int = f((x, y) => x)
-                     ^
-2 errors
+                      ^
+1 error

--- a/test/junit/scala/TypeInferenceTest.scala
+++ b/test/junit/scala/TypeInferenceTest.scala
@@ -1,0 +1,43 @@
+package scala
+
+import scala.tools.testkit.RunTesting
+
+import org.junit.Test
+
+class TypeInferenceTest extends RunTesting {
+  @Test def testBasicInference(): Unit = {
+    runner.run("""class RS[I]() {
+
+  def map[O](value: ScopedValue[I, O]): RS[O] = ???
+}
+
+trait ScopedValue[I, O] { }
+
+object Test {
+
+  implicit def value[I, O](func: (I) => O): ScopedValue[I, O] =
+    new ScopedValue[I, O] { }
+  
+  val exec = new RS[Long]()
+  val set = exec.map[Long] { (l: Long) => l }
+}""")
+  }
+
+  @Test def testUnrestrictedImplicit(): Unit = {
+    runner.run("""class RS[I]() {
+
+  def map[O](value: ScopedValue[I, O]): RS[O] = ???
+}
+
+trait ScopedValue[I, O] { }
+
+object Test {
+
+  implicit def value[I, O](func: (I) => O): ScopedValue[I, O] =
+    new ScopedValue[I, O] { }
+  
+  val exec = new RS[Long]()
+  val set = exec.map[Long] { l => l }
+}""")
+  }
+}


### PR DESCRIPTION
Fixes a minor type inference bug where the compiler can't determine the type of an anonymous function even with all the necessary type information present.  Allows the unwrapping of a base type to return the base type instead of failing and fixes a place were a non-empty name is assumed.

Fixes scala/bug#12609