### PR TITLE
Tasty Reader: Add support for Scala 3.2

### DIFF
--- a/project/DottySupport.scala
+++ b/project/DottySupport.scala
@@ -12,7 +12,7 @@ import sbt.librarymanagement.{
   * Settings to support validation of TastyUnpickler against the release of dotty with the matching TASTy version
   */
 object TastySupport {
-  val supportedTASTyRelease = "3.1.2-RC1" // TASTy version 28.1-0
+  val supportedTASTyRelease = "3.2.0-RC1" // TASTy version 28.2-1
   val scala3Compiler = "org.scala-lang" % "scala3-compiler_3" % supportedTASTyRelease
   val scala3Library = "org.scala-lang" % "scala3-library_3" % supportedTASTyRelease
 

--- a/src/compiler/scala/tools/nsc/tasty/TreeUnpickler.scala
+++ b/src/compiler/scala/tools/nsc/tasty/TreeUnpickler.scala
@@ -706,7 +706,7 @@ class TreeUnpickler[Tasty <: TastyUniverse](
           rdr.readTerm()(ctx)
         }
       )(annotCtx.retractMode(IndexScopedStats))
-      DeferredAnnotation.fromTree(mkTree)
+      DeferredAnnotation.fromTree(annotSym)(mkTree)
     }
 
     private def traceAnnotation(annotStart: Addr, annotSym: Symbol, annotee: Symbol) = TraceInfo[Tree](

--- a/src/compiler/scala/tools/nsc/tasty/bridge/AnnotationOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/AnnotationOps.scala
@@ -41,19 +41,19 @@ trait AnnotationOps { self: TastyUniverse =>
     }
   }
 
-  sealed abstract class DeferredAnnotation {
+  sealed abstract class DeferredAnnotation(annotSym: Symbol) {
 
-    private[bridge] def eager(annotee: Symbol)(implicit ctx: Context): u.AnnotationInfo
+    protected def eager(annotee: Symbol)(implicit ctx: Context): u.AnnotationInfo
     private[bridge] final def lzy(annotee: Symbol)(implicit ctx: Context): u.LazyAnnotationInfo = {
-      u.AnnotationInfo.lazily(eager(annotee))
+      u.AnnotationInfo.lazily(annotSym, eager(annotee))
     }
   }
 
   object DeferredAnnotation {
 
-    def fromTree(tree: Symbol => Context => Tree): DeferredAnnotation = {
-      new DeferredAnnotation {
-        private[bridge] final def eager(annotee: Symbol)(implicit ctx: Context): u.AnnotationInfo = {
+    def fromTree(annotSym: Symbol)(tree: Symbol => Context => Tree): DeferredAnnotation = {
+      new DeferredAnnotation(annotSym) {
+        protected final def eager(annotee: Symbol)(implicit ctx: Context): u.AnnotationInfo = {
           val atree = tree(annotee)(ctx)
           mkAnnotation(atree)
         }

--- a/src/compiler/scala/tools/nsc/tasty/bridge/ContextOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/ContextOps.scala
@@ -96,22 +96,22 @@ trait ContextOps { self: TastyUniverse =>
 
   /**Perform an operation within a context that has the mode `IndexStats` will force any collected annotations
    * afterwards */
-  def inIndexStatsContext(op: Context => Unit)(implicit ctx: Context): Unit = {
+  def inIndexStatsContext[T](op: Context => T)(implicit ctx: Context): T = {
     val statsCtx = ctx.addMode(IndexStats)
-    op(statsCtx)
-    statsCtx.initialContext.forceAnnotations()
+    try op(statsCtx)
+    finally statsCtx.initialContext.forceAnnotations()
   }
 
   /** Perform an operation within a context that has the mode `InnerScope` will enter any inline methods afterwards */
-  def inInnerScopeContext(op: Context => Unit)(implicit ctx: Context): Unit = {
+  def inInnerScopeContext[T](op: Context => T)(implicit ctx: Context): T = {
     val innerCtx = ctx.addMode(InnerScope)
-    op(innerCtx)
-    innerCtx.initialContext.enterLatentDefs(innerCtx.owner)
+    try op(innerCtx)
+    finally innerCtx.initialContext.enterLatentDefs(innerCtx.owner)
   }
 
 
   /** an aggregate of `inInnerScopeContext` within `inIndexStatsContext` */
-  def inIndexScopedStatsContext(op: Context => Unit)(implicit ctx: Context): Unit = {
+  def inIndexScopedStatsContext[T](op: Context => T)(implicit ctx: Context): T = {
     inIndexStatsContext(inInnerScopeContext(op)(_))(ctx)
   }
 

--- a/src/compiler/scala/tools/nsc/tasty/bridge/TreeOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/TreeOps.scala
@@ -166,7 +166,7 @@ trait TreeOps { self: TastyUniverse =>
       }
     }
 
-    def Annotated(tpt: Tree, annot: Tree): Tree = {
+    def Annotated(tpt: Tree, annot: Tree)(implicit ctx: Context): Tree = {
       if (annot.tpe.typeSymbol === defn.RepeatedAnnot
           && tpt.tpe.typeSymbol.isSubClass(u.definitions.SeqClass)
           && tpt.tpe.typeArgs.length == 1) {

--- a/src/compiler/scala/tools/nsc/tasty/bridge/TypeOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/TypeOps.scala
@@ -223,9 +223,9 @@ trait TypeOps { self: TastyUniverse =>
     def IntersectionType(tps: Type*): Type = u.intersectionType(tps.toList)
     def IntersectionType(tps: List[Type]): Type = u.intersectionType(tps)
 
-    def AnnotatedType(tpe: Type, annot: Tree): Type = tpe match {
-      case u.AnnotatedType(annots, tpe) => u.AnnotatedType(annots :+ mkAnnotation(annot), tpe)
-      case _                            => u.AnnotatedType(mkAnnotation(annot) :: Nil   , tpe)
+    def AnnotatedType(tpe: Type, annot: Tree)(implicit ctx: Context): Type = tpe match {
+      case u.AnnotatedType(annots, tpe) => u.AnnotatedType(annots :+ mkAnnotation(annot, tpe), tpe)
+      case _                            => u.AnnotatedType(mkAnnotation(annot, tpe) :: Nil   , tpe)
     }
 
     def SuperType(thisTpe: Type, superTpe: Type): Type = u.SuperType(thisTpe, superTpe)

--- a/src/compiler/scala/tools/tasty/TastyFormat.scala
+++ b/src/compiler/scala/tools/tasty/TastyFormat.scala
@@ -22,34 +22,34 @@ object TastyFormat {
     */
   final val header: Array[Int] = Array(0x5C, 0xA1, 0xAB, 0x1F)
 
-  /**Natural number. Each increment of the `MajorVersion` begins a
-   * new series of backward compatible TASTy versions.
+  /** Natural number. Each increment of the `MajorVersion` begins a
+   *  new series of backward compatible TASTy versions.
    *
-   * A TASTy file in either the preceding or succeeding series is
-   * incompatible with the current value.
+   *  A TASTy file in either the preceeding or succeeding series is
+   *  incompatible with the current value.
    */
   final val MajorVersion: Int = 28
 
-  /**Natural number. Each increment of the `MinorVersion`, within
-   * a series declared by the `MajorVersion`, breaks forward
-   * compatibility, but remains backwards compatible, with all
-   * preceding `MinorVersion`.
+  /** Natural number. Each increment of the `MinorVersion`, within
+   *  a series declared by the `MajorVersion`, breaks forward
+   *  compatibility, but remains backwards compatible, with all
+   *  preceeding `MinorVersion`.
    */
-  final val MinorVersion: Int = 1
+  final val MinorVersion: Int = 2
 
-  /**Natural Number. The `ExperimentalVersion` allows for
-   * experimentation with changes to TASTy without committing
-   * to any guarantees of compatibility.
+  /** Natural Number. The `ExperimentalVersion` allows for
+   *  experimentation with changes to TASTy without committing
+   *  to any guarantees of compatibility.
    *
-   * A zero value indicates that the TASTy version is from a
-   * stable, final release.
+   *  A zero value indicates that the TASTy version is from a
+   *  stable, final release.
    *
-   * A strictly positive value indicates that the TASTy
-   * version is experimental. An experimental TASTy file
-   * can only be read by a tool with the same version.
-   * However, tooling with an experimental TASTy version
-   * is able to read final TASTy documents if the file's
-   * `MinorVersion` is strictly less than the current value.
+   *  A strictly positive value indicates that the TASTy
+   *  version is experimental. An experimental TASTy file
+   *  can only be read by a tool with the same version.
+   *  However, tooling with an experimental TASTy version
+   *  is able to read final TASTy documents if the file's
+   *  `MinorVersion` is strictly less than the current value.
    */
   final val ExperimentalVersion: Int = 0
 
@@ -78,30 +78,14 @@ object TastyFormat {
    * with an unstable TASTy version.
    *
    * We follow the given algorithm:
+   *
    * ```
-   * if file.major != compiler.major then
-   *   return incompatible
-   * if compiler.experimental == 0 then
-   *   if file.experimental != 0 then
-   *     return incompatible
-   *   if file.minor > compiler.minor then
-   *     return incompatible
-   *   else
-   *     return compatible
-   * else invariant[compiler.experimental != 0]
-   *   if file.experimental == compiler.experimental then
-   *     if file.minor == compiler.minor then
-   *       return compatible (all fields equal)
-   *     else
-   *       return incompatible
-   *   else if file.experimental == 0,
-   *     if file.minor < compiler.minor then
-   *       return compatible (an experimental version can read a previous released version)
-   *     else
-   *       return incompatible (an experimental version cannot read its own minor version or any later version)
-   *   else invariant[file.experimental is non-0 and different than compiler.experimental]
-   *     return incompatible
+   * (fileMajor, fileMinor, fileExperimental) match
+   *   case (`compilerMajor`, `compilerMinor`, `compilerExperimental`) => true // full equality
+   *   case (`compilerMajor`, minor, 0) if minor < compilerMinor       => true // stable backwards compatibility
+   *   case _                                                          => false
    * ```
+   * @syntax markdown
    */
   def isVersionCompatible(
     fileMajor: Int,
@@ -111,18 +95,9 @@ object TastyFormat {
     compilerMinor: Int,
     compilerExperimental: Int
   ): Boolean = (
-    fileMajor == compilerMajor && (
-      if (fileExperimental == compilerExperimental) {
-        if (compilerExperimental == 0) {
-          fileMinor <= compilerMinor
-        }
-        else {
-          fileMinor == compilerMinor
-        }
-      }
-      else {
-        fileExperimental == 0 && fileMinor < compilerMinor
-      }
+    fileMajor == compilerMajor &&
+      (  fileMinor == compilerMinor && fileExperimental == compilerExperimental // full equality
+      || fileMinor <  compilerMinor && fileExperimental == 0 // stable backwards compatibility
     )
   )
 
@@ -199,11 +174,13 @@ object TastyFormat {
   // Cat. 1:    tag
 
   final val firstSimpleTreeTag = UNITconst
+  // final val ??? = 1
   final val UNITconst = 2
   final val FALSEconst = 3
   final val TRUEconst = 4
   final val NULLconst = 5
   final val PRIVATE = 6
+  // final val ??? = 7
   final val PROTECTED = 8
   final val ABSTRACT = 9
   final val FINAL = 10
@@ -226,6 +203,7 @@ object TastyFormat {
   final val CASEaccessor = 27
   final val COVARIANT = 28
   final val CONTRAVARIANT = 29
+  // final val ??? = 30
   final val HASDEFAULT = 31
   final val STABLE = 32
   final val MACRO = 33
@@ -301,6 +279,7 @@ object TastyFormat {
   final val IMPORT = 132
   final val TYPEPARAM = 133
   final val PARAM = 134
+  // final val ??? = 135
   final val APPLY = 136
   final val TYPEAPPLY = 137
   final val TYPED = 138
@@ -331,7 +310,9 @@ object TastyFormat {
   final val TYPEBOUNDS = 163
   final val TYPEBOUNDStpt = 164
   final val ANDtype = 165
+  // final val ??? = 166
   final val ORtype = 167
+  // final val ??? = 168
   final val POLYtype = 169
   final val TYPELAMBDAtype = 170
   final val LAMBDAtpt = 171
@@ -341,7 +322,8 @@ object TastyFormat {
   final val TYPEREFin = 175
   final val SELECTin = 176
   final val EXPORT = 177
-
+  // final val ??? = 178
+  // final val ??? = 179
   final val METHODtype = 180
 
   final val MATCHtype = 190

--- a/src/compiler/scala/tools/tasty/TastyHeaderUnpickler.scala
+++ b/src/compiler/scala/tools/tasty/TastyHeaderUnpickler.scala
@@ -44,14 +44,18 @@ class TastyHeaderUnpickler(reader: TastyReader) {
         start
       }
 
-      val validVersion = TastyFormat.isVersionCompatible(
-        fileMajor            = fileMajor,
-        fileMinor            = fileMinor,
-        fileExperimental     = fileExperimental,
-        compilerMajor        = MajorVersion,
-        compilerMinor        = MinorVersion,
-        compilerExperimental = ExperimentalVersion
-      )
+      val validVersion = {
+        val stdCheck = TastyFormat.isVersionCompatible(
+          fileMajor            = fileMajor,
+          fileMinor            = fileMinor,
+          fileExperimental     = fileExperimental,
+          compilerMajor        = MajorVersion,
+          compilerMinor        = MinorVersion,
+          compilerExperimental = ExperimentalVersion
+        )
+        val fallback = fileMajor == 28 && fileMinor == 2 && fileExperimental == 1 // 3.2.0-RC1
+        stdCheck || fallback
+      }
 
       check(validVersion, {
         val signature = signatureString(fileMajor, fileMinor, fileExperimental)

--- a/src/tastytest/scala/tools/tastytest/TastyTest.scala
+++ b/src/tastytest/scala/tools/tastytest/TastyTest.scala
@@ -15,8 +15,8 @@ import java.io.OutputStream
 
 object TastyTest {
 
-  private[tastytest] val verbose = true
-  private[tastytest] val debug = true
+  private[tastytest] val verbose = false
+  private[tastytest] val debug = false
 
   private def log(s: => String): Unit =
     if (verbose) println(s)

--- a/test/tasty/neg/src-2/TestForcedIllegalAnnotations.check
+++ b/test/tasty/neg/src-2/TestForcedIllegalAnnotations.check
@@ -1,7 +1,7 @@
-TestForcedIllegalAnnotations_fail.scala:4: error: Unsupported Scala 3 match expression in an annotation of method forcedMatchInAnnot; note that complex trees are not yet supported for Annotations; found in method forcedMatchInAnnot in class tastytest.ForcedIllegalAnnotations.Match.
-  def test1 = new ForcedIllegalAnnotations.Match() // error: Unsupported Scala 3 match expression in an annotation of method forcedMatchInAnnot
-              ^
-TestForcedIllegalAnnotations_fail.scala:5: error: Unsupported Scala 3 block expression in an annotation of method forcedBlockInAnnot; note that complex trees are not yet supported for Annotations; found in method forcedBlockInAnnot in class tastytest.ForcedIllegalAnnotations.Block.
-  def test2 = new ForcedIllegalAnnotations.Block() // error: Unsupported Scala 3 block expression in an annotation of method forcedBlockInAnnot
-              ^
+TestForcedIllegalAnnotations_fail.scala:5: error: Unsupported Scala 3 match expression in an annotation of method forcedMatchInAnnot; note that complex trees are not yet supported for Annotations; found in method forcedMatchInAnnot in class tastytest.ForcedIllegalAnnotations.Match.
+    new ForcedIllegalAnnotations.Match().forcedMatchInAnnot() // error: match expression in annotation arguments
+                                         ^
+TestForcedIllegalAnnotations_fail.scala:8: error: Unsupported Scala 3 block expression in an annotation of method forcedBlockInAnnot; note that complex trees are not yet supported for Annotations; found in method forcedBlockInAnnot in class tastytest.ForcedIllegalAnnotations.Block.
+    new ForcedIllegalAnnotations.Block().forcedBlockInAnnot() // error: block expression in annotation arguments.
+                                         ^
 2 errors

--- a/test/tasty/neg/src-2/TestForcedIllegalAnnotations_fail.scala
+++ b/test/tasty/neg/src-2/TestForcedIllegalAnnotations_fail.scala
@@ -1,6 +1,9 @@
 package tastytest
 
 object TestForcedIllegalAnnotations {
-  def test1 = new ForcedIllegalAnnotations.Match() // error: Unsupported Scala 3 match expression in an annotation of method forcedMatchInAnnot
-  def test2 = new ForcedIllegalAnnotations.Block() // error: Unsupported Scala 3 block expression in an annotation of method forcedBlockInAnnot
+  def test1 =
+    new ForcedIllegalAnnotations.Match().forcedMatchInAnnot() // error: match expression in annotation arguments
+
+  def test2 =
+    new ForcedIllegalAnnotations.Block().forcedBlockInAnnot() // error: block expression in annotation arguments.
 }

--- a/test/tasty/neg/src-2/TestSelectWithTarget.check
+++ b/test/tasty/neg/src-2/TestSelectWithTarget.check
@@ -1,4 +1,11 @@
 TestSelectWithTarget_fail.scala:13: error: Unsupported Scala 3 selection of method foo with @targetName("fooString"); found in method selectFooString in object tastytest.SelectWithTarget.
   def test = TestSelectWithTargetPre.forceAnnots[SelectWithTarget.type, SelectWithTarget.defAnnot]
                                                 ^
+warning: Implementation limitation: multiple argument lists on annotations are
+currently not supported; ignoring arguments List(23) on
+@mctorAnnot("a")(23) method methodWithAnnotMultipleParams in class tastytest.SelectWithTarget.MultiParamsAnnot
+warning: Implementation limitation: multiple argument lists on annotations are
+currently not supported; ignoring arguments List(23) on
+type scala.Int @mctorAnnot("a")(23) of method foo in object tastytest.SelectWithTarget.MultiParamsAnnotTpe
+2 warnings
 1 error

--- a/test/tasty/neg/src-2/TestSelectWithTarget.check
+++ b/test/tasty/neg/src-2/TestSelectWithTarget.check
@@ -1,4 +1,4 @@
-TestSelectWithTarget_fail.scala:10: error: Unsupported Scala 3 selection of method foo with @targetName("fooString"); found in method selectFooString in object tastytest.SelectWithTarget.
-  def test = SelectWithTarget.selectFooString
-                              ^
+TestSelectWithTarget_fail.scala:13: error: Unsupported Scala 3 selection of method foo with @targetName("fooString"); found in method selectFooString in object tastytest.SelectWithTarget.
+  def test = TestSelectWithTargetPre.forceAnnots[SelectWithTarget.type, SelectWithTarget.defAnnot]
+                                                ^
 1 error

--- a/test/tasty/neg/src-2/TestSelectWithTarget_fail.scala
+++ b/test/tasty/neg/src-2/TestSelectWithTarget_fail.scala
@@ -2,11 +2,14 @@ package tastytest
 
 object TestSelectWithTarget {
 
-  // We error when an annotation selects a
-  // method overloaded with a targetAnnot
-  // until we can erase them correctly.
-  // e.g. the annotation arguments may be
-  // reflected by a macro into real trees
-  def test = SelectWithTarget.selectFooString
+  // We error when an annotation selects a method overloaded with a targetAnnot
+  // until we can erase them correctly. e.g. the annotation arguments may be
+  // reflected by a macro into real trees.
+
+  // here it is necessary to call a macro to force the `defAnnot` annotation,
+  // alternatively we could use the `@deprecated` annotation as the compiler
+  // will analyse that, but this illustrates that most annotations can be
+  // harmless unless we specificially need to analyse them.
+  def test = TestSelectWithTargetPre.forceAnnots[SelectWithTarget.type, SelectWithTarget.defAnnot]
 
 }

--- a/test/tasty/neg/src-2/TestSelectWithTarget_fail.scala
+++ b/test/tasty/neg/src-2/TestSelectWithTarget_fail.scala
@@ -12,4 +12,9 @@ object TestSelectWithTarget {
   // harmless unless we specificially need to analyse them.
   def test = TestSelectWithTargetPre.forceAnnots[SelectWithTarget.type, SelectWithTarget.defAnnot]
 
+
+  def test2 = TestSelectWithTargetPre.forceAnnots[SelectWithTarget.MultiParamsAnnot, SelectWithTarget.mctorAnnot]
+
+  def test3 = SelectWithTarget.MultiParamsAnnotTpe.foo
+
 }

--- a/test/tasty/neg/src-2/TestSelectWithTarget_pre.scala
+++ b/test/tasty/neg/src-2/TestSelectWithTarget_pre.scala
@@ -1,0 +1,25 @@
+package tastytest
+
+import scala.language.experimental.macros
+
+import scala.reflect.macros.blackbox.Context
+
+object TestSelectWithTargetPre {
+
+  /** forces annotations of type `A` on methods from class `T` */
+  def forceAnnots[T, A]: Unit = macro Macros.forceAnnotsImpl[T, A]
+
+  object Macros {
+    def forceAnnotsImpl[T, A](c: Context)(implicit T: c.WeakTypeTag[T], A: c.WeakTypeTag[A]): c.Expr[Unit] = {
+      import c.universe._
+      for {
+        method <- weakTypeOf[T].members.filter(_.isMethod)
+        annot <- method.annotations.find(_.tree.tpe =:= weakTypeOf[A])
+      } {
+        annot.tree
+      }
+      c.Expr[Unit](q"()")
+    }
+  }
+
+}

--- a/test/tasty/neg/src-3/SelectWithTarget.scala
+++ b/test/tasty/neg/src-3/SelectWithTarget.scala
@@ -6,8 +6,20 @@ object SelectWithTarget {
 
   class defAnnot(arg: Any) extends StaticAnnotation
 
+  class mctorAnnot(s: String)(i: Int) extends scala.annotation.Annotation
+
   @defAnnot(Overloads.foo("hi"))
   def selectFooString: Int = 23
+
+  class MultiParamsAnnot {
+    @mctorAnnot("a")(23)
+    def methodWithAnnotMultipleParams = 47
+  }
+
+  object MultiParamsAnnotTpe {
+    def foo: Int @mctorAnnot("a")(23) = 47
+  }
+
 
   object Overloads {
 

--- a/test/tasty/pos/src-2/tastytest/TestAnnotated.scala
+++ b/test/tasty/pos/src-2/tastytest/TestAnnotated.scala
@@ -1,7 +1,6 @@
 package tastytest
 
 object TestAnnotated {
-  def test1 = new Annotated {}
   def test2 = new RootAnnotated {}
   def test3 = {
     val o = new OuterClassAnnotated {}

--- a/test/tasty/pos/src-2/tastytest/TestAnnotated.scala
+++ b/test/tasty/pos/src-2/tastytest/TestAnnotated.scala
@@ -1,16 +1,37 @@
 package tastytest
 
 object TestAnnotated {
-  def test2 = new RootAnnotated {}
+  def test2 = forceAnnots[RootAnnotated, rootAnnot, "new tastytest.rootAnnot(1)"]
   def test3 = {
-    val o = new OuterClassAnnotated {}
-    o.foo
+    forceAnnots[
+      OuterClassAnnotated,
+      basicAnnot[String],
+      "new  <: tastytest.basicAnnot[String](OuterClassAnnotated.this.xyz)"
+    ]
   }
-  def test4 = new ParameterizedAnnotated(23).foo
+  def test4 = {
+    forceAnnots[
+      ParameterizedAnnotated,
+      basicAnnot[Int],
+      "new  <: tastytest.basicAnnot[Int](tastytest#ParameterizedAnnotated.type.value)"
+    ]
+  }
   def test5 = {
     val o = new OuterAnnotated {}
-    o.foo
+    forceAnnots[OuterAnnotated, o.innerAnnot, "new OuterAnnotated.this.innerAnnot(new Inner())"]
   }
-  def test6 = new SelectInAnnotated.AmbiguousAnnotated {}
-  def test7 = new SelectInAnnotatedinParent.AmbiguousAnnotated {}
+  def test6 = {
+    forceAnnots[
+      SelectInAnnotated.AmbiguousAnnotated,
+      SelectInAnnotated.ambig.annot,
+      "new tastytest.SelectInAnnotated.ambig.annot(tastytest.SelectInAnnotated.e.type)"
+    ]
+  }
+  def test7 = {
+    forceAnnots[
+      SelectInAnnotatedinParent.AmbiguousAnnotated,
+      SelectInAnnotatedinParent.ambig.annotBox,
+      "new tastytest.SelectInAnnotatedinParent.ambig.annotBox(0.0)"
+    ]
+  }
 }

--- a/test/tasty/pos/src-2/tastytest/TestArrayAnnot.scala
+++ b/test/tasty/pos/src-2/tastytest/TestArrayAnnot.scala
@@ -1,5 +1,11 @@
 package tastytest
 
 object TestArrayAnnot {
-  def test = new Tagged()
+  def test = {
+    forceAnnots[
+      Tagged, 
+      SuppressWarnings,
+      "new SuppressWarnings(Array.type.apply[String]((Array[String]{\"xyz\", \"foo\"}: String*))(reflect#ClassTag.type.apply[String](classOf[java.lang.String])))"
+    ]
+  }
 }

--- a/test/tasty/pos/src-2/tastytest/TestFromJavaObjectConsume.scala
+++ b/test/tasty/pos/src-2/tastytest/TestFromJavaObjectConsume.scala
@@ -2,6 +2,14 @@ package tastytest
 
 object TestFromJavaObjectConsume {
 
-  def test = new FromJavaObjectConsume.Foo {}
+  def test1 = new FromJavaObjectConsume.Foo {}
+
+  def test2 = {
+    forceAnnots[
+      FromJavaObjectConsume.Foo,
+      basicAnnot[Any],
+      "new  <: tastytest.basicAnnot[Int](tastytest#FromJavaObjectBox.type.id[Int](23))"
+    ]
+  }
 
 }

--- a/test/tasty/pos/src-2/tastytest/TestNestedAnnot.scala
+++ b/test/tasty/pos/src-2/tastytest/TestNestedAnnot.scala
@@ -1,5 +1,9 @@
 package tastytest
 
 object TestNestedAnnot {
-  def test = new TaggedMega.Tagged()
+  def test = {
+    val _ = new TaggedMega.Tagged()
+    compiletimeHasChild[TaggedMega.ForceChildren]("tastytest.TaggedMega.Nested.Nested2.Tags")
+    forceAnnots[TaggedMega.Tagged, TaggedMega.Nested.Nested2.Tags, "new tastytest#TaggedMega.Nested.Nested2.Tags(\"xyz,foo\")"]
+  }
 }

--- a/test/tasty/pos/src-2/tastytest/TestReflection.scala
+++ b/test/tasty/pos/src-2/tastytest/TestReflection.scala
@@ -2,4 +2,12 @@ package tastytest
 
 object TestReflection {
   def test1 = assert(new Reflection().fieldAtIndex(1) == "Hello") // test reading `classOf` in the @throws annotation
+
+  def test2 = {
+    forceAnnots[
+      Reflection,
+      scala.throws[Throwable],
+      "new  <: throws[IndexOutOfBoundsException](classOf[java.lang.IndexOutOfBoundsException])"
+    ]
+  }
 }

--- a/test/tasty/pos/src-3/tastytest/Annotated.scala
+++ b/test/tasty/pos/src-3/tastytest/Annotated.scala
@@ -1,8 +1,5 @@
 package tastytest
 
-@symbolicAnnot(new tastytest_>>>.Member)
-trait Annotated
-
 @rootAnnot(1)
 trait RootAnnotated
 

--- a/test/tasty/pos/src-3/tastytest/symbolicAnnot.scala
+++ b/test/tasty/pos/src-3/tastytest/symbolicAnnot.scala
@@ -1,3 +1,0 @@
-package tastytest
-
-final class symbolicAnnot(member: tastytest_>>>.Member) extends scala.annotation.StaticAnnotation

--- a/test/tasty/pos/src-3/tastytest_weirdname/package.scala
+++ b/test/tasty/pos/src-3/tastytest_weirdname/package.scala
@@ -1,3 +1,0 @@
-package object tastytest_>>> {
-  class Member
-}

--- a/test/tasty/run/pre/tastytest/package.scala
+++ b/test/tasty/run/pre/tastytest/package.scala
@@ -1,3 +1,5 @@
+import scala.language.experimental.macros
+
 import scala.util.Random
 
 import scala.reflect.macros.blackbox.Context
@@ -37,7 +39,47 @@ package object tastytest {
     def poly[T: c.WeakTypeTag]: Tree = q"${c.weakTypeOf[T].toString}"
   }
 
+  /** forces annotations of type `A` on methods from class `T` */
+  def forceAnnots[T, A, S <: String with Singleton]: Unit = macro Macros.AnnotsBundle.forceAnnotsImpl[T, A, S]
+
   object Macros {
+
+    class AnnotsBundle(val c: Context) {
+      import c.universe._
+
+      private def annotType(annot: Annotation): Type = annot.tree.tpe match {
+        case TypeBounds(lo, hi) => hi
+        case tpe => tpe
+      }
+
+      private def toExplore[T](implicit T: c.WeakTypeTag[T]): List[Symbol] = (
+        weakTypeOf[T].typeSymbol
+        +: weakTypeOf[T].typeSymbol.asInstanceOf[ClassSymbol].primaryConstructor
+        +: weakTypeOf[T].members.filter(_.isMethod).toList.flatMap(method =>
+          method :: method.asInstanceOf[MethodSymbol].paramLists.flatten
+        )
+      )
+
+      private def stringAssert[S <: String with Singleton](implicit S: c.WeakTypeTag[S]): String =
+        weakTypeOf[S] match {
+          case ConstantType(Constant(str: String)) => str
+          case _ => ???
+        }
+
+      def forceAnnotsImpl[T, A, S <: String with Singleton](implicit T: c.WeakTypeTag[T], A: c.WeakTypeTag[A], S: c.WeakTypeTag[S]): c.Expr[Unit] = {
+        val trees = {
+          for {
+            defn <- toExplore[T]
+            annot <- defn.annotations.filter(annotType(_).typeSymbol == weakTypeOf[A].typeSymbol)
+          } yield {
+            s"${annot.tree}"
+          }
+        }
+        val annotStr = trees.head
+        assert(annotStr == stringAssert[S], s"actually, was $annotStr")
+        c.Expr[Unit](q"()")
+      }
+    }
 
     def hasStaticAnnotImpl[T, A](c: Context)(implicit T: c.WeakTypeTag[T], A: c.WeakTypeTag[A]): c.Expr[Boolean] = {
       import c.universe._

--- a/test/tasty/run/src-2/tastytest/TestArrayCtors.scala
+++ b/test/tasty/run/src-2/tastytest/TestArrayCtors.scala
@@ -7,4 +7,17 @@ object TestArrayCtors extends Suite("TestArrayCtors") {
   test(assert(EmptyArrayCtor != null))
   test(assert(EmptyArrayCtor2 != null))
 
+  def compiletimeAsserts = {
+    def test1 = forceAnnots[
+      ArrayCtors.EmptyArrayCtor.type,
+      ArrayCtors.arrayAnnot,
+      "new tastytest.ArrayCtors.arrayAnnot(Array.type.apply[tastytest.ArrayCtors.Module.type.type]((Array[tastytest.ArrayCtors.Module.type]{}: tastytest.ArrayCtors.Module.type*))(reflect#ClassTag.type.apply[tastytest.ArrayCtors.Module.type](classOf[tastytest.ArrayCtors$$Module])))"
+    ]
+    def test2 = forceAnnots[
+      ArrayCtors.EmptyArrayCtor2.type,
+      ArrayCtors.arrayAnnot2,
+      "new tastytest.ArrayCtors.arrayAnnot2(Array.type.apply[Array[tastytest.ArrayCtors.Module.type.type]]((Array[Array[tastytest.ArrayCtors.Module.type]]{}: Array[tastytest.ArrayCtors.Module.type]*))(reflect#ClassTag.type.apply[tastytest.ArrayCtors.Module.type](classOf[tastytest.ArrayCtors$$Module]).wrap))"
+    ]
+  }
+
 }

--- a/test/tasty/run/src-2/tastytest/TestCtorUsingClauses.scala
+++ b/test/tasty/run/src-2/tastytest/TestCtorUsingClauses.scala
@@ -1,0 +1,18 @@
+package tastytest
+
+import CtorUsingClauses._
+import CtorUsingClause._
+
+object TestCtorUsingClauses extends Suite("TestCtorUsingClauses") {
+  // TODO: test unpickle calling a ctor with a using clause
+  
+  test(assert(new CtorUsingClause(implicitly[Int])("hello").i === 23))
+  test(assert(new Contextual(implicitly[Int])().i === 23))
+
+  test(assert(new CtorUsingClauses.Sub1().i === 23))
+  test(assert(new CtorUsingClauses.Sub2().i === 23))
+  test(assert(new CtorUsingClauses.Sub3().i === 23))
+
+  test(assert(new CtorUsingClauses.Annotated().j === 47))
+  test(assert(new CtorUsingClauses.AnnotatedOld().k === 97))
+}

--- a/test/tasty/run/src-2/tastytest/TestCtorUsingClauses.scala
+++ b/test/tasty/run/src-2/tastytest/TestCtorUsingClauses.scala
@@ -15,4 +15,17 @@ object TestCtorUsingClauses extends Suite("TestCtorUsingClauses") {
 
   test(assert(new CtorUsingClauses.Annotated().j === 47))
   test(assert(new CtorUsingClauses.AnnotatedOld().k === 97))
+
+  def compiletimeAsserts = {
+    def test1 = forceAnnots[
+      CtorUsingClauses.Annotated,
+      CtorUsingClauses.CtxAnnot,
+      "new tastytest.CtorUsingClauses.CtxAnnot(tastytest#CtorUsingClauses.CtorUsingClause.given_Int.type)"
+    ]
+    def test2 = forceAnnots[
+      CtorUsingClauses.AnnotatedOld,
+      CtorUsingClauses.CtxAnnotOld,
+      "new tastytest.CtorUsingClauses.CtxAnnotOld(tastytest#CtorUsingClauses.CtorUsingClause.given_Int.type)"
+    ]
+  }
 }

--- a/test/tasty/run/src-2/tastytest/TestDefAnnots.scala
+++ b/test/tasty/run/src-2/tastytest/TestDefAnnots.scala
@@ -6,4 +6,28 @@ object TestDefAnnots extends Suite("TestDefAnnots") {
   test(assert(DefAnnots.withParamInferAnnot("arg") === ("arg" : Any)))
   test(assert(DefAnnots.withAnnotatedAnnot("arg") === ("arg": Any)))
 
+  def compiletimeAsserts = {
+    def test1 = {
+      forceAnnots[
+        DefAnnots.type,
+        DefAnnots.inferAnnot[Any],
+        "new  <: tastytest.DefAnnots.inferAnnot[tastytest.DefAnnots.Inner.Foo.type](tastytest.DefAnnots.Inner.type.Foo)"
+      ]
+    }
+    def test2 = {
+      forceAnnots[
+        DefAnnots.type,
+        DefAnnots.Wrapper.annotatedAnnot,
+        "new tastytest.DefAnnots.Wrapper.annotatedAnnot()"
+      ]
+    }
+    def test3 = {
+      forceAnnots[
+        DefAnnots.Wrapper.annotatedAnnot,
+        DefAnnots.Wrapper.annot,
+        "new tastytest.DefAnnots.Wrapper.annot()"
+      ]
+    }
+  }
+
 }

--- a/test/tasty/run/src-2/tastytest/TestExportsInExtensions.scala
+++ b/test/tasty/run/src-2/tastytest/TestExportsInExtensions.scala
@@ -1,0 +1,9 @@
+package tastytest
+
+
+object TestExportsInExtensions extends Suite("TestExportsInExtensions") {
+  test(assert(ExportsInExtensions.bar(3) == 3))
+  test(assert(ExportsInExtensions.baz(17)(3) == 2))
+  test(assert(ExportsInExtensions.bam(3) == 9))
+  test(assert(ExportsInExtensions.::(10)(2) == 10 - 2))  // same as for implicit class C
+}

--- a/test/tasty/run/src-2/tastytest/TestJavaEnumTypes.scala
+++ b/test/tasty/run/src-2/tastytest/TestJavaEnumTypes.scala
@@ -8,4 +8,11 @@ object TestJavaEnumTypes extends Suite("TestJavaEnumTypes") {
   test(assert(new JavaEnumTypes.TypeBox[ElementType.TYPE.type]().id(ElementType.TYPE) === ElementType.TYPE))
   test(assert(JavaEnumTypes.foo === 23))
 
+  def compiletimeAsserts =
+    forceAnnots[
+      JavaEnumTypes.type,
+      JavaEnumTypes.simulatedTarget,
+      "new tastytest.JavaEnumTypes.simulatedTarget(Array.type.apply[java.lang.annotation.ElementType]((Array[java.lang.annotation.ElementType]{annotation#ElementType.type.LOCAL_VARIABLE}: java.lang.annotation.ElementType*))(reflect#ClassTag.type.apply[java.lang.annotation.ElementType](classOf[java.lang.annotation.ElementType])))"
+    ]
+
 }

--- a/test/tasty/run/src-2/tastytest/TestSymbollicEnums.scala
+++ b/test/tasty/run/src-2/tastytest/TestSymbollicEnums.scala
@@ -18,7 +18,7 @@ object TestSymbollicEnums extends Suite("TestSymbollicEnums") {
     }
   }
 
-  val Laws = new Laws[Long]
+  val Laws = new Laws[Long](implicitly[Interpreter[Long]])()
   import Laws._
 
   test(assert(additiveIdentity(getRandomNat.toLong.lit)))

--- a/test/tasty/run/src-2/tastytest/TestTupleBounds.scala
+++ b/test/tasty/run/src-2/tastytest/TestTupleBounds.scala
@@ -1,0 +1,5 @@
+package tastytest
+
+object TestTupleBounds extends Suite("TestTupleBounds") {
+  test(assert(TupleBounds.hello == "hello"))
+}

--- a/test/tasty/run/src-3/tastytest/CtorUsingClause.scala
+++ b/test/tasty/run/src-3/tastytest/CtorUsingClause.scala
@@ -1,0 +1,33 @@
+package tastytest
+
+import CtorUsingClauses.CtorUsingClause.given
+
+object CtorUsingClauses {
+  class CtorUsingClause(using x: Int)(y: String):
+    val i = x
+  
+  object CtorUsingClause {
+    given Int = 23
+  }
+
+  class Contextual(using x: Int): // ctor: <init>(using x: Int)()
+    val i = x
+
+  class Implicit(implicit x: Int): // ctor: <init>()(implicit x: Int)
+    val i = x
+
+  class Sub1()(using x: Int) extends CtorUsingClause("Sub")
+  class Sub2()(using x: Int) extends Contextual
+  class Sub3()(using x: Int) extends Implicit
+
+  class CtxAnnot(using x: Int) extends scala.annotation.Annotation // ctor: <init>(using x: Int)()
+  class CtxAnnotOld(implicit x: Int) extends scala.annotation.Annotation // ctor: <init>()(implicit x: Int)
+
+  @CtxAnnot
+  class Annotated:
+    val j = 47
+
+  @CtxAnnotOld
+  class AnnotatedOld:
+    val k = 97
+}

--- a/test/tasty/run/src-3/tastytest/ExportsInExtensions.scala
+++ b/test/tasty/run/src-3/tastytest/ExportsInExtensions.scala
@@ -1,0 +1,13 @@
+package tastytest
+
+object ExportsInExtensions:
+
+  class C(x: Int):
+    def bar = x
+    def baz(y: Int) = x % y
+    val bam = x * x
+    def :: (y: Int) = x - y
+
+  extension (x: Int)
+    private def cm = new C(x)
+    export cm.*

--- a/test/tasty/run/src-3/tastytest/TupleBounds.scala
+++ b/test/tasty/run/src-3/tastytest/TupleBounds.scala
@@ -1,0 +1,27 @@
+package tastytest
+
+/** The purpose of this test source is to see what remains unforced when
+ *  depending on only the hello method from Scala 2.
+ *  If any of the other definitions are forced, they will reach the tuple bound
+ *  and fail compilation.
+ */
+object TupleBounds {
+
+  def hello = "hello"
+
+  class SomeDef[T <: scala.Tuple] // test is unforced
+
+  type SomeOtherDef = { // test is unforced
+    type T <: scala.Tuple
+    def foo: scala.Tuple
+    val bar: scala.Tuple
+  }
+
+  type SomeBoundedDef[T <: scala.Tuple] // test is unforced
+
+  class TupleAnnot(t: scala.Tuple) extends scala.annotation.Annotation // test is unforced
+
+  @TupleAnnot((1, "abc", true)) // test is unforced
+  def someAnnotated: scala.Tuple = ??? // test is unforced
+
+}


### PR DESCRIPTION
supports the tasty for Scala 3.2.0 (i.e. `28.2-0`)

- Added support for the new constructor encoding in TASTy.
- Stops forcing Scala 3 methods in SpecializeTypes
- Reduces how many annotations are forced so that problematic API's are not forced accidentally when the user never accesses them.

fixes https://github.com/scala/bug/issues/12585

Note that the sequel PR #10127 updates this for Scala 3.2.0 final (and removes the exception for `3.2.0-RCx` (`28.2-1`)).
