### PR TITLE
Revert currentRun.isScala3 to a Boolean

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1167,8 +1167,9 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
     keepPhaseStack = settings.log.isSetByUser
 
     // We hit these checks regularly. They shouldn't change inside the same run, so cache the comparisons here.
-    val isScala3 = settings.isScala3
-    val isScala3ImplicitResolution = settings.Yscala3ImplicitResolution
+    @nowarn("cat=deprecation")
+    val isScala3: Boolean = settings.isScala3.value
+    val isScala3ImplicitResolution: Boolean = settings.Yscala3ImplicitResolution.value
 
     // used in sbt
     def uncheckedWarnings: List[(Position, String)]   = reporting.uncheckedWarnings

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -528,7 +528,7 @@ trait Scanners extends ScannersCommon {
           (sepRegions.isEmpty || sepRegions.head == RBRACE)) {
         if (pastBlankLine()) insertNL(NEWLINES)
         else if (!isLeadingInfixOperator) insertNL(NEWLINE)
-        else if (!currentRun.isScala3.value) {
+        else if (!currentRun.isScala3) {
           val msg = """|Line starts with an operator that in future
                        |will be taken as an infix expression continued from the previous line.
                        |To force the previous interpretation as a separate statement,
@@ -978,7 +978,7 @@ trait Scanners extends ScannersCommon {
         nextRawChar()
         if (isTripleQuote()) {
           setStrVal()
-          if(!currentRun.isScala3.value) replaceUnicodeEscapesInTriple()
+          if (!currentRun.isScala3) replaceUnicodeEscapesInTriple()
           token = STRINGLIT
         } else
           getRawStringLit()

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -19,12 +19,12 @@ package settings
 
 import java.util.zip.Deflater
 
-import scala.language.existentials
-import scala.annotation.elidable
-import scala.tools.util.PathResolver.Defaults
+import scala.annotation.{elidable, nowarn}
 import scala.collection.mutable
+import scala.language.existentials
 import scala.reflect.internal.util.{ StatisticsStatics, StringContextStripMarginOps }
 import scala.tools.nsc.util.DefaultJarFactory
+import scala.tools.util.PathResolver.Defaults
 import scala.util.chaining._
 
 trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSettings =>
@@ -124,6 +124,7 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
   val mainClass          = StringSetting       ("-Xmain-class", "path", "Class for manifest's Main-Class entry (only useful with -d <jar>)", "")
   val sourceReader       = StringSetting       ("-Xsource-reader", "classname", "Specify a custom method for reading source files.", "")
   val reporter           = StringSetting       ("-Xreporter", "classname", "Specify a custom subclass of FilteringReporter for compiler messages.", "scala.tools.nsc.reporters.ConsoleReporter")
+  @nowarn("cat=deprecation")
   val source             = ScalaVersionSetting ("-Xsource", "version", "Enable features that will be available in a future version of Scala, for purposes of early migration and alpha testing.", initial = ScalaVersion("2.13")).withPostSetHook { s =>
     if (s.value >= ScalaVersion("3"))
       isScala3.value = true
@@ -132,6 +133,7 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
     else if (s.value < ScalaVersion("2.13"))
       errorFn.apply(s"-Xsource must be at least the current major version (${ScalaVersion("2.13").versionString})")
   }
+  @deprecated("Use currentRun.isScala3 instead", since="2.13.9")
   val isScala3           = BooleanSetting      ("isScala3", "Is -Xsource Scala 3?").internalOnly()
   // The previous "-Xsource" option is intended to be used mainly though ^ helper
 

--- a/src/compiler/scala/tools/nsc/typechecker/Adaptations.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Adaptations.scala
@@ -97,7 +97,7 @@ trait Adaptations {
       }
       if (args.nonEmpty)
         warnAdaptation
-      else if (currentRun.isScala3.value)
+      else if (currentRun.isScala3)
         noAdaptation
       else
         deprecatedAdaptation

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1069,7 +1069,7 @@ trait Contexts { self: Analyzer =>
       !(
         // [eed3si9n] ideally I'd like to do this: val fd = currentRun.isScala3 && sym.isDeprecated
         // but implicit caching currently does not report sym.isDeprecated correctly.
-        currentRun.isScala3.value && (sym == currentRun.runDefinitions.Predef_any2stringaddMethod)
+        currentRun.isScala3 && (sym == currentRun.runDefinitions.Predef_any2stringaddMethod)
       ) &&
       !(imported && {
         val e = scope.lookupEntry(name)

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -904,7 +904,7 @@ trait Infer extends Checkable {
       case _                         =>
         tpe2 match {
           case PolyType(tparams2, rtpe2) => isAsSpecificValueType(tpe1, rtpe2, undef1, undef2 ::: tparams2)
-          case _ if !currentRun.isScala3ImplicitResolution.value => existentialAbstraction(undef1, tpe1) <:< existentialAbstraction(undef2, tpe2)
+          case _ if !currentRun.isScala3ImplicitResolution => existentialAbstraction(undef1, tpe1) <:< existentialAbstraction(undef2, tpe2)
           case _ =>
             // Backport of fix for https://github.com/scala/bug/issues/2509
             // from Dotty https://github.com/lampepfl/dotty/commit/89540268e6c49fb92b9ca61249e46bb59981bf5a

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1127,7 +1127,7 @@ trait Namers extends MethodSynthesis {
         case _ => defnTyper.computeType(tree.rhs, pt)
       }
       tree.tpt.defineType {
-        if (currentRun.isScala3.value && !pt.isWildcard && pt != NoType && !pt.isErroneous) pt
+        if (currentRun.isScala3 && !pt.isWildcard && pt != NoType && !pt.isErroneous) pt
         else dropIllegalStarTypes(widenIfNecessary(tree.symbol, rhsTpe, pt))
       }.setPos(tree.pos.focus)
       tree.tpt.tpe
@@ -1471,7 +1471,7 @@ trait Namers extends MethodSynthesis {
             context.warning(ddef.pos, msg, WarningCategory.OtherNullaryOverride)
             meth.updateAttachment(NullaryOverrideAdapted)
           }
-          context.unit.toCheck += (if (currentRun.isScala3.value) error _ else warn _)
+          context.unit.toCheck += (if (currentRun.isScala3) error _ else warn _)
           ListOfNil
         } else vparamSymss
       }

--- a/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
@@ -553,7 +553,7 @@ trait NamesDefaults { self: Analyzer =>
         val NamedArg(Ident(name), rhs) = arg: @unchecked
         params indexWhere (p => matchesName(p, name, argIndex)) match {
           case -1 =>
-            val warnVariableInScope = !currentRun.isScala3.value && context0.lookupSymbol(name, _.isVariable).isSuccess
+            val warnVariableInScope = !currentRun.isScala3 && context0.lookupSymbol(name, _.isVariable).isSuccess
             UnknownParameterNameNamesDefaultError(arg, name, warnVariableInScope)
           case paramPos if argPos contains paramPos =>
             val existingArgIndex = argPos.indexWhere(_ == paramPos)

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -438,7 +438,7 @@ abstract class RefChecks extends Transform {
                   && !javaDetermined(member) && !member.overrides.exists(javaDetermined)
               ) {
                 val msg = "method with a single empty parameter list overrides method without any parameter list"
-                if (currentRun.isScala3.value)
+                if (currentRun.isScala3)
                   overrideErrorWithMemberInfo(msg)
                 else
                   refchecksWarning(member.pos, msg, WarningCategory.OtherNullaryOverride)
@@ -812,7 +812,7 @@ abstract class RefChecks extends Transform {
             .filter(c => c.exists && c.isClass)
           overridden foreach { sym2 =>
             def msg(what: String) = s"shadowing a nested class of a parent is $what but $clazz shadows $sym2 defined in ${sym2.owner}; rename the class to something else"
-            if (currentRun.isScala3.value) reporter.error(clazz.pos, msg("unsupported"))
+            if (currentRun.isScala3) reporter.error(clazz.pos, msg("unsupported"))
             else runReporting.deprecationWarning(clazz.pos, clazz, currentOwner, msg("deprecated"), "2.13.2")
           }
         }

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -882,8 +882,6 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
         val arity = mt.params.length
 
-        val sourceLevel3 = currentRun.isScala3
-
         def warnTree = original orElse tree
 
         def warnEtaZero(): Boolean = {
@@ -941,7 +939,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           if (arity == 0)
             expectingFunctionOfArity && warnEtaZero()
           else
-            expectingFunctionOfArity || expectingSamOfArity && warnEtaSam() || sourceLevel3.value
+            expectingFunctionOfArity || expectingSamOfArity && warnEtaSam() || currentRun.isScala3
         }
 
         def matchNullaryLoosely: Boolean = {
@@ -4913,7 +4911,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
           val result = typed(Function(Nil, methodValue) setSymbol funSym setPos pos, mode, pt)
 
-          if (currentRun.isScala3.value) {
+          if (currentRun.isScala3) {
             UnderscoreNullaryEtaError(methodValue)
           } else {
             context.deprecationWarning(pos, NoSymbol, UnderscoreNullaryEtaWarnMsg, "2.13.2")

--- a/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
@@ -97,7 +97,7 @@ trait Unapplies extends ast.TreeDSL {
   }
 
   private def applyShouldInheritAccess(mods: Modifiers) =
-    currentRun.isScala3.value && (mods.hasFlag(PRIVATE) || (!mods.hasFlag(PROTECTED) && mods.hasAccessBoundary))
+    currentRun.isScala3 && (mods.hasFlag(PRIVATE) || (!mods.hasFlag(PROTECTED) && mods.hasAccessBoundary))
 
   /** The module corresponding to a case class; overrides toString to show the module's name
    */
@@ -271,7 +271,7 @@ trait Unapplies extends ast.TreeDSL {
       val argss = mmap(paramss)(toIdent)
       val body: Tree = New(classTpe, argss)
       val copyMods =
-        if (currentRun.isScala3.value) {
+        if (currentRun.isScala3) {
           val inheritedMods = constrMods(cdef)
           Modifiers(SYNTHETIC | (inheritedMods.flags & AccessFlags), inheritedMods.privateWithin)
         }

--- a/src/compiler/scala/tools/reflect/FastStringInterpolator.scala
+++ b/src/compiler/scala/tools/reflect/FastStringInterpolator.scala
@@ -34,7 +34,7 @@ trait FastStringInterpolator extends FormatInterpolator {
           parts.mapConserve {
             case lit @ Literal(Constant(stringVal: String)) =>
               val value =
-                if (isRaw && currentRun.isScala3.value) stringVal
+                if (isRaw && currentRun.isScala3) stringVal
                 else if (isRaw) {
                   val processed = StringContext.processUnicode(stringVal)
                   if (processed != stringVal) {


### PR DESCRIPTION
Also deprecate the setting, which is set only from `-Xsource`
and read only by `currentRun`.

This is a follow-up to https://github.com/scala/scala/pull/9575/commits/a91eea6ce9c2ce270003346f726f13777fe77128 which changed the Boolean to a Setting, and https://github.com/scala/scala/pull/10069/commits/0d252f6b1f6211a56030bfd1bdcf509a7ad084f8 which dumped the boxing conversion in favor of writing `.value` everywhere.

A few spots were still using `settings` instead of `currentRun`, so the deprecation should lock that down.