### PR TITLE
[REVERTED] Completion bugfix: Matcher should be able to match on name exactly

### DIFF
--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -1190,7 +1190,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
             symbol.name.isTermName == name.isTermName || // Keep names of the same type
             name.isTypeName && isStable // Completing a type: keep stable terms (paths)
         }
-        !isJunk && member.accessible && !symbol.isConstructor && (name.isEmpty || matcher(member.sym.name) && nameTypeOk)
+        !isJunk && member.accessible && !symbol.isConstructor && (name.isEmpty || matcher(member.sym.name)) && nameTypeOk
 
       }
     }

--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -992,7 +992,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
 
   private[interactive] def getScopeCompletion(pos: Position, response: Response[List[Member]]): Unit = {
     informIDE("getScopeCompletion" + pos)
-    respond(response) { scopeMemberFlatten(scopeMembers(pos)) }
+    respond(response) { scopeMembers(pos) }
   }
 
   @nowarn("msg=inheritance from class LinkedHashMap")
@@ -1045,14 +1045,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
         // imported val and var are always marked as inaccessible, but they could be accessed through their getters. scala/bug#7995
         val member = if (s.hasGetter)
           ScopeMember(s, st, context.isAccessible(s.getter, pre, superAccess = false), viaImport)
-        else {
-          if (s.isAliasType) {
-            val aliasInfo = ScopeMember(s, st, context.isAccessible(s, pre, superAccess = false), viaImport)
-            ScopeMember(s.info.typeSymbol, s.info.typeSymbol.tpe,
-                                              context.isAccessible(s.info.typeSymbol, pre, superAccess = false), viaImport,
-                                              aliasInfo = Some(aliasInfo))
-          } else ScopeMember(s, st, context.isAccessible(s, pre, superAccess = false), viaImport)
-        }
+        else ScopeMember(s, st, context.isAccessible(s, pre, superAccess = false), viaImport)
         member.prefix = pre
         member
       }
@@ -1197,13 +1190,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
             symbol.name.isTermName == name.isTermName || // Keep names of the same type
             name.isTypeName && isStable // Completing a type: keep stable terms (paths)
         }
-        // scala/bug#11846 aliasInfo should be match
-        def aliasTypeOk: Boolean = {
-          matcher(member.aliasInfo.map(_.sym.name).getOrElse(NoSymbol.name)) && !forImport && symbol.name.isTermName == name.isTermName
-        }
-        
-        !isJunk && member.accessible && !symbol.isConstructor && (name.isEmpty || (matcher(member.sym.name) || aliasTypeOk)
-          && nameTypeOk)
+        !isJunk && member.accessible && !symbol.isConstructor && (name.isEmpty || matcher(member.sym.name) && nameTypeOk)
 
       }
     }
@@ -1222,11 +1209,6 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
       override def positionDelta = 0
       override def forImport: Boolean = false
     }
-  }
-
-  private def scopeMemberFlatten(members: List[ScopeMember]): List[ScopeMember] = {
-    val (infoWithoutAlias, infoWithAlias) = members.partition(_.aliasInfo.isEmpty)
-    infoWithoutAlias ++ infoWithAlias ++ infoWithAlias.flatten(_.aliasInfo)
   }
 
   final def completionsAt(pos: Position): CompletionResult = {
@@ -1256,13 +1238,13 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
         val allMembers = scopeMembers(pos)
         val positionDelta: Int = pos.start - focus1.pos.start
         val subName = name.subName(0, positionDelta)
-        CompletionResult.ScopeMembers(positionDelta, scopeMemberFlatten(allMembers), subName, forImport = false)
+        CompletionResult.ScopeMembers(positionDelta, allMembers, subName, forImport = false)
       case imp@Import(i @ Ident(name), head :: Nil) if head.name == nme.ERROR =>
         val allMembers = scopeMembers(pos)
         val nameStart = i.pos.start
         val positionDelta: Int = pos.start - nameStart
         val subName = name.subName(0, pos.start - i.pos.start)
-        CompletionResult.ScopeMembers(positionDelta, scopeMemberFlatten(allMembers), subName, forImport = true)
+        CompletionResult.ScopeMembers(positionDelta, allMembers, subName, forImport = true)
       case imp@Import(qual, selectors) =>
         selectors.reverseIterator.find(_.namePos <= pos.start) match {
           case None => CompletionResult.NoResults
@@ -1285,7 +1267,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
         val allMembers = scopeMembers(pos)
         val positionDelta: Int = pos.start - focus1.pos.start
         val subName = name.subName(0, positionDelta)
-        CompletionResult.ScopeMembers(positionDelta, scopeMemberFlatten(allMembers), subName, forImport = false)
+        CompletionResult.ScopeMembers(positionDelta, allMembers, subName, forImport = false)
       case _ =>
         CompletionResult.NoResults
     }

--- a/src/repl-frontend/scala/tools/nsc/interpreter/jline/Reader.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/jline/Reader.scala
@@ -350,7 +350,7 @@ class Completion(delegate: shell.Completion) extends shell.Completion with Compl
     }
 
     val parsedLineWord = parsedLine.word()
-    result.candidates.filter(c => c.name == parsedLineWord || c.alias.fold(false)(a => a == parsedLineWord)) match {
+    result.candidates.filter(_.name == parsedLineWord) match {
       case Nil =>
       case exacts =>
         val declStrings = exacts.map(_.declString()).filterNot(_ == "")

--- a/src/repl/scala/tools/nsc/interpreter/Interface.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Interface.scala
@@ -336,7 +336,6 @@ case class CompletionCandidate(
   isDeprecated: Boolean = false,
   isUniversal: Boolean = false,
   declString: () => String = () => "",
-  alias: Option[String] = None
 )
 object CompletionCandidate {
   sealed trait Arity

--- a/src/repl/scala/tools/nsc/interpreter/PresentationCompilation.scala
+++ b/src/repl/scala/tools/nsc/interpreter/PresentationCompilation.scala
@@ -216,7 +216,12 @@ trait PresentationCompilation { self: IMain =>
         val ccs = for {
           member <- matching
           if seen.add(member.sym)
-          sym <- if (member.sym.isClass && isNew) member.sym.info.decl(nme.CONSTRUCTOR).alternatives else member.sym.alternatives
+          candidate <- if (member.sym.isAliasType) {
+            val dealiased = member.sym.info.dealias.typeSymbol
+              seen.add(dealiased)
+              List(member.sym, dealiased)
+          } else List(member.sym)
+          sym <- if (candidate.isClass && isNew) candidate.info.decl(nme.CONSTRUCTOR).alternatives else candidate.alternatives
           sugared = sym.sugaredSymbolOrSelf
         } yield {
           CompletionCandidate(
@@ -232,9 +237,7 @@ trait PresentationCompilation { self: IMain =>
                 val methodOtherDesc = if (!desc.exists(_ != "")) "" else " " + desc.filter(_ != "").mkString(" ")
                 sugared.defStringSeenAs(tp) + methodOtherDesc
               }
-            },
-            alias = member.aliasInfo.fold[Option[String]](None)(s => Some(s.sym.nameString))
-            )
+            })
         }
         ccs
       }


### PR DESCRIPTION
Previously, we would get completion candidates that would by filter by a wrong name if it was an alias (name of the type that was liased). Now, we find dealiased candidates later on, so no need to add the alias info.

The problem appeared since we use the name matcher to fuzzy match on the input string. If the name that we match on is wrong then the results will also be wrong.

Follow up from https://github.com/scala/scala/pull/9754/files

@SethTisue if it's a sensible change I could also revert the rest of the changes from the other PR. Or do you think we should keep it as is?
