### PR TITLE
Synthesize productIterator for AnyVal case classes only

### DIFF
--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -874,7 +874,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val ProductRootClass: ClassSymbol = requiredClass[scala.Product]
       def Product_productArity          = getMemberMethod(ProductRootClass, nme.productArity)
       def Product_productElement        = getMemberMethod(ProductRootClass, nme.productElement)
-      def Product_productElementName        = getMemberIfDefined(ProductRootClass, nme.productElementName)
+      def Product_productElementName    = getMemberIfDefined(ProductRootClass, nme.productElementName)
       def Product_iterator              = getMemberMethod(ProductRootClass, nme.productIterator)
       def Product_productPrefix         = getMemberMethod(ProductRootClass, nme.productPrefix)
       def Product_canEqual              = getMemberMethod(ProductRootClass, nme.canEqual_)

--- a/test/files/run/idempotency-case-classes.check
+++ b/test/files/run/idempotency-case-classes.check
@@ -20,7 +20,6 @@ C(2,3)
       case 1 => C.this.y
       case _ => scala.runtime.Statics.ioobe[Any](x$1)
     };
-    override <synthetic> def productIterator: Iterator[Any] = scala.runtime.ScalaRunTime.typedProductIterator[Any](C.this);
     <synthetic> def canEqual(x$1: Any): Boolean = x$1.$isInstanceOf[C]();
     override <synthetic> def productElementName(x$1: Int): String = x$1 match {
       case 0 => "x"

--- a/test/files/scalap/caseClass.check
+++ b/test/files/scalap/caseClass.check
@@ -6,7 +6,6 @@ case class CaseClass[A <: scala.Seq[scala.Int]](i: A, s: scala.Predef.String) ex
   override def productPrefix: java.lang.String = { /* compiled code */ }
   def productArity: scala.Int = { /* compiled code */ }
   def productElement(x$1: scala.Int): scala.Any = { /* compiled code */ }
-  override def productIterator: scala.collection.Iterator[scala.Any] = { /* compiled code */ }
   def canEqual(x$1: scala.Any): scala.Boolean = { /* compiled code */ }
   override def productElementName(x$1: scala.Int): java.lang.String = { /* compiled code */ }
   override def hashCode(): scala.Int = { /* compiled code */ }

--- a/test/files/scalap/caseObject.check
+++ b/test/files/scalap/caseObject.check
@@ -3,7 +3,6 @@ case object CaseObject extends scala.AnyRef with scala.Product with scala.Serial
   override def productPrefix: java.lang.String = { /* compiled code */ }
   def productArity: scala.Int = { /* compiled code */ }
   def productElement(x$1: scala.Int): scala.Any = { /* compiled code */ }
-  override def productIterator: scala.collection.Iterator[scala.Any] = { /* compiled code */ }
   def canEqual(x$1: scala.Any): scala.Boolean = { /* compiled code */ }
   override def hashCode(): scala.Int = { /* compiled code */ }
   override def toString(): java.lang.String = { /* compiled code */ }

--- a/test/files/scalap/caseValueClass.check
+++ b/test/files/scalap/caseValueClass.check
@@ -1,0 +1,32 @@
+final case class CaseValueClass(s: scala.Predef.String) extends scala.AnyVal with scala.Product with scala.Serializable {
+  val s: scala.Predef.String = { /* compiled code */ }
+  def baz: scala.Int = { /* compiled code */ }
+  def copy(s: scala.Predef.String): CaseValueClass = { /* compiled code */ }
+  override def productPrefix: java.lang.String = { /* compiled code */ }
+  def productArity: scala.Int = { /* compiled code */ }
+  def productElement(x$1: scala.Int): scala.Any = { /* compiled code */ }
+  def canEqual(x$1: scala.Any): scala.Boolean = { /* compiled code */ }
+  override def productElementName(x$1: scala.Int): java.lang.String = { /* compiled code */ }
+  override def hashCode(): scala.Int = { /* compiled code */ }
+  override def equals(x$1: scala.Any): scala.Boolean = { /* compiled code */ }
+  override def toString(): java.lang.String = { /* compiled code */ }
+  override def productIterator: scala.collection.Iterator[scala.Any] = { /* compiled code */ }
+}
+object CaseValueClass extends scala.runtime.AbstractFunction1[scala.Predef.String, CaseValueClass] with java.io.Serializable {
+  def this() = { /* compiled code */ }
+  final override def toString(): java.lang.String = { /* compiled code */ }
+  def apply(s: scala.Predef.String): CaseValueClass = { /* compiled code */ }
+  def unapply(x$0: CaseValueClass): scala.Option[scala.Predef.String] = { /* compiled code */ }
+  final def baz$extension($this: CaseValueClass): scala.Int = { /* compiled code */ }
+  final def copy$extension($this: CaseValueClass)(s: scala.Predef.String): CaseValueClass = { /* compiled code */ }
+  final def copy$default$1$extension($this: CaseValueClass): scala.Predef.String = { /* compiled code */ }
+  final def productPrefix$extension($this: CaseValueClass): java.lang.String = { /* compiled code */ }
+  final def productArity$extension($this: CaseValueClass): scala.Int = { /* compiled code */ }
+  final def productElement$extension($this: CaseValueClass)(x$1: scala.Int): scala.Any = { /* compiled code */ }
+  final def canEqual$extension($this: CaseValueClass)(x$1: scala.Any): scala.Boolean = { /* compiled code */ }
+  final def productElementName$extension($this: CaseValueClass)(x$1: scala.Int): java.lang.String = { /* compiled code */ }
+  final def hashCode$extension($this: CaseValueClass)(): scala.Int = { /* compiled code */ }
+  final def equals$extension($this: CaseValueClass)(x$1: scala.Any): scala.Boolean = { /* compiled code */ }
+  final def toString$extension($this: CaseValueClass)(): java.lang.String = { /* compiled code */ }
+  final def productIterator$extension($this: CaseValueClass): scala.collection.Iterator[scala.Any] = { /* compiled code */ }
+}

--- a/test/files/scalap/caseValueClass.scala
+++ b/test/files/scalap/caseValueClass.scala
@@ -1,0 +1,3 @@
+case class CaseValueClass(s: String) extends AnyVal {
+  def baz = 239
+}

--- a/test/scaladoc/run/implicits-chaining.scala
+++ b/test/scaladoc/run/implicits-chaining.scala
@@ -23,7 +23,7 @@ object Test extends ScaladocModelTest {
     val A = base._class("A")
 
     conv = A._conversion(base.qualifiedName + ".convertToZ")
-    assertEquals(2, conv.members.length)
+    assertEquals(3, conv.members.length)
     assertEquals(1, conv.constraints.length)
 
 //// class B ///////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -31,7 +31,7 @@ object Test extends ScaladocModelTest {
     val B = base._class("B")
 
     conv = B._conversion(base.qualifiedName + ".convertToZ")
-    assertEquals(2, conv.members.length)
+    assertEquals(3, conv.members.length)
     assertEquals(0, conv.constraints.length)
 
 //// class C ///////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -45,7 +45,7 @@ object Test extends ScaladocModelTest {
     val D = base._class("D")
 
     conv = D._conversion(base.qualifiedName + ".convertToZ")
-    assertEquals(2, conv.members.length)
+    assertEquals(3, conv.members.length)
     assertEquals(0, conv.constraints.length)
 
 //// class E ///////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -53,7 +53,7 @@ object Test extends ScaladocModelTest {
     val E = base._class("E")
 
     conv = E._conversion(base.qualifiedName + ".convertToZ")
-    assertEquals(2, conv.members.length)
+    assertEquals(3, conv.members.length)
     assertEquals(0, conv.constraints.length)
 
 //// class F ///////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
We can't reuse the inherited method from `Product` when the case class is `AnyVal`, because then the `productIterator$extension` would be missing from the companion. This restores binary compatibility with Scala 2.13.8 for `AnyVal` case classes.

Alternative to #10155