### PR TITLE
Always emit Java 8 bytecode on 2.12, regardless of `-release`; deprecate `-target`

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1369,16 +1369,6 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
       settings.userSetSettings filter (_.isDeprecated) foreach { s =>
         runReporting.deprecationWarning(NoPosition, s.name + " is deprecated: " + s.deprecationMessage.get, "", "", "")
       }
-      if (!StandardScalaSettings.SupportedTargetVersions.contains(settings.target.value)) {
-        runReporting.deprecationWarning(
-          NoPosition,
-          settings.target.name + ":" + settings.target.value + " is deprecated and has no effect, setting to " + StandardScalaSettings.DefaultTargetVersion,
-          since = "2.12.16",
-          site = "",
-          origin = ""
-        )
-        settings.target.value = StandardScalaSettings.DefaultTargetVersion
-      }
       settings.conflictWarning.foreach(runReporting.warning(NoPosition, _, WarningCategory.Other, site = ""))
     }
 

--- a/test/files/run/t12543-target.scala
+++ b/test/files/run/t12543-target.scala
@@ -1,0 +1,8 @@
+// javaVersion: 11+
+// scalac: -release:11
+
+trait T { val x = 42 }
+class C extends T
+object Test {
+  def main(args: Array[String]): Unit = { new C(); () }
+}


### PR DESCRIPTION
Unlike Scala 2.13, Scala 2.12 cannot emit valid class files for target bytecode versions newer than 8. Thus, this PR deprecates `-target` on 2.12.

Regardless, you may still use `-release` to compile against a specific platform API version.

For more information on `-release`, see the Scala 2.13 PR #9982. This PR, taken together with #10089, effectively backports 9982 to 2.12, with the exception that on 2.12, bytecode version 8 is always emitted.