### PR TITLE
Usage of "tpe" in an Exception message

### DIFF
--- a/src/compiler/scala/reflect/reify/package.scala
+++ b/src/compiler/scala/reflect/reify/package.scala
@@ -72,7 +72,7 @@ package object reify {
     if (tpe.isSpliceable) {
       val classTagInScope = typer0.resolveClassTag(enclosingMacroPosition, tpe, allowMaterialization = false)
       if (!classTagInScope.isEmpty) return Select(classTagInScope, nme.runtimeClass)
-      if (concrete) throw ReificationException(enclosingMacroPosition, "tpe %s is an unresolved spliceable type".format(tpe))
+      if (concrete) throw ReificationException(enclosingMacroPosition, s"type $tpe is an unresolved spliceable type")
     }
 
     tpe.dealiasWiden match {

--- a/test/files/neg/t10073.check
+++ b/test/files/neg/t10073.check
@@ -1,4 +1,4 @@
-t10073.scala:7: error: tpe Unused is an unresolved spliceable type
+t10073.scala:7: error: type Unused is an unresolved spliceable type
   "".yo()
   ^
 1 error

--- a/test/files/neg/t10073b.check
+++ b/test/files/neg/t10073b.check
@@ -1,4 +1,4 @@
-t10073b.scala:7: error: tpe Unused is an unresolved spliceable type
+t10073b.scala:7: error: type Unused is an unresolved spliceable type
    "".yo()
    ^
 1 error


### PR DESCRIPTION
Fixing a typo (I think ?) in an error message.

As a developer who is not familiar with the internals of the Scala compiler, I was a bit surprised when I've came across the error message "tpe U is an unresolved spliceable type."
I've checked here and there in the code, and most of the time it's "type" that is being used in info/error messages and not tpe (variable name)

The only places I've seen "tpe" used in a string were for debug strings (debug internal to the Scala compiler), assertion messages, or to print the value of the tpe variable.
