### PR TITLE
Java wrappers need not be case classes

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -39,6 +39,11 @@ object MimaFilters extends AutoPlugin {
     // internal to wrappers
     ProblemFilters.exclude[NewMixinForwarderProblem]("scala.collection.convert.JavaCollectionWrappers#JMapWrapperLike.getOrElseUpdate"),
     ProblemFilters.exclude[NewMixinForwarderProblem]("scala.collection.convert.JavaCollectionWrappers#JMapWrapperLike.updateWith"),
+
+    // removing case classing from wrappers means synthetic methods and parent types and companions are missing
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.convert.JavaCollectionWrappers#*"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.convert.JavaCollectionWrappers$*"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.convert.JavaCollectionWrappers$*"),
   )
 
   override val buildSettings = Seq(

--- a/src/library/scala/collection/convert/AsJavaConverters.scala
+++ b/src/library/scala/collection/convert/AsJavaConverters.scala
@@ -38,9 +38,9 @@ trait AsJavaConverters {
    * @return  A Java `Iterator` view of the argument.
    */
   def asJava[A](i: Iterator[A]): ju.Iterator[A] = i match {
-    case null                       => null
-    case JIteratorWrapper(wrapped)  => wrapped.asInstanceOf[ju.Iterator[A]]
-    case _                          => IteratorWrapper(i)
+    case null                             => null
+    case wrapper: JIteratorWrapper[A @uc] => wrapper.underlying
+    case _                                => new IteratorWrapper(i)
   }
 
   /**
@@ -56,9 +56,9 @@ trait AsJavaConverters {
    * @return  A Java `Enumeration` view of the argument.
    */
   def asJavaEnumeration[A](i: Iterator[A]): ju.Enumeration[A] = i match {
-    case null                         => null
-    case JEnumerationWrapper(wrapped) => wrapped.asInstanceOf[ju.Enumeration[A]]
-    case _                            => IteratorWrapper(i)
+    case null                                => null
+    case wrapper: JEnumerationWrapper[A @uc] => wrapper.underlying
+    case _                                   => new IteratorWrapper(i)
   }
 
   /**
@@ -74,9 +74,9 @@ trait AsJavaConverters {
    * @return  A Java `Iterable` view of the argument.
    */
   def asJava[A](i: Iterable[A]): jl.Iterable[A] = i match {
-    case null                       => null
-    case JIterableWrapper(wrapped)  => wrapped.asInstanceOf[jl.Iterable[A]]
-    case _                          => IterableWrapper(i)
+    case null                             => null
+    case wrapper: JIterableWrapper[A @uc] => wrapper.underlying
+    case _                                => new IterableWrapper(i)
   }
 
   /**
@@ -89,9 +89,9 @@ trait AsJavaConverters {
    * @return  A Java `Collection` view of the argument.
    */
   def asJavaCollection[A](i: Iterable[A]): ju.Collection[A] = i match {
-    case null                         => null
-    case JCollectionWrapper(wrapped)  => wrapped.asInstanceOf[ju.Collection[A]]
-    case _                            => IterableWrapper(i)
+    case null                               => null
+    case wrapper: JCollectionWrapper[A @uc] => wrapper.underlying
+    case _                                  => new IterableWrapper(i)
   }
 
   /**
@@ -107,9 +107,9 @@ trait AsJavaConverters {
    * @return A Java `List` view of the argument.
    */
   def asJava[A](b: mutable.Buffer[A]): ju.List[A] = b match {
-    case null                   => null
-    case JListWrapper(wrapped)  => wrapped
-    case _                      => MutableBufferWrapper(b)
+    case null                         => null
+    case wrapper: JListWrapper[A @uc] => wrapper.underlying
+    case _                            => new MutableBufferWrapper(b)
   }
 
   /**
@@ -125,9 +125,9 @@ trait AsJavaConverters {
    * @return  A Java `List` view of the argument.
    */
   def asJava[A](s: mutable.Seq[A]): ju.List[A] = s match {
-    case null                   => null
-    case JListWrapper(wrapped)  => wrapped
-    case _                      => MutableSeqWrapper(s)
+    case null                         => null
+    case wrapper: JListWrapper[A @uc] => wrapper.underlying
+    case _                            => new MutableSeqWrapper(s)
   }
 
   /**
@@ -143,9 +143,9 @@ trait AsJavaConverters {
    * @return  A Java `List` view of the argument.
    */
   def asJava[A](s: Seq[A]): ju.List[A] = s match {
-    case null                   => null
-    case JListWrapper(wrapped)  => wrapped.asInstanceOf[ju.List[A]]
-    case _                      => SeqWrapper(s)
+    case null                         => null
+    case wrapper: JListWrapper[A @uc] => wrapper.underlying
+    case _                            => new SeqWrapper(s)
   }
 
   /**
@@ -161,9 +161,9 @@ trait AsJavaConverters {
    * @return  A Java `Set` view of the argument.
    */
   def asJava[A](s: mutable.Set[A]): ju.Set[A] = s match {
-    case null                 => null
-    case JSetWrapper(wrapped) => wrapped
-    case _                    => MutableSetWrapper(s)
+    case null                        => null
+    case wrapper: JSetWrapper[A @uc] => wrapper.underlying
+    case _                           => new MutableSetWrapper(s)
   }
 
     /**
@@ -179,9 +179,9 @@ trait AsJavaConverters {
    * @return  A Java `Set` view of the argument.
    */
   def asJava[A](s: Set[A]): ju.Set[A] = s match {
-    case null                 => null
-    case JSetWrapper(wrapped) => wrapped
-    case _                    => new SetWrapper(s)
+    case null                        => null
+    case wrapper: JSetWrapper[A @uc] => wrapper.underlying
+    case _                           => new SetWrapper(s)
   }
 
   /**
@@ -197,9 +197,9 @@ trait AsJavaConverters {
    * @return  A Java `Map` view of the argument.
    */
   def asJava[K, V](m: mutable.Map[K, V]): ju.Map[K, V] = m match {
-    case null                         => null
-    case w: JMapWrapper[K @uc, V @uc] => w.underlying
-    case _                            => MutableMapWrapper(m)
+    case null                               => null
+    case wrapper: JMapWrapper[K @uc, V @uc] => wrapper.underlying
+    case _                                  => new MutableMapWrapper(m)
   }
 
   /**
@@ -216,9 +216,9 @@ trait AsJavaConverters {
    * @return  A Java `Dictionary` view of the argument.
    */
   def asJavaDictionary[K, V](m: mutable.Map[K, V]): ju.Dictionary[K, V] = m match {
-    case null                         => null
-    case JDictionaryWrapper(wrapped)  => wrapped
-    case _                            => DictionaryWrapper(m)
+    case null                                      => null
+    case wrapper: JDictionaryWrapper[K @uc, V @uc] => wrapper.underlying
+    case _                                         => new DictionaryWrapper(m)
   }
 
   /**
@@ -234,9 +234,9 @@ trait AsJavaConverters {
    * @return  A Java `Map` view of the argument.
    */
   def asJava[K, V](m: Map[K, V]): ju.Map[K, V] = m match {
-    case null                         => null
-    case w: JMapWrapper[K @uc, V @uc] => w.underlying
-    case _                            => new MapWrapper(m)
+    case null                               => null
+    case wrapper: JMapWrapper[K @uc, V @uc] => wrapper.underlying
+    case _                                  => new MapWrapper(m)
   }
 
   /**
@@ -253,8 +253,8 @@ trait AsJavaConverters {
    * @return  A Java `ConcurrentMap` view of the argument.
    */
   def asJava[K, V](m: concurrent.Map[K, V]): juc.ConcurrentMap[K, V] = m match {
-    case null                           => null
-    case JConcurrentMapWrapper(wrapped) => wrapped
-    case _                              => new ConcurrentMapWrapper(m)
+    case null                                         => null
+    case wrapper: JConcurrentMapWrapper[K @uc, V @uc] => wrapper.underlying
+    case _                                            => new ConcurrentMapWrapper(m)
   }
 }

--- a/src/library/scala/collection/convert/AsScalaConverters.scala
+++ b/src/library/scala/collection/convert/AsScalaConverters.scala
@@ -17,6 +17,8 @@ package convert
 import java.util.{concurrent => juc}
 import java.{lang => jl, util => ju}
 
+import scala.{unchecked => uc}
+
 /** Defines converter methods from Java to Scala collections.
   * These methods are available through the [[scala.jdk.javaapi.CollectionConverters]] object.
   */
@@ -36,9 +38,9 @@ trait AsScalaConverters {
    * @return  A Scala `Iterator` view of the argument.
    */
   def asScala[A](i: ju.Iterator[A]): Iterator[A] = i match {
-    case null                     => null
-    case IteratorWrapper(wrapped) => wrapped
-    case _                        => JIteratorWrapper(i)
+    case null                            => null
+    case wrapper: IteratorWrapper[A @uc] => wrapper.underlying
+    case _                               => new JIteratorWrapper(i)
   }
 
   /**
@@ -54,9 +56,9 @@ trait AsScalaConverters {
    * @return  A Scala `Iterator` view of the argument.
    */
   def asScala[A](e: ju.Enumeration[A]): Iterator[A] = e match {
-    case null                     => null
-    case IteratorWrapper(wrapped) => wrapped
-    case _                        => JEnumerationWrapper(e)
+    case null                            => null
+    case wrapper: IteratorWrapper[A @uc] => wrapper.underlying
+    case _                               => new JEnumerationWrapper(e)
   }
 
   /**
@@ -72,9 +74,9 @@ trait AsScalaConverters {
    * @return  A Scala `Iterable` view of the argument.
    */
   def asScala[A](i: jl.Iterable[A]): Iterable[A] = i match {
-    case null                     => null
-    case IterableWrapper(wrapped) => wrapped
-    case _                        => JIterableWrapper(i)
+    case null                            => null
+    case wrapper: IterableWrapper[A @uc] => wrapper.underlying
+    case _                               => new JIterableWrapper(i)
   }
 
   /**
@@ -87,9 +89,9 @@ trait AsScalaConverters {
    * @return  A Scala `Iterable` view of the argument.
    */
   def asScala[A](c: ju.Collection[A]): Iterable[A] = c match {
-    case null                     => null
-    case IterableWrapper(wrapped) => wrapped
-    case _                        => JCollectionWrapper(c)
+    case null                            => null
+    case wrapper: IterableWrapper[A @uc] => wrapper.underlying
+    case _                               => new JCollectionWrapper(c)
   }
 
   /**
@@ -105,9 +107,9 @@ trait AsScalaConverters {
    * @return A Scala mutable `Buffer` view of the argument.
    */
   def asScala[A](l: ju.List[A]): mutable.Buffer[A] = l match {
-    case null                           => null
-    case MutableBufferWrapper(wrapped)  => wrapped
-    case _                              => new JListWrapper(l)
+    case null                                 => null
+    case wrapper: MutableBufferWrapper[A @uc] => wrapper.underlying
+    case _                                    => new JListWrapper(l)
   }
 
   /**
@@ -123,9 +125,9 @@ trait AsScalaConverters {
    * @return  A Scala mutable `Set` view of the argument.
    */
   def asScala[A](s: ju.Set[A]): mutable.Set[A] = s match {
-    case null                       => null
-    case MutableSetWrapper(wrapped) => wrapped
-    case _                          => new JSetWrapper(s)
+    case null                              => null
+    case wrapper: MutableSetWrapper[A @uc] => wrapper.underlying
+    case _                                 => new JSetWrapper(s)
   }
 
   /**
@@ -145,10 +147,10 @@ trait AsScalaConverters {
    * @param m The Java `Map` to be converted.
    * @return  A Scala mutable `Map` view of the argument.
    */
-  def asScala[A, B](m: ju.Map[A, B]): mutable.Map[A, B] = m match {
-    case null                       => null
-    case MutableMapWrapper(wrapped) => wrapped
-    case _                          => new JMapWrapper(m)
+  def asScala[K, V](m: ju.Map[K, V]): mutable.Map[K, V] = m match {
+    case null                                     => null
+    case wrapper: MutableMapWrapper[K @uc, V @uc] => wrapper.underlying
+    case _                                        => new JMapWrapper(m)
   }
 
   /**
@@ -164,10 +166,10 @@ trait AsScalaConverters {
    * @param m The Java `ConcurrentMap` to be converted.
    * @return  A Scala mutable `ConcurrentMap` view of the argument.
    */
-  def asScala[A, B](m: juc.ConcurrentMap[A, B]): concurrent.Map[A, B] = m match {
-    case null                             => null
-    case cmw: ConcurrentMapWrapper[_, _]  => cmw.underlying
-    case _                                => new JConcurrentMapWrapper(m)
+  def asScala[K, V](m: juc.ConcurrentMap[K, V]): concurrent.Map[K, V] = m match {
+    case null                                        => null
+    case wrapper: ConcurrentMapWrapper[K @uc, V @uc] => wrapper.underlyingConcurrentMap
+    case _                                           => new JConcurrentMapWrapper(m)
   }
 
     /**
@@ -182,10 +184,10 @@ trait AsScalaConverters {
    * @param d The Java `Dictionary` to be converted.
    * @return  A Scala mutable `Map` view of the argument.
    */
-  def asScala[A, B](d: ju.Dictionary[A, B]): mutable.Map[A, B] = d match {
-    case null                       => null
-    case DictionaryWrapper(wrapped) => wrapped
-    case _                          => new JDictionaryWrapper(d)
+  def asScala[K, V](d: ju.Dictionary[K, V]): mutable.Map[K, V] = d match {
+    case null                                     => null
+    case wrapper: DictionaryWrapper[K @uc, V @uc] => wrapper.underlying
+    case _                                        => new JDictionaryWrapper(d)
   }
 
   /**

--- a/src/library/scala/collection/convert/JavaCollectionWrappers.scala
+++ b/src/library/scala/collection/convert/JavaCollectionWrappers.scala
@@ -27,7 +27,7 @@ import scala.util.chaining._
 // not private[convert] because `WeakHashMap` uses JMapWrapper
 private[collection] object JavaCollectionWrappers extends Serializable {
   @SerialVersionUID(3L)
-  case class IteratorWrapper[A](underlying: Iterator[A]) extends ju.Iterator[A] with ju.Enumeration[A] with Serializable {
+  class IteratorWrapper[A](val underlying: Iterator[A]) extends ju.Iterator[A] with ju.Enumeration[A] with Serializable {
     def hasNext = underlying.hasNext
     def next() = underlying.next()
     def hasMoreElements = underlying.hasNext
@@ -36,13 +36,13 @@ private[collection] object JavaCollectionWrappers extends Serializable {
   }
 
   @SerialVersionUID(3L)
-  case class JIteratorWrapper[A](underlying: ju.Iterator[A]) extends AbstractIterator[A] with Iterator[A] with Serializable {
+  class JIteratorWrapper[A](val underlying: ju.Iterator[A]) extends AbstractIterator[A] with Iterator[A] with Serializable {
     def hasNext = underlying.hasNext
     def next() = underlying.next
   }
 
   @SerialVersionUID(3L)
-  case class JEnumerationWrapper[A](underlying: ju.Enumeration[A]) extends AbstractIterator[A] with Iterator[A] with Serializable {
+  class JEnumerationWrapper[A](val underlying: ju.Enumeration[A]) extends AbstractIterator[A] with Iterator[A] with Serializable {
     def hasNext = underlying.hasMoreElements
     def next() = underlying.nextElement
   }
@@ -50,15 +50,15 @@ private[collection] object JavaCollectionWrappers extends Serializable {
   trait IterableWrapperTrait[A] extends ju.AbstractCollection[A] {
     val underlying: Iterable[A]
     def size = underlying.size
-    override def iterator = IteratorWrapper(underlying.iterator)
+    override def iterator = new IteratorWrapper(underlying.iterator)
     override def isEmpty = underlying.isEmpty
   }
 
   @SerialVersionUID(3L)
-  case class IterableWrapper[A](underlying: Iterable[A]) extends ju.AbstractCollection[A] with IterableWrapperTrait[A] with Serializable
+  class IterableWrapper[A](val underlying: Iterable[A]) extends ju.AbstractCollection[A] with IterableWrapperTrait[A] with Serializable
 
   @SerialVersionUID(3L)
-  case class JIterableWrapper[A](underlying: jl.Iterable[A])
+  class JIterableWrapper[A](val underlying: jl.Iterable[A])
     extends AbstractIterable[A]
       with StrictOptimizedIterableOps[A, Iterable, Iterable[A]]
       with Serializable {
@@ -68,7 +68,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
   }
 
   @SerialVersionUID(3L)
-  case class JCollectionWrapper[A](underlying: ju.Collection[A])
+  class JCollectionWrapper[A](val underlying: ju.Collection[A])
     extends AbstractIterable[A]
       with StrictOptimizedIterableOps[A, Iterable, Iterable[A]]
       with Serializable {
@@ -80,12 +80,12 @@ private[collection] object JavaCollectionWrappers extends Serializable {
   }
 
   @SerialVersionUID(3L)
-  case class SeqWrapper[A](underlying: Seq[A]) extends ju.AbstractList[A] with IterableWrapperTrait[A] with Serializable {
+  class SeqWrapper[A](val underlying: Seq[A]) extends ju.AbstractList[A] with IterableWrapperTrait[A] with Serializable {
     def get(i: Int) = underlying(i)
   }
 
   @SerialVersionUID(3L)
-  case class MutableSeqWrapper[A](underlying: mutable.Seq[A]) extends ju.AbstractList[A] with IterableWrapperTrait[A] with Serializable {
+  class MutableSeqWrapper[A](val underlying: mutable.Seq[A]) extends ju.AbstractList[A] with IterableWrapperTrait[A] with Serializable {
     def get(i: Int) = underlying(i)
     override def set(i: Int, elem: A) = {
       val p = underlying(i)
@@ -95,7 +95,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
   }
 
   @SerialVersionUID(3L)
-  case class MutableBufferWrapper[A](underlying: mutable.Buffer[A]) extends ju.AbstractList[A] with IterableWrapperTrait[A] with Serializable {
+  class MutableBufferWrapper[A](val underlying: mutable.Buffer[A]) extends ju.AbstractList[A] with IterableWrapperTrait[A] with Serializable {
     def get(i: Int) = underlying(i)
     override def set(i: Int, elem: A) = { val p = underlying(i); underlying(i) = elem; p }
     override def add(elem: A) = { underlying += elem; true }
@@ -103,7 +103,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
   }
 
   @SerialVersionUID(3L)
-  case class JListWrapper[A](underlying: ju.List[A])
+  class JListWrapper[A](val underlying: ju.List[A])
     extends mutable.AbstractBuffer[A]
       with SeqOps[A, mutable.Buffer, mutable.Buffer[A]]
       with StrictOptimizedSeqOps[A, mutable.Buffer, mutable.Buffer[A]]
@@ -126,7 +126,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
     def clear() = underlying.clear()
     // Note: Clone cannot just call underlying.clone because in Java, only specific collections
     // expose clone methods.  Generically, they're protected.
-    override def clone(): JListWrapper[A] = JListWrapper(new ju.ArrayList[A](underlying))
+    override def clone(): JListWrapper[A] = new JListWrapper(new ju.ArrayList[A](underlying))
     def patchInPlace(from: Int, patch: scala.collection.IterableOnce[A], replaced: Int): this.type = {
       remove(from, replaced)
       insertAll(from, patch)
@@ -167,7 +167,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
   }
 
   @SerialVersionUID(3L)
-  case class MutableSetWrapper[A](underlying: mutable.Set[A]) extends SetWrapper[A](underlying) with Serializable {
+  class MutableSetWrapper[A](val underlying: mutable.Set[A]) extends SetWrapper[A](underlying) with Serializable {
     override def add(elem: A) = {
       val sz = underlying.size
       underlying += elem
@@ -180,7 +180,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
   }
 
   @SerialVersionUID(3L)
-  case class JSetWrapper[A](underlying: ju.Set[A])
+  class JSetWrapper[A](val underlying: ju.Set[A])
     extends mutable.AbstractSet[A]
       with mutable.SetOps[A, mutable.Set, mutable.Set[A]]
       with StrictOptimizedSetOps[A, mutable.Set, mutable.Set[A]]
@@ -202,7 +202,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
       underlying.clear()
     }
 
-    override def empty: mutable.Set[A] = JSetWrapper(new ju.HashSet[A])
+    override def empty: mutable.Set[A] = new JSetWrapper(new ju.HashSet[A])
 
     // Note: Clone cannot just call underlying.clone because in Java, only specific collections
     // expose clone methods.  Generically, they're protected.
@@ -290,7 +290,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
   }
 
   @SerialVersionUID(3L)
-  case class MutableMapWrapper[K, V](underlying: mutable.Map[K, V]) extends MapWrapper[K, V](underlying) {
+  class MutableMapWrapper[K, V](val underlying: mutable.Map[K, V]) extends MapWrapper[K, V](underlying) {
     override def put(k: K, v: V) = underlying.put(k, v) match {
       case Some(v1) => v1
       case None => null.asInstanceOf[V]
@@ -406,7 +406,9 @@ private[collection] object JavaCollectionWrappers extends Serializable {
   }
 
   @SerialVersionUID(3L)
-  class ConcurrentMapWrapper[K, V](override val underlying: concurrent.Map[K, V]) extends MutableMapWrapper[K, V](underlying) with juc.ConcurrentMap[K, V] {
+  class ConcurrentMapWrapper[K, V](underlying: concurrent.Map[K, V]) extends MutableMapWrapper[K, V](underlying) with juc.ConcurrentMap[K, V] {
+
+    def underlyingConcurrentMap: concurrent.Map[K, V] = underlying
 
     override def putIfAbsent(k: K, v: V) = underlying.putIfAbsent(k, v) match {
       case Some(v) => v
@@ -433,7 +435,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
    *  are not guaranteed to be atomic.
    */
   @SerialVersionUID(3L)
-  case class JConcurrentMapWrapper[K, V](underlying: juc.ConcurrentMap[K, V])
+  class JConcurrentMapWrapper[K, V](val underlying: juc.ConcurrentMap[K, V])
     extends AbstractJMapWrapper[K, V]
       with concurrent.Map[K, V] {
 
@@ -466,7 +468,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
   }
 
   @SerialVersionUID(3L)
-  case class DictionaryWrapper[K, V](underlying: mutable.Map[K, V]) extends ju.Dictionary[K, V] with Serializable {
+  class DictionaryWrapper[K, V](val underlying: mutable.Map[K, V]) extends ju.Dictionary[K, V] with Serializable {
     def size: Int = underlying.size
     def isEmpty: Boolean = underlying.isEmpty
     def keys: ju.Enumeration[K] = underlying.keysIterator.asJavaEnumeration
@@ -494,7 +496,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
   }
 
   @SerialVersionUID(3L)
-  case class JDictionaryWrapper[K, V](underlying: ju.Dictionary[K, V]) extends mutable.AbstractMap[K, V] with Serializable {
+  class JDictionaryWrapper[K, V](val underlying: ju.Dictionary[K, V]) extends mutable.AbstractMap[K, V] with Serializable {
     override def size: Int = underlying.size
     override def isEmpty: Boolean = underlying.isEmpty
     override def knownSize: Int = if (underlying.isEmpty) 0 else super.knownSize
@@ -517,7 +519,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
   }
 
   @SerialVersionUID(3L)
-  case class JPropertiesWrapper(underlying: ju.Properties)
+  class JPropertiesWrapper(underlying: ju.Properties)
     extends mutable.AbstractMap[String, String]
       with mutable.MapOps[String, String, mutable.Map, mutable.Map[String, String]]
       with StrictOptimizedMapOps[String, String, mutable.Map, mutable.Map[String, String]]
@@ -558,7 +560,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
 
     override def clear() = underlying.clear()
 
-    override def empty = JPropertiesWrapper(new ju.Properties)
+    override def empty = new JPropertiesWrapper(new ju.Properties)
 
     def getProperty(key: String) = underlying.getProperty(key)
 

--- a/test/scalacheck/scala/collection/convert/WrapperProperties.scala
+++ b/test/scalacheck/scala/collection/convert/WrapperProperties.scala
@@ -14,7 +14,7 @@ object WrapperProperties extends Properties("Wrappers") {
     val actual: collection.Set[Int] = {
       val jset = new java.util.HashSet[Int]()
       hs.foreach(jset.add)
-      JavaCollectionWrappers.JSetWrapper(jset)
+      new JavaCollectionWrappers.JSetWrapper(jset)
     }.filterInPlace(p)
     actual ?= expected
   }


### PR DESCRIPTION
Inspired by https://github.com/lampepfl/dotty/issues/15764#issuecomment-1206641469 to consider whether the wrapper classes ought to be case classes, as they have been since early days.

The hierarchy is complex (because collections).

`ConcurrentMapWrapper` overrode the `underlying` case class field in `MutableMapWrapper`, to narrow the result type. Now it provides `underlyingConcurrentMap` as a convenience.

Arguably, the pattern matches are easier to read.

It would be nice to backport universal apply and compile library with `-Xsource:3`.

Mima may disagree and require persuading.