### PR TITLE
Support JDK 17 `PermittedSubclasses` in classfiles

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1727,10 +1727,8 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
   } // class Run
 
   def printAllUnits(): Unit = {
-    print("[[syntax trees at end of %25s]]".format(phase))
-    exitingPhase(phase)(currentRun.units foreach { unit =>
-      nodePrinters showUnit unit
-    })
+    print(f"[[syntax trees at end of $phase%25s]]")
+    exitingPhase(phase)(currentRun.units.foreach(nodePrinters.showUnit(_)))
   }
 
   /** We resolve the class/object ambiguity by passing a type/term name.

--- a/src/compiler/scala/tools/nsc/ast/parser/CommonTokens.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/CommonTokens.scala
@@ -51,7 +51,7 @@ abstract class CommonTokens {
   // J: PUBLIC = 42
   final val PROTECTED = 43
   final val PRIVATE = 44
-  // S: SEALED = 45
+  final val SEALED = 45     // J: contextual keyword
   final val ABSTRACT = 46
   // J: DEFAULT = 47
   // J: STATIC = 48

--- a/src/compiler/scala/tools/nsc/ast/parser/Tokens.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Tokens.scala
@@ -28,7 +28,6 @@ object Tokens extends CommonTokens {
   /** modifiers */
   final val IMPLICIT = 40
   final val OVERRIDE = 41
-  final val SEALED = 45
   final val LAZY = 55
   final val MACRO = 57
 

--- a/src/compiler/scala/tools/nsc/javac/JavaTokens.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaTokens.scala
@@ -38,6 +38,7 @@ object JavaTokens extends ast.parser.CommonTokens {
   final val NATIVE = 53
   final val STRICTFP = 54
   final val THROWS = 56
+  final val UNSEALED = 57   // contextual keyword
 
   /** templates */
   final val INTERFACE = 66

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -885,7 +885,7 @@ trait ContextErrors extends splain.SplainErrors {
 
       // def stabilize
       def NotAValueError(tree: Tree, sym: Symbol) = {
-        issueNormalTypeError(tree, sym.kindString + " " + sym.fullName + " is not a value")
+        issueNormalTypeError(tree, s"${sym.kindString} ${sym.fullName} is not a value")
         setError(tree)
       }
 

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1811,7 +1811,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         if (parent == DynamicClass) checkFeature(parentPos, currentRun.runDefinitions.DynamicsFeature)
 
       def validateParentClass(parent: Tree, superclazz: Symbol) =
-        if (!parent.isErrorTyped) {
+        if (!parent.isErrorTyped) { // redundant
           val psym = parent.tpe.typeSymbol.initialize
 
           if (!context.unit.isJava)
@@ -1876,7 +1876,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
       if (!parents.isEmpty && parents.forall(!_.isErrorTyped)) {
         val superclazz = parents.head.tpe.typeSymbol
-        for (p <- parents) validateParentClass(p, superclazz)
+        parents.foreach(validateParentClass(_, superclazz))
       }
 
       pending.foreach(ErrorUtils.issueTypeError)
@@ -2054,7 +2054,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       val body1 = pluginsEnterStats(this, namer.expandMacroAnnotations(templ.body))
       enterSyms(context.outer.make(templ, clazz, clazz.info.decls), body1)
       if (!templ.isErrorTyped) // if `parentTypes` has invalidated the template, don't validate it anymore
-      validateParentClasses(parents1, selfType, clazz.isTrait)
+        validateParentClasses(parents1, selfType, clazz.isTrait)
       if (clazz.isCase)
         validateNoCaseAncestor(clazz)
       if (clazz.isTrait && hasSuperArgs(parents1.head))
@@ -2088,11 +2088,10 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         ctors.foreach(AuxConstrInConstantAnnotation(_, clazz))
       }
 
-
       if (clazz.isTrait) {
-        for (decl <- clazz.info.decls if decl.isTerm && decl.isEarlyInitialized) {
-          context.warning(decl.pos, "Implementation restriction: early definitions in traits are not initialized before the super class is initialized.", WarningCategory.Other)
-        }
+        for (decl <- clazz.info.decls)
+          if (decl.isTerm && decl.isEarlyInitialized)
+            context.warning(decl.pos, "Implementation restriction: early definitions in traits are not initialized before the super class is initialized.", WarningCategory.Other)
       }
 
       treeCopy.Template(templ, parents1, self1, body3) setType clazz.tpe_*

--- a/src/partest/scala/tools/partest/nest/AbstractRunner.scala
+++ b/src/partest/scala/tools/partest/nest/AbstractRunner.scala
@@ -291,7 +291,7 @@ class AbstractRunner(val config: RunnerSpec.Config, protected final val testSour
             List(pathSettings.testParent / norm)
           }
         }
-        .distinct
+        .distinct.filter(denotesTestPath)
       }
 
       val isRerun = config.optFailed

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -154,4 +154,8 @@ trait StdAttachments {
   case object FieldTypeInferred extends PlainAttachment
 
   case class LookupAmbiguityWarning(msg: String) extends PlainAttachment
+
+  /** Java sealed classes may be qualified with a permits clause specifying allowed subclasses. */
+  case class PermittedSubclasses(permits: List[Tree]) extends PlainAttachment
+  case class PermittedSubclassSymbols(permits: List[Symbol]) extends PlainAttachment
 }

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -320,6 +320,7 @@ trait StdNames {
     final val SignatureATTR: NameType              = nameType("Signature")
     final val SourceFileATTR: NameType             = nameType("SourceFile")
     final val SyntheticATTR: NameType              = nameType("Synthetic")
+    final val PermittedSubclassesATTR: NameType    = nameType("PermittedSubclasses")
 
     final val scala_ : NameType = nameType("scala")
 
@@ -1277,11 +1278,16 @@ trait StdNames {
     final val keywords = kw.result
   }
 
-  // "The identifiers var, yield, and record are restricted identifiers because they are not allowed in some contexts"
-  // A type identifier is an identifier that is not the character sequence var, yield, or record.
-  // An unqualified method identifier is an identifier that is not the character sequence yield.
+  // The identifiers non-sealed, permits, record, sealed, var, and yield are restricted identifiers
+  // because they are not allowed in some contexts.
+  // A type identifier is an identifier that is not the character sequence permits, record, sealed, var, or yield.
+  // An unqualified method identifier is an identifier that is not the character sequence yield. (JLS 3.8)
   class JavaRestrictedIdentifiers {
+    final val PERMITS: TermName = TermName("permits")
     final val RECORD: TermName = TermName("record")
+    final val SEALED: TermName = TermName("sealed")
+    final val UNSEALED: TermName = TermName("non-sealed")
+    final val NON: TermName = TermName("non")
     final val VAR: TermName    = TermName("var")
     final val YIELD: TermName  = TermName("yield")
   }

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -1011,13 +1011,6 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     final def isStaticOwner: Boolean =
       isPackageClass || isModuleClass && isStatic
 
-    /** A helper function for isEffectivelyFinal. */
-    private def isNotOverridden =
-      owner.isClass && (
-           owner.isEffectivelyFinal
-        || owner.isSealed && owner.sealedChildren.forall(c => c.isEffectivelyFinal && overridingSymbol(c) == NoSymbol)
-      )
-
     /** Is this symbol effectively final? I.e, it cannot be overridden */
     final def isEffectivelyFinal: Boolean = (
          hasFlag(FINAL | PACKAGE) && this != SingletonClass
@@ -1028,7 +1021,14 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       || isClass && !isRefinementClass && originalOwner.isTerm && children.isEmpty
     )
     /** Is this symbol effectively final or a concrete term member of sealed class whose children do not override it */
-    final def isEffectivelyFinalOrNotOverridden: Boolean = isEffectivelyFinal || (isTerm && !isDeferred && isNotOverridden)
+    final def isEffectivelyFinalOrNotOverridden: Boolean = {
+      def isNotOverridden =
+        owner.isClass && (
+             owner.isEffectivelyFinal
+          || owner.isSealed && owner.sealedChildren.forall(c => c.isEffectivelyFinal && overridingSymbol(c) == NoSymbol)
+        )
+      isEffectivelyFinal || isTerm && !isDeferred && isNotOverridden
+    }
 
     /** Is this symbol owned by a package? */
     final def isTopLevel = owner.isPackageClass

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -1426,7 +1426,7 @@ trait Trees extends api.Trees {
       else Modifiers(flags, privateWithin, newAnns) setPositions positions
     }
 
-    override def toString = "Modifiers(%s, %s, %s)".format(flagString, annotations mkString ", ", positions)
+    override def toString = s"Modifiers($flagString, ${annotations.mkString(",")}, $positions)"
   }
 
   object Modifiers extends ModifiersExtractor

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1769,9 +1769,9 @@ trait Types
         }
       }
     }
-    //Console.println("baseTypeSeq(" + typeSymbol + ") = " + baseTypeSeqCache.toList);//DEBUG
+    //Console.println(s"baseTypeSeq(${tpe.typeSymbol}) = ${tpe.baseTypeSeqCache.toList}") //DEBUG
     if (tpe.baseTypeSeqCache eq undetBaseTypeSeq)
-      throw new TypeError("illegal cyclic inheritance involving " + tpe.typeSymbol)
+      throw new TypeError(s"illegal cyclic inheritance involving ${tpe.typeSymbol}")
   }
 
   protected def defineBaseClassesOfCompoundType(tpe: CompoundType): Unit = {
@@ -2792,8 +2792,9 @@ trait Types
         }
       }
     }
+    //Console.println(s"baseTypeSeq(${tpe.typeSymbol}) = ${tpe.baseTypeSeqCache.toList}") //DEBUG
     if (tpe.baseTypeSeqCache == undetBaseTypeSeq)
-      throw new TypeError("illegal cyclic inheritance involving " + tpe.sym)
+      throw new TypeError(s"illegal cyclic inheritance involving ${tpe.sym}")
   }
 
   /** A class representing a method type with parameters.

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -80,6 +80,8 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.TypedExpectingUnitAttachment
     this.FieldTypeInferred
     this.LookupAmbiguityWarning
+    this.PermittedSubclasses
+    this.PermittedSubclassSymbols
     this.noPrint
     this.typeDebug
     // inaccessible: this.posAssigner

--- a/test/files/neg/t12159.check
+++ b/test/files/neg/t12159.check
@@ -1,0 +1,4 @@
+s.scala:11: error: not found: type ZZ
+class Z extends ZZ // fail compile: remove when source flags are restored
+                ^
+1 error

--- a/test/files/neg/t12159/H.java
+++ b/test/files/neg/t12159/H.java
@@ -1,0 +1,19 @@
+// javaVersion: 17+
+package p;
+
+sealed public class H {
+}
+
+final class K extends H {
+}
+
+non-sealed class L extends H {
+}
+
+sealed
+class P extends H {
+}
+
+final
+class Q extends P {
+}

--- a/test/files/neg/t12159/I.java
+++ b/test/files/neg/t12159/I.java
@@ -1,0 +1,6 @@
+// javaVersion: 17+
+
+package p;
+
+sealed interface I permits J {
+}

--- a/test/files/neg/t12159/J.java
+++ b/test/files/neg/t12159/J.java
@@ -1,0 +1,6 @@
+// javaVersion: 17+
+
+package p;
+
+sealed public class J implements I permits M {
+}

--- a/test/files/neg/t12159/M.java
+++ b/test/files/neg/t12159/M.java
@@ -1,0 +1,9 @@
+// javaVersion: 17+
+
+package p;
+
+public final class M extends J {
+}
+
+final class N extends L {
+}

--- a/test/files/neg/t12159/s.scala
+++ b/test/files/neg/t12159/s.scala
@@ -1,0 +1,11 @@
+// javaVersion: 17+
+
+package p
+
+class S extends H {
+}
+
+trait T extends I {
+}
+
+class Z extends ZZ // fail compile: remove when source flags are restored

--- a/test/files/neg/t12159b.check
+++ b/test/files/neg/t12159b.check
@@ -1,0 +1,4 @@
+s_2.scala:5: error: illegal inheritance from sealed trait I
+class S extends I
+                ^
+1 error

--- a/test/files/neg/t12159b/I.java
+++ b/test/files/neg/t12159b/I.java
@@ -1,0 +1,6 @@
+// javaVersion: 17+
+
+package p;
+
+sealed interface I permits J {
+}

--- a/test/files/neg/t12159b/J.java
+++ b/test/files/neg/t12159b/J.java
@@ -1,0 +1,6 @@
+// javaVersion: 17+
+
+package p;
+
+public final class J implements I {
+}

--- a/test/files/neg/t12159b/s_2.scala
+++ b/test/files/neg/t12159b/s_2.scala
@@ -1,0 +1,5 @@
+// javaVersion: 17+
+
+package p
+
+class S extends I

--- a/test/files/neg/t12159c.check
+++ b/test/files/neg/t12159c.check
@@ -1,0 +1,7 @@
+s_2.scala:7: warning: match may not be exhaustive.
+It would fail on the following input: K()
+    h match {
+    ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/t12159c/H.java
+++ b/test/files/neg/t12159c/H.java
@@ -1,0 +1,14 @@
+// javaVersion: 17+
+package p;
+
+sealed abstract public class H {
+}
+
+final class J extends H {
+}
+
+final class K extends H {
+}
+
+final class L extends H {
+}

--- a/test/files/neg/t12159c/s_2.scala
+++ b/test/files/neg/t12159c/s_2.scala
@@ -1,0 +1,12 @@
+// javaVersion: 17+
+// scalac: -Werror
+package p
+
+class C {
+  def f(h: H) =
+    h match {
+      case j: J => j.toString
+      case l: L => l.toString
+    }
+}
+

--- a/test/files/pos/t12159/H.java
+++ b/test/files/pos/t12159/H.java
@@ -1,0 +1,19 @@
+// javaVersion: 17+
+package p;
+
+sealed public class H {
+}
+
+final class K extends H {
+}
+
+non-sealed class L extends H {
+}
+
+sealed
+class P extends H {
+}
+
+final
+class Q extends P {
+}

--- a/test/files/pos/t12159/I.java
+++ b/test/files/pos/t12159/I.java
@@ -1,0 +1,6 @@
+// javaVersion: 17+
+
+package p;
+
+sealed interface I permits J {
+}

--- a/test/files/pos/t12159/J.java
+++ b/test/files/pos/t12159/J.java
@@ -1,0 +1,6 @@
+// javaVersion: 17+
+
+package p;
+
+sealed public class J implements I permits M {
+}

--- a/test/files/pos/t12159/M.java
+++ b/test/files/pos/t12159/M.java
@@ -1,0 +1,9 @@
+// javaVersion: 17+
+
+package p;
+
+public final class M extends J {
+}
+
+final class N extends L {
+}

--- a/test/files/pos/t12159/s.scala
+++ b/test/files/pos/t12159/s.scala
@@ -1,0 +1,6 @@
+// javaVersion: 17+
+
+package p
+
+class S extends L {
+}

--- a/test/files/pos/t12159b/H_1.java
+++ b/test/files/pos/t12159b/H_1.java
@@ -1,0 +1,14 @@
+// javaVersion: 17+
+package p;
+
+sealed abstract public class H_1 {
+}
+
+final class J extends H_1 {
+}
+
+final class K extends H_1 {
+}
+
+final class L extends H_1 {
+}

--- a/test/files/pos/t12159b/s_2.scala
+++ b/test/files/pos/t12159b/s_2.scala
@@ -1,0 +1,13 @@
+// javaVersion: 17+
+// scalac: -Werror
+package p
+
+class C {
+  def f(h: H_1) =
+    h match {
+      case j: J => j.toString
+      case k: K => k.toString
+      case l: L => l.toString
+    }
+}
+

--- a/test/files/pos/t12474/Nat.java
+++ b/test/files/pos/t12474/Nat.java
@@ -1,0 +1,6 @@
+// javaVersion: 17+
+
+public sealed interface Nat permits Nat.Zero, Nat.Succ {
+    public static final record Zero() implements Nat {}
+    public static final record Succ(Nat pred) implements Nat {}
+}

--- a/test/files/pos/t12474/s.scala
+++ b/test/files/pos/t12474/s.scala
@@ -1,0 +1,5 @@
+// javaVersion: 17+
+
+class S {
+  def j: Nat = new Nat.Zero
+}


### PR DESCRIPTION
Fixes scala/bug#12171
Fixes scala/bug#12159

Also adds test coverage for scala/bug#12474

`ClassfileParser` hint from https://github.com/scala/scala/pull/9228

Implementation: a quick hack takes `non-sealed` in Java sources as three tokens.