### PR TITLE
[backport] with Xsource:2.13, include private[this] members in override checking

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/OverridingPairs.scala
+++ b/src/compiler/scala/tools/nsc/transform/OverridingPairs.scala
@@ -25,15 +25,17 @@ abstract class OverridingPairs extends SymbolPairs {
   import global._
 
   class Cursor(base: Symbol) extends super.Cursor(base) {
+    private lazy val isScala213 = settings.isScala213
+
     /** Symbols to exclude: Here these are constructors and private/artifact symbols,
      *  including bridges. But it may be refined in subclasses.
      */
-    override protected def exclude(sym: Symbol) = (
-         sym.isPrivateLocal
-      || sym.isArtifact
-      || sym.isConstructor
-      || (sym.isPrivate && sym.owner != base) // Privates aren't inherited. Needed for pos/t7475a.scala
-    )
+    override protected def exclude(sym: Symbol) = {
+      sym.isPrivateLocal && (sym.isParamAccessor || !isScala213) ||
+        sym.isArtifact ||
+        sym.isConstructor ||
+        (sym.isPrivate && sym.owner != base) // Privates aren't inherited. Needed for pos/t7475a.scala
+    }
 
     /** Types always match. Term symbols match if their member types
      *  relative to `self` match.

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1248,7 +1248,7 @@ trait Contexts { self: Analyzer =>
 
       var importLookupFor213MigrationWarning = false
       def depthOk213 = {
-        settings.isScala213 && !thisContext.unit.isJava && !cx(ContextMode.InPackageClauseName) && defSym.exists && isPackageOwnedInDifferentUnit(defSym) && {
+        currentRun.isScala213 && !thisContext.unit.isJava && !cx(ContextMode.InPackageClauseName) && defSym.exists && isPackageOwnedInDifferentUnit(defSym) && {
           importLookupFor213MigrationWarning = true
           true
         }

--- a/test/files/neg/t9334.check
+++ b/test/files/neg/t9334.check
@@ -1,0 +1,5 @@
+t9334.scala:7: error: overriding method aaa in class A of type => Int;
+ method aaa has weaker access privileges; it should not be private
+  private[this] def aaa: Int = 42
+                    ^
+one error found

--- a/test/files/neg/t9334.scala
+++ b/test/files/neg/t9334.scala
@@ -1,0 +1,8 @@
+// scalac: -Xsource:2.13
+
+class A {
+  def aaa: Int = 10
+}
+class B extends A {
+  private[this] def aaa: Int = 42
+}


### PR DESCRIPTION
Backport of https://github.com/scala/scala/pull/9542