### PR TITLE
Accessible lint less triggered for sealed, restricted owners

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -1012,18 +1012,17 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       isPackageClass || isModuleClass && isStatic
 
     /** A helper function for isEffectivelyFinal. */
-    private def isNotOverridden = (
+    private def isNotOverridden =
       owner.isClass && (
            owner.isEffectivelyFinal
-        || (owner.isSealed && owner.sealedChildren.forall(c => c.isEffectivelyFinal && (overridingSymbol(c) == NoSymbol)))
+        || owner.isSealed && owner.sealedChildren.forall(c => c.isEffectivelyFinal && overridingSymbol(c) == NoSymbol)
       )
-    )
 
     /** Is this symbol effectively final? I.e, it cannot be overridden */
     final def isEffectivelyFinal: Boolean = (
-         ((this hasFlag FINAL | PACKAGE) && this != SingletonClass)
+         hasFlag(FINAL | PACKAGE) && this != SingletonClass
       || isModuleOrModuleClass
-      || isTerm && (isPrivate || isLocalToBlock || (hasAllFlags(notPRIVATE | METHOD) && !hasFlag(DEFERRED)))
+      || isTerm && (isPrivate || isLocalToBlock || hasAllFlags(notPRIVATE | METHOD) && !hasFlag(DEFERRED))
       // We track known subclasses of term-owned classes, use that to infer finality.
       // However, don't look at owner for refinement classes (it's basically arbitrary).
       || isClass && !isRefinementClass && originalOwner.isTerm && children.isEmpty

--- a/test/files/pos/t9490.scala
+++ b/test/files/pos/t9490.scala
@@ -1,0 +1,27 @@
+// scalac: -Werror -Xlint:inaccessible
+
+package ws {
+  private[ws] trait Foo
+  private[ws] object Test {
+    class Bar {
+      def apply(f: Foo) = ???
+    }
+  }
+}
+
+package p {
+  private[p] class D
+  sealed trait T { def f(d: D): Unit }
+  final class C extends T { def f(d: D) = () }
+}
+
+/* was:
+t9490.scala:7: warning: method apply in class Bar references private[ws] trait Foo.
+Classes which cannot access Foo may be unable to override apply.
+      def apply(f: Foo) = ???
+          ^
+t9490.scala:14: warning: method f in trait T references private[p] class D.
+Classes which cannot access D may be unable to provide a concrete implementation of f.
+  sealed trait T { def f(d: D): Unit }
+                       ^
+ */


### PR DESCRIPTION
Fixes scala/bug#9490
Fixes scala/bug#11835

The exclusion for `sealed` is because they know what they're doing, rather than a strict check for possible children that violate the expectation. (The closed ticket is not quite a duplicate.)

The check for all owners asks if there is any owner that already restricts access.