### PR TITLE
[REJECTED] Processed string literal is a SimpleExpr1

### DIFF
--- a/spec/01-lexical-syntax.md
+++ b/spec/01-lexical-syntax.md
@@ -323,7 +323,6 @@ Literal  ::=  [‘-’] integerLiteral
            |  booleanLiteral
            |  characterLiteral
            |  stringLiteral
-           |  interpolatedString
            |  symbolLiteral
            |  ‘null’
 ```
@@ -510,6 +509,8 @@ escape                 ::= ‘$$’
                          | ‘$’ BlockExpr
 alphaid                ::= upper idrest
                          |  varid
+SimpleExpr1            ::=  Literal
+                         |  interpolatedString
 
 ```
 

--- a/spec/13-syntax-summary.md
+++ b/spec/13-syntax-summary.md
@@ -97,7 +97,6 @@ grammar:
                       |  booleanLiteral
                       |  characterLiteral
                       |  stringLiteral
-                      |  interpolatedString
                       |  symbolLiteral
                       |  ‘null’
 
@@ -163,6 +162,7 @@ grammar:
                       |  BlockExpr
                       |  SimpleExpr1 [‘_’]
   SimpleExpr1       ::=  Literal
+                      |  interpolatedString
                       |  Path
                       |  ‘_’
                       |  ‘(’ [Exprs] ‘)’


### PR DESCRIPTION
SIP-11 calls it a `processedStringLiteral`

https://docs.scala-lang.org/sips/string-interpolation.html

It's not a `Literal` but a `SimpleExpr1` in SIP-11. We expect a literal not to be an expression that produces arbitrary values.

As a `SimpleExpr1`, it supports placeholder syntax for etapolators.
