### PR TITLE
[backport] Align -release and -target per Scala 3

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/PostProcessorFrontendAccess.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/PostProcessorFrontendAccess.scala
@@ -184,7 +184,7 @@ object PostProcessorFrontendAccess {
 
       @inline def debug: Boolean = s.isDebug
 
-      val target: String = s.target.value
+      val target: String = s.targetValue
 
       private val singleOutDir = s.outputDirs.getSingleOutput
       // the call to `outputDirFor` should be frontendSynch'd, but we assume that the setting is not mutated during the backend

--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -230,13 +230,6 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
   def BooleanSetting(name: String, descr: String, default: Boolean = false) = add(new BooleanSetting(name, descr, default))
   def ChoiceSetting(name: String, helpArg: String, descr: String, choices: List[String], default: String, choicesHelp: List[String] = Nil) =
     add(new ChoiceSetting(name, helpArg, descr, choices, default, choicesHelp))
-  def ChoiceSettingForcedDefault(name: String, helpArg: String, descr: String, choices: List[String], supported: List[String], default: String, choicesHelp: List[String] = Nil) =
-    ChoiceSetting(name, helpArg, descr, choices, default, choicesHelp).withPostSetHook(sett =>
-      if (!supported.contains(sett.value)) {
-        sett.withDeprecationMessage(s"${name}:${sett.value} is deprecated, forcing use of $default")
-        sett.value = default
-      }
-    )
   def IntSetting(name: String, descr: String, default: Int, range: Option[(Int, Int)], parser: String => Option[Int]) =
     add(new IntSetting(name, descr, default, range, parser))
   def MultiStringSetting(name: String, arg: String, descr: String, default: List[String] = Nil, helpText: Option[String] = None, prepend: Boolean = false) =

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -87,15 +87,6 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
       domain  = languageFeatures
     )
   }
-  val release = StringSetting("-release", "<release>", "Compile for a specific version of the Java platform. Supported targets: 6, 7, 8, 9", "").withPostSetHook { (value: StringSetting) =>
-    if (value.value != "" && !scala.util.Properties.isJavaAtLeast("9")) {
-      errorFn.apply("-release is only supported on Java 9 and higher")
-    } else {
-      // TODO validate numeric value
-      // TODO validate release <= java.specification.version
-    }
-  }
-  def releaseValue: Option[String] = Option(release.value).filter(_ != "")
 
   /*
    * The previous "-source" option is intended to be used mainly

--- a/test/files/neg/t12543.check
+++ b/test/files/neg/t12543.check
@@ -1,0 +1,4 @@
+t12543.scala:9: error: value of is not a member of object java.util.List
+    val ss = java.util.List.of("Hello", who)
+                            ^
+one error found

--- a/test/files/neg/t12543.scala
+++ b/test/files/neg/t12543.scala
@@ -1,0 +1,16 @@
+
+// scalac: -Werror -release:8
+
+import scala.collection.JavaConverters._
+import sun._
+
+object HelloWorld {
+  def main(args: Array[String]) = {
+    val ss = java.util.List.of("Hello", who)
+    println(ss.asScala.mkString("", ", ", "!"))
+  }
+}
+
+object sun {
+  val who = "world"
+}


### PR DESCRIPTION
Backport https://github.com/scala/scala/pull/9982

Reminder by https://github.com/scala/bug/issues/12625

Omits fixes to arg processing. `-release:8` but not `-release 8`.

```
➜  ~ skala -target:jvm-1.5
Welcome to Scala 2.12.17-20220726-143638-9f37fd6 (OpenJDK 64-Bit Server VM, Java 18.0.1.1).
Type in expressions for evaluation. Or try :help.

scala> 42
warning: -target is deprecated: -target:5 is deprecated, forcing use of 8
res0: Int = 42

scala> :quit
➜  ~ skala -target:jvm-11
Welcome to Scala 2.12.17-20220726-143638-9f37fd6 (OpenJDK 64-Bit Server VM, Java 18.0.1.1).
Type in expressions for evaluation. Or try :help.

scala> 42
warning: -target is deprecated: Use -release instead to compile against the correct platform API.
res0: Int = 42
```
The hack to allow one shot at setting deprecation on the settings incurs a limitation:
```
➜  ~ skala
Welcome to Scala 2.12.17-20220726-143638-9f37fd6 (OpenJDK 64-Bit Server VM, Java 18.0.1.1).
Type in expressions for evaluation. Or try :help.

scala> 42
res0: Int = 42

scala> :replay -target:jvm-1.5
Replaying: 42
[init] warning: -target is deprecated: -target:5 is deprecated, forcing use of 8
warning: -target is deprecated: -target:5 is deprecated, forcing use of 8
res0: Int = 42


scala> :replay -target:jvm-11
Replaying: 42
[init] warning: -target is deprecated: -target:5 is deprecated, forcing use of 8
warning: -target is deprecated: -target:5 is deprecated, forcing use of 8
res0: Int = 42
```
Unexpectedly, or perhaps expectedly, `reset` does not `reset` enough:
```
scala> :reset -target:jvm-11
Resetting interpreter state.
Forgetting this session history:

42


scala> 42
[init] warning: -target is deprecated: -target:5 is deprecated, forcing use of 8
warning: -target is deprecated: -target:5 is deprecated, forcing use of 8
res0: Int = 42
```