### PR TITLE
Abstract parent `copy` does not suspend case `copy`

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1210,7 +1210,7 @@ trait Namers extends MethodSynthesis {
         val modClass = companionSymbolOf(clazz, context).moduleClass
         modClass.attachments.get[ClassForCaseCompanionAttachment] foreach { cma =>
           val cdef = cma.caseClass
-          def hasCopy = (decls containsName nme.copy) || parents.exists(_.member(nme.copy).exists)
+          def hasCopy = decls.containsName(nme.copy) || parents.exists { p => val ov = p.member(nme.copy); ov.exists && !ov.isDeferred }
 
           // scala/bug#5956 needs (cdef.symbol == clazz): there can be multiple class symbols with the same name
           if (cdef.symbol == clazz && !hasCopy)

--- a/test/files/pos/t12623.scala
+++ b/test/files/pos/t12623.scala
@@ -1,0 +1,19 @@
+
+trait MapI[C] {
+  def i: Int
+  def s: String
+  def copy(i: Int = this.i, s: String = this.s): C
+  def mapI(i: Int): C = copy(i)
+}
+
+case class C(i: Int, s: String) extends MapI[C]
+
+/*
+was:
+t12623.scala:9: error: class C needs to be abstract.
+Missing implementation for member of trait MapI:
+  def copy(i: Int, s: String): C = ???
+
+case class C(i: Int, s: String) extends MapI[C]
+           ^
+ */


### PR DESCRIPTION
A case class may inherit an abstract `copy` method, which it will implement as usual.

Fixes scala/bug#12623