### PR TITLE
test: write a failing test for cyclic java dependency

### DIFF
--- a/test/junit/scala/reflect/internal/CyclicReferenceTest.scala
+++ b/test/junit/scala/reflect/internal/CyclicReferenceTest.scala
@@ -1,0 +1,43 @@
+package scala.reflect.internal
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.reflect.runtime.universe
+import scala.util.Try
+
+// [Note] make sure to run each test in a separate JVM process
+//        otherwise they'll have a different (corrupt) state of cache that'll affect the other test
+@RunWith(classOf[JUnit4])
+class CyclicReferenceTest {
+
+  private val mirror = universe.runtimeMirror(getClass.getClassLoader)
+
+  private val cyclicTypeClazz = classOf[CyclicType]
+  private val cyclicTypeContainerClazz = classOf[CyclicTypeContainer]
+
+  @Test def handleCyclicReferencesThatJavaCanHandle(): Unit = {
+    // currently this throws the following exception:
+    //   scala.reflect.internal.Symbols$CyclicReference: illegal cyclic reference involving class CyclicType
+    mirror.classSymbol(cyclicTypeClazz).info
+  }
+
+  @Test def consistentlyEitherSuccessOrFail(): Unit = {
+    // currently the first try fails with
+    //   scala.reflect.internal.Symbols$CyclicReference: illegal cyclic reference involving class CyclicType
+    // and the second try succeeds with
+    //   Scope{}
+
+    val tryMethods1 = Try {
+      mirror.classSymbol(cyclicTypeContainerClazz).info.decls
+    }
+
+    val tryMethods2 = Try {
+      mirror.classSymbol(cyclicTypeContainerClazz).info.decls
+    }
+
+    assert(tryMethods1 == tryMethods2, s"First try was ${tryMethods1} but second try was ${tryMethods2}.")
+  }
+
+}

--- a/test/junit/scala/reflect/internal/CyclicTypeContainer.java
+++ b/test/junit/scala/reflect/internal/CyclicTypeContainer.java
@@ -1,0 +1,14 @@
+package scala.reflect.internal;
+
+interface CyclicTypeContainer {
+  CyclicType.CyclicTypeChild method1();
+  String method2();
+}
+
+interface CyclicType extends ParametrizedInterface<CyclicType.CyclicTypeChild> {
+  interface CyclicTypeChild {
+  }
+}
+
+interface ParametrizedInterface<A> {
+}


### PR DESCRIPTION
Reproducing an issue that we encountered, while trying to mock the interface [RekognitionClient](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-rekognition/classes/rekognitionclient.html) of aws's `rekognition` SDK using [mockito-scala](https://github.com/mockito/mockito-scala) which uses **runtime reflection** of Scala to accomplish this.

The issue occurs when you try to extract `info` of **class A** using `runtimeMirror` where it extends another **class B** that has a type-arg pointing back to an inner **class A.X** embedded inside of **class A**. The result is an exception thrown in runtime with the following content:

```
scala.reflect.internal.Symbols$CyclicReference: illegal cyclic reference involving class A
```

Here's a demonstration of the scenario I described:

```
interface A extends B<A.X> {
  interface X {
  }
}

val mirror = universe.runtimeMirror(getClass.getClassLoader)
mirror.classSymbol(classOf[A]).info // <-- exception thrown in here
```

The situation become more dire if another class **class C** has a few methods, that one of them has `A.X` as either return-type of argument-type. Example:

```
interface C {
  A.X method1();
  String method2();
}

mirror.classSymbol(classOf[C]).info // <-- exception thrown in here
mirror.classSymbol(classOf[C]).info // <-- no exception, with partial result returned
```

In this scenario in the 1st attempt to access `info` of the C, you'll receive a `CyclicReference` exception. However in the 2nd attempt the call succeed with partial result that differs every time. It is due to partial data cached in the 1st run that is not cleaned up after failure. Sometimes the result is missing both methods, sometimes it only contains `method2`.