### PR TITLE
Close long-standing soundness loophole involving overriding and bridge methods

### DIFF
--- a/src/reflect/scala/reflect/internal/transform/Erasure.scala
+++ b/src/reflect/scala/reflect/internal/transform/Erasure.scala
@@ -279,8 +279,7 @@ trait Erasure {
       case TypeRef(pre, `clazz`, args) =>
         typeRef(pre, clazz, List())
       case tp =>
-        if (!(clazz == ArrayClass || tp.isError))
-          assert(clazz == ArrayClass || tp.isError, s"!!! unexpected constructor erasure $tp for $clazz")
+        assert(clazz == ArrayClass || tp.isError, s"unexpected constructor erasure $tp for $clazz")
         specialScalaErasureFor(clazz)(tp)
     }
   }

--- a/test/files/neg/t9912.check
+++ b/test/files/neg/t9912.check
@@ -1,0 +1,7 @@
+t9912.scala:7: error: bridge generated for member method compareTo: (b: B): Int in class B
+which overrides method compareTo: (x$1: T): Int in trait Comparable
+clashes with definition of method compareTo: (o: Any): Int in class A;
+both have erased type (x$1: Object): Int
+  def compareTo(b: B): Int = 0
+      ^
+1 error

--- a/test/files/neg/t9912.scala
+++ b/test/files/neg/t9912.scala
@@ -1,0 +1,20 @@
+// skalac: -Vdebug -Vlog:_ -Vprint:erasure
+
+class A {
+  def compareTo(o: Any): Int = 0
+}
+class B extends A with Comparable[B] {
+  def compareTo(b: B): Int = 0
+}
+object C {
+  def main(args: Array[String]): Unit = {
+    println(new B().compareTo(new Object()))
+  }
+}
+
+/*
+java.lang.ClassCastException: class java.lang.Object cannot be cast to class B (java.lang.Object is in module java.base of loader 'bootstrap'; B is in unnamed module of loader java.net.URLClassLoader @3af17be2)
+        at B.compareTo(t9912.scala:5)
+        at Main$.main(t9912.scala:10)
+        at Main.main(t9912.scala)
+*/

--- a/test/files/neg/t9912b.check
+++ b/test/files/neg/t9912b.check
@@ -1,0 +1,7 @@
+t9912.scala:6: error: name clash between defined and inherited member:
+def compareTo(o: java.util.List[_]): Int in class Comparer and
+def compareTo(other: java.util.List[A]): Int at line 6
+have same type after erasure: (o: java.util.List): Int
+  def compareTo(other: java.util.List[A]): Int = 0
+      ^
+1 error

--- a/test/files/neg/t9912b/Comparer.java
+++ b/test/files/neg/t9912b/Comparer.java
@@ -1,0 +1,7 @@
+
+
+public class Comparer {
+  public int compareTo(java.util.List o) {
+    return 0;
+  }
+}

--- a/test/files/neg/t9912b/t9912.scala
+++ b/test/files/neg/t9912b/t9912.scala
@@ -1,0 +1,12 @@
+
+import scala.jdk.CollectionConverters._
+
+// superclass can't write other erased types so as to clash with bridge
+class B[A: Ordering] extends Comparer with Comparable[java.util.List[A]] {
+  def compareTo(other: java.util.List[A]): Int = 0
+}
+object C {
+  def main(args: Array[String]): Unit = println {
+    new B[Int]().compareTo(List(42).asJava)
+  }
+}

--- a/test/files/neg/t9912c.check
+++ b/test/files/neg/t9912c.check
@@ -1,0 +1,7 @@
+t9912c.scala:8: error: bridge generated for member method compareTo: (b: B): Int in class C3
+which overrides method compareTo: (t: T): Int in trait C2
+clashes with definition of method compareTo: (a: A): Int in class C1;
+both have erased type (t: A): Int
+class C3 extends C1 with C2[B] { def compareTo(b: B): Int = 1 }
+                                     ^
+1 error

--- a/test/files/neg/t9912c.scala
+++ b/test/files/neg/t9912c.scala
@@ -1,0 +1,14 @@
+class A
+class B extends A
+
+class C1 { def compareTo(a: A): Int = 0 }
+
+trait C2[T <: A] { def compareTo(t: T): Int }
+
+class C3 extends C1 with C2[B] { def compareTo(b: B): Int = 1 }
+
+object Test extends App {
+  println {
+    (new C3).compareTo(new A)
+  }
+}


### PR DESCRIPTION
An error with inheritance that previously resulted in a runtime exception is now correctly rejected.

Erasure already checks that if the bridge overrides a member, then the bridged method also overrides that member. The check was restricted to members cavorting with `AnyVal`; this commit includes bridge methods with an `Object`-typed parameter, since it is more possible to clash with a user-written member. (More correctly, bridge methods with parameters which are erased type parameters, where erasure is to an upper bound, which might be `Object`.)

Fixes scala/bug#9912