### PR TITLE
don't consider imports when typing package declaration name

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1527,7 +1527,8 @@ trait Contexts { self: Analyzer =>
           @inline def importCompetesWithDefinition =
             if (thisContext.unit.isJava) imp.depth == symbolDepth && defIsLevel4
             else defIsLevel4
-          imp.depth > symbolDepth || importCompetesWithDefinition
+          !cx(ContextMode.InPackageClauseName) &&
+            (imp.depth > symbolDepth || importCompetesWithDefinition)
         }
 
         while (!impSym.exists && importCursor.imp1Exists && importCanShadowAtDepth(importCursor.imp1)) {
@@ -2031,6 +2032,8 @@ object ContextMode {
     * When set, Java annotations may be instantiated directly.
     */
   final val TypingAnnotation: ContextMode         = 1 << 19
+
+  final val InPackageClauseName: ContextMode      = 1 << 20
 
   /** TODO: The "sticky modes" are EXPRmode, PATTERNmode, TYPEmode.
    *  To mimic the sticky mode behavior, when captain stickyfingers

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5632,7 +5632,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
       def typedPackageDef(pdef0: PackageDef) = {
         val pdef = treeCopy.PackageDef(pdef0, pdef0.pid, pluginsEnterStats(this, namer.expandMacroAnnotations(pdef0.stats)))
-        val pid1 = typedPackageQualifier(pdef.pid).asInstanceOf[RefTree]
+        val pid1 = context.withMode(ContextMode.InPackageClauseName)(typedPackageQualifier(pdef.pid).asInstanceOf[RefTree])
         assert(sym.moduleClass ne NoSymbol, sym)
         if (pid1.symbol.ne(NoSymbol) && !(pid1.symbol.hasPackageFlag || pid1.symbol.isModule))
           reporter.error(pdef.pos, s"There is name conflict between the ${pid1.symbol.fullName} and the package ${sym.fullName}.")


### PR DESCRIPTION
Similar to Scala 3:

  - https://github.com/lampepfl/dotty/blob/3.1.3/compiler/src/dotty/tools/dotc/typer/Typer.scala#L2594
  - https://github.com/lampepfl/dotty/blob/3.1.3/compiler/src/dotty/tools/dotc/typer/Typer.scala#L166

```scala
package a.x
class C { def inA = 0 }
```

```scala
package b
import a._
package x {
  class C { def inB = 0 }
}
```

Before this PR, the `PackageDef.pid` for `b.x` refers to the package symbol `a.x`.

I couldn't spot any uses of `PackageDef.pid` in the compiler, so it's probably benign.