### PR TITLE
Deprecate conversion of BooleanSetting to Boolean

### DIFF
--- a/src/compiler/scala/reflect/macros/contexts/Reifiers.scala
+++ b/src/compiler/scala/reflect/macros/contexts/Reifiers.scala
@@ -67,15 +67,15 @@ trait Reifiers {
     def logFreeVars(symtab: SymbolTable): Unit =
       // logging free vars only when they are untyped prevents avalanches of duplicate messages
       symtab.syms map (sym => symtab.symDef(sym)) foreach {
-        case FreeTermDef(_, _, binding, _, origin) if universe.settings.logFreeTerms && binding.tpe == null =>
+        case FreeTermDef(_, _, binding, _, origin) if universe.settings.logFreeTerms.value && binding.tpe == null =>
           reporter.echo(position, s"free term: ${showRaw(binding)} $origin")
-        case FreeTypeDef(_, _, binding, _, origin) if universe.settings.logFreeTypes && binding.tpe == null =>
+        case FreeTypeDef(_, _, binding, _, origin) if universe.settings.logFreeTypes.value && binding.tpe == null =>
           reporter.echo(position, s"free type: ${showRaw(binding)} $origin")
         case _ =>
           // do nothing
       }
 
-    if (universe.settings.logFreeTerms || universe.settings.logFreeTypes)
+    if (universe.settings.logFreeTerms.value || universe.settings.logFreeTypes.value)
       (reification: @unchecked) match {
         case ReifiedTree(_, _, symtab, _, _, _, _) => logFreeVars(symtab)
         case ReifiedType(_, _, symtab, _, _, _)    => logFreeVars(symtab)

--- a/src/compiler/scala/reflect/reify/Phases.scala
+++ b/src/compiler/scala/reflect/reify/Phases.scala
@@ -37,7 +37,7 @@ trait Phases extends Reshape
     if (reifyDebug) println("[reshape phase]")
     tree = reshape.transform(tree)
     if (reifyDebug) println("[interlude]")
-    if (reifyDebug) println("reifee = " + (if (settings.Xshowtrees || settings.XshowtreesCompact || settings.XshowtreesStringified) "\n" + nodePrinters.nodeToString(tree).trim else tree.toString))
+    if (reifyDebug) println("reifee = " + (if (settings.Xshowtrees.value || settings.XshowtreesCompact.value || settings.XshowtreesStringified.value) "\n" + nodePrinters.nodeToString(tree).trim else tree.toString))
 
     if (reifyDebug) println("[calculate phase]")
     calculate.traverse(tree)

--- a/src/compiler/scala/reflect/reify/Reifier.scala
+++ b/src/compiler/scala/reflect/reify/Reifier.scala
@@ -67,7 +67,7 @@ abstract class Reifier extends States
 
       val result = reifee match {
         case tree: Tree =>
-          reifyTrace("reifying = ")(if (settings.Xshowtrees || settings.XshowtreesCompact || settings.XshowtreesStringified) "\n" + nodePrinters.nodeToString(tree).trim else tree.toString)
+          reifyTrace("reifying = ")(if (settings.Xshowtrees.value || settings.XshowtreesCompact.value || settings.XshowtreesStringified.value) "\n" + nodePrinters.nodeToString(tree).trim else tree.toString)
           reifyTrace("reifee is located at: ")(tree.pos)
           reifyTrace("universe = ")(universe)
           reifyTrace("mirror = ")(mirror)

--- a/src/compiler/scala/tools/nsc/CompilerCommand.scala
+++ b/src/compiler/scala/tools/nsc/CompilerCommand.scala
@@ -105,14 +105,14 @@ class CompilerCommand(arguments: List[String], val settings: Settings) {
   def getInfoMessage(global: Global): String = {
     import settings._
 
-    if (version)            Properties.versionFor(cmdDesc)
-    else if (help)          usageMsg + global.pluginOptionsHelp
-    else if (Vhelp)         vusageMsg
-    else if (Whelp)         wusageMsg
-    else if (Xhelp)         xusageMsg
-    else if (Yhelp)         yusageMsg
-    else if (showPlugins)   global.pluginDescriptions
-    else if (showPhases)    global.phaseDescriptions + (
+    if (version.value)            Properties.versionFor(cmdDesc)
+    else if (help.value)          usageMsg + global.pluginOptionsHelp
+    else if (Vhelp.value)         vusageMsg
+    else if (Whelp.value)         wusageMsg
+    else if (Xhelp.value)         xusageMsg
+    else if (Yhelp.value)         yusageMsg
+    else if (showPlugins.value)   global.pluginDescriptions
+    else if (showPhases.value)    global.phaseDescriptions + (
       if (settings.isDebug) "\n" + global.phaseFlagDescriptions else ""
     )
     else if (genPhaseGraph.isSetByUser) {

--- a/src/compiler/scala/tools/nsc/Driver.scala
+++ b/src/compiler/scala/tools/nsc/Driver.scala
@@ -33,7 +33,7 @@ abstract class Driver {
 
   /** True to continue compilation. */
   protected def processSettingsHook(): Boolean = {
-    if (settings.version) { reporter echo versionMsg ; false }
+    if (settings.version.value) { reporter echo versionMsg ; false }
     else !reporter.hasErrors
   }
 

--- a/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
+++ b/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
@@ -64,5 +64,5 @@ class GenericRunnerSettings(error: String => Unit, pathFactory: PathFactory) ext
       "-nc",
       "do not use the legacy fsc compilation daemon").withAbbreviation("-nocompdaemon").withAbbreviation("--no-compilation-daemon")
       .withDeprecationMessage("scripts use cold compilation by default; use -Yscriptrunner for custom behavior")
-      .withPostSetHook { x: BooleanSetting => Yscriptrunner.value = if (x) "default" else "resident" }
+      .withPostSetHook { x: BooleanSetting => Yscriptrunner.value = if (x.value) "default" else "resident" }
 }

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -58,7 +58,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
   // the mirror --------------------------------------------------
 
   override def isCompilerUniverse = true
-  override val useOffsetPositions = !currentSettings.Yrangepos
+  override val useOffsetPositions = !currentSettings.Yrangepos.value
 
   type RuntimeClass = java.lang.Class[_]
   implicit val RuntimeClassTag: ClassTag[RuntimeClass] = ClassTag[RuntimeClass](classOf[RuntimeClass])
@@ -371,7 +371,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
     }
   }
 
-  if (settings.verbose || settings.Ylogcp)
+  if (settings.verbose.value || settings.Ylogcp.value)
     reporter.echo(
       s"[search path for source files: ${classPath.asSourcePathString}]\n" +
       s"[search path for class files: ${classPath.asClassPathString}]"
@@ -430,7 +430,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
       if ((unit ne null) && unit.exists)
         lastSeenSourceFile = unit.source
 
-      if (settings.isDebug && (settings.verbose || currentRun.size < 5))
+      if (settings.isDebug && (settings.verbose.value || currentRun.size < 5))
         inform("[running phase " + name + " on " + unit + "]")
     }
 
@@ -494,7 +494,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
   //
   // factory for phases: namer, packageobjects, typer
   lazy val analyzer =
-    if (settings.YmacroAnnotations) new { val global: Global.this.type = Global.this } with Analyzer with MacroAnnotationNamers
+    if (settings.YmacroAnnotations.value) new { val global: Global.this.type = Global.this } with Analyzer with MacroAnnotationNamers
     else new { val global: Global.this.type = Global.this } with Analyzer
 
   // phaseName = "superaccessors"
@@ -786,7 +786,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
     val maxName = phaseNames.map(_.length).max
     val width   = maxName min Limit
     val maxDesc = MaxCol - (width + 6)  // descriptions not novels
-    val fmt     = if (settings.verbose || !elliptically) s"%${maxName}s  %2s  %s%n"
+    val fmt     = if (settings.verbose.value || !elliptically) s"%${maxName}s  %2s  %s%n"
                   else s"%${width}.${width}s  %2s  %.${maxDesc}s%n"
 
     val line1 = fmt.format("phase name", "id", title)
@@ -1126,7 +1126,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
 
   def echoPhaseSummary(ph: Phase) = {
     /* Only output a summary message under debug if we aren't echoing each file. */
-    if (settings.isDebug && !(settings.verbose || currentRun.size < 5))
+    if (settings.isDebug && !(settings.verbose.value || currentRun.size < 5))
       inform("[running phase " + ph.name + " on " + currentRun.size +  " compilation units]")
   }
 
@@ -1539,14 +1539,14 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
           informTime(globalPhase.description, phaseTimer.nanos)
 
         // progress update
-        if ((settings.Xprint containsPhase globalPhase) || settings.printLate && runIsAt(cleanupPhase)) {
+        if ((settings.Xprint containsPhase globalPhase) || settings.printLate.value && runIsAt(cleanupPhase)) {
           // print trees
-          if (settings.Xshowtrees || settings.XshowtreesCompact || settings.XshowtreesStringified) nodePrinters.printAll()
+          if (settings.Xshowtrees.value || settings.XshowtreesCompact.value || settings.XshowtreesStringified.value) nodePrinters.printAll()
           else printAllUnits()
         }
 
         // print the symbols presently attached to AST nodes
-        if (settings.Yshowsyms)
+        if (settings.Yshowsyms.value)
           trackerFactory.snapshot()
 
         // print members
@@ -1568,7 +1568,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
           runCheckers()
 
         // output collected statistics
-        if (settings.YstatisticsEnabled && settings.Ystatistics.contains(phase.name))
+        if (settings.YstatisticsEnabled.value && settings.Ystatistics.contains(phase.name))
           printStatisticsFor(phase)
 
         advancePhase()
@@ -1609,7 +1609,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
 
       // Clear any sets or maps created via perRunCaches.
       perRunCaches.clearAll()
-      if (settings.verbose)
+      if (settings.verbose.value)
         println("Name table size after compilation: " + nameTableSize + " chars")
     }
 
@@ -1688,14 +1688,14 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
       List(statistics.retainedCount, statistics.retainedByType)
     private val parserStats = {
       import statistics.treeNodeCount
-      if (settings.YhotStatisticsEnabled) treeNodeCount :: hotCounters
+      if (settings.YhotStatisticsEnabled.value) treeNodeCount :: hotCounters
       else List(treeNodeCount)
     }
 
     final def printStatisticsFor(phase: Phase) = {
       inform("*** Cumulative statistics at phase " + phase)
 
-      if (settings.YhotStatisticsEnabled) {
+      if (settings.YhotStatisticsEnabled.value) {
         // High overhead, only enable retained stats under hot stats
         statistics.retainedCount.value = 0
         for (c <- statistics.retainedByType.keys)
@@ -1708,7 +1708,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
 
       val quants: Iterable[statistics.Quantity] =
         if (phase.name == "parser") parserStats
-        else if (settings.YhotStatisticsEnabled) statistics.allQuantities
+        else if (settings.YhotStatisticsEnabled.value) statistics.allQuantities
         else statistics.allQuantities.filterNot(q => hotCounters.contains(q))
       for (q <- quants if q.showAt(phase.name)) inform(q.line)
     }

--- a/src/compiler/scala/tools/nsc/Main.scala
+++ b/src/compiler/scala/tools/nsc/Main.scala
@@ -26,7 +26,7 @@ class MainClass extends Driver with EvalLoop {
   override def newCompiler(): Global = Global(settings)
 
   override def doCompile(compiler: Global): Unit = {
-    if (settings.resident) resident(compiler)
+    if (settings.resident.value) resident(compiler)
     else super.doCompile(compiler)
   }
 }

--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -283,7 +283,7 @@ trait Reporting extends internal.Reporting { self: ast.Positions with Compilatio
     var seenMacroExpansionsFallingBack = false
 
     // i.e., summarize warnings
-    def summarizeErrors(): Unit = if (!reporter.hasErrors && !settings.nowarn) {
+    def summarizeErrors(): Unit = if (!reporter.hasErrors && !settings.nowarn.value) {
       for (c <- summarizedWarnings.keys.toList.sortBy(_.name))
         summarize(Action.WarningSummary, c)
       for (c <- summarizedInfos.keys.toList.sortBy(_.name))
@@ -295,7 +295,7 @@ trait Reporting extends internal.Reporting { self: ast.Positions with Compilatio
 
       // todo: migrationWarnings
 
-      if (settings.fatalWarnings && reporter.hasWarnings)
+      if (settings.fatalWarnings.value && reporter.hasWarnings)
         reporter.error(NoPosition, "No warnings can be incurred under -Werror.")
     }
   }

--- a/src/compiler/scala/tools/nsc/ScriptRunner.scala
+++ b/src/compiler/scala/tools/nsc/ScriptRunner.scala
@@ -148,7 +148,7 @@ abstract class AbstractScriptRunner(settings: GenericRunnerSettings) extends Scr
      */
     util.waitingForThreads {
       // either update the jar or don't use a cache jar at all, just use the class files, if they exist
-      if (settings.save) withLatestJar()
+      if (settings.save.value) withLatestJar()
       else {
         compile match {
           case Some(cp) if hasClassToRun(cp) => handler(cp.path)
@@ -173,7 +173,7 @@ abstract class AbstractScriptRunner(settings: GenericRunnerSettings) extends Scr
     if (!f.exists) Some(new IOException(s"no such file: $scriptFile"))
     else if (!f.canRead) Some(new IOException(s"can't read: $scriptFile"))
     else if (f.isDirectory) Some(new IOException(s"can't compile a directory: $scriptFile"))
-    else if (!settings.nc && !f.isFile) Some(new IOException(s"compile server requires a regular file: $scriptFile"))
+    else if (!settings.nc.value && !f.isFile) Some(new IOException(s"compile server requires a regular file: $scriptFile"))
     else withCompiledScript(scriptFile) { runCompiled(_, scriptArgs) }
   }
 

--- a/src/compiler/scala/tools/nsc/ast/NodePrinters.scala
+++ b/src/compiler/scala/tools/nsc/ast/NodePrinters.scala
@@ -39,7 +39,7 @@ abstract class NodePrinters {
   }
 
   trait DefaultPrintAST extends PrintAST {
-    val printPos = settings.Xprintpos || settings.Yposdebug
+    val printPos = settings.Xprintpos.value || settings.Yposdebug.value
 
     def showNameAndPos(tree: NameTree) = showPosition(tree) + showName(tree.name)
     def showDefTreeName(tree: DefTree) = showName(tree.name)
@@ -107,8 +107,8 @@ abstract class NodePrinters {
 
     def stringify(tree: Tree): String = {
       buf.clear()
-      if (settings.XshowtreesStringified) buf.append(tree.toString + EOL)
-      if (settings.XshowtreesCompact) {
+      if (settings.XshowtreesStringified.value) buf.append(tree.toString + EOL)
+      if (settings.XshowtreesCompact.value) {
         buf.append(showRaw(tree, printIds = settings.uniqid, printTypes = settings.printtypes))
       } else {
         level = 0

--- a/src/compiler/scala/tools/nsc/ast/Positions.scala
+++ b/src/compiler/scala/tools/nsc/ast/Positions.scala
@@ -39,6 +39,6 @@ trait Positions extends scala.reflect.internal.Positions {
   }
 
   override protected[this] lazy val posAssigner: PosAssigner =
-    if (settings.Yrangepos && settings.isDebug || settings.Yposdebug) new ValidatingPosAssigner
+    if (settings.Yrangepos.value && settings.isDebug || settings.Yposdebug.value) new ValidatingPosAssigner
     else new DefaultPosAssigner
 }

--- a/src/compiler/scala/tools/nsc/ast/Printers.scala
+++ b/src/compiler/scala/tools/nsc/ast/Printers.scala
@@ -201,7 +201,7 @@ trait Printers extends scala.reflect.internal.Printers { this: Global =>
   def newCompactTreePrinter(writer: PrintWriter): CompactTreePrinter = new CompactTreePrinter(writer)
 
   override def newTreePrinter(writer: PrintWriter): AstTreePrinter =
-    if (settings.Ycompacttrees) newCompactTreePrinter(writer)
+    if (settings.Ycompacttrees.value) newCompactTreePrinter(writer)
     else newStandardTreePrinter(writer)
   override def newTreePrinter(stream: OutputStream): AstTreePrinter = newTreePrinter(new PrintWriter(stream))
   override def newTreePrinter(): AstTreePrinter = newTreePrinter(new PrintWriter(ConsoleWriter))

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -664,7 +664,7 @@ self =>
     }
 
     def isSoftModifier: Boolean =
-      currentRun.isScala3 && in.token == IDENTIFIER && softModifierNames.contains(in.name)
+      currentRun.isScala3.value && in.token == IDENTIFIER && softModifierNames.contains(in.name)
 
     /** Is the current token a soft modifier in a position where such a modifier is allowed? */
     def isValidSoftModifier: Boolean =
@@ -938,7 +938,7 @@ self =>
 
     /** Is current ident a `*`, and is it followed by a `)` or `, )`? */
     def followingIsScala3Vararg(): Boolean =
-      currentRun.isScala3 && isRawStar && lookingAhead {
+      currentRun.isScala3.value && isRawStar && lookingAhead {
         in.token == RPAREN ||
         in.token == COMMA && {
           in.nextToken()
@@ -1058,7 +1058,7 @@ self =>
                   tuple))),
             InfixMode.FirstOp
           )
-          if (currentRun.isScala3) andType(tpt) else tpt
+          if (currentRun.isScala3.value) andType(tpt) else tpt
         }
       }
       private def makeExistentialTypeTree(t: Tree) = {
@@ -1135,7 +1135,7 @@ self =>
               else
                 atPos(start)(makeSafeTupleType(inParens(types())))
             case _      =>
-              if (settings.isScala3 && (in.name == raw.PLUS || in.name == raw.MINUS) && lookingAhead(in.token == USCORE)) {
+              if (settings.isScala3.value && (in.name == raw.PLUS || in.name == raw.MINUS) && lookingAhead(in.token == USCORE)) {
                 val start = in.offset
                 val identName = in.name.encode.append("_").toTypeName
                 in.nextToken()
@@ -1268,7 +1268,7 @@ self =>
        */
       def infixType(mode: InfixMode.Value): Tree = {
         val tpt = placeholderTypeBoundary { infixTypeRest(compoundType(), mode) }
-        if (currentRun.isScala3) andType(tpt) else tpt
+        if (currentRun.isScala3.value) andType(tpt) else tpt
       }
 
       /** {{{
@@ -1501,7 +1501,7 @@ self =>
 
       // Scala 2 allowed uprooted Ident for purposes of virtualization
       val t1 =
-        if (currentRun.isScala3) atPos(o2p(start)) { Select(Select(Ident(nme.ROOTPKG), nme.scala_), nme.StringContextName) }
+        if (currentRun.isScala3.value) atPos(o2p(start)) { Select(Select(Ident(nme.ROOTPKG), nme.scala_), nme.StringContextName) }
         else atPos(o2p(start)) { Ident(nme.StringContextName) }
       val t2 = atPos(start) { Apply(t1, partsBuf.toList) } updateAttachment InterpolatedString
       t2 setPos t2.pos.makeTransparent
@@ -2033,7 +2033,7 @@ self =>
         def msg(what: String, instead: String): String = s"`val` keyword in for comprehension is $what: $instead"
         if (hasEq) {
           val without = "instead, bind the value without `val`"
-          if (currentRun.isScala3) syntaxError(in.offset, msg("unsupported", without))
+          if (currentRun.isScala3.value) syntaxError(in.offset, msg("unsupported", without))
           else deprecationWarning(in.offset, msg("deprecated", without), "2.10.0")
         }
         else syntaxError(in.offset, msg("unsupported", "just remove `val`"))
@@ -2476,7 +2476,7 @@ self =>
         syntaxError(implicitOffset, "an implicit parameter section must be last")
       if (warnAt != -1)
         syntaxError(warnAt, "multiple implicit parameter sections are not allowed")
-      else if (settings.warnExtraImplicit) {
+      else if (settings.warnExtraImplicit.value) {
         // guard against anomalous class C(private implicit val x: Int)(implicit s: String)
         val ttl = vds.count { case ValDef(mods, _, _, _) :: _ => mods.isImplicit ; case _ => false }
         if (ttl > 1)
@@ -2587,7 +2587,7 @@ self =>
         checkQMarkDefinition()
         checkKeywordDefinition()
         val pname: TypeName =
-          if (in.token == USCORE && (isAbstractOwner || !currentRun.isScala3)) {
+          if (in.token == USCORE && (isAbstractOwner || !currentRun.isScala3.value)) {
             if (!isAbstractOwner)
               deprecationWarning(in.offset, "Top-level wildcard is not allowed and will error under -Xsource:3", "2.13.7")
             in.nextToken()
@@ -2602,7 +2602,7 @@ self =>
           def msg(what: String) = s"""view bounds are $what; use an implicit parameter instead.
                                      |  example: instead of `def f[A <% Int](a: A)` use `def f[A](a: A)(implicit ev: A => Int)`""".stripMargin
           while (in.token == VIEWBOUND) {
-            if (currentRun.isScala3) syntaxError(in.offset, msg("unsupported"))
+            if (currentRun.isScala3.value) syntaxError(in.offset, msg("unsupported"))
             else deprecationWarning(in.offset, msg("deprecated"), "2.12.0")
             contextBoundBuf += atPos(in.skipToken())(makeFunctionTypeTree(List(Ident(pname)), typ()))
           }
@@ -2680,12 +2680,12 @@ self =>
         val selectors: List[ImportSelector] = in.token match {
           case USCORE =>
             List(wildImportSelector()) // import foo.bar._
-          case IDENTIFIER if currentRun.isScala3 && in.name == raw.STAR =>
+          case IDENTIFIER if currentRun.isScala3.value && in.name == raw.STAR =>
             List(wildImportSelector()) // import foo.bar.*
           case LBRACE =>
             importSelectors()          // import foo.bar.{ x, y, z }
           case _ =>
-            if (settings.isScala3 && lookingAhead { isRawIdent && in.name == nme.as })
+            if (settings.isScala3.value && lookingAhead { isRawIdent && in.name == nme.as })
               List(importSelector())  // import foo.bar as baz
             else {
               val nameOffset = in.offset
@@ -2730,7 +2730,7 @@ self =>
       // Treat an import of `*, given` or `given, *` as if it was an import of `*`
       // since the former in Scala 3 has the same semantics as the latter in Scala 2.
       val selectors =
-        if (currentRun.isScala3 && selectors0.exists(_.isWildcard))
+        if (currentRun.isScala3.value && selectors0.exists(_.isWildcard))
           selectors0.filterNot(sel => sel.name == nme.`given` && sel.rename == sel.name)
         else
           selectors0
@@ -2740,7 +2740,7 @@ self =>
     }
 
     def wildcardOrIdent() =
-      if (in.token == USCORE || settings.isScala3 && isRawStar) { in.nextToken() ; nme.WILDCARD }
+      if (in.token == USCORE || settings.isScala3.value && isRawStar) { in.nextToken() ; nme.WILDCARD }
       else ident()
 
     /** {{{
@@ -2754,7 +2754,7 @@ self =>
       var renameOffset = -1
 
       val rename =
-        if (in.token == ARROW || (settings.isScala3 && isRawIdent && in.name == nme.as)) {
+        if (in.token == ARROW || (settings.isScala3.value && isRawIdent && in.name == nme.as)) {
           in.nextToken()
           renameOffset = in.offset
           if (name == nme.WILDCARD && !bbq) syntaxError(renameOffset, "Wildcard import cannot be renamed")
@@ -2907,10 +2907,13 @@ self =>
         atPos(start, in.skipToken()) {
           val vparamss = paramClauses(nme.CONSTRUCTOR, classContextBounds map (_.duplicate), ofCaseClass = false)
           newLineOptWhenFollowedBy(LBRACE)
-          val rhs = in.token match {
-            case LBRACE if !currentRun.isScala3 => missingEquals(); atPos(in.offset) { constrBlock(vparamss) }
-            case _                              => accept(EQUALS) ; atPos(in.offset) { constrExpr(vparamss) }
-          }
+          val rhs =
+            if (in.token == LBRACE && !currentRun.isScala3.value) {
+              missingEquals(); atPos(in.offset) { constrBlock(vparamss) }
+            }
+            else {
+              accept(EQUALS) ; atPos(in.offset) { constrExpr(vparamss) }
+            }
           DefDef(mods, nme.CONSTRUCTOR, List(), vparamss, TypeTree(), rhs)
         }
       }
@@ -2938,14 +2941,14 @@ self =>
         val rhs =
           if (isStatSep || in.token == RBRACE) {
             if (restype.isEmpty) {
-              if (currentRun.isScala3) syntaxError(in.lastOffset, msg("unsupported", ": Unit"))
+              if (currentRun.isScala3.value) syntaxError(in.lastOffset, msg("unsupported", ": Unit"))
               else deprecationWarning(in.lastOffset, msg("deprecated", ": Unit"), "2.13.0")
               restype = scalaUnitConstr
             }
             newmods |= Flags.DEFERRED
             EmptyTree
           } else if (restype.isEmpty && in.token == LBRACE) {
-            if (currentRun.isScala3) syntaxError(in.offset, msg("unsupported", ": Unit ="))
+            if (currentRun.isScala3.value) syntaxError(in.offset, msg("unsupported", ": Unit ="))
             else deprecationWarning(in.offset, msg("deprecated", ": Unit ="), "2.13.0")
             restype = scalaUnitConstr
             blockExpr()
@@ -2965,7 +2968,7 @@ self =>
           def instead = DefDef(newmods, name.toTermName.decodedName, tparams, vparamss.drop(1), restype, rhs)
           def unaryMsg(what: String) = s"unary prefix operator definition with empty parameter list is $what: instead, remove () to declare as `$instead`"
           def warnNilary(): Unit =
-            if (currentRun.isScala3) syntaxError(nameOffset, unaryMsg("unsupported"))
+            if (currentRun.isScala3.value) syntaxError(nameOffset, unaryMsg("unsupported"))
             else deprecationWarning(nameOffset, unaryMsg("deprecated"), "2.13.4")
           vparamss match {
             case List(List())                               => warnNilary()
@@ -3094,7 +3097,7 @@ self =>
       checkKeywordDefinition()
       val nameOffset = in.offset
       val name = identForType()
-      if (currentRun.isScala3 && in.token == LBRACKET && isAfterLineEnd)
+      if (currentRun.isScala3.value && in.token == LBRACKET && isAfterLineEnd)
         deprecationWarning(in.offset, "type parameters should not follow newline", "2.13.7")
       atPos(start, if (name == tpnme.ERROR) start else nameOffset) {
         savingClassContextBounds {
@@ -3103,7 +3106,7 @@ self =>
           classContextBounds = contextBoundBuf.toList
           val tstart = (in.offset :: classContextBounds.map(_.pos.start)).min
           if (!classContextBounds.isEmpty && mods.isTrait) {
-            val viewBoundsExist = if (currentRun.isScala3) "" else " nor view bounds `<% ...`"
+            val viewBoundsExist = if (currentRun.isScala3.value) "" else " nor view bounds `<% ...`"
               syntaxError(s"traits cannot have type parameters with context bounds `: ...`$viewBoundsExist", skipIt = false)
             classContextBounds = List()
           }
@@ -3198,7 +3201,7 @@ self =>
         val (self, body) = templateBody(isPre = true)
         if (in.token == WITH && (self eq noSelfType)) {
           val advice =
-            if (currentRun.isScala3) "use trait parameters instead."
+            if (currentRun.isScala3.value) "use trait parameters instead."
             else "they will be replaced by trait parameters in 3.0, see the migration guide on avoiding var/val in traits."
           deprecationWarning(braceOffset, s"early initializers are deprecated; $advice", "2.13.0")
           val earlyDefs: List[Tree] = body.map(ensureEarlyDef).filter(_.nonEmpty)
@@ -3221,7 +3224,7 @@ self =>
         copyValDef(vdef)(mods = mods | Flags.PRESUPER)
       case tdef @ TypeDef(mods, name, tparams, rhs) =>
         def msg(what: String): String = s"early type members are $what: move them to the regular body; the semantics are the same"
-        if (currentRun.isScala3) syntaxError(tdef.pos.point, msg("unsupported"))
+        if (currentRun.isScala3.value) syntaxError(tdef.pos.point, msg("unsupported"))
         else deprecationWarning(tdef.pos.point, msg("deprecated"), "2.11.0")
         treeCopy.TypeDef(tdef, mods | Flags.PRESUPER, name, tparams, rhs)
       case docdef @ DocDef(comm, rhs) =>
@@ -3263,7 +3266,7 @@ self =>
       val templatePos = o2p(templateOffset)
 
       // warn now if user wrote parents for package object; `gen.mkParents` adds AnyRef to parents
-      if (currentRun.isScala3 && name == nme.PACKAGEkw && !parents.isEmpty)
+      if (currentRun.isScala3.value && name == nme.PACKAGEkw && !parents.isEmpty)
         deprecationWarning(tstart, """package object inheritance is deprecated (https://github.com/scala/scala-dev/issues/441);
                                      |drop the `extends` clause or use a regular object instead""".stripMargin, "3.0.0")
 

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -528,7 +528,7 @@ trait Scanners extends ScannersCommon {
           (sepRegions.isEmpty || sepRegions.head == RBRACE)) {
         if (pastBlankLine()) insertNL(NEWLINES)
         else if (!isLeadingInfixOperator) insertNL(NEWLINE)
-        else if (!currentRun.isScala3) {
+        else if (!currentRun.isScala3.value) {
           val msg = """|Line starts with an operator that in future
                        |will be taken as an infix expression continued from the previous line.
                        |To force the previous interpretation as a separate statement,
@@ -978,7 +978,7 @@ trait Scanners extends ScannersCommon {
         nextRawChar()
         if (isTripleQuote()) {
           setStrVal()
-          if(!currentRun.isScala3) replaceUnicodeEscapesInTriple()
+          if(!currentRun.isScala3.value) replaceUnicodeEscapesInTriple()
           token = STRINGLIT
         } else
           getRawStringLit()
@@ -1283,7 +1283,7 @@ trait Scanners extends ScannersCommon {
           syntaxError("missing integer number") // e.g., 0x; previous error shadows this one
           0L
         } else {
-          if (settings.warnOctalLiteral && base == 10 && strVal.charAt(0) == '0' && strVal.length() > 1)
+          if (settings.warnOctalLiteral.value && base == 10 && strVal.charAt(0) == '0' && strVal.length() > 1)
             deprecationWarning("Decimal integer literals should not have a leading zero. (Octal syntax is obsolete.)", since="2.10")
           convertIt
         }

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -651,7 +651,7 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
       // without it.  This is particularly bad because the availability of
       // generic information could disappear as a consequence of a seemingly
       // unrelated change.
-         settings.Ynogenericsig
+         settings.Ynogenericsig.value
       || sym.isArtifact
       || sym.isLiftedMethod
       || sym.isBridge
@@ -692,7 +692,7 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
             catch { case _: Throwable => false }
           }
 
-      if (settings.Xverify) {
+      if (settings.Xverify.value) {
         // Run the signature parser to catch bogus signatures.
         val isValidSignature = wrap {
           // Alternative: scala.tools.reflect.SigParser (frontend to sun.reflect.generics.parser.SignatureParser)

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -214,7 +214,7 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
 
       } else {
 
-        if (!settings.noForwarders) {
+        if (!settings.noForwarders.value) {
           val lmoc = claszSymbol.companionModule
           // add static forwarders if there are no name conflicts; see bugs #363 and #1735
           if (lmoc != NoSymbol) {

--- a/src/compiler/scala/tools/nsc/fsc/CompileClient.scala
+++ b/src/compiler/scala/tools/nsc/fsc/CompileClient.scala
@@ -31,12 +31,12 @@ class StandardCompileClient extends HasCompileSocket with CompileOutputCommon {
     val settings     = new FscSettings(Console.println)
     val command      = new OfflineCompilerCommand(args.toList, settings)
     val shutdown     = settings.shutdown.value
-    val extraVmArgs  = if (settings.preferIPv4) List(s"-Djava.net.preferIPv4Stack=true") else Nil
+    val extraVmArgs  = if (settings.preferIPv4.value) List(s"-Djava.net.preferIPv4Stack=true") else Nil
 
     val vmArgs  = settings.jvmargs.unparse ++ settings.defines.unparse ++ extraVmArgs
     val fscArgs = args.toList ++ command.extraFscArgs
 
-    if (settings.version) {
+    if (settings.version.value) {
       Console println versionMsg
       return true
     }

--- a/src/compiler/scala/tools/nsc/plugins/Plugins.scala
+++ b/src/compiler/scala/tools/nsc/plugins/Plugins.scala
@@ -122,7 +122,7 @@ trait Plugins { global: Global =>
         def withPlug          = plug :: pick(tail, plugNames + plug.name, phaseNames ++ plugPhaseNames)
         lazy val commonPhases = phaseNames intersect plugPhaseNames
 
-        def note(msg: String): Unit = if (settings.verbose) inform(msg format plug.name)
+        def note(msg: String): Unit = if (settings.verbose.value) inform(msg format plug.name)
         def fail(msg: String)       = { note(msg) ; withoutPlug }
 
         if (plugNames contains plug.name)

--- a/src/compiler/scala/tools/nsc/profile/Profiler.scala
+++ b/src/compiler/scala/tools/nsc/profile/Profiler.scala
@@ -30,7 +30,7 @@ import scala.tools.nsc.{Global, Phase, Settings}
 
 object Profiler {
   def apply(settings: Settings):Profiler =
-    if (!settings.YprofileEnabled) NoOpProfiler
+    if (!settings.YprofileEnabled.value) NoOpProfiler
     else {
       val reporter = settings.YprofileDestination.value match {
         case _ if !settings.YprofileDestination.isSetByUser => NoOpProfileReporter

--- a/src/compiler/scala/tools/nsc/reporters/ConsoleReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/ConsoleReporter.scala
@@ -26,7 +26,7 @@ class ConsoleReporter(val settings: Settings, val reader: BufferedReader, val wr
 
   override def finish(): Unit = {
     import reflect.internal.util.StringOps.countElementsAsString
-    if (!settings.nowarn && hasWarnings)
+    if (!settings.nowarn.value && hasWarnings)
       echo(countElementsAsString(warningCount, WARNING.toString.toLowerCase))
     if (hasErrors)
       echo(countElementsAsString(errorCount, ERROR.toString.toLowerCase))

--- a/src/compiler/scala/tools/nsc/reporters/PrintReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/PrintReporter.scala
@@ -43,7 +43,7 @@ trait PrintReporter extends internal.Reporter {
   private def printMessage(msg: String): Unit = {
     writer.println(trimTrailing(msg))
     writer.flush()
-    if (settings.prompt) displayPrompt()
+    if (settings.prompt.value) displayPrompt()
   }
 
   /** Prints the message to the echoWriter, which is usually stdout. */

--- a/src/compiler/scala/tools/nsc/reporters/Reporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/Reporter.scala
@@ -118,7 +118,7 @@ abstract class FilteringReporter extends Reporter {
     }
     // Invoked when an error or warning is filtered by position.
     @inline def suppress = {
-      if (settings.prompt) doReport(pos, msg, severity)
+      if (settings.prompt.value) doReport(pos, msg, severity)
       else if (settings.isDebug) doReport(pos, s"[ suppressed ] $msg", severity)
       Suppress
     }

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -188,9 +188,9 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
   val termConflict    = ChoiceSetting     ("-Yresolve-term-conflict", "strategy", "Resolve term conflicts.", List("package", "object", "error"), "error")
   val Ynogenericsig   = BooleanSetting    ("-Yno-generic-signatures", "Suppress generation of generic signatures for Java.")
   val noimports       = BooleanSetting    ("-Yno-imports", "Compile without importing scala.*, java.lang.*, or Predef.")
-                       .withPostSetHook(bs => if (bs) imports.value = Nil)
+                       .withPostSetHook(bs => if (bs.value) imports.value = Nil)
   val nopredef        = BooleanSetting    ("-Yno-predef", "Compile without importing Predef.")
-                       .withPostSetHook(bs => if (bs && !noimports) imports.value = "java.lang" :: "scala" :: Nil)
+                       .withPostSetHook(bs => if (bs.value && !noimports.value) imports.value = "java.lang" :: "scala" :: Nil)
   val imports         = MultiStringSetting(name="-Yimports", arg="import", descr="Custom root imports, default is `java.lang,scala,scala.Predef`.", helpText=Some(
   sm"""|Specify a list of packages and objects to import from as "root" imports.
        |Root imports form the root context in which all Scala source is evaluated.
@@ -523,9 +523,9 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
   val Ystatistics = PhasesSetting("-Vstatistics", "Print compiler statistics for specific phases", "parser,typer,patmat,erasure,cleanup,jvm")
     .withPostSetHook(s => YstatisticsEnabled.value = s.value.nonEmpty)
     .withAbbreviation("-Ystatistics")
-  val YstatisticsEnabled = BooleanSetting("-Ystatistics-enabled", "Internal setting, indicating that statistics are enabled for some phase.").internalOnly().withPostSetHook(s => if (s) StatisticsStatics.enableColdStatsAndDeoptimize())
+  val YstatisticsEnabled = BooleanSetting("-Ystatistics-enabled", "Internal setting, indicating that statistics are enabled for some phase.").internalOnly().withPostSetHook(s => if (s.value) StatisticsStatics.enableColdStatsAndDeoptimize())
   val YhotStatisticsEnabled = BooleanSetting("-Vhot-statistics", s"Enable `${Ystatistics.name}` to also print hot statistics.")
-    .withAbbreviation("-Yhot-statistics").withPostSetHook(s => if (s && YstatisticsEnabled) StatisticsStatics.enableHotStatsAndDeoptimize())
+    .withAbbreviation("-Yhot-statistics").withPostSetHook(s => if (s.value && YstatisticsEnabled.value) StatisticsStatics.enableHotStatsAndDeoptimize())
   val Yshowsyms       = BooleanSetting("-Vsymbols", "Print the AST symbol hierarchy after each phase.") withAbbreviation "-Yshow-syms"
   val Ytyperdebug        = BooleanSetting("-Vtyper", "Trace type assignments.") withAbbreviation "-Ytyper-debug"
   val Vimplicits            = BooleanSetting("-Vimplicits", "Print dependent missing implicits.").withAbbreviation("-Xlog-implicits")

--- a/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
@@ -48,7 +48,7 @@ trait StandardScalaSettings { _: MutableSettings =>
   }
   val g =               ChoiceSetting ("-g", "level", "Set level of generated debugging info.", List("none", "source", "line", "vars", "notailcalls"), "vars")
   val help =           BooleanSetting ("-help", "Print a synopsis of standard options") withAbbreviation "--help" withAbbreviation("-h")
-  val nowarn =         BooleanSetting ("-nowarn", "Generate no warnings.") withAbbreviation "--no-warnings" withPostSetHook { s => if (s) maxwarns.value = 0 }
+  val nowarn =         BooleanSetting ("-nowarn", "Generate no warnings.") withAbbreviation "--no-warnings" withPostSetHook { s => if (s.value) maxwarns.value = 0 }
   val optimise:        BooleanSetting // depends on post hook which mutates other settings
   val print =          BooleanSetting ("-print", "Print program with Scala-specific features removed.") withAbbreviation "--print"
   val release =

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -240,7 +240,7 @@ trait Warnings {
   def warnRecurseWithDefault     = lint contains RecurseWithDefault
   def unitSpecialization         = lint contains UnitSpecialization
   def multiargInfix              = lint contains MultiargInfix
-  def lintImplicitRecursion      = lint.contains(ImplicitRecursion) || (warnSelfImplicit: @nowarn("cat=deprecation"))
+  def lintImplicitRecursion      = lint.contains(ImplicitRecursion) || (warnSelfImplicit.value: @nowarn("cat=deprecation"))
   def lintUniversalMethods       = lint.contains(UniversalMethods)
 
   // The Xlint warning group.

--- a/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
@@ -188,10 +188,10 @@ abstract class SymbolLoaders {
     ((classRep.binary, classRep.source) : @unchecked) match {
       case (Some(bin), Some(src))
       if platform.needCompile(bin, src) && !binaryOnly(owner, nameOf(classRep)) =>
-        if (settings.verbose) inform("[symloader] picked up newer source file for " + src.path)
+        if (settings.verbose.value) inform("[symloader] picked up newer source file for " + src.path)
         enterToplevelsFromSource(owner, nameOf(classRep), src)
       case (None, Some(src)) =>
-        if (settings.verbose) inform("[symloader] no class, picked up source file for " + src.path)
+        if (settings.verbose.value) inform("[symloader] no class, picked up source file for " + src.path)
         enterToplevelsFromSource(owner, nameOf(classRep), src)
       case (Some(bin), _) =>
         enterClassAndModule(owner, nameOf(classRep), new ClassfileLoader(bin, _, _))

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -162,7 +162,7 @@ abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
         this.clazz        = clazz
         this.staticModule = module
         this.isScala      = false
-        this.YtastyReader = settings.YtastyReader
+        this.YtastyReader = settings.YtastyReader.value
 
         val magic = in.getInt(in.bp)
         if (magic != JAVA_MAGIC && file.name.endsWith(".sig")) {
@@ -421,7 +421,7 @@ abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
     //   - better owner than `NoSymbol`
     //   - remove eager warning
     val msg = s"Class $name not found - continuing with a stub."
-    if ((!settings.isScaladoc) && (settings.verbose || settings.isDeveloper))
+    if ((!settings.isScaladoc) && (settings.verbose.value || settings.isDeveloper))
       loaders.warning(NoPosition, msg, WarningCategory.OtherDebug, clazz.fullNameString)
     NoSymbol.newStubSymbol(name.toTypeName, msg)
   }

--- a/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
@@ -89,7 +89,7 @@ abstract class Pickler extends SubComponent {
                 if (writeToSigFile)
                   writeSigFile(sym, pickle)
               }
-              if (sigWriter.isDefined && settings.YpickleWriteApiOnly) {
+              if (sigWriter.isDefined && settings.YpickleWriteApiOnly.value) {
                 pickle(noPrivates = false, writeToSymData = true, writeToSigFile = false)
                 pickle(noPrivates = true, writeToSymData = false, writeToSigFile = true)
               } else {
@@ -142,7 +142,7 @@ abstract class Pickler extends SubComponent {
     private def closeSigWriter(): Unit = {
       sigWriter.foreach { writer =>
         writer.close()
-        if (settings.verbose)
+        if (settings.verbose.value)
           reporter.echo(NoPosition, "[sig files written]")
       }
     }

--- a/src/compiler/scala/tools/nsc/tasty/bridge/ContextOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/ContextOps.scala
@@ -204,7 +204,7 @@ trait ContextOps { self: TastyUniverse =>
 
     final def globallyVisibleOwner: Symbol = owner.logicallyEnclosingMember
 
-    final def ignoreAnnotations: Boolean = u.settings.YtastyNoAnnotations
+    final def ignoreAnnotations: Boolean = u.settings.YtastyNoAnnotations.value
 
     def requiresLatentEntry(decl: Symbol): Boolean = decl.isScala3Inline
 
@@ -213,7 +213,7 @@ trait ContextOps { self: TastyUniverse =>
     }
 
     final def log(str: => String): Unit = {
-      if (u.settings.YdebugTasty) {
+      if (u.settings.YdebugTasty.value) {
         logImpl(str)
       }
     }
@@ -238,7 +238,7 @@ trait ContextOps { self: TastyUniverse =>
         op.tap(eval => logImpl(s"${yellow(id0)} ${cyan(s">>>")} ${magenta(i.res(eval))}$modStr"))
       }
 
-      if (u.settings.YdebugTasty) initialContext.subTrace(addInfo(info, op))
+      if (u.settings.YdebugTasty.value) initialContext.subTrace(addInfo(info, op))
       else op
     }
 

--- a/src/compiler/scala/tools/nsc/transform/CleanUp.scala
+++ b/src/compiler/scala/tools/nsc/transform/CleanUp.scala
@@ -80,7 +80,7 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
     def transformApplyDynamic(ad: ApplyDynamic) = {
       val qual0 = ad.qual
       val params = ad.args
-        if (settings.logReflectiveCalls)
+        if (settings.logReflectiveCalls.value)
           reporter.echo(ad.pos, "method invocation uses reflection")
 
         val typedPos = typedWithPos(ad.pos) _

--- a/src/compiler/scala/tools/nsc/transform/Constructors.scala
+++ b/src/compiler/scala/tools/nsc/transform/Constructors.scala
@@ -791,7 +791,7 @@ abstract class Constructors extends Statics with Transform with TypingTransforme
       val prunedStats = (defs filterNot omittableStat) ::: delayedHookDefs ::: constructors
 
       val statsWithInitChecks =
-        if (settings.checkInit) {
+        if (settings.checkInit.value) {
           val addChecks = new SynthInitCheckedAccessorsIn(currentOwner)
           prunedStats mapConserve {
             case dd: DefDef if addChecks.needsWrapping(dd) => deriveDefDef(dd)(addChecks.wrapRhsWithInitChecks(dd.symbol))

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -94,8 +94,8 @@ abstract class Erasure extends InfoTransform
       if (! ts.isEmpty && ! result) { apply(ts.head) ; untilApply(ts.tail) }
   }
 
-  override protected def verifyJavaErasure = settings.Xverify || settings.isDebug
-  private def needsJavaSig(sym: Symbol, tp: Type, throwsArgs: List[Type]) = !settings.Ynogenericsig && {
+  override protected def verifyJavaErasure = settings.Xverify.value || settings.isDebug
+  private def needsJavaSig(sym: Symbol, tp: Type, throwsArgs: List[Type]) = !settings.Ynogenericsig.value && {
     def needs(tp: Type) = NeedsSigCollector(sym.isClassConstructor).collect(tp)
     needs(tp) || throwsArgs.exists(needs)
   }

--- a/src/compiler/scala/tools/nsc/transform/Fields.scala
+++ b/src/compiler/scala/tools/nsc/transform/Fields.scala
@@ -501,7 +501,7 @@ abstract class Fields extends InfoTransform with ast.TreeDSL with TypingTransfor
 
         val newDecls =
           // under -Xcheckinit we generate all kinds of bitmaps, even when there are no lazy vals
-          if (expandedModulesAndLazyVals.isEmpty && mixedInAccessorAndFields.isEmpty && !settings.checkInit)
+          if (expandedModulesAndLazyVals.isEmpty && mixedInAccessorAndFields.isEmpty && !settings.checkInit.value)
             oldDecls.filterNot(omittableField)
           else {
             // must not alter `decls` directly

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -1294,7 +1294,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
    *  If it is a 'no-specialization' run, it is applied only to loaded symbols.
    */
   override def transformInfo(sym: Symbol, tpe: Type): Type = {
-    if (settings.nospecialization && currentRun.compiles(sym)) {
+    if (settings.nospecialization.value && currentRun.compiles(sym)) {
       tpe
     } else tpe.resultType match {
       case cinfo @ ClassInfoType(parents, decls, clazz) if !unspecializableClass(cinfo) =>
@@ -1524,7 +1524,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
 
   class SpecializationTransformer(unit: CompilationUnit) extends TypingTransformer(unit) {
 
-    override def transformUnit(unit: CompilationUnit): Unit = if (!settings.nospecialization) {
+    override def transformUnit(unit: CompilationUnit): Unit = if (!settings.nospecialization.value) {
       informProgress("specializing " + unit)
       try {
         exitingSpecialize(super.transformUnit(unit))

--- a/src/compiler/scala/tools/nsc/transform/async/AsyncPhase.scala
+++ b/src/compiler/scala/tools/nsc/transform/async/AsyncPhase.scala
@@ -25,7 +25,7 @@ abstract class AsyncPhase extends Transform with TypingTransformers with AnfTran
   protected[async] val tracing = new Tracing
 
   val phaseName: String = "async"
-  override def enabled: Boolean = settings.async
+  override def enabled: Boolean = settings.async.value
 
   private final case class AsyncAttachment(awaitSymbol: Symbol, postAnfTransform: Block => Block,
                                            stateDiagram: ((Symbol, Tree) => Option[String => Unit]),
@@ -42,7 +42,7 @@ abstract class AsyncPhase extends Transform with TypingTransformers with AnfTran
   final def markForAsyncTransform(owner: Symbol, method: DefDef, awaitMethod: Symbol,
                                   config: Map[String, AnyRef]): DefDef = {
     val pos = owner.pos
-    if (!settings.async)
+    if (!settings.async.value)
       reporter.warning(pos, s"${settings.async.name} must be enabled for async transformation.")
     sourceFilesToTransform += pos.source
     val postAnfTransform = config.getOrElse("postAnfTransform", (x: Block) => x).asInstanceOf[Block => Block]
@@ -61,7 +61,7 @@ abstract class AsyncPhase extends Transform with TypingTransformers with AnfTran
 
   /** Should refchecks defer reporting `@compileTimeOnly` errors for `sym` and instead let this phase issue the warning
    *  if they survive the async tranform? */
-  private[scala] def deferCompileTimeOnlyError(sym: Symbol): Boolean = settings.async && {
+  private[scala] def deferCompileTimeOnlyError(sym: Symbol): Boolean = settings.async.value && {
     awaits.contains(sym) || {
       val msg = sym.compileTimeOnlyMessage.getOrElse("")
       val shouldDefer =
@@ -77,7 +77,7 @@ abstract class AsyncPhase extends Transform with TypingTransformers with AnfTran
     private lazy val liftableMap = new mutable.AnyRefMap[Symbol, (Symbol, List[Tree])]()
 
     override def transformUnit(unit: CompilationUnit): Unit = {
-      if (settings.async) {
+      if (settings.async.value) {
         // NoSourceFile can happen for, e.g., toolbox compilation; overestimate by always transforming them. See test/async/jvm/toolbox.scala
         val shouldTransform = unit.source == NoSourceFile || sourceFilesToTransform.contains(unit.source)
         if (shouldTransform) super.transformUnit(unit)

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
@@ -190,7 +190,7 @@ trait MatchTranslation {
         case _                                                    => (cases, None)
       }
 
-      if (!settings.XnoPatmatAnalysis) checkMatchVariablePatterns(nonSyntheticCases)
+      if (!settings.XnoPatmatAnalysis.value) checkMatchVariablePatterns(nonSyntheticCases)
 
       // we don't transform after uncurry
       // (that would require more sophistication when generating trees,
@@ -229,7 +229,7 @@ trait MatchTranslation {
       // if they're already simple enough to be handled by the back-end, we're done
       if (caseDefs forall treeInfo.isCatchCase) {
         // well, we do need to look for unreachable cases
-        if (!settings.XnoPatmatAnalysis) unreachableTypeSwitchCase(caseDefs).foreach(cd => reportUnreachable(cd.body.pos))
+        if (!settings.XnoPatmatAnalysis.value) unreachableTypeSwitchCase(caseDefs).foreach(cd => reportUnreachable(cd.body.pos))
 
         caseDefs
       } else {
@@ -255,7 +255,7 @@ trait MatchTranslation {
 
           val exSym = freshSym(pos, ThrowableTpe, "ex")
           val suppression =
-            if (settings.XnoPatmatAnalysis) Suppression.FullSuppression
+            if (settings.XnoPatmatAnalysis.value) Suppression.FullSuppression
             else Suppression.NoSuppression.copy(suppressExhaustive = true) // try/catches needn't be exhaustive
 
           List(

--- a/src/compiler/scala/tools/nsc/typechecker/Adaptations.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Adaptations.scala
@@ -97,7 +97,7 @@ trait Adaptations {
       }
       if (args.nonEmpty)
         warnAdaptation
-      else if (currentRun.isScala3)
+      else if (currentRun.isScala3.value)
         noAdaptation
       else
         deprecatedAdaptation

--- a/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
@@ -92,7 +92,7 @@ trait Analyzer extends AnyRef
     def newPhase(prev: Phase): StdPhase = new TyperPhase(prev)
     final class TyperPhase(prev: Phase) extends StdPhase(prev) {
       override def keepsTypeParams = false
-      override def shouldSkipThisPhaseForJava: Boolean = !(settings.YpickleJava || createJavadoc)
+      override def shouldSkipThisPhaseForJava: Boolean = !settings.YpickleJava.value && !createJavadoc
       resetTyper()
       // the log accumulates entries over time, even though it should not (Adriaan, Martin said so).
       // Lacking a better fix, we clear it here (before the phase is created, meaning for each
@@ -116,7 +116,7 @@ trait Analyzer extends AnyRef
           val typer = newTyper(rootContext(unit))
           unit.body = typer.typed(unit.body)
           // interactive typed may finish by throwing a `TyperResult`
-          if (!settings.Youtline) {
+          if (!settings.Youtline.value) {
             for (workItem <- unit.toCheck) workItem()
             if (!settings.isScaladoc && settings.warnUnusedImport)
               warnUnusedImports(unit)

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -108,7 +108,7 @@ trait ContextErrors extends splain.SplainErrors {
     def issueTypeError(err: AbsTypeError)(implicit context: Context): Unit = { context.issue(err) }
 
     def typeErrorMsg(context: Context, found: Type, req: Type) =
-      if (context.openImplicits.nonEmpty && !settings.Vimplicits)
+      if (context.openImplicits.nonEmpty && !settings.Vimplicits.value)
          // OPT: avoid error string creation for errors that won't see the light of day, but predicate
         //       this on -Xsource:2.13 for bug compatibility with https://github.com/scala/scala/pull/7147#issuecomment-418233611
         "type mismatch"
@@ -1239,7 +1239,7 @@ trait ContextErrors extends splain.SplainErrors {
       def NotWithinBounds(tree: Tree, prefix: String, targs: List[Type],
                           tparams: List[Symbol], kindErrors: List[String]) =
         issueNormalTypeError(tree,
-          NotWithinBoundsErrorMessage(prefix, targs, tparams, settings.explaintypes))
+          NotWithinBoundsErrorMessage(prefix, targs, tparams, settings.explaintypes.value))
 
       //substExpr
       def PolymorphicExpressionInstantiationError(tree: Tree, undetparams: List[Symbol], pt: Type) =

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1069,7 +1069,7 @@ trait Contexts { self: Analyzer =>
       !(
         // [eed3si9n] ideally I'd like to do this: val fd = currentRun.isScala3 && sym.isDeprecated
         // but implicit caching currently does not report sym.isDeprecated correctly.
-        currentRun.isScala3 && (sym == currentRun.runDefinitions.Predef_any2stringaddMethod)
+        currentRun.isScala3.value && (sym == currentRun.runDefinitions.Predef_any2stringaddMethod)
       ) &&
       !(imported && {
         val e = scope.lookupEntry(name)

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -444,7 +444,7 @@ trait Implicits extends splain.SplainData {
     def pos = if (pos0 != NoPosition) pos0 else tree.pos
 
     @inline final def failure(what: Any, reason: => String, pos: Position = this.pos): SearchResult = {
-      if (settings.debug)
+      if (settings.debug.value)
         reporter.echo(pos, s"$what is not a valid implicit value for $pt because:\n$reason")
       SearchFailure
     }
@@ -1509,7 +1509,7 @@ trait Implicits extends splain.SplainData {
       )
       // todo. migrate hardcoded materialization in Implicits to corresponding implicit macros
       val materializer = atPos(pos.focus)(gen.mkMethodCall(TagMaterializers(tagClass), List(tp), if (prefix != EmptyTree) List(prefix) else List()))
-      if (settings.debug) reporter.echo(pos, "materializing requested %s.%s[%s] using %s".format(pre, tagClass.name, tp, materializer))
+      if (settings.debug.value) reporter.echo(pos, "materializing requested %s.%s[%s] using %s".format(pre, tagClass.name, tp, materializer))
       if (context.macrosEnabled) success(materializer)
       // don't call `failure` here. if macros are disabled, we just fail silently
       // otherwise -Vimplicits/-Vdebug will spam the long with zillions of "macros are disabled"

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -903,9 +903,9 @@ trait Infer extends Checkable {
         isAsSpecificValueType(rtpe1, tpe2, undef1 ::: tparams1, undef2)
       case _                         =>
         tpe2 match {
-          case PolyType(tparams2, rtpe2)                   => isAsSpecificValueType(tpe1, rtpe2, undef1, undef2 ::: tparams2)
-          case _ if !currentRun.isScala3ImplicitResolution => existentialAbstraction(undef1, tpe1) <:< existentialAbstraction(undef2, tpe2)
-          case _                                           =>
+          case PolyType(tparams2, rtpe2) => isAsSpecificValueType(tpe1, rtpe2, undef1, undef2 ::: tparams2)
+          case _ if !currentRun.isScala3ImplicitResolution.value => existentialAbstraction(undef1, tpe1) <:< existentialAbstraction(undef2, tpe2)
+          case _ =>
             // Backport of fix for https://github.com/scala/bug/issues/2509
             // from Dotty https://github.com/lampepfl/dotty/commit/89540268e6c49fb92b9ca61249e46bb59981bf5a
             //

--- a/src/compiler/scala/tools/nsc/typechecker/MacroAnnotationNamers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MacroAnnotationNamers.scala
@@ -537,7 +537,7 @@ trait MacroAnnotationNamers { self: Analyzer =>
               if (defSym == NoSymbol) cx = cx.outer
             }
           }
-          if (defSym == NoSymbol && settings.exposeEmptyPackage) {
+          if (defSym == NoSymbol && settings.exposeEmptyPackage.value) {
             defSym = rootMirror.EmptyPackageClass.info member name
           }
 

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -845,7 +845,7 @@ trait Namers extends MethodSynthesis {
           // check that lower bound is not an F-bound
           // but carefully: class Foo[T <: Bar[_ >: T]] should be allowed
           for (tp1 @ TypeRef(_, sym, _) <- lo) {
-            if (settings.breakCycles) {
+            if (settings.breakCycles.value) {
               if (!sym.maybeInitialize) {
                 log(s"Cycle inspecting $lo for possible f-bounds: ${sym.fullLocationString}")
                 return sym
@@ -1127,7 +1127,7 @@ trait Namers extends MethodSynthesis {
         case _ => defnTyper.computeType(tree.rhs, pt)
       }
       tree.tpt.defineType {
-        if (currentRun.isScala3 && !pt.isWildcard && pt != NoType && !pt.isErroneous) pt
+        if (currentRun.isScala3.value && !pt.isWildcard && pt != NoType && !pt.isErroneous) pt
         else dropIllegalStarTypes(widenIfNecessary(tree.symbol, rhsTpe, pt))
       }.setPos(tree.pos.focus)
       tree.tpt.tpe
@@ -1257,7 +1257,7 @@ trait Namers extends MethodSynthesis {
         enclosingNamerWithScope(clazz.owner.rawInfo.decls).ensureCompanionObject(cdef)
       }
 
-      if (settings.YmacroAnnotations && treeInfo.isMacroAnnotation(cdef))
+      if (settings.YmacroAnnotations.value && treeInfo.isMacroAnnotation(cdef))
         typer.typedMacroAnnotation(cdef)
 
       pluginsTp
@@ -1471,7 +1471,7 @@ trait Namers extends MethodSynthesis {
             context.warning(ddef.pos, msg, WarningCategory.OtherNullaryOverride)
             meth.updateAttachment(NullaryOverrideAdapted)
           }
-          context.unit.toCheck += (if (currentRun.isScala3) error _ else warn _)
+          context.unit.toCheck += (if (currentRun.isScala3.value) error _ else warn _)
           ListOfNil
         } else vparamSymss
       }

--- a/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
@@ -553,7 +553,7 @@ trait NamesDefaults { self: Analyzer =>
         val NamedArg(Ident(name), rhs) = arg: @unchecked
         params indexWhere (p => matchesName(p, name, argIndex)) match {
           case -1 =>
-            val warnVariableInScope = !currentRun.isScala3 && context0.lookupSymbol(name, _.isVariable).isSuccess
+            val warnVariableInScope = !currentRun.isScala3.value && context0.lookupSymbol(name, _.isVariable).isSuccess
             UnknownParameterNameNamesDefaultError(arg, name, warnVariableInScope)
           case paramPos if argPos contains paramPos =>
             val existingArgIndex = argPos.indexWhere(_ == paramPos)

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -438,7 +438,7 @@ abstract class RefChecks extends Transform {
                   && !javaDetermined(member) && !member.overrides.exists(javaDetermined)
               ) {
                 val msg = "method with a single empty parameter list overrides method without any parameter list"
-                if (currentRun.isScala3)
+                if (currentRun.isScala3.value)
                   overrideErrorWithMemberInfo(msg)
                 else
                   refchecksWarning(member.pos, msg, WarningCategory.OtherNullaryOverride)
@@ -812,7 +812,7 @@ abstract class RefChecks extends Transform {
             .filter(c => c.exists && c.isClass)
           overridden foreach { sym2 =>
             def msg(what: String) = s"shadowing a nested class of a parent is $what but $clazz shadows $sym2 defined in ${sym2.owner}; rename the class to something else"
-            if (currentRun.isScala3) reporter.error(clazz.pos, msg("unsupported"))
+            if (currentRun.isScala3.value) reporter.error(clazz.pos, msg("unsupported"))
             else runReporting.deprecationWarning(clazz.pos, clazz, currentOwner, msg("deprecated"), "2.13.2")
           }
         }
@@ -1239,7 +1239,7 @@ abstract class RefChecks extends Transform {
       catch {
         case ex: TypeError =>
           reporter.error(tree0.pos, ex.getMessage())
-          if (settings.explaintypes) {
+          if (settings.explaintypes.value) {
             val bounds = tparams map (tp => tp.info.instantiateTypeParams(tparams, argtps).bounds)
             foreach2(argtps, bounds)((targ, bound) => explainTypes(bound.lo, targ))
             foreach2(argtps, bounds)((targ, bound) => explainTypes(targ, bound.hi))

--- a/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
@@ -371,7 +371,7 @@ trait SyntheticMethods extends ast.TreeDSL {
           !hasOverridingImplementation(m) || {
             clazz.isDerivedValueClass && (m == Any_hashCode || m == Any_equals) && {
               // Without a means to suppress this warning, I've thought better of it.
-              if (settings.warnValueOverrides) {
+              if (settings.warnValueOverrides.value) {
                  (clazz.info nonPrivateMember m.name) filter (m => (m.owner != AnyClass) && (m.owner != clazz) && !m.isDeferred) andAlso { m =>
                    typer.context.warning(clazz.pos, s"Implementation of ${m.name} inherited from ${m.owner} overridden in $clazz to enforce value class semantics", WarningCategory.Other /* settings.warnValueOverrides is not exposed as compiler flag */)
                  }

--- a/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
@@ -24,7 +24,7 @@ abstract class TreeCheckers extends Analyzer {
   override protected def onTreeCheckerError(pos: Position, msg: String): Unit = {
     // could thread the `site` through ContextReporter for errors, like we do for warnings, but it
     // looks like an overkill since it would only be used here.
-    if (settings.fatalWarnings)
+    if (settings.fatalWarnings.value)
       runReporting.warning(pos, "\n** Error during internal checking:\n" + msg, WarningCategory.OtherDebug, site = "")
   }
 
@@ -177,7 +177,7 @@ abstract class TreeCheckers extends Analyzer {
   def errorFn(msg: Any): Unit                = errorFn(NoPosition, msg)
 
   def informFn(msg: Any): Unit = {
-    if (settings.verbose || settings.isDebug)
+    if (settings.verbose.value || settings.isDebug)
       println("[check: %s] %s".format(phase.prev, msg))
   }
 
@@ -195,7 +195,7 @@ abstract class TreeCheckers extends Analyzer {
   }
 
   def checkTrees(): Unit = {
-    if (settings.verbose)
+    if (settings.verbose.value)
       Console.println("[consistency check at the beginning of phase " + phase + "]")
 
     currentRun.units foreach (x => wrap(x)(check(x)))

--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -487,7 +487,7 @@ trait TypeDiagnostics extends splain.SplainDiagnostics {
     }
 
     def apply(context: Context, tree: Tree): Tree = {
-      if (settings.warnDeadCode && context.unit.exists && treeOK(tree) && !context.contextMode.inAny(ContextMode.SuppressDeadArgWarning))
+      if (settings.warnDeadCode.value && context.unit.exists && treeOK(tree) && !context.contextMode.inAny(ContextMode.SuppressDeadArgWarning))
         context.warning(tree.pos, "dead code following this construct", WarningCategory.WFlagDeadCode)
       tree
     }

--- a/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
@@ -97,7 +97,7 @@ trait Unapplies extends ast.TreeDSL {
   }
 
   private def applyShouldInheritAccess(mods: Modifiers) =
-    currentRun.isScala3 && (mods.hasFlag(PRIVATE) || (!mods.hasFlag(PROTECTED) && mods.hasAccessBoundary))
+    currentRun.isScala3.value && (mods.hasFlag(PRIVATE) || (!mods.hasFlag(PROTECTED) && mods.hasAccessBoundary))
 
   /** The module corresponding to a case class; overrides toString to show the module's name
    */
@@ -271,7 +271,7 @@ trait Unapplies extends ast.TreeDSL {
       val argss = mmap(paramss)(toIdent)
       val body: Tree = New(classTpe, argss)
       val copyMods =
-        if (currentRun.isScala3) {
+        if (currentRun.isScala3.value) {
           val inheritedMods = constrMods(cdef)
           Modifiers(SYNTHETIC | (inheritedMods.flags & AccessFlags), inheritedMods.privateWithin)
         }

--- a/src/compiler/scala/tools/nsc/typechecker/splain/SplainData.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/splain/SplainData.scala
@@ -41,14 +41,14 @@ trait SplainData {
     def removeErrorsFor(tpe: Type): Unit = errors = errors.dropWhile(_.tpe == tpe)
 
     def startSearch(expectedType: Type): Unit = {
-      if (settings.Vimplicits) {
+      if (settings.Vimplicits.value) {
         if (!nested) errors = List()
         stack = expectedType :: stack
       }
     }
 
     def finishSearch(success: Boolean, expectedType: Type): Unit = {
-      if (settings.Vimplicits) {
+      if (settings.Vimplicits.value) {
         if (success) removeErrorsFor(expectedType)
         stack = stack.drop(1)
       }

--- a/src/compiler/scala/tools/nsc/typechecker/splain/SplainDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/splain/SplainDiagnostics.scala
@@ -20,7 +20,7 @@ trait SplainDiagnostics extends splain.SplainFormatting {
   import global._
 
   def splainFoundReqMsg(found: Type, req: Type): String = {
-    if (settings.VtypeDiffs) ";\n" + showFormattedL(formatDiff(found, req, top = true), break = true).indent.joinLines
+    if (settings.VtypeDiffs.value) ";\n" + showFormattedL(formatDiff(found, req, top = true), break = true).indent.joinLines
     else ""
   }
 }

--- a/src/compiler/scala/tools/nsc/typechecker/splain/SplainErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/splain/SplainErrors.scala
@@ -24,7 +24,7 @@ trait SplainErrors { self: Analyzer with SplainFormatting =>
     }
 
   def splainPushOrReportNotFound(tree: Tree, param: Symbol, annotationMsg: String): String =
-    if (settings.Vimplicits)
+    if (settings.Vimplicits.value)
       if (ImplicitErrors.nested) {
         splainPushNotFound(tree, param)
         ""
@@ -39,7 +39,7 @@ trait SplainErrors { self: Analyzer with SplainFormatting =>
     tparams: List[Symbol],
     originalError: Option[AbsTypeError],
   ): Unit = {
-    if (settings.Vimplicits) {
+    if (settings.Vimplicits.value) {
       val specifics = ImplicitErrorSpecifics.NonconformantBounds(targs, tparams, originalError)
       ImplicitErrors.push(ImplicitError(tpe, candidate, ImplicitErrors.nesting, specifics))
     }
@@ -53,7 +53,7 @@ trait SplainErrors { self: Analyzer with SplainFormatting =>
         case _ =>
       }
     }
-    if (settings.Vimplicits) {
+    if (settings.Vimplicits.value) {
       implicitTree match {
         case       TypeApply(fun, args)     => pushImpFailure(fun, args)
         case Apply(TypeApply(fun, args), _) => pushImpFailure(fun, args)

--- a/src/compiler/scala/tools/nsc/typechecker/splain/SplainFormatting.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/splain/SplainFormatting.scala
@@ -500,7 +500,7 @@ trait SplainFormatting extends SplainFormatters {
     chain.map(formatNestedImplicit).flatMap { case (h, t, _) => h :: t }
 
   def formatImplicitChain(chain: List[ImplicitError]): List[String] = {
-    val compact = if (settings.VimplicitsVerboseTree) None else formatImplicitChainTreeCompact(chain)
+    val compact = if (settings.VimplicitsVerboseTree.value) None else formatImplicitChainTreeCompact(chain)
     compact.getOrElse(formatImplicitChainTreeFull(chain))
   }
 

--- a/src/compiler/scala/tools/reflect/FastStringInterpolator.scala
+++ b/src/compiler/scala/tools/reflect/FastStringInterpolator.scala
@@ -34,7 +34,7 @@ trait FastStringInterpolator extends FormatInterpolator {
           parts.mapConserve {
             case lit @ Literal(Constant(stringVal: String)) =>
               val value =
-                if (isRaw && currentRun.isScala3) stringVal
+                if (isRaw && currentRun.isScala3.value) stringVal
                 else if (isRaw) {
                   val processed = StringContext.processUnicode(stringVal)
                   if (processed != stringVal) {

--- a/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
+++ b/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
@@ -383,11 +383,11 @@ abstract class ToolBoxFactory[U <: JavaUniverse](val u: U) { factorySelf =>
     def typecheck(tree: u.Tree, mode: TypecheckMode = TERMmode, expectedType: u.Type, silent: Boolean = false, withImplicitViewsDisabled: Boolean = false, withMacrosDisabled: Boolean = false): u.Tree = withCompilerApi { compilerApi =>
       import compilerApi._
 
-      if (compiler.settings.verbose) println("importing "+tree+", expectedType = "+expectedType)
+      if (compiler.settings.verbose.value) println("importing "+tree+", expectedType = "+expectedType)
       val ctree: compiler.Tree = importer.importTree(tree)
       val cexpectedType: compiler.Type = importer.importType(expectedType)
 
-      if (compiler.settings.verbose) println("typing "+ctree+", expectedType = "+expectedType)
+      if (compiler.settings.verbose.value) println("typing "+ctree+", expectedType = "+expectedType)
       val ttree: compiler.Tree = compiler.typecheck(ctree, cexpectedType, mode, silent = silent, withImplicitViewsDisabled = withImplicitViewsDisabled, withMacrosDisabled = withMacrosDisabled)
       val uttree = exporter.importTree(ttree)
       uttree
@@ -406,12 +406,12 @@ abstract class ToolBoxFactory[U <: JavaUniverse](val u: U) { factorySelf =>
     private def inferImplicit(tree: u.Tree, pt: u.Type, isView: Boolean, silent: Boolean, withMacrosDisabled: Boolean, pos: u.Position): u.Tree = withCompilerApi { compilerApi =>
       import compilerApi._
 
-      if (compiler.settings.verbose) println(s"importing pt=$pt, tree=$tree, pos=$pos")
+      if (compiler.settings.verbose.value) println(s"importing pt=$pt, tree=$tree, pos=$pos")
       val ctree: compiler.Tree = importer.importTree(tree)
       val cpt: compiler.Type = importer.importType(pt)
       val cpos: compiler.Position = importer.importPosition(pos)
 
-      if (compiler.settings.verbose) println("inferring implicit %s of type %s, macros = %s".format(if (isView) "view" else "value", pt, !withMacrosDisabled))
+      if (compiler.settings.verbose.value) println("inferring implicit %s of type %s, macros = %s".format(if (isView) "view" else "value", pt, !withMacrosDisabled))
       val itree: compiler.Tree = compiler.inferImplicit(ctree, cpt, isView = isView, silent = silent, withMacrosDisabled = withMacrosDisabled, pos = cpos)
       val uitree = exporter.importTree(itree)
       uitree
@@ -429,7 +429,7 @@ abstract class ToolBoxFactory[U <: JavaUniverse](val u: U) { factorySelf =>
 
     def parse(code: String): u.Tree = withCompilerApi { compilerApi =>
       import compilerApi._
-      if (compiler.settings.verbose) println("parsing "+code)
+      if (compiler.settings.verbose.value) println("parsing "+code)
       val ctree: compiler.Tree = compiler.parse(code)
       val utree = exporter.importTree(ctree)
       utree
@@ -438,20 +438,20 @@ abstract class ToolBoxFactory[U <: JavaUniverse](val u: U) { factorySelf =>
     def compile(tree: u.Tree): () => Any = withCompilerApi { compilerApi =>
       import compilerApi._
 
-      if (compiler.settings.verbose) println("importing "+tree)
+      if (compiler.settings.verbose.value) println("importing "+tree)
       val ctree: compiler.Tree = importer.importTree(tree)
 
-      if (compiler.settings.verbose) println("compiling "+ctree)
+      if (compiler.settings.verbose.value) println("compiling "+ctree)
       compiler.compile(ctree)
     }
 
     def define(tree: u.ImplDef): u.Symbol = withCompilerApi { compilerApi =>
       import compilerApi._
 
-      if (compiler.settings.verbose) println("importing "+tree)
+      if (compiler.settings.verbose.value) println("importing "+tree)
       val ctree: compiler.ImplDef = importer.importTree(tree).asInstanceOf[compiler.ImplDef]
 
-      if (compiler.settings.verbose) println("defining "+ctree)
+      if (compiler.settings.verbose.value) println("defining "+ctree)
       val csym: compiler.Symbol = compiler.define(ctree)
       val usym = exporter.importSymbol(csym)
       usym

--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -293,7 +293,7 @@ final class PathResolver(settings: Settings, closeableRegistry: CloseableRegistr
 
   def result: ClassPath = {
     val cp = computeResult()
-    if (settings.Ylogcp) {
+    if (settings.Ylogcp.value) {
       Console print f"Classpath built from ${settings.toConciseString} %n"
       Console print s"Defaults: ${PathResolver.Defaults}"
       Console print s"Calculated: $Calculated"

--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -586,7 +586,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
     for (s <- allSources; if !ignoredFiles(s.file); unit <- getUnit(s)) {
       try {
         if (!unit.isUpToDate)
-          if (unit.problems.isEmpty || !settings.YpresentationStrict)
+          if (unit.problems.isEmpty || !settings.YpresentationStrict.value)
             typeCheck(unit)
           else debugLog("%s has syntax errors. Skipped typechecking".format(unit))
         else debugLog("already up to date: "+unit)

--- a/src/interactive/scala/tools/nsc/interactive/Main.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Main.scala
@@ -37,7 +37,7 @@ object Main extends nsc.MainClass {
       compiler.askShutdown()
     }
     super.processSettingsHook() && (
-      if (this.settings.Yidedebug) { run() ; false } else true
+      if (this.settings.Yidedebug.value) { run() ; false } else true
     )
   }
 }

--- a/src/interactive/scala/tools/nsc/interactive/REPL.scala
+++ b/src/interactive/scala/tools/nsc/interactive/REPL.scala
@@ -39,7 +39,7 @@ object REPL {
     val settings = new Settings(replError)
     reporter = new ConsoleReporter(settings)
     val command = new CompilerCommand(args.toList, settings)
-    if (command.settings.version)
+    if (command.settings.version.value)
       reporter.echo(versionMsg)
     else {
       try {

--- a/src/interactive/scala/tools/nsc/interactive/tests/Tester.scala
+++ b/src/interactive/scala/tools/nsc/interactive/tests/Tester.scala
@@ -26,7 +26,7 @@ class Tester(ntests: Int, inputs: Array[SourceFile], settings: Settings) {
   val compiler = new Global(settings, reporter)
 
   def askAndListen[T, U](msg: String,  arg: T, op: (T, Response[U]) => Unit): Unit = {
-    if (settings.verbose) print(msg+" "+arg+": ")
+    if (settings.verbose.value) print(msg+" "+arg+": ")
     val TIMEOUT = 10 // ms
     val limit = System.currentTimeMillis() + randomDelayMillis
     val res = new Response[U]
@@ -37,7 +37,7 @@ class Tester(ntests: Int, inputs: Array[SourceFile], settings: Settings) {
       } else res.get(TIMEOUT.toLong) match {
         case Some(Left(t)) =>
           /**/
-          if (settings.verbose) println(t)
+          if (settings.verbose.value) println(t)
         case Some(Right(ex)) =>
           ex.printStackTrace()
           println(ex)

--- a/src/reflect/scala/reflect/internal/Positions.scala
+++ b/src/reflect/scala/reflect/internal/Positions.scala
@@ -171,7 +171,7 @@ trait Positions extends api.Positions { self: SymbolTable =>
   }
   def validatePositions(tree: Tree): Unit = if (!useOffsetPositions) {
     object worker {
-      val trace = settings.Yposdebug && settings.verbose
+      val trace = settings.Yposdebug.value && settings.verbose.value
       val topTree = tree
 
       object solidChildrenCollector extends ChildSolidDescendantsCollector {

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -77,11 +77,11 @@ abstract class SymbolTable extends macros.Universe
   protected def elapsedMessage(msg: String, startNs: Long) =
     msg + " in " + (TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNs)) + "ms"
 
-  def informProgress(msg: String)            = if (settings.verbose) inform("[" + msg + "]")
-  def informTime(msg: String, startNs: Long) = if (settings.verbose) informProgress(elapsedMessage(msg, startNs))
+  def informProgress(msg: String)            = if (settings.verbose.value) inform("[" + msg + "]")
+  def informTime(msg: String, startNs: Long) = if (settings.verbose.value) informProgress(elapsedMessage(msg, startNs))
   @inline final def informingProgress[T](msg: => String)(fn: => T) : T = {
-    val verbose: Boolean = settings.verbose
-    val start = if(verbose) System.nanoTime() else 0L
+    val verbose: Boolean = settings.verbose.value
+    val start = if (verbose) System.nanoTime() else 0L
     try fn finally if (verbose) informTime(msg, start)
   }
 

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -304,7 +304,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def shortSymbolClass = shortClassOfInstance(this)
     def symbolCreationString: String = (
       "%s%25s | %-40s | %s".format(
-        if (settings.uniqid) "%06d | ".format(id) else "",
+        if (settings.uniqid.value) "%06d | ".format(id) else "",
         shortSymbolClass,
         name.decode + " in " + owner,
         rawFlagString

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3147,7 +3147,7 @@ trait Types
 
     private def existentialClauses = {
       val str = quantified.map(_.existentialToString).mkString(" forSome { ", "; ", " }")
-      if (settings.explaintypes) "(" + str + ")" else str
+      if (settings.explaintypes.value) "(" + str + ")" else str
     }
 
     /** An existential can only be printed with wildcards if:
@@ -3764,7 +3764,7 @@ trait Types
         if (sym.owner.isTerm && (sym.owner != encl)) Some(sym.owner) else None
       ).flatten map (s => s.decodedName + tparamsOfSym(s)) mkString "#"
     }
-    private def levelString = if (settings.explaintypes) level else ""
+    private def levelString = if (settings.explaintypes.value) level else ""
     override def safeToString = (
       if ((constr eq null) || (inst eq null)) "TVar<" + originName + "=null>"
       else if (inst ne NoType) "=?" + inst
@@ -5218,12 +5218,12 @@ trait Types
 
   /** If option `explaintypes` is set, print a subtype trace for `found <:< required`. */
   def explainTypes(found: Type, required: Type): Unit = {
-    if (settings.explaintypes) withTypesExplained(found <:< required)
+    if (settings.explaintypes.value) withTypesExplained(found <:< required)
   }
 
   /** If option `explaintypes` is set, print a subtype trace for `op(found, required)`. */
   def explainTypes(op: (Type, Type) => Any, found: Type, required: Type): Unit = {
-    if (settings.explaintypes) withTypesExplained(op(found, required))
+    if (settings.explaintypes.value) withTypesExplained(op(found, required))
   }
 
   /** Execute `op` while printing a trace of the operations on types executed. */

--- a/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
+++ b/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
@@ -68,14 +68,10 @@ abstract class MutableSettings extends AbsSettings {
 }
 
 object MutableSettings {
-  import scala.language.implicitConversions
-  /** Support the common use case, `if (settings.debug) println("Hello, martin.")` */
-  @inline implicit def reflectSettingToBoolean(s: MutableSettings#BooleanSetting): Boolean = s.value
-
   implicit class SettingsOps(private val settings: MutableSettings) extends AnyVal {
-    @inline final def areStatisticsEnabled = (StatisticsStatics.COLD_STATS_GETTER.invokeExact(): Boolean) && settings.YstatisticsEnabled
-    @inline final def areHotStatisticsEnabled = (StatisticsStatics.HOT_STATS_GETTER.invokeExact(): Boolean) && settings.YhotStatisticsEnabled
-    @inline final def isDebug: Boolean     = (StatisticsStatics.DEBUG_GETTER.invokeExact(): Boolean) && settings.debug
-    @inline final def isDeveloper: Boolean = (StatisticsStatics.DEVELOPER_GETTER.invokeExact(): Boolean) && settings.developer
+    @inline final def areStatisticsEnabled = (StatisticsStatics.COLD_STATS_GETTER.invokeExact(): Boolean) && settings.YstatisticsEnabled.value
+    @inline final def areHotStatisticsEnabled = (StatisticsStatics.HOT_STATS_GETTER.invokeExact(): Boolean) && settings.YhotStatisticsEnabled.value
+    @inline final def isDebug: Boolean     = (StatisticsStatics.DEBUG_GETTER.invokeExact(): Boolean) && settings.debug.value
+    @inline final def isDeveloper: Boolean = (StatisticsStatics.DEVELOPER_GETTER.invokeExact(): Boolean) && settings.developer.value
   }
 }

--- a/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
+++ b/src/reflect/scala/reflect/internal/settings/MutableSettings.scala
@@ -68,6 +68,17 @@ abstract class MutableSettings extends AbsSettings {
 }
 
 object MutableSettings {
+  import scala.language.implicitConversions
+  /** Support the common use case, `if (settings.debug) println("Hello, martin.")`.
+   *
+   *  Unfortunately, due to the way the `Settings` hierarchy is structured, this abstraction incurs boxing.
+   *  Although boxing the Boolean primitive may be a trivial cost for a single invocation,
+   *  it is significant for a test in a hot spot. Therefore, this method is deprecated.
+   *  For the convenience of plugin authors, it has not been removed outright.
+   */
+  @deprecated("Use `setting.value` directly to avoid boxing.", since="2.13.9")
+  @inline implicit def reflectSettingToBoolean(s: MutableSettings#BooleanSetting): Boolean = s.value
+
   implicit class SettingsOps(private val settings: MutableSettings) extends AnyVal {
     @inline final def areStatisticsEnabled = (StatisticsStatics.COLD_STATS_GETTER.invokeExact(): Boolean) && settings.YstatisticsEnabled.value
     @inline final def areHotStatisticsEnabled = (StatisticsStatics.HOT_STATS_GETTER.invokeExact(): Boolean) && settings.YhotStatisticsEnabled.value

--- a/src/reflect/scala/reflect/runtime/Settings.scala
+++ b/src/reflect/scala/reflect/runtime/Settings.scala
@@ -58,7 +58,7 @@ private[reflect] class Settings extends MutableSettings {
   val uniqid            = new BooleanSetting(false)
   val verbose           = new BooleanSetting(false)
 
-  val YhotStatisticsEnabled = new BooleanSetting(false) { override def postSetHook() = if (v && YstatisticsEnabled) StatisticsStatics.enableHotStatsAndDeoptimize()  }
+  val YhotStatisticsEnabled = new BooleanSetting(false) { override def postSetHook() = if (v && YstatisticsEnabled.value) StatisticsStatics.enableHotStatsAndDeoptimize()  }
   val YstatisticsEnabled    = new BooleanSetting(false) { override def postSetHook() = if (v)                       StatisticsStatics.enableColdStatsAndDeoptimize() }
 
   val Yrecursion = new IntSetting(0)

--- a/src/reflect/scala/reflect/runtime/SymbolTable.scala
+++ b/src/reflect/scala/reflect/runtime/SymbolTable.scala
@@ -22,7 +22,7 @@ package runtime
 private[scala] trait SymbolTable extends internal.SymbolTable with JavaMirrors with SymbolLoaders with SynchronizedOps with Gil with ThreadLocalStorage {
 
   def info(msg: => String) =
-    if (settings.verbose) println("[reflect-compiler] "+msg)
+    if (settings.verbose.value) println("[reflect-compiler] "+msg)
 
   def debugInfo(msg: => String) =
     if (settings.isDebug) info(msg)

--- a/src/repl-frontend/scala/tools/nsc/MainGenericRunner.scala
+++ b/src/repl-frontend/scala/tools/nsc/MainGenericRunner.scala
@@ -21,7 +21,7 @@ object JarRunner extends CommonRunner {
     val jarURLs   = util.ClassPath expandManifestPath jarPath
     val urls      = if (jarURLs.isEmpty) io.File(jarPath).toURL +: settings.classpathURLs else jarURLs
 
-    if (settings.Ylogcp) {
+    if (settings.Ylogcp.value) {
       Console.err.println("Running jar with these URLs as the classpath:")
       urls foreach println
     }

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/ReplCompletion.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/ReplCompletion.scala
@@ -65,7 +65,7 @@ class ReplCompletion(intp: Repl, val accumulator: Accumulator = new Accumulator)
       }
     } catch {
       case NonFatal(e) =>
-        if (intp.settings.debug)
+        if (intp.settings.debug.value)
           e.printStackTrace()
         NoCompletions
     }

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/Reporter.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/Reporter.scala
@@ -98,7 +98,7 @@ class ReplReporterImpl(val config: ShellConfig, val settings: Settings = new Set
     *  debugging information (like printing the classpath) is not rendered
     *  invisible due to the max message length.
     */
-  var truncationOK: Boolean = !settings.verbose
+  var truncationOK: Boolean = !settings.verbose.value
 
   def truncate(str: String): String =
     if (truncationOK && (maxPrintString != 0 && str.length > maxPrintString)) (str take maxPrintString - 3) + "..."
@@ -216,7 +216,7 @@ class ReplReporterImpl(val config: ShellConfig, val settings: Settings = new Set
 
       if (isSynthetic) printMessage("\n(To diagnose errors in synthetic code, try adding `// show` to the end of your input.)")
     }
-    if (settings.prompt) displayPrompt()
+    if (settings.prompt.value) displayPrompt()
   }
 
   def printMessage(msg: String): Unit =

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/ShellConfig.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/ShellConfig.scala
@@ -34,7 +34,7 @@ object ShellConfig {
       val filesToLoad: List[String] = settings.loadfiles.value
       val batchText: String = if (settings.execute.isSetByUser) settings.execute.value else ""
       val batchMode: Boolean = batchText.nonEmpty
-      val doCompletion: Boolean = !(settings.noCompletion || batchMode)
+      val doCompletion: Boolean = !(settings.noCompletion.value || batchMode)
       val haveInteractiveConsole: Boolean = settings.Xjline.value != "off"
       override val viMode = super.viMode || settings.Xjline.value == "vi"
     }
@@ -43,7 +43,7 @@ object ShellConfig {
       val filesToLoad: List[String] = Nil
       val batchText: String = ""
       val batchMode: Boolean = false
-      val doCompletion: Boolean = !settings.noCompletion
+      val doCompletion: Boolean = !settings.noCompletion.value
       val haveInteractiveConsole: Boolean = settings.Xjline.value != "off"
       override val viMode = super.viMode || settings.Xjline.value == "vi"
     }

--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -421,7 +421,7 @@ class IMain(val settings: Settings, parentClassLoaderOverride: Option[ClassLoade
   }
 
   private[nsc] def replwarn(msg: => String): Unit = {
-    if (!settings.nowarnings)
+    if (!settings.nowarnings.value)
       reporter.printMessage(msg)
   }
 
@@ -1177,7 +1177,7 @@ class IMain(val settings: Settings, parentClassLoaderOverride: Option[ClassLoade
         runReporting.summarizeErrors()
       if (reporter.hasErrors) Left(Error)
       else if (isIncomplete) Left(Incomplete)
-      else if (reporter.hasWarnings && settings.fatalWarnings) Left(Error)
+      else if (reporter.hasWarnings && settings.fatalWarnings.value) Left(Error)
       else Right((trees, unit.firstXmlPos))
     }.tap(_ => if (!isIncomplete) reporter.reset())
   }
@@ -1258,7 +1258,7 @@ class IMain(val settings: Settings, parentClassLoaderOverride: Option[ClassLoade
     (implicits.toList,
       if (filtered.nonEmpty)
         "" // collected in implicits
-      else if (global.settings.nopredef || global.settings.noimports)
+      else if (global.settings.nopredef.value || global.settings.noimports.value)
         "No implicits have been imported."
       else
         "No implicits have been imported other than those in Predef."
@@ -1406,7 +1406,7 @@ object IMain {
    */
   private[interpreter] def withSuppressedSettings[A](settings: Settings, global: => Global)(body: => A): A = {
     import settings.{reporter => _, _}
-    val wasWarning = !nowarn
+    val wasWarning = !nowarn.value
     val oldMaxWarn = maxwarns.value
     val noisy = List(Xprint, Ytyperdebug, browse)
     val current = (Xprint.value, Ytyperdebug.value, browse.value)

--- a/src/repl/scala/tools/nsc/interpreter/Power.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Power.scala
@@ -75,7 +75,7 @@ class Power[ReplValsImpl <: ReplVals : ru.TypeTag: ClassTag](val intp: IMain, re
       pass += 1
       val (repeats, unseen) = todo partition seen
       unseenHistory += unseen.size
-      if (settings.verbose) {
+      if (settings.verbose.value) {
         println("%3d  %s accumulated, %s discarded.  This pass: %s unseen, %s repeats".format(
           pass, keep.size, discarded, unseen.size, repeats.size))
       }

--- a/src/scaladoc/scala/tools/nsc/doc/DocFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/DocFactory.scala
@@ -90,11 +90,11 @@ class DocFactory(val reporter: Reporter, val settings: doc.Settings) { processor
 
     modelFactory.makeModel match {
       case Some(madeModel) =>
-        if (settings.verbose)
+        if (settings.verbose.value)
           reporter.echo("model contains " + modelFactory.templatesCount + " documentable templates")
         Some(madeModel)
       case None =>
-        if (settings.verbose)
+        if (settings.verbose.value)
           reporter.echo("no documentable class found in compilation units")
         None
     }
@@ -104,7 +104,7 @@ class DocFactory(val reporter: Reporter, val settings: doc.Settings) { processor
 
   val documentError: PartialFunction[Throwable, Unit] = {
     case NoCompilerRunException =>
-      if (settings.verbose)
+      if (settings.verbose.value)
         reporter.echo("No documentation generated with unsuccessful compiler run")
     case e @ (_:ClassNotFoundException | _:IllegalAccessException | _:InstantiationException | _:SecurityException | _:ClassCastException) =>
       reporter.error(null, s"Cannot load the doclet class ${settings.docgenerator.value} (specified with ${settings.docgenerator.name}): $e. Leaving the default settings will generate the html version of scaladoc.")
@@ -144,7 +144,7 @@ class DocFactory(val reporter: Reporter, val settings: doc.Settings) { processor
   }
 
   private[doc] def docdbg(msg: String): Unit = {
-    if (settings.Ydocdebug)
+    if (settings.Ydocdebug.value)
       println(msg)
   }
 }

--- a/src/scaladoc/scala/tools/nsc/doc/ScaladocGlobal.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/ScaladocGlobal.scala
@@ -55,6 +55,6 @@ class ScaladocGlobal(settings: doc.Settings, reporter: Reporter) extends Global(
   override def createJavadoc = if (settings.docNoJavaComments.value) false else true
 
   override lazy val analyzer =
-    if (settings.YmacroAnnotations) new { val global: ScaladocGlobal.this.type = ScaladocGlobal.this } with ScaladocAnalyzer with MacroAnnotationNamers
+    if (settings.YmacroAnnotations.value) new { val global: ScaladocGlobal.this.type = ScaladocGlobal.this } with ScaladocAnalyzer with MacroAnnotationNamers
     else new { val global: ScaladocGlobal.this.type = ScaladocGlobal.this } with ScaladocAnalyzer
 }

--- a/src/scaladoc/scala/tools/nsc/doc/Uncompilable.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/Uncompilable.scala
@@ -56,7 +56,7 @@ trait Uncompilable {
   lazy val pairs = files flatMap { f =>
     val code = f.slurp()
     val comments = docPairs(code)
-    if (settings.verbose) {
+    if (settings.verbose.value) {
       inform(s"Found ${comments.size} doc comments in parse-only file $f: " + comments.map(_._1).mkString(", "))
     }
     comments
@@ -65,7 +65,7 @@ trait Uncompilable {
   def symbols   = pairs map (_._1)
   def templates = symbols.filter(x => x.isClass || x.isTrait || x == AnyRefClass/* which is now a type alias */).toSet
   def comments = {
-    if (settings.isDebug || settings.verbose)
+    if (settings.isDebug || settings.verbose.value)
       inform("Found %d uncompilable files: %s".format(files.size, files mkString ", "))
 
     if (pairs.isEmpty)

--- a/src/scaladoc/scala/tools/nsc/doc/html/HtmlPage.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/HtmlPage.scala
@@ -76,7 +76,7 @@ abstract class HtmlPage extends Page { thisPage =>
   def writeFor(site: HtmlFactory): Unit = {
     writeFile(site)(writeHtml(site.encoding))
 
-    if (site.universe.settings.docRawOutput)
+    if (site.universe.settings.docRawOutput.value)
       writeFile(site, ".raw") {
         // we're only interested in the body, as this will go into the diff
         _.write(textOf(body))

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
@@ -293,7 +293,7 @@ trait EntityPage extends HtmlPage {
                 List(
                   Li(`class`="public in", elems=Span(elems=Txt("Public"))),
                   Li(`class`="protected out", elems=Span(elems=Txt("Protected")))
-                ) ++ List(Li(`class`="private out", elems=Span(elems=Txt("Private")))).filter(_ => universe.settings.visibilityPrivate))
+                ) ++ List(Li(`class`="private out", elems=Span(elems=Txt("Private")))).filter(_ => universe.settings.visibilityPrivate.value))
           ))
         )
       ))
@@ -431,7 +431,7 @@ trait EntityPage extends HtmlPage {
       else Div(`class`="comment cmt", elems= commentToHtml(mbr.comment)) :: NoElems
 
     val authorComment =
-      if (! s.docAuthor || mbr.comment.isEmpty ||
+      if (!s.docAuthor.value || mbr.comment.isEmpty ||
         mbr.comment.isDefined && mbr.comment.get.authors.isEmpty) NoElems
       else Div(`class`= "comment cmt", elems=
         H(6, Txt(if (mbr.comment.get.authors.size > 1) "Authors:" else "Author:" )) ::

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/diagram/DiagramStats.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/diagram/DiagramStats.scala
@@ -49,7 +49,7 @@ object DiagramStats {
   private[this] var fixedImages = 0
 
   def printStats(settings: Settings) = {
-    if (settings.docDiagramsDebug) {
+    if (settings.docDiagramsDebug.value) {
       settings.printMsg("\nDiagram generation running time breakdown:\n")
       filterTrack.printStats(settings.printMsg)
       modelTrack.printStats(settings.printMsg)

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
@@ -295,7 +295,7 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
     assert(!(docTemplatesCache isDefinedAt sym), sym)
     docTemplatesCache += (sym -> this)
 
-    if (settings.verbose)
+    if (settings.verbose.value)
       inform("Creating doc template for " + sym)
 
     override def linkTarget: DocTemplateImpl = this
@@ -367,7 +367,7 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
 
     // the implicit conversions are generated lazily, on completeModel
     lazy val conversions: List[ImplicitConversionImpl] =
-      if (settings.docImplicits) makeImplicitConversions(sym, this) else Nil
+      if (settings.docImplicits.value) makeImplicitConversions(sym, this) else Nil
 
     // members as given by the compiler
     lazy val memberSyms      = sym.info.members.filter(s => membersShouldDocument(s, this)).toList
@@ -1041,7 +1041,7 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
 
   // whether or not to create a page for an {abstract,alias} type
   def typeShouldDocument(bSym: Symbol, inTpl: DocTemplateImpl) =
-    (settings.docExpandAllTypes && (bSym.sourceFile != null)) ||
+    (settings.docExpandAllTypes.value && (bSym.sourceFile != null)) ||
     (bSym.isAliasType || bSym.isAbstractType) &&
     { val rawComment = global.expandedDocComment(bSym, inTpl.sym)
       rawComment.contains("@template") || rawComment.contains("@documentable") }

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactoryImplicitSupport.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactoryImplicitSupport.scala
@@ -177,7 +177,7 @@ trait ModelFactoryImplicitSupport {
         return Nil
       }
 
-      if (!settings.docImplicitsShowAll && viewSimplifiedType.resultType.typeSymbol == sym) {
+      if (!settings.docImplicitsShowAll.value && viewSimplifiedType.resultType.typeSymbol == sym) {
         // If, when looking at views for a class A, we find one that returns A as well
         // (possibly with different type parameters), we ignore it.
         // It usually is a way to build a "whatever" into an A, but we already have an A, as in:
@@ -267,7 +267,7 @@ trait ModelFactoryImplicitSupport {
       available match {
         case Some(true) =>
           Nil
-        case Some(false) if !settings.docImplicitsShowAll =>
+        case Some(false) if !settings.docImplicitsShowAll.value =>
           // if -implicits-show-all is not set, we get rid of impossible conversions (such as Numeric[String])
           throw new ImplicitNotFound(implType)
         case _ =>

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactoryTypeSupport.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactoryTypeSupport.scala
@@ -151,7 +151,7 @@ trait ModelFactoryTypeSupport {
           }
 
           val prefix =
-            if (!settings.docNoPrefixes && needsPrefix && (bSym != AnyRefClass /* which we normalize */)) {
+            if (!settings.docNoPrefixes.value && needsPrefix && (bSym != AnyRefClass /* which we normalize */)) {
               if (!owner.isRefinementClass) {
                 val qName = makeQualifiedName(owner, Some(inTpl.sym))
                 if (qName != "") qName + "." else ""
@@ -321,7 +321,7 @@ trait ModelFactoryTypeSupport {
 
     // scala/bug#4360: Entity caching depends on both the type AND the template it's in, as the prefixes might change for the
     // same type based on the template the type is shown in.
-    if (settings.docNoPrefixes)
+    if (settings.docNoPrefixes.value)
       typeCache.getOrElseUpdate(aType, createTypeEntity)
     else createTypeEntity
   }

--- a/src/scaladoc/scala/tools/nsc/doc/model/diagram/DiagramDirectiveParser.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/diagram/DiagramDirectiveParser.scala
@@ -265,7 +265,7 @@ trait DiagramDirectiveParser {
             hideNodesFilter = hideNodesFilter0,
             hideEdgesFilter = hideEdgesFilter0)
 
-      if (settings.docDiagramsDebug && result != NoDiagramAtAll && result != FullDiagram)
+      if (settings.docDiagramsDebug.value && result != NoDiagramAtAll && result != FullDiagram)
         settings.printMsg(template.kind + " " + template.qualifiedName + " filter: " + result)
       tFilter += System.currentTimeMillis
 

--- a/test/benchmarks/src/main/scala/scala/reflect/internal/util/AlmostFinalValueBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/reflect/internal/util/AlmostFinalValueBenchmark.scala
@@ -8,16 +8,16 @@ import org.openjdk.jmh.infra.Blackhole
 class AlmostFinalValueBenchSettings extends scala.reflect.runtime.Settings {
   val flag = new BooleanSetting(false)
 
-  @inline final def isTrue2: Boolean = AlmostFinalValueBenchmarkStatics.isTrue && flag
+  @inline final def isTrue2: Boolean = AlmostFinalValueBenchmarkStatics.isTrue && flag.value
 }
 
 object AlmostFinalValueBenchSettings {
   implicit class SettingsOps(private val settings: AlmostFinalValueBenchSettings) extends AnyVal {
-    @inline final def isTrue3: Boolean = AlmostFinalValueBenchmarkStatics.isTrue && settings.flag
+    @inline final def isTrue3: Boolean = AlmostFinalValueBenchmarkStatics.isTrue && settings.flag.value
   }
 
   @inline def isTrue4(settings: AlmostFinalValueBenchSettings): Boolean =
-    AlmostFinalValueBenchmarkStatics.isTrue && settings.flag
+    AlmostFinalValueBenchmarkStatics.isTrue && settings.flag.value
 }
 
 @Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
@@ -33,10 +33,10 @@ class AlmostFinalValueBenchmark {
   private def pretendToWorkHard() = Blackhole.consumeCPU(3)
 
   @Benchmark def bench0_unit                  = ()
-  @Benchmark def bench0_usingStaticFinalFalse = if (STATIC_FINAL_FALSE && flag) pretendToWorkHard()
+  @Benchmark def bench0_usingStaticFinalFalse = if (STATIC_FINAL_FALSE && flag.value) pretendToWorkHard()
   @Benchmark def bench0_workingHard           = pretendToWorkHard()
 
-  @Benchmark def bench1_usingAlmostFinalFalse = if (AlmostFinalValueBenchmarkStatics.isTrue && flag) pretendToWorkHard()
+  @Benchmark def bench1_usingAlmostFinalFalse = if (AlmostFinalValueBenchmarkStatics.isTrue && flag.value) pretendToWorkHard()
   @Benchmark def bench2_usingInlineMethod     = if (settings.isTrue2) pretendToWorkHard()
   @Benchmark def bench3_usingExtMethod        = if (settings.isTrue3) pretendToWorkHard()
   @Benchmark def bench4_usingObjectMethod     = if (AlmostFinalValueBenchSettings.isTrue4(settings)) pretendToWorkHard()

--- a/test/files/run/t11802-pluginsdir/ploogin.scala
+++ b/test/files/run/t11802-pluginsdir/ploogin.scala
@@ -19,7 +19,7 @@ abstract class Ploogin(val global: Global, val name: String = "ploogin") extends
     def newPhase(prev: Phase) = new TestPhase(prev)
     class TestPhase(prev: Phase) extends StdPhase(prev) {
       override def description = TestComponent.this.description
-      def apply(unit: CompilationUnit): Unit = if (settings.developer) inform(s"My phase name is $phaseName")
+      def apply(unit: CompilationUnit): Unit = if (settings.developer.value) inform(s"My phase name is $phaseName")
     }
   }
 }

--- a/test/files/run/t4841-isolate-plugins/ploogin.scala
+++ b/test/files/run/t4841-isolate-plugins/ploogin.scala
@@ -23,7 +23,7 @@ class Ploogin(val global: Global, val name: String = "ploogin") extends Plugin {
     class TestPhase(prev: Phase) extends StdPhase(prev) {
       override def description = TestComponent.this.description
       def apply(unit: CompilationUnit): Unit = {
-        if (settings.developer) inform(s"My phase name is $phaseName")
+        if (settings.developer.value) inform(s"My phase name is $phaseName")
       }
     }
   }

--- a/test/files/run/t8935-class.check
+++ b/test/files/run/t8935-class.check
@@ -15,6 +15,6 @@ val res3: Option[Any] = Some(64)
 scala> $intp.valueOfTerm("i")
 val res4: Option[Any] = Some(17)
 
-scala> assert($intp.settings.Yreplclassbased)
+scala> assert($intp.settings.Yreplclassbased.value)
 
 scala> :quit

--- a/test/junit/scala/tools/nsc/settings/SettingsTest.scala
+++ b/test/junit/scala/tools/nsc/settings/SettingsTest.scala
@@ -304,7 +304,6 @@ class SettingsTest {
       val d = Choice("d")
     }
     val m = s.MultiChoiceSetting("-m", "args", "magic sauce", mChoices, Some(List("a")))
-    println(s"m $m has value ${m.value}")
 
     def check(args: String*)(t: s.MultiChoiceSetting[mChoices.type] => Boolean): Boolean = {
       m.clear()
@@ -349,6 +348,6 @@ class SettingsTest {
 }
 object SettingsTest {
   import language.implicitConversions
-  /** Support the common use case, `if (settings.debug) println("Hello, martin.")` Alas, incurs boxing and unboxing. */
+  /** Avoid deprecated conversion. */
   @inline implicit def reflectSettingToBoolean(s: MutableSettings#BooleanSetting): Boolean = s.value
 }

--- a/test/junit/scala/tools/nsc/settings/SettingsTest.scala
+++ b/test/junit/scala/tools/nsc/settings/SettingsTest.scala
@@ -3,12 +3,10 @@ package settings
 
 import org.junit.Assert._
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 import scala.tools.testkit.AssertUtil.assertThrows
 
-@RunWith(classOf[JUnit4])
 class SettingsTest {
+  import SettingsTest._
   private def settings = new MutableSettings(msg => throw new IllegalArgumentException(msg))
 
   @Test def booleanSettingColon(): Unit = {
@@ -348,4 +346,9 @@ class SettingsTest {
     assertFalse(s.optInlinerEnabled)
     assertTrue(s.optBoxUnbox)
   }
+}
+object SettingsTest {
+  import language.implicitConversions
+  /** Support the common use case, `if (settings.debug) println("Hello, martin.")` Alas, incurs boxing and unboxing. */
+  @inline implicit def reflectSettingToBoolean(s: MutableSettings#BooleanSetting): Boolean = s.value
 }


### PR DESCRIPTION
Removes the conversion detested by retronym and all those who hate boxed booleans. Ichoran might agree if asked.

The first commit removes the conversion and updates the code base; the second commit restores it, albeit deprecated.

I did not benchmark whether this improves any hotspots.

I expected only `reflect` to lose the convenience, but also `compiler` because of residual abstraction.