### PR TITLE
case class no longer deprecates itself

### DIFF
--- a/src/compiler/scala/tools/nsc/profile/Profiler.scala
+++ b/src/compiler/scala/tools/nsc/profile/Profiler.scala
@@ -184,7 +184,7 @@ private [profile] class RealProfiler(reporter : ProfileReporter, val settings: S
 
   private def doGC(): Unit = {
     System.gc()
-    System.runFinalization()
+    System.runFinalization(): @nowarn("cat=deprecation") // since Java 18
   }
 
   reporter.header(this)

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1905,13 +1905,6 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
         warnTypeParameterShadow(tparams1, clazz)
 
-        if (!isPastTyper) {
-          for (ann <- clazz.getAnnotation(DeprecatedAttr)) {
-            val m = companionSymbolOf(clazz, context)
-            if (m != NoSymbol)
-              m.moduleClass.addAnnotation(AnnotationInfo(ann.atp, ann.args, Nil))
-          }
-        }
         treeCopy.ClassDef(cdef, typedMods, cdef.name, tparams1, impl2)
           .setType(NoType)
       } finally {

--- a/test/files/neg/classmanifests_new_deprecations.scala
+++ b/test/files/neg/classmanifests_new_deprecations.scala
@@ -1,4 +1,4 @@
-// scalac: -deprecation -Xfatal-warnings
+// scalac: -Xlint -Werror
 //
 object Test extends App {
   def rcm1[T: scala.reflect.ClassManifest] = ???

--- a/test/files/neg/t2799.check
+++ b/test/files/neg/t2799.check
@@ -1,0 +1,15 @@
+t2799.scala:7: warning: trait T is deprecated: other mother
+class C[A: T] {
+           ^
+t2799.scala:8: warning: trait T is deprecated: other mother
+  def f = (t: T[A]) => null.asInstanceOf[T[A]]
+              ^
+t2799.scala:8: warning: trait T is deprecated: other mother
+  def f = (t: T[A]) => null.asInstanceOf[T[A]]
+                                         ^
+t2799.scala:9: warning: method int2float in object Int is deprecated (since 2.13.1): Implicit conversion from Int to Float is dangerous because it loses precision. Write `.toFloat` instead.
+  def g() = implicitly[Int => Float]
+                      ^
+error: No warnings can be incurred under -Werror.
+4 warnings
+1 error

--- a/test/files/neg/t2799.scala
+++ b/test/files/neg/t2799.scala
@@ -1,0 +1,10 @@
+// scalac: -Xlint -Werror
+
+@deprecated("other mother", "")
+trait T[A]
+
+// warn even though parameter is synthetic
+class C[A: T] {
+  def f = (t: T[A]) => null.asInstanceOf[T[A]]
+  def g() = implicitly[Int => Float]
+}

--- a/test/files/neg/t8685.check
+++ b/test/files/neg/t8685.check
@@ -1,6 +1,3 @@
-t8685.scala:8: warning: constructor D in class D is deprecated (since now): ctor D is depr
-case class D @deprecated("ctor D is depr", since="now") (i: Int)
-           ^
 t8685.scala:37: warning: class C is deprecated (since now): class C is depr
   def f = C(42)
           ^
@@ -44,5 +41,5 @@ t8685.scala:55: warning: class K in object J is deprecated (since now): Inner K 
   def l = new J.K(42)
                 ^
 error: No warnings can be incurred under -Werror.
-15 warnings
+14 warnings
 1 error

--- a/test/files/pos/t2799.scala
+++ b/test/files/pos/t2799.scala
@@ -1,6 +1,11 @@
 
-// scalac: -deprecation -Xfatal-warnings
-//
-// companion is also deprecated to avoid warning
-//
+// scalac: -Xlint -Werror
+
 @deprecated("hi mom", "") case class Bob ()
+
+@deprecated("other mother", "")
+trait T
+
+object T extends T {
+  def t = Bob()
+}


### PR DESCRIPTION
Reverts the ancient fix for https://github.com/scala/bug/issues/2799 at https://github.com/scala/scala/commit/95d7ef40ebde72d9300bf64d4a4fc45b5a0508d7

Surprised to see nothing broke. It would be nice to know why and apply that fairydust to Dotty. (Edit: actually, I mentioned `scala.io.Position` on the dotty ticket.)

Instead of juggling annotations, the deprecation loophole is expanded to look more like the tax code.
