### PR TITLE
Correctly represent `abstract override` methods in error messages

### DIFF
--- a/src/reflect/scala/reflect/internal/Flags.scala
+++ b/src/reflect/scala/reflect/internal/Flags.scala
@@ -437,7 +437,7 @@ class Flags extends ModifierFlags {
     case               MACRO => "<macro>"                             // (1L << 15)
     case         BYNAMEPARAM => "<bynameparam/captured/covariant>"    // (1L << 16)
     case       CONTRAVARIANT => "<contravariant/inconstructor/label>" // (1L << 17)
-    case         ABSOVERRIDE => "absoverride"                         // (1L << 18)
+    case         ABSOVERRIDE => "abstract override"                   // (1L << 18)
     case               LOCAL => "<local>"                             // (1L << 19)
     case                JAVA => "<java>"                              // (1L << 20)
     case           SYNTHETIC => "<synthetic>"                         // (1L << 21)

--- a/test/files/neg/abstract-report2.check
+++ b/test/files/neg/abstract-report2.check
@@ -76,12 +76,12 @@ Missing implementation for member of trait Collection:
 class JustOne extends Collection[Int] {
       ^
 abstract-report2.scala:47: error: class C needs to be a mixin.
-absoverride def t(): Int (defined in trait T) is marked `abstract` and `override`, but no concrete implementation could be found in a base class
+abstract override def t(): Int (defined in trait T) is marked `abstract` and `override`, but no concrete implementation could be found in a base class
 class C extends T               // refchecks
       ^
 abstract-report2.scala:50: error: class D needs to be a mixin.
-absoverride def t(): Int (defined in trait W) is marked `abstract` and `override` and overrides incomplete superclass member
-absoverride def t(): Int (defined in trait V)
+abstract override def t(): Int (defined in trait W) is marked `abstract` and `override` and overrides incomplete superclass member
+abstract override def t(): Int (defined in trait V)
 class D extends W
       ^
 7 errors

--- a/test/files/neg/t12529.check
+++ b/test/files/neg/t12529.check
@@ -1,0 +1,6 @@
+t12529.scala:21: error: `abstract override` modifiers required to override:
+abstract override def m(a: Int): Int (defined in trait C)
+  with override def m(a: Int): Int (defined in trait D)
+class X extends E with D
+      ^
+1 error

--- a/test/files/neg/t12529.scala
+++ b/test/files/neg/t12529.scala
@@ -1,0 +1,21 @@
+trait A {
+  def m(a:Int): Int
+}
+
+trait B extends A {
+  override def m(a:Int): Int = { return a; }
+}
+
+trait C extends A {
+  abstract override def m(a:Int):Int = { return super.m(a); }
+}
+
+trait D extends B with C {
+  override def m(a:Int):Int = { return super.m(a); }
+}
+
+trait E extends C with B {
+  abstract override def m(a:Int):Int = { return super.m(a); }
+}
+
+class X extends E with D

--- a/test/files/neg/t2497.check
+++ b/test/files/neg/t2497.check
@@ -1,6 +1,6 @@
 t2497.scala:21: error: cannot override a concrete member without a third member that's overridden by both (this rule is designed to prevent accidental overrides)
 def eval: Int (defined in class Foo)
-  with absoverride def eval: Int (defined in trait DebugNode)
+  with abstract override def eval: Int (defined in trait DebugNode)
   (new Foo with DebugNode).eval
        ^
 1 error


### PR DESCRIPTION
in case of compilation error due to incorrect application of "abstract override" flags, the compiler output contained "absoverride" which have been changed to "abstract override". All tests in neg category of partests are pass.

Fixes https://github.com/scala/bug/issues/12529