### PR TITLE
Don't suspend warnings without position

### DIFF
--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -15,11 +15,10 @@ package tools
 package nsc
 
 import java.util.regex.PatternSyntaxException
-
 import scala.collection.mutable
 import scala.reflect.internal
 import scala.reflect.internal.util.StringOps.countElementsAsString
-import scala.reflect.internal.util.{Position, SourceFile}
+import scala.reflect.internal.util.{NoSourceFile, Position, SourceFile}
 import scala.tools.nsc.Reporting.Version.{NonParseableVersion, ParseableVersion}
 import scala.tools.nsc.Reporting._
 import scala.util.matching.{ Regex, UnanchoredRegex }
@@ -121,13 +120,16 @@ trait Reporting extends scala.reflect.internal.Reporting { self: ast.Positions w
       }
     }
 
-    def issueIfNotSuppressed(warning: Message): Unit = {
-      if (suppressionsComplete(warning.pos.source)) {
+    def shouldSuspend(warning: Message): Boolean =
+      warning.pos.source != NoSourceFile && !suppressionsComplete(warning.pos.source)
+
+    def issueIfNotSuppressed(warning: Message): Unit =
+      if (shouldSuspend(warning))
+        suspendedMessages.getOrElseUpdate(warning.pos.source, mutable.LinkedHashSet.empty) += warning
+      else {
         if (!isSuppressed(warning))
           issueWarning(warning)
-      } else
-        suspendedMessages.getOrElseUpdate(warning.pos.source, mutable.LinkedHashSet.empty) += warning
-    }
+      }
 
     private def summarize(action: Action, category: WarningCategory): Unit = {
       def rerunMsg: String = {


### PR DESCRIPTION
In `@nowarn` support, don't suspend warnings without positions.

Typer inspects all `@nowarn` annotations in a file ("suppressions").
Warnings reported before typer are suspended (buffered) so they
can later be filtered.

Warnings without a position are never filtered, so they should be
reported directly. Currently, they are reported thanks to
`reportSuspendedMessages` which is invoked at the very end of
a compilation run.