### PR TITLE
for `ValueOf`, improve Scaladoc and `implicitNotFound` message

### DIFF
--- a/src/library/scala/ValueOf.scala
+++ b/src/library/scala/ValueOf.scala
@@ -17,7 +17,10 @@ package scala
  * single inhabitant. Eligible types are singleton types of the form `stablePath.type`,
  * Unit and singleton types corresponding to value literals.
  *
- * Instances of `ValueOf[T]` are provided implicitly for all eligible types. Typically
+ * The value itself can conveniently be retrieved with [[Predef#valueOf]], which requires
+ * a `ValueOf` to be available in implicit scope.
+ *
+ * The compiler provides instances of `ValueOf[T]` for all eligible types. Typically
  * an instance would be required where a runtime value corresponding to a type level
  * computation is needed.
 
@@ -48,5 +51,5 @@ package scala
  * is required in the implementation of `+` it is provided at the call site via the
  * implicit argument `m` of type `ValueOf[M]`.
  */
-@scala.annotation.implicitNotFound(msg = "No singleton value available for ${T}.")
+@scala.annotation.implicitNotFound(msg = "No singleton value available for ${T}; eligible singleton types for `ValueOf` synthesis include literals and stable paths.")
 final class ValueOf[T](val value: T) extends AnyVal


### PR DESCRIPTION
example:

```scala
scala> def foo[T : ValueOf] = valueOf[T]
def foo[T](implicit evidence$1: ValueOf[T]): T

scala> foo[3]
val res2: Int = 3

scala> foo[Int]
          ^
       error: No singleton value available for Int. (Eligible singleton types for `ValueOf` synthesis include literals and stable paths.)
```

references lampepfl/dotty#15829

review by @mbovel, @cayhorstmann?