### PR TITLE
Fix `-release` on JDK 17 by updating optimizer class path

### DIFF
--- a/project/PartestUtil.scala
+++ b/project/PartestUtil.scala
@@ -36,7 +36,7 @@ object PartestUtil {
     val knownUnaryOptions = List(
       "--pos", "--neg", "--run", "--jvm", "--res", "--ant", "--scalap", "--specialized",
       "--instrumented", "--presentation", "--failed", "--update-check", "--no-exec",
-      "--show-diff", "--show-log", "--verbose", "--terse", "--debug", "--version", "--help")
+      "--show-diff", "--show-log", "--verbose", "--terse", "--debug", "--realeasy", "--version", "--help")
     val srcPathOption = "--srcpath"
     val compilerPathOption = "--compilerpath"
     val grepOption = "--grep"

--- a/src/partest/scala/tools/partest/nest/AbstractRunner.scala
+++ b/src/partest/scala/tools/partest/nest/AbstractRunner.scala
@@ -33,6 +33,7 @@ class AbstractRunner(val config: RunnerSpec.Config, protected final val testSour
   val debug: Boolean                 = config.optDebug || propOrFalse("partest.debug")
   val verbose: Boolean               = config.optVerbose
   val terse: Boolean                 = config.optTerse
+  val realeasy: Boolean              = config.optDev
 
   protected val printSummary         = true
   protected val partestCmd           = "test/partest"

--- a/src/partest/scala/tools/partest/nest/AbstractRunner.scala
+++ b/src/partest/scala/tools/partest/nest/AbstractRunner.scala
@@ -18,6 +18,7 @@ import utils.Properties._
 import scala.tools.nsc.Properties.{propOrFalse, setProp, versionMsg}
 import scala.collection.mutable
 import scala.reflect.internal.util.Collections.distinctBy
+import scala.sys.process.Process
 import scala.util.{Try, Success, Failure}
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -36,7 +37,7 @@ class AbstractRunner(val config: RunnerSpec.Config, protected final val testSour
   val realeasy: Boolean              = config.optDev
 
   protected val printSummary         = true
-  protected val partestCmd           = "test/partest"
+  protected val partestCmd           = "partest"
 
   private[this] var totalTests       = 0
   private[this] val passedTests      = mutable.ListBuffer[TestState]()
@@ -65,6 +66,12 @@ class AbstractRunner(val config: RunnerSpec.Config, protected final val testSour
   }
 
   private[this] val realSysErr = System.err
+
+  val gitRunner = List("/usr/local/bin/git", "/usr/bin/git").map(f => new java.io.File(f)).find(_.canRead)
+  def runGit[R](cmd: String)(f: LazyList[String] => R): Option[R] =
+    Try {
+      gitRunner.map(git => f(Process(s"$git $cmd").lazyLines_!))
+    }.toOption.flatten
 
   def statusLine(state: TestState, durationMs: Long) = {
     import state._
@@ -164,15 +171,27 @@ class AbstractRunner(val config: RunnerSpec.Config, protected final val testSour
           }
         }
 
-        val bslash = "\\"
-        def files_s = failed0.map(_.testFile).mkString(s" ${bslash}\n  ")
-        echo("# Failed test paths (this command will update checkfiles)")
-        echo(s"$partestCmd --update-check ${bslash}\n  $files_s\n")
+        if (failed0.size == 1) {
+          echo("# A test failed. To update the check file:")
+          echo(s"$partestCmd --update-check ${failed0.head.testIdent}")
+        }
+        else {
+          val bslash = "\\"
+          def files_s = failed0.map(_.testFile).mkString(s" ${bslash}\n  ")
+          echo("# Failed test paths (this command will update checkfiles)")
+          echo(s"$partestCmd --update-check ${bslash}\n  $files_s\n")
+        }
       }
 
       if (printSummary) {
         echo(message)
         levyJudgment()
+      }
+      if (realeasy) {
+        runGit("status --porcelain")(_.filter(_.endsWith(".check")).map(_.drop(3)).mkString("\n")).foreach { danger =>
+          echo(bold(red("# There are uncommitted check files!")))
+          echo(s"$danger\n")
+        }
       }
     }
   }

--- a/src/partest/scala/tools/partest/nest/Runner.scala
+++ b/src/partest/scala/tools/partest/nest/Runner.scala
@@ -333,18 +333,10 @@ class Runner(val testInfo: TestInfo, val suiteRunner: AbstractRunner) {
     compareContents(original = checked, revised = logged, originalName = checkname, revisedName = logFile.getName)
   }
 
-  val gitRunner = List("/usr/local/bin/git", "/usr/bin/git") map (f => new java.io.File(f)) find (_.canRead)
-  val gitDiffOptions = "--ignore-space-at-eol --no-index " + propOrEmpty("partest.git_diff_options")
-    // --color=always --word-diff
-
   def gitDiff(f1: File, f2: File): Option[String] = {
-    try gitRunner map { git =>
-      val cmd  = s"$git diff $gitDiffOptions $f1 $f2"
-      val diff = Process(cmd).lazyLines_!.drop(4).map(_ + "\n").mkString
-
-      "\n" + diff
-    }
-    catch { case t: Exception => None }
+    val gitDiffOptions = "--ignore-space-at-eol --no-index " + propOrEmpty("partest.git_diff_options")
+      // --color=always --word-diff
+    runGit(s"diff $gitDiffOptions $f1 $f2")(_.drop(4).map(_ + "\n").mkString).map("\n" + _)
   }
 
   /** Normalize the log output by applying test-specific filters

--- a/src/partest/scala/tools/partest/nest/Runner.scala
+++ b/src/partest/scala/tools/partest/nest/Runner.scala
@@ -33,6 +33,7 @@ import TestState.{Crash, Fail, Pass, Skip, Updated}
 import FileManager.{compareContents, joinPaths, withTempFile}
 import scala.reflect.internal.util.ScalaClassLoader.URLClassLoader
 import scala.util.{Failure, Success, Try, Using}
+import scala.util.Properties.isJavaAtLeast
 import scala.util.chaining._
 import scala.util.control.ControlThrowable
 
@@ -453,11 +454,17 @@ class Runner(val testInfo: TestInfo, val suiteRunner: AbstractRunner) {
   }
 
   // all sources in a round may contribute flags via // scalac: -flags
+  // under --realeasy, if a javaVersion isn't specified, require the minimum viable using -release 8
+  // to avoid accidentally committing a test that requires a later JVM.
   def flagsForCompilation(sources: List[File]): List[String] = {
-    val perFile = toolArgsFor(sources)("scalac")
-    if (parentFile.getParentFile.getName == "macro-annot") "-Ymacro-annotations" :: perFile
-    else perFile
+    var perFile = toolArgsFor(sources)("scalac")
+    if (parentFile.getParentFile.getName == "macro-annot")
+      perFile ::= "-Ymacro-annotations"
+    if (realeasy && isJavaAtLeast(9) && !perFile.exists(releaseFlag.matches) && toolArgsFor(sources)("javaVersion", split = false).isEmpty)
+      perFile ::= "-release:8"
+    perFile
   }
+  private val releaseFlag = raw"--?release(?::\d+)?".r
 
   // inspect sources for tool args
   def toolArgs(tool: String, split: Boolean = true): List[String] =

--- a/src/partest/scala/tools/partest/nest/RunnerSpec.scala
+++ b/src/partest/scala/tools/partest/nest/RunnerSpec.scala
@@ -56,8 +56,9 @@ trait RunnerSpec extends Spec with Meta.StdOpts with Interpolation {
   val optDebug        = "debug"        / "enable debugging output, preserve generated files" --?
 
   heading("Other options:")
-  val optVersion      = "version"      / "show Scala version and exit"  --?
-  val optHelp         = "help"         / "show this page and exit"      --?
+  val optDev     = "realeasy" / "real easy way to test --release 8 and check uncommitted checks" --?
+  val optVersion = "version"  / "show Scala version and exit"                                    --?
+  val optHelp    = "help"     / "show this page and exit"                                        --?
 
 }
 

--- a/src/repl/scala/tools/nsc/interpreter/ReplGlobal.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplGlobal.scala
@@ -98,12 +98,13 @@ trait ReplGlobal extends Global {
   }
 
   override def optimizerClassPath(base: ClassPath): ClassPath = {
+    val base1 = super.optimizerClassPath(base)
     settings.outputDirs.getSingleOutput match {
-      case None => base
+      case None => base1
       case Some(out) =>
         // Make bytecode of previous lines available to the inliner
         val replOutClasspath = ClassPathFactory.newClassPath(settings.outputDirs.getSingleOutput.get, settings, closeableRegistry)
-        AggregateClassPath.createAggregate(platform.classPath, replOutClasspath)
+        AggregateClassPath.createAggregate(base1, replOutClasspath)
     }
   }
 

--- a/test/files/neg/t3420b.check
+++ b/test/files/neg/t3420b.check
@@ -1,0 +1,4 @@
+t3420b.scala:8: error: value translateEscapes is not a member of String
+  def f(s: String) = s.translateEscapes
+                       ^
+1 error

--- a/test/files/neg/t3420b.scala
+++ b/test/files/neg/t3420b.scala
@@ -1,0 +1,9 @@
+
+// scalac: --release 8 -opt:inline:** -Wopt -Werror
+//
+class C {
+  val cv = Map[Int, Int](1 -> 2)
+  lazy val cl = Map[Int, Int](1 -> 2)
+  def cd = Map[Int, Int](1 -> 2)
+  def f(s: String) = s.translateEscapes
+}

--- a/test/files/pos/t3420b.scala
+++ b/test/files/pos/t3420b.scala
@@ -1,0 +1,8 @@
+
+// scalac: --release 8 -opt:inline:** -Wopt -Werror
+//
+class C {
+    val cv = Map[Int, Int](1 -> 2)
+    lazy val cl = Map[Int, Int](1 -> 2)
+    def cd = Map[Int, Int](1 -> 2)
+}

--- a/test/files/run/repl-release.check
+++ b/test/files/run/repl-release.check
@@ -1,0 +1,42 @@
+
+scala> def callerOfCaller = Thread.currentThread.getStackTrace.drop(2).head.getMethodName
+def callerOfCaller: String
+
+scala> @noinline def g = callerOfCaller
+def g: String
+
+scala> @noinline def h = g
+def h: String
+
+scala> assert(h == "g", h)
+
+scala> @inline def g = callerOfCaller
+def g: String
+
+scala> @noinline def h = g
+def h: String
+
+scala> assert(h == "h", h)
+
+scala> :quit
+
+scala> def callerOfCaller = Thread.currentThread.getStackTrace.drop(2).head.getMethodName
+def callerOfCaller: String
+
+scala> @noinline def g = callerOfCaller
+def g: String
+
+scala> @noinline def h = g
+def h: String
+
+scala> assert(h == "g", h)
+
+scala> @inline def g = callerOfCaller
+def g: String
+
+scala> @noinline def h = g
+def h: String
+
+scala> assert(h == "h", h)
+
+scala> :quit

--- a/test/files/run/repl-release.scala
+++ b/test/files/run/repl-release.scala
@@ -1,0 +1,33 @@
+import scala.tools.partest.ReplTest
+import scala.tools.nsc._
+import scala.tools.nsc.Settings
+import scala.tools.nsc.interpreter.shell.ReplReporterImpl
+
+// cf run/repl-inline.scala
+object Test extends ReplTest {
+
+  var count = 0
+
+  override def transformSettings(s: Settings) = {
+    s.processArguments("-release:8" :: "-opt:inline:**" :: "-Wopt" :: Nil, processAll = true)
+    s.Yreplclassbased.value = count > 0
+    count += 1
+    s
+  }
+
+  override def code =
+    """
+def callerOfCaller = Thread.currentThread.getStackTrace.drop(2).head.getMethodName
+@noinline def g = callerOfCaller
+@noinline def h = g
+assert(h == "g", h)
+@inline def g = callerOfCaller
+@noinline def h = g
+assert(h == "h", h)
+  """
+
+  override def show() = {
+    super.show()
+    super.show()
+  }
+}


### PR DESCRIPTION
Fixes scala/bug#12612

This was nominally a follow-up to https://github.com/scala/scala/pull/10056 and https://github.com/scala/scala/pull/10059

The `IOOBE` grew very familiar. The reason `pos/t3420` failed was inlining `Integer.valueOf` to box the ints in `Map(1 -> 2)`.