### PR TITLE
Fix #12619: Tasty Reader: Add DEFAULTPARAM to default accessors.

### DIFF
--- a/src/compiler/scala/tools/nsc/tasty/TreeUnpickler.scala
+++ b/src/compiler/scala/tools/nsc/tasty/TreeUnpickler.scala
@@ -470,7 +470,11 @@ class TreeUnpickler[Tasty <: TastyUniverse](
         flags.is(Opaque) && !isClass
       if (lacksDefinition && tag != PARAM) flags |= Deferred
       if (isClass && flags.is(Trait)) flags |= Abstract
-      if (tag === DEFDEF) flags |= Method
+      if (tag === DEFDEF) {
+        flags |= Method
+        if (name.isDefaultName)
+          flags |= HasDefault // this corresponds to DEFAULTPARAM
+      }
       if (tag === VALDEF) {
         if (flags.is(Inline) || ctx.owner.is(Trait))
           flags |= FieldAccessor

--- a/test/tasty/pos/src-2/tastytest/TestDefaultParamFlags.scala
+++ b/test/tasty/pos/src-2/tastytest/TestDefaultParamFlags.scala
@@ -1,0 +1,12 @@
+package tastytest
+
+class DefaultParamFlagsScala2 {
+  def method(a: Int, b: Int = 1): Int = a + b
+}
+
+object TestDefaultParamFlags {
+
+  compiletimeTestDefaultParamFlags[DefaultParamFlags]()
+  compiletimeTestDefaultParamFlags[DefaultParamFlagsScala2]()
+
+}

--- a/test/tasty/pos/src-3/tastytest/DefaultParamFlags.scala
+++ b/test/tasty/pos/src-3/tastytest/DefaultParamFlags.scala
@@ -1,0 +1,5 @@
+package tastytest
+
+class DefaultParamFlags {
+  def method(a: Int, b: Int = 1): Int = a + b
+}


### PR DESCRIPTION
In dotc, default accessors are identified by a semantic name. In scalac, they have the DEFAULTPARAM flag instead. We now add that flag to methods that have a default-param name.

I verified that this fixes https://github.com/scala-js/scala-js/issues/4700 as well.