### PR TITLE
fix `Range#contains` for very large negative starting values

### DIFF
--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -373,11 +373,11 @@ sealed abstract class Range(
     if (x == end && !isInclusive) false
     else if (step > 0) {
       if (x < start || x > end) false
-      else (step == 1) || (((x - start) % step) == 0)
+      else (step == 1) || (Integer.remainderUnsigned(x - start, step) == 0)
     }
     else {
       if (x < end || x > start) false
-      else (step == -1) || (((x - start) % step) == 0)
+      else (step == -1) || (Integer.remainderUnsigned(start - x, -step) == 0)
     }
   }
   /* Seq#contains has a type parameter so the optimised contains above doesn't override it */

--- a/test/junit/scala/collection/immutable/NumericRangeTest.scala
+++ b/test/junit/scala/collection/immutable/NumericRangeTest.scala
@@ -131,4 +131,30 @@ class NumericRangeTest {
       TestRange(BigDecimal(9.474), BigDecimal(49.474), BigDecimal(1)) //BigDecimal in "large" increments
       ).foreach(tr => assertEquals(foldListIncrement(tr).length, createRangeFromRangeTest(tr).length))
   }
+
+  @Test
+  def numericRangeContains() = {
+    def check(r: Range): List[Int] = {
+      r.filterNot(r.contains).toList
+    }
+
+    val testIncreaseCase = Int.MinValue until 1092265081 by 359972081
+
+    assertEquals(Nil, check(testIncreaseCase))
+    assertEquals(Nil, check(testIncreaseCase.drop(1)))
+    assertEquals(Nil, check(testIncreaseCase.drop(2)))
+    assertEquals(Nil, check(testIncreaseCase.drop(3)))
+    assertEquals(Nil, check(testIncreaseCase.start to testIncreaseCase.last by testIncreaseCase.step))
+    assertEquals(Nil, check(testIncreaseCase.inclusive))
+
+
+    val testDecreaseCase = Int.MaxValue until 1092265081 by -359972081
+
+    assertEquals(Nil, check(testDecreaseCase))
+    assertEquals(Nil, check(testDecreaseCase.drop(1)))
+    assertEquals(Nil, check(testDecreaseCase.drop(2)))
+    assertEquals(Nil, check(testDecreaseCase.drop(3)))
+    assertEquals(Nil, check(testDecreaseCase.start to testIncreaseCase.last by testIncreaseCase.step))
+    assertEquals(Nil, check(testDecreaseCase.inclusive))
+  }
 }


### PR DESCRIPTION
fix scala/bug#12635