### PR TITLE
Improve performance of `quickSort` method with fix to pivot selection

### DIFF
--- a/src/library/scala/util/Sorting.scala
+++ b/src/library/scala/util/Sorting.scala
@@ -66,8 +66,8 @@ object Sorting {
           else
             if (ord.compare(a(i0), a(iK)) < 0) i0
             else
-              if (ord.compare(a(iN - 1), a(iK)) <= 0) iN - 1
-              else iK
+              if (ord.compare(a(iN - 1), a(iK)) <= 0) iK
+              else iN - 1
         val pivot = a(pL)
         // pL is the start of the pivot block; move it into the middle if needed
         if (pL != iK) { a(pL) = a(iK); a(iK) = pivot; pL = iK }


### PR DESCRIPTION
Median-of-three pivot selection in the quickSort method should return a(iK) when a(i0) > a(iN - 1) && a(i0) > a(iK) && a(iN-1) <= a(iK) .
Same issues exist in 2.12.x, 2.11.x, 2.10.x

## What?
Fix the Median-of-three pivot selection in the quickSort method
quickSort[K: Ordering](a: Array[K]): Unit

## Why?
The original code snippet about the Median-of-three pivot selection has an issue (it probably was a typo). it supposed to always return the median of three elements a(i0), a(iK), a(iN-1), but it actually returned the minimum a(iN - 1) in the the conditional branch：a(i0) > a(iN - 1) && a(i0) > a(iK) && a(iN-1) <= a(iK)。It might cause a bad pivot selection and then dramatically reduce the sorting efficiency.
This change make sure It returns the median a(iK) instead of the minimum a(iN-1) when a(i0) > a(iN - 1) && a(i0) > a(iK) && a(iN-1) <= a(iK)

## How?
See committed code.

## Testing?
Since there are 4 quickSort methods and a variable 'qsortThreshold=16' in this file, for calling the method quickSort[K: Ordering](a: Array[K]), we have to create a complex data type such Person(name: String, age: Int) and make an array(number of elements > 16) by this type.
For simplicity, we can change the qsortThreshold to 3, and use the test cases below:

case class Person(name: String, age: Int) extends Ordered[Person]{
override def compare(that: Person): Int = {
this.age-that.age
}
}

Passed Case:
Input: a1 = Array(Person("a0",6),Person("a1",4),Person("a2",10),Person("a3",7),Person("a4",15))
Output: a[pL] is Person("a2",10) as expected in the first iteration

Failed Case:
Input: a2 = Array(Person("a0",15),Person("a1",4),Person("a2",10),Person("a3",7),Person("a4",6))
Output: a[pL] expected to be Person("a2",10), actually output Person("a4",6) in the first iteration

Failed Case:
Input: a3 = Array(Person("a0",19),Person("a1",4),Person("a2",10),Person("a3",7),Person("a4",3))
Output: a[pL] expected to be Person("a2",10), actually output Person("a4",3) in the first iteration

Any case which meets the condition a(i0) > a(iK) > a(iN-1) will fail since it always gets the minimum element a(iN - 1)

## Conclusion
Test by sorting an array which includes 1000,000 objects, After the change, it can reduce the times of recursion from 458000 to 428000,  about 6.5%. if the array size is less than 100, there is not much effect, but the recursion times still less than the unchanged edition.
