### PR TITLE
REVERTED: Args files are 1 arg per line, fix -Vprint-args -

### DIFF
--- a/src/compiler/scala/tools/nsc/CompilerCommand.scala
+++ b/src/compiler/scala/tools/nsc/CompilerCommand.scala
@@ -127,10 +127,10 @@ class CompilerCommand(arguments: List[String], val settings: Settings) {
     import java.nio.file.{Files, Paths}
     import scala.jdk.CollectionConverters._
     def stripComment(s: String) = s.takeWhile(_ != '#')
-    val file = Paths.get(arg stripPrefix "@")
+    val file = Paths.get(arg.stripPrefix("@"))
     if (!Files.exists(file))
       throw new java.io.FileNotFoundException(s"argument file $file could not be found")
-    settings.splitParams(Files.readAllLines(file).asScala.map(stripComment).mkString(" "))
+    Files.readAllLines(file).asScala.map(stripComment).toList
   }
 
   // override this if you don't want arguments processed here

--- a/src/compiler/scala/tools/nsc/CompilerCommand.scala
+++ b/src/compiler/scala/tools/nsc/CompilerCommand.scala
@@ -126,11 +126,11 @@ class CompilerCommand(arguments: List[String], val settings: Settings) {
   def expandArg(arg: String): List[String] = {
     import java.nio.file.{Files, Paths}
     import scala.jdk.CollectionConverters._
-    def stripComment(s: String) = s.takeWhile(_ != '#')
+    def stripComment(s: String) = s.takeWhile(_ != '#').trim()
     val file = Paths.get(arg.stripPrefix("@"))
     if (!Files.exists(file))
       throw new java.io.FileNotFoundException(s"argument file $file could not be found")
-    Files.readAllLines(file).asScala.map(stripComment).toList
+    Files.readAllLines(file).asScala.map(stripComment).filter(_ != "").toList
   }
 
   // override this if you don't want arguments processed here

--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -973,5 +973,5 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
 }
 
 private object Optionlike {
-  def unapply(s: String): Boolean = s.startsWith("-")
+  def unapply(s: String): Boolean = s.startsWith("-") && s != "-"
 }


### PR DESCRIPTION
Previously, lines of `@my.args` files were concatenated and parsed, but this is not desirable.

This commit takes an args file as one arg per line. This makes spaces unambiguous:
```
--classpath
C:\Program Files\Java\bin
```
This change also makes backslashes unambiguous. In the shell, call them bashslackers.

Also trim lines and remove empty lines.
```
arg # comment should not introduce space after arg
# comment line should be removed
```
Not sure if anyone exploits these advanced arg file features.

Also fix processing of `-Vprint-args -` where `-` is a legal option setting.

Fixes scala/scala-dev#814