### PR TITLE
[backport] Accept space separated argument in ChoiceSetting

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -855,7 +855,11 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
     override def isHelping = sawHelp
     override def help = usageErrorMessage
 
-    def tryToSet(args: List[String]) = errorAndValue(usageErrorMessage, None)
+    def tryToSet(args: List[String]) =
+      args match {
+        case Nil => errorAndValue(usageErrorMessage, None)
+        case arg :: rest => tryToSetColon(List(arg)).map(_ => rest)
+      }
 
     override def tryToSetColon(args: List[String]) = args map _preSetHook match {
       case Nil                            => errorAndValue(usageErrorMessage, None)


### PR DESCRIPTION
Backport of part of https://github.com/scala/scala/pull/9982, follow-up for https://github.com/scala/scala/pull/10089