### PR TITLE
Tweak messaging for -Xlint:eta-sam

### DIFF
--- a/src/compiler/scala/reflect/reify/Errors.scala
+++ b/src/compiler/scala/reflect/reify/Errors.scala
@@ -10,10 +10,12 @@
  * additional information regarding copyright ownership.
  */
 
-package scala.reflect.reify
+package scala.reflect
+package reify
 
-import scala.reflect.macros.ReificationException
-import scala.reflect.macros.UnexpectedReificationException
+import internal.util.StringContextStripMarginOps
+import macros.ReificationException
+import macros.UnexpectedReificationException
 
 trait Errors {
   self: Reifier =>

--- a/src/compiler/scala/tools/nsc/package.scala
+++ b/src/compiler/scala/tools/nsc/package.scala
@@ -12,6 +12,8 @@
 
 package scala.tools
 
+import scala.reflect.internal.util.StringContextStripMarginOps
+
 package object nsc {
   type Mode = scala.reflect.internal.Mode
   val Mode = scala.reflect.internal.Mode
@@ -32,4 +34,8 @@ package object nsc {
 
   @deprecated("Use scala.reflect.internal.util.ListOfNil", "2.11.0")
   lazy val ListOfNil = scala.reflect.internal.util.ListOfNil
+
+  /** Adds the `sm` interpolator to a [[scala.StringContext]].
+   */
+  implicit val `strip margin`: StringContext => StringContextStripMarginOps = StringContextStripMarginOps
 }

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -205,7 +205,7 @@ trait Warnings {
     val Serial                 = LintWarning("serial",                    "@SerialVersionUID on traits and non-serializable classes.")
     val ValPattern             = LintWarning("valpattern",                "Enable pattern checks in val definitions.")
     val EtaZero                = LintWarning("eta-zero",                  "Usage `f` of parameterless `def f()` resulted in eta-expansion, not empty application `f()`.")
-    val EtaSam                 = LintWarning("eta-sam",                   "The Java-defined target interface for eta-expansion was not annotated @FunctionalInterface.")
+    val EtaSam                 = LintWarning("eta-sam",                   "A method reference was eta-expanded but the expected SAM type was not annotated @FunctionalInterface.")
     val Deprecation            = LintWarning("deprecation",               "Enable -deprecation and also check @deprecated annotations.")
     val ByNameImplicit         = LintWarning("byname-implicit",           "Block adapted by implicit with by-name parameter.")
     val RecurseWithDefault     = LintWarning("recurse-with-default",      "Recursive call used default argument.")

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
@@ -10,7 +10,8 @@
  * additional information regarding copyright ownership.
  */
 
-package scala.tools.nsc.transform.patmat
+package scala.tools.nsc
+package transform.patmat
 
 /** Translate typed Trees that represent pattern matches into the patternmatching IR, defined by TreeMakers.
  */

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -17,7 +17,7 @@ package typechecker
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.reflect.internal.{Chars, TypesStats}
-import scala.reflect.internal.util.{FreshNameCreator, ListOfNil, Statistics}
+import scala.reflect.internal.util.{FreshNameCreator, ListOfNil, Statistics, StringContextStripMarginOps}
 import scala.tools.nsc.Reporting.{MessageFilter, Suppression, WConf, WarningCategory}
 import scala.util.chaining._
 import mutable.ListBuffer
@@ -901,9 +901,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             val samClazz = sam.owner
             if (sam.exists && (!samClazz.hasFlag(JAVA) || samClazz.hasFlag(INTERFACE)) && !samClazz.hasAnnotation(definitions.FunctionalInterfaceClass))
               context.warning(tree.pos,
-                s"""Eta-expansion performed to meet expected type $pt, which is SAM-equivalent to ${samToFunctionType(pt)},
+                sm"""Eta-expansion performed to meet expected type $pt, which is SAM-equivalent to ${samToFunctionType(pt)},
                    |even though $samClazz is not annotated with `@FunctionalInterface`;
-                   |to suppress warning, add the annotation or write out the equivalent function literal.""".stripMargin,
+                   |to suppress warning, add the annotation or write out the equivalent function literal.""",
                 WarningCategory.LintEtaSam)
             true
           }

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -19,6 +19,7 @@ import scala.collection.mutable
 import Flags._
 import scala.reflect.api.{Universe => ApiUniverse}
 import PartialFunction.cond
+import util.StringContextStripMarginOps
 
 trait Definitions extends api.StandardDefinitions {
   self: SymbolTable =>

--- a/src/reflect/scala/reflect/internal/SymbolPairs.scala
+++ b/src/reflect/scala/reflect/internal/SymbolPairs.scala
@@ -14,7 +14,7 @@ package scala
 package reflect
 package internal
 
-import util.HashSet
+import util.{HashSet, StringContextStripMarginOps}
 import scala.annotation.tailrec
 
 /** An abstraction for considering symbol pairs.

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -509,12 +509,6 @@ abstract class SymbolTable extends macros.Universe
   @deprecated("use enteringPhase", "2.10.0") // Used in sbt 0.12.4
   @inline final def atPhase[T](ph: Phase)(op: => T): T = enteringPhase(ph)(op)
 
-
-  /**
-   * Adds the `sm` String interpolator to a [[scala.StringContext]].
-   */
-  implicit val StringContextStripMarginOps: StringContext => StringContextStripMarginOps = util.StringContextStripMarginOps
-
   protected[scala] def currentRunProfilerBeforeCompletion(root: Symbol, associatedFile: AbstractFile): Unit = ()
   protected[scala] def currentRunProfilerAfterCompletion(root: Symbol, associatedFile: AbstractFile): Unit = ()
 }

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -19,7 +19,7 @@ import scala.annotation.{nowarn, tailrec}
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.reflect.macros.Attachments
-import util.{ReusableInstance, Statistics}
+import util.{ReusableInstance, Statistics, StringContextStripMarginOps}
 
 trait Trees extends api.Trees {
   self: SymbolTable =>

--- a/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
@@ -15,9 +15,9 @@ package reflect
 package internal
 package tpe
 
-import scala.collection.mutable
-import util.TriState
 import scala.annotation.tailrec
+import scala.collection.mutable
+import util.{StringContextStripMarginOps, TriState}
 
 trait TypeComparers {
   self: SymbolTable =>

--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -15,11 +15,12 @@ package reflect
 package internal
 package tpe
 
-import scala.collection.{immutable, mutable}
-import Flags._
 import scala.annotation.{nowarn, tailrec}
-import Variance._
+import scala.collection.{immutable, mutable}
 import scala.collection.mutable.ListBuffer
+import Flags._
+import Variance._
+import util.StringContextStripMarginOps
 
 private[internal] trait TypeMaps {
   self: SymbolTable =>

--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -14,12 +14,6 @@ package scala
 package reflect
 package runtime
 
-import scala.language.existentials
-
-import scala.ref.WeakReference
-import scala.collection.mutable.WeakHashMap
-import scala.collection.immutable.ArraySeq
-
 import java.io.IOException
 import java.lang.{ Class => jClass, Package => jPackage }
 import java.lang.annotation.{ Annotation => jAnnotation }
@@ -31,15 +25,19 @@ import java.lang.reflect.{
   ParameterizedType, WildcardType, AnnotatedElement }
 import java.nio.charset.StandardCharsets.UTF_8
 
+import scala.annotation.nowarn
+import scala.collection.immutable.ArraySeq
+import scala.collection.mutable.{ListBuffer, WeakHashMap}
+import scala.language.existentials
+import scala.ref.WeakReference
+import scala.reflect.api.TypeCreator
 import scala.reflect.internal.{ JavaAccFlags, MissingRequirementError }
+import scala.runtime.{BoxesRunTime, ClassValueCompat, ScalaRunTime}
+import internal.Flags._
 import internal.pickling.ByteCodecs
 import internal.pickling.UnPickler
-import scala.collection.mutable.ListBuffer
-import internal.Flags._
+import internal.util.StringContextStripMarginOps
 import ReflectionUtils._
-import scala.annotation.nowarn
-import scala.reflect.api.TypeCreator
-import scala.runtime.{BoxesRunTime, ClassValueCompat, ScalaRunTime}
 
 private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUniverse with TwoWayCaches { thisUniverse: SymbolTable =>
 

--- a/test/files/neg/t11644a.check
+++ b/test/files/neg/t11644a.check
@@ -1,0 +1,17 @@
+t11644a.scala:20: error: type mismatch;
+ found   : Int
+ required: AcciSamZero
+  val t2AcciSam: AcciSamZero = m2 // error, nilary methods don't eta-expand to SAM types
+                               ^
+t11644a.scala:21: error: type mismatch;
+ found   : Int
+ required: SamZero
+  val t2Sam: SamZero = m2         // error, nilary methods don't eta-expand to SAM types
+                       ^
+t11644a.scala:24: warning: Eta-expansion performed to meet expected type AcciSamOne, which is SAM-equivalent to Int => Int,
+even though trait AcciSamOne is not annotated with `@FunctionalInterface`;
+to suppress warning, add the annotation or write out the equivalent function literal.
+  val t3AcciSam: AcciSamOne = m3  // warn
+                              ^
+1 warning
+2 errors

--- a/test/files/neg/t11644a.check
+++ b/test/files/neg/t11644a.check
@@ -10,7 +10,7 @@ t11644a.scala:21: error: type mismatch;
                        ^
 t11644a.scala:24: warning: Eta-expansion to expected type AcciSamOne, which is not a function type but is SAM-convertible to Int => Int.
 trait AcciSamOne should be annotated with `@FunctionalInterface` if eta-expansion is desired.
-Or, avoid eta-expansion by writing the function literal `((x: Int) => m3(x))` or `m3(_)`.
+Avoid eta-expansion by writing the function literal `((x: Int) => m3(x))` or `m3(_)`.
 This warning can be filtered with `-Wconf:cat=lint-eta-sam`.
   val t3AcciSam: AcciSamOne = m3  // warn
                               ^

--- a/test/files/neg/t11644a.check
+++ b/test/files/neg/t11644a.check
@@ -8,9 +8,10 @@ t11644a.scala:21: error: type mismatch;
  required: SamZero
   val t2Sam: SamZero = m2         // error, nilary methods don't eta-expand to SAM types
                        ^
-t11644a.scala:24: warning: Eta-expansion performed to meet expected type AcciSamOne, which is SAM-equivalent to Int => Int,
-even though trait AcciSamOne is not annotated with `@FunctionalInterface`;
-to suppress warning, add the annotation or write out the equivalent function literal.
+t11644a.scala:24: warning: Eta-expansion to expected type AcciSamOne, which is not a function type but is SAM-convertible to Int => Int.
+trait AcciSamOne should be annotated with `@FunctionalInterface` if eta-expansion is desired.
+Or, avoid eta-expansion by writing the function literal `((x: Int) => m3(x))` or `m3(_)`.
+This warning can be filtered with `-Wconf:cat=lint-eta-sam`.
   val t3AcciSam: AcciSamOne = m3  // warn
                               ^
 1 warning

--- a/test/files/neg/t11644a.scala
+++ b/test/files/neg/t11644a.scala
@@ -22,5 +22,7 @@ class EtaExpand214 {
 
   val t3: Int => Any = m3         // no warn
   val t3AcciSam: AcciSamOne = m3  // warn
+  val t3SamLit: AcciSamOne = (x: Int) => m3(x) // no warn
+  val t3SamPH: AcciSamOne = m3(_) // no warn
   val t3Sam: SamOne = m3          // no warn
 }

--- a/test/files/neg/t11644a.scala
+++ b/test/files/neg/t11644a.scala
@@ -1,0 +1,26 @@
+// scalac: -Xsource:3
+//
+// eta-expansion to SAM type always warns in Scala 3 world
+
+trait AcciSamZero { def apply(): Int }
+
+@FunctionalInterface
+trait SamZero { def apply(): Int }
+
+trait AcciSamOne { def apply(i: Int): Int }
+
+@FunctionalInterface
+trait SamOne { def apply(i: Int): Int }
+
+class EtaExpand214 {
+  def m2() = 1
+  def m3(x: Int) = x
+
+  val t2: () => Any  = m2         // eta-expanded with lint warning
+  val t2AcciSam: AcciSamZero = m2 // error, nilary methods don't eta-expand to SAM types
+  val t2Sam: SamZero = m2         // error, nilary methods don't eta-expand to SAM types
+
+  val t3: Int => Any = m3         // no warn
+  val t3AcciSam: AcciSamOne = m3  // warn
+  val t3Sam: SamOne = m3          // no warn
+}

--- a/test/files/neg/t11644b.check
+++ b/test/files/neg/t11644b.check
@@ -14,7 +14,7 @@ Write m2() to invoke method m2, or change the expected type.
                        ^
 t11644b.scala:22: warning: Eta-expansion to expected type AcciSamOne, which is not a function type but is SAM-convertible to Int => Int.
 trait AcciSamOne should be annotated with `@FunctionalInterface` if eta-expansion is desired.
-Or, avoid eta-expansion by writing the function literal `((x: Int) => m3(x))` or `m3(_)`.
+Avoid eta-expansion by writing the function literal `((x: Int) => m3(x))` or `m3(_)`.
 This warning can be filtered with `-Wconf:cat=lint-eta-sam`.
   val t3AcciSam: AcciSamOne = m3  // warn
                               ^

--- a/test/files/neg/t11644b.check
+++ b/test/files/neg/t11644b.check
@@ -1,0 +1,21 @@
+t11644b.scala:18: error: type mismatch;
+ found   : Int
+ required: AcciSamZero
+  val t2AcciSam: AcciSamZero = m2 // error, nilary methods don't eta-expand to SAM types under -Xsource:3
+                               ^
+t11644b.scala:19: error: type mismatch;
+ found   : Int
+ required: SamZero
+  val t2Sam: SamZero = m2         // error, nilary methods don't eta-expand to SAM types under -Xsource:3
+                       ^
+t11644b.scala:17: warning: An unapplied 0-arity method was eta-expanded (due to the expected type () => Any), rather than applied to `()`.
+Write m2() to invoke method m2, or change the expected type.
+  val t2: () => Any  = m2         // eta-expanded with lint warning
+                       ^
+t11644b.scala:22: warning: Eta-expansion performed to meet expected type AcciSamOne, which is SAM-equivalent to Int => Int,
+even though trait AcciSamOne is not annotated with `@FunctionalInterface`;
+to suppress warning, add the annotation or write out the equivalent function literal.
+  val t3AcciSam: AcciSamOne = m3  // warn
+                              ^
+2 warnings
+2 errors

--- a/test/files/neg/t11644b.check
+++ b/test/files/neg/t11644b.check
@@ -12,9 +12,10 @@ t11644b.scala:17: warning: An unapplied 0-arity method was eta-expanded (due to 
 Write m2() to invoke method m2, or change the expected type.
   val t2: () => Any  = m2         // eta-expanded with lint warning
                        ^
-t11644b.scala:22: warning: Eta-expansion performed to meet expected type AcciSamOne, which is SAM-equivalent to Int => Int,
-even though trait AcciSamOne is not annotated with `@FunctionalInterface`;
-to suppress warning, add the annotation or write out the equivalent function literal.
+t11644b.scala:22: warning: Eta-expansion to expected type AcciSamOne, which is not a function type but is SAM-convertible to Int => Int.
+trait AcciSamOne should be annotated with `@FunctionalInterface` if eta-expansion is desired.
+Or, avoid eta-expansion by writing the function literal `((x: Int) => m3(x))` or `m3(_)`.
+This warning can be filtered with `-Wconf:cat=lint-eta-sam`.
   val t3AcciSam: AcciSamOne = m3  // warn
                               ^
 2 warnings

--- a/test/files/neg/t11644b.scala
+++ b/test/files/neg/t11644b.scala
@@ -1,0 +1,24 @@
+// scalac: -Xlint:deprecation,eta-zero,eta-sam
+
+trait AcciSamZero { def apply(): Int }
+
+@FunctionalInterface
+trait SamZero { def apply(): Int }
+
+trait AcciSamOne { def apply(i: Int): Int }
+
+@FunctionalInterface
+trait SamOne { def apply(i: Int): Int }
+
+class EtaExpand214 {
+  def m2() = 1
+  def m3(x: Int) = x
+
+  val t2: () => Any  = m2         // eta-expanded with lint warning
+  val t2AcciSam: AcciSamZero = m2 // error, nilary methods don't eta-expand to SAM types under -Xsource:3
+  val t2Sam: SamZero = m2         // error, nilary methods don't eta-expand to SAM types under -Xsource:3
+
+  val t3: Int => Any = m3         // no warn
+  val t3AcciSam: AcciSamOne = m3  // warn
+  val t3Sam: SamOne = m3          // no warn
+}

--- a/test/files/neg/t11644c.check
+++ b/test/files/neg/t11644c.check
@@ -1,0 +1,14 @@
+s.scala:13: warning: Eta-expansion to expected type J, which is not a function type but is SAM-convertible to Int => Int.
+Avoid eta-expansion by writing the function literal `((i: Int) => bump(i))` or `bump(_)`.
+This warning can be filtered with `-Wconf:cat=lint-eta-sam`.
+    c.f(bump),
+        ^
+s.scala:14: warning: Eta-expansion to expected type K, which is not a function type but is SAM-convertible to Int => Int.
+trait K should be annotated with `@FunctionalInterface` if eta-expansion is desired.
+Avoid eta-expansion by writing the function literal `((i: Int) => bump(i))` or `bump(_)`.
+This warning can be filtered with `-Wconf:cat=lint-eta-sam`.
+    c.g(bump),
+        ^
+error: No warnings can be incurred under -Werror.
+2 warnings
+1 error

--- a/test/files/neg/t11644c/J.java
+++ b/test/files/neg/t11644c/J.java
@@ -1,0 +1,7 @@
+
+public abstract class J {
+        public abstract int f(int i);
+}
+interface K {
+	int f(int i);
+}

--- a/test/files/neg/t11644c/s.scala
+++ b/test/files/neg/t11644c/s.scala
@@ -1,0 +1,16 @@
+// scalac: -Xsource:3 -Werror
+
+class C {
+  def f(j: J): Int = j.f(42)
+  def g(k: K): Int = k.f(17)
+}
+object Test extends App {
+  def bump(i: Int): Int = i + 1
+  val c = new C
+  println {(
+    c.f((i: Int) => i + 1),
+    c.g((i: Int) => i + 1),
+    c.f(bump),
+    c.g(bump),
+  )}
+}

--- a/test/files/neg/t7187-3.check
+++ b/test/files/neg/t7187-3.check
@@ -6,12 +6,12 @@ t7187-3.scala:13: error: type mismatch;
 t7187-3.scala:15: error: type mismatch;
  found   : Int
  required: AcciSamZero
-  val t2AcciSam: AcciSamZero = m2 // error, nilary methods don't eta-expand to SAM types under -Xsource:3
+  val t2AcciSam: AcciSamZero = m2 // error, nilary methods don't eta-expand to SAM types
                                ^
 t7187-3.scala:16: error: type mismatch;
  found   : Int
  required: SamZero
-  val t2Sam: SamZero = m2         // error, nilary methods don't eta-expand to SAM types under -Xsource:3
+  val t2Sam: SamZero = m2         // error, nilary methods don't eta-expand to SAM types
                        ^
 t7187-3.scala:27: error: Methods without a parameter list and by-name params can not be converted to functions as `m _`, write a function literal `() => m` instead
   val t7 = m1 _ // error: eta-expanding a nullary method

--- a/test/files/neg/t7187-3.scala
+++ b/test/files/neg/t7187-3.scala
@@ -12,8 +12,8 @@ class EtaExpand214 {
 
   val t1: () => Any  = m1   // error
   val t2: () => Any  = m2   // eta-expanded with lint warning
-  val t2AcciSam: AcciSamZero = m2 // error, nilary methods don't eta-expand to SAM types under -Xsource:3
-  val t2Sam: SamZero = m2         // error, nilary methods don't eta-expand to SAM types under -Xsource:3
+  val t2AcciSam: AcciSamZero = m2 // error, nilary methods don't eta-expand to SAM types
+  val t2Sam: SamZero = m2         // error, nilary methods don't eta-expand to SAM types
   val t3: Int => Any = m3   // ok
 
   val t4 = m1 // apply

--- a/test/files/neg/t7187-deprecation.check
+++ b/test/files/neg/t7187-deprecation.check
@@ -6,12 +6,12 @@ t7187-deprecation.scala:17: error: type mismatch;
 t7187-deprecation.scala:19: error: type mismatch;
  found   : Int
  required: AcciSamZero
-  val t2AcciSam: AcciSamZero = m2 // error, nilary methods don't eta-expand to SAM types under -Xsource:3
+  val t2AcciSam: AcciSamZero = m2 // error, nilary methods don't eta-expand to SAM types
                                ^
 t7187-deprecation.scala:20: error: type mismatch;
  found   : Int
  required: SamZero
-  val t2Sam: SamZero = m2         // error, nilary methods don't eta-expand to SAM types under -Xsource:3
+  val t2Sam: SamZero = m2         // error, nilary methods don't eta-expand to SAM types
                        ^
 t7187-deprecation.scala:31: error: Methods without a parameter list and by-name params can not be converted to functions as `m _`, write a function literal `() => m` instead
   val t7 = m1 _ // error: eta-expanding a nullary method

--- a/test/files/neg/t7187-deprecation.scala
+++ b/test/files/neg/t7187-deprecation.scala
@@ -16,8 +16,8 @@ class EtaExpand214 {
 
   val t1: () => Any  = m1   // error
   val t2: () => Any  = m2   // eta-expanded, only warns w/ -Xlint:eta-zero
-  val t2AcciSam: AcciSamZero = m2 // error, nilary methods don't eta-expand to SAM types under -Xsource:3
-  val t2Sam: SamZero = m2         // error, nilary methods don't eta-expand to SAM types under -Xsource:3
+  val t2AcciSam: AcciSamZero = m2 // error, nilary methods don't eta-expand to SAM types
+  val t2Sam: SamZero = m2         // error, nilary methods don't eta-expand to SAM types
   val t3: Int => Any = m3   // ok
 
   val t4 = m1 // apply

--- a/test/files/neg/t7187.check
+++ b/test/files/neg/t7187.check
@@ -49,9 +49,10 @@ t7187.scala:33: warning: An unapplied 0-arity method was eta-expanded (due to th
 Write zap()() to invoke method zap, or change the expected type.
   val t4b: () => Any = zap()   // ditto
                           ^
-t7187.scala:40: warning: Eta-expansion performed to meet expected type AcciSamOne, which is SAM-equivalent to Int => Int,
-even though trait AcciSamOne is not annotated with `@FunctionalInterface`;
-to suppress warning, add the annotation or write out the equivalent function literal.
+t7187.scala:40: warning: Eta-expansion to expected type AcciSamOne, which is not a function type but is SAM-convertible to Int => Int.
+trait AcciSamOne should be annotated with `@FunctionalInterface` if eta-expansion is desired.
+Or, avoid eta-expansion by writing the function literal `((x: Int) => zup(x))` or `zup(_)`.
+This warning can be filtered with `-Wconf:cat=lint-eta-sam`.
   val t5AcciSam: AcciSamOne = zup // ok, but warning
                               ^
 8 warnings

--- a/test/files/neg/t7187.check
+++ b/test/files/neg/t7187.check
@@ -51,7 +51,7 @@ Write zap()() to invoke method zap, or change the expected type.
                           ^
 t7187.scala:40: warning: Eta-expansion to expected type AcciSamOne, which is not a function type but is SAM-convertible to Int => Int.
 trait AcciSamOne should be annotated with `@FunctionalInterface` if eta-expansion is desired.
-Or, avoid eta-expansion by writing the function literal `((x: Int) => zup(x))` or `zup(_)`.
+Avoid eta-expansion by writing the function literal `((x: Int) => zup(x))` or `zup(_)`.
 This warning can be filtered with `-Wconf:cat=lint-eta-sam`.
   val t5AcciSam: AcciSamOne = zup // ok, but warning
                               ^

--- a/test/files/neg/t7187.scala
+++ b/test/files/neg/t7187.scala
@@ -1,4 +1,4 @@
-// scalac: -deprecation -Xlint:eta-zero -Xlint:eta-sam
+// scalac: -Xlint:deprecation,eta-zero,eta-sam
 //
 
 trait AcciSamOne { def apply(x: Int): Int }


### PR DESCRIPTION
Always warn under `-Xsource:3` because Scala 3 always warns. The warning can be filtered.

Warn when the SAM type is a Java class, but don't suggest annotating, which is not legal in Java.

Improve the message by providing an explicit sample, pun on sam.

Fixes scala/bug#11644