### PR TITLE
Allow security manager for partest on JVM18

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -892,6 +892,7 @@ lazy val test = project
     IntegrationTest / fork := true,
     Compile / scalacOptions += "-Yvalidate-pos:parser,typer",
     IntegrationTest / javaOptions ++= List("-Xmx2G", "-Dpartest.exec.in.process=true", "-Dfile.encoding=UTF-8", "-Duser.language=en", "-Duser.country=US") ++ addOpensForTesting,
+    IntegrationTest / javaOptions ++= { if (scala.util.Properties.isJavaAtLeast("18")) List("-Djava.security.manager=allow") else Nil },
     IntegrationTest / testOptions += Tests.Argument("-Dfile.encoding=UTF-8", "-Duser.language=en", "-Duser.country=US"),
     testFrameworks += new TestFramework("scala.tools.partest.sbt.Framework"),
     IntegrationTest / testOptions += Tests.Argument(s"-Dpartest.java_opts=-Xmx1024M -Xms64M ${addOpensForTesting.mkString(" ")}"),

--- a/src/partest/scala/tools/partest/nest/AbstractRunner.scala
+++ b/src/partest/scala/tools/partest/nest/AbstractRunner.scala
@@ -163,9 +163,10 @@ class AbstractRunner(val config: RunnerSpec.Config, protected final val testSour
           }
         }
 
-        def files_s = failed0.map(_.testFile).mkString(""" \""" + "\n  ")
+        val bslash = "\\"
+        def files_s = failed0.map(_.testFile).mkString(s" ${bslash}\n  ")
         echo("# Failed test paths (this command will update checkfiles)")
-        echo(partestCmd + " --update-check \\\n  " + files_s + "\n")
+        echo(s"$partestCmd --update-check ${bslash}\n  $files_s\n")
       }
 
       if (printSummary) {


### PR DESCRIPTION
Stop-gap to keep partest running under jdk18.

Previously at https://github.com/scala/scala/pull/10069