### PR TITLE
Reflect future status of `App` in scaladoc

### DIFF
--- a/src/library/scala/App.scala
+++ b/src/library/scala/App.scala
@@ -38,9 +38,20 @@ import scala.collection.mutable.ListBuffer
  *
  *  Future versions of this trait will no longer extend `DelayedInit`.
  * 
- *  In Scala 3, `App` exists only in a limited form that does not support command line
- *  arguments and will be deprecated in the future. If programs need to cross-build
- *  between Scala 2 and Scala 3, it is recommended to use an explicit `main` method:
+ *  In Scala 3, the `DelayedInit` feature was dropped. `App` exists only in a limited form
+ *  that also does not support command line arguments and will be deprecated in the future.
+ * 
+ *  [[https://docs.scala-lang.org/scala3/book/methods-main-methods.html @main]] methods are the
+ *  recommended scheme to generate programs that can be invoked from the command line in Scala 3.
+ * 
+ *  {{{
+ *  @main def runMyProgram(args: String*): Unit = {
+ *    // your program here
+ *  }
+ *  }}}
+ * 
+ *  If programs need to cross-build between Scala 2 and Scala 3, it is recommended to use an
+ *  explicit `main` method:
  *  {{{
  *  object Main {
  *    def main(args: Array[String]): Unit = {

--- a/src/library/scala/App.scala
+++ b/src/library/scala/App.scala
@@ -37,6 +37,11 @@ import scala.collection.mutable.ListBuffer
  *  before the main method has been executed.'''''
  *
  *  Future versions of this trait will no longer extend `DelayedInit`.
+ * 
+ *  In Scala 3, `App` exists only in a limited form that does not support command line
+ *  arguments and will be deprecated in the future. If programs need to cross-build
+ *  between Scala 2 and Scala 3, it is recommended to use an explicit `main` method with
+ *  an `Array[String]` argument instead.
  */
 @nowarn("""cat=deprecation&origin=scala\.DelayedInit""")
 trait App extends DelayedInit {

--- a/src/library/scala/App.scala
+++ b/src/library/scala/App.scala
@@ -40,8 +40,14 @@ import scala.collection.mutable.ListBuffer
  * 
  *  In Scala 3, `App` exists only in a limited form that does not support command line
  *  arguments and will be deprecated in the future. If programs need to cross-build
- *  between Scala 2 and Scala 3, it is recommended to use an explicit `main` method with
- *  an `Array[String]` argument instead.
+ *  between Scala 2 and Scala 3, it is recommended to use an explicit `main` method:
+ *  {{{
+ *  object Main {
+ *    def main(args: Array[String]): Unit = {
+ *      // your program here
+ *    }
+ *  }
+ *  }}}
  */
 @nowarn("""cat=deprecation&origin=scala\.DelayedInit""")
 trait App extends DelayedInit {


### PR DESCRIPTION
To match Dotty documenation at https://github.com/lampepfl/dotty/blob/8bae490bb513c4ce78812ff721144dfc78dbb430/docs/_docs/reference/changed-features/main-functions.md?plain=1#L86

Since the standard library is shared with Scala 3 seems particularly important to get this information in there?

https://www.scala-lang.org/api/3.1.2/scala/App.html
