### PR TITLE
Don't warn for an unused type alias if its member type is used

### DIFF
--- a/test/files/pos/t12600.scala
+++ b/test/files/pos/t12600.scala
@@ -1,0 +1,7 @@
+// scalac: -Wunused:privates,locals,patvars
+
+class Private {
+  private type Curry[A] = { type T[B] = Either[A, B] }
+  def m2[T[A]] :Unit = ()
+  m2[Curry[Int]#T]
+}


### PR DESCRIPTION
scala/bug#12600