### PR TITLE
Windows fix: msys2 and mingw now also call cygpath on classpath

### DIFF
--- a/src/compiler/templates/tool-unix.tmpl
+++ b/src/compiler/templates/tool-unix.tmpl
@@ -171,7 +171,7 @@ done
 # reset "$@@" to the remaining args
 set -- "${scala_args[@@]}"
 
-if [[ -n "$cygwin" ]]; then
+if [[ -n "$cygwin$mingw$msys" ]]; then
     if [[ "$OS" = "Windows_NT" ]] && cygpath -m .>/dev/null 2>/dev/null ; then
         format=mixed
     else


### PR DESCRIPTION
When rrunning the scala2 bash launch script in an msys2 or mingw64 bash session, the classpath is not being adjusted, causing the launch to fail.

```bash
philwalk@d5 MINGW64 ~/workspace/scala
# /opt/scala-2.13.8/bin/scala
Error: Could not find or load main class scala.tools.nsc.MainGenericRunner
Caused by: java.lang.ClassNotFoundException: scala.tools.nsc.MainGenericRunner
```
This appears to be due to the following section of the bash script, starting on line 174.   The `TOOL_CLASSPATH` should be handled the same in `cygwin`, `mingw64` and `msys2`.

```bash
if [[ -n "$cygwin" ]]; then
    if [[ "$OS" = "Windows_NT" ]] && cygpath -m .>/dev/null 2>/dev/null ; then
        format=mixed
    else
        format=windows
    fi
    SCALA_HOME="$(cygpath --$format "$SCALA_HOME")"
    if [[ -n "$JAVA_HOME" ]]; then
        JAVA_HOME="$(cygpath --$format "$JAVA_HOME")"
    fi
    TOOL_CLASSPATH="$(cygpath --path --$format "$TOOL_CLASSPATH")"
fi
```

The fix is to modify line 174 to the following: (borrowing the pattern on line 109):
```bash
if [[ -n "$cygwin$mingw$msys" ]]; then
```


After the change, a REPL session is successful:

```sh
philwalk@d5 MINGW64 ~/workspace/scala
# /opt/scala-2.13.8/bin/scala
Welcome to Scala 2.13.8 (Java HotSpot(TM) 64-Bit Server VM, Java 11.0.12).
Type in expressions for evaluation. Or try :help.

scala>
```