### PR TITLE
Fix 2.13.9 regression in linting, causing spurious "variable x is never used" warnings

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -547,7 +547,7 @@ trait TypeDiagnostics extends splain.SplainDiagnostics {
               if (sym.isPrimaryConstructor)
                 for (cpa <- sym.owner.constrParamAccessors if cpa.isPrivateLocal) params += cpa
               else if (sym.isSynthetic && sym.isImplicit) return
-              else if (!sym.isConstructor && !isTrivial(rhs))
+              else if (!sym.isConstructor && !sym.isVar && !isTrivial(rhs))
                 for (vs <- vparamss) params ++= vs.map(_.symbol)
               defnTrees += m
             case _ =>

--- a/test/files/pos/t12646.scala
+++ b/test/files/pos/t12646.scala
@@ -1,0 +1,11 @@
+
+// scalac: -Werror -Wunused:params
+
+trait T {
+  private var x: String = _
+
+  def y: String = {
+    if (x eq null) x = "hello, world"
+    x
+  }
+}


### PR DESCRIPTION
The setter can be detected as isVar. Ignore its synthetic parameter.

Fixes scala/bug#12646