### PR TITLE
Faster `Vector` concatenation

### DIFF
--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -289,11 +289,11 @@ sealed abstract class Vector[+A] private[immutable] (private[immutable] final va
 
   override final def foreach[U](f: A => U): Unit = {
     val c = vectorSliceCount
-      var i = 0
-      while(i < c) {
-        foreachRec(vectorSliceDim(c, i)-1, vectorSlice(i), f)
-        i += 1
-      }
+    var i = 0
+    while (i < c) {
+      foreachRec(vectorSliceDim(c, i) - 1, vectorSlice(i), f)
+      i += 1
+    }
   }
 
   // The following definitions are needed for binary compatibility with ParVector
@@ -1538,7 +1538,7 @@ final class VectorBuilder[A] extends ReusableBuilder[A, Vector[A]] {
         depth = 6
         offset = WIDTH5 - v6.len12345
         setLen(v6.length0 + offset)
-        a6 = new Arr6(WIDTH)
+        a6 = new Arr6(LASTWIDTH)
         a6(0) = copyPrepend(copyPrepend(copyPrepend(copyPrepend(v6.prefix1, v6.prefix2), v6.prefix3), v6.prefix4), v6.prefix5)
         System.arraycopy(d6, 0, a6, 1, d6.length)
         a5 = copyOf(s5, WIDTH)
@@ -1641,7 +1641,7 @@ final class VectorBuilder[A] extends ReusableBuilder[A, Vector[A]] {
       a3((idx >>> BITS2) & MASK) = a2
       a4((idx >>> BITS3) & MASK) = a3
       a5((idx >>> BITS4) & MASK) = a4
-    } else if (xor < WIDTH6) { // level = 5
+    } else if (xor > 0) { // level = 5
       if (depth == 5) { a6 = new Array(LASTWIDTH); a6(0) = a5; depth += 1 }
       a1 = new Array(WIDTH)
       a2 = new Array(WIDTH)
@@ -1771,8 +1771,6 @@ private[immutable] object VectorInline {
   final val WIDTH4 = 1 << BITS4
   final val BITS5 = BITS * 5
   final val WIDTH5 = 1 << BITS5
-  final val BITS6 = BITS * 6
-  final val WIDTH6 = 1 << BITS6
   final val LASTWIDTH = WIDTH << 1 // 1 extra bit in the last level to go up to Int.MaxValue (2^31-1) instead of 2^30:
   final val Log2ConcatFaster = 5
 

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/VectorConcatAlignToWorstCaseBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/VectorConcatAlignToWorstCaseBenchmark.scala
@@ -1,0 +1,39 @@
+package scala.collection.immutable
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(1)
+@Threads(1)
+@Warmup(iterations = 4)
+@Measurement(iterations = 5)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class VectorConcatAlignToWorstCaseBenchmark {
+  @Param(Array("1", "15", "31", "33", "63", "65", "127", "255", "513", "1023", "1025", "2047")) // should not be divisible by 32
+  var size: Int = _
+  @Param(Array("1", "32", "64", "128", "256"))
+  var sizeDifference: Int = _
+
+  val o = new AnyRef
+
+  var shorter: Vector[String] = _
+  var longer: Vector[String] = _
+
+  @Setup(Level.Trial) def init(): Unit = {
+    shorter = Vector.fill(size)("s")
+    longer = Vector.fill(size + sizeDifference)("l")
+  }
+
+  @Benchmark def withoutAlignTo(bh: Blackhole): Any =
+    bh.consume(new VectorBuilder[String]().addAll(shorter).addAll(longer).result())
+
+  @Benchmark def withAlignTo(bh: Blackhole): Any =
+    bh.consume(new VectorBuilder[String]().alignTo(shorter.length, longer).addAll(shorter).addAll(longer).result())
+
+  @Benchmark def concat(bh: Blackhole): Any =
+    bh.consume(shorter ++ longer)
+}

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/VectorConcatBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/VectorConcatBenchmark.scala
@@ -21,7 +21,7 @@ class VectorConcatBenchmark {
   var vAligned: Vector[AnyRef] = _
   var vShifted: Vector[AnyRef] = _
 
-  @Setup(Level.Trial) def init: Unit = {
+  @Setup(Level.Trial) def init(): Unit = {
     vAligned = Vector.fillSparse(size)(o)
     vShifted = Vector.fillSparse(size + 5)(o).drop(5)
   }
@@ -30,7 +30,7 @@ class VectorConcatBenchmark {
     var coll = a
     val coll1 = b
     var i = 0
-    while(i < 10) {
+    while(i < times) {
       coll = coll.appendedAll(coll1)
       i += 1
     }

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/VectorConcatBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/VectorConcatBenchmark.scala
@@ -1,0 +1,52 @@
+package scala.collection.immutable
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(1)
+@Threads(1)
+@Warmup(iterations = 4)
+@Measurement(iterations = 5)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class VectorConcatBenchmark {
+  @Param(Array("30", "32", "1000", "1024", "30000", "32000", "30720", "32768", "1048576", "33554432"))
+  var size: Int = _
+
+  val o = new AnyRef
+
+  var vAligned: Vector[AnyRef] = _
+  var vShifted: Vector[AnyRef] = _
+
+  @Setup(Level.Trial) def init: Unit = {
+    vAligned = Vector.fillSparse(size)(o)
+    vShifted = Vector.fillSparse(size + 5)(o).drop(5)
+  }
+
+  def concat(bh: Blackhole, a: Vector[AnyRef], b: Vector[AnyRef], times: Int = 10): Any = {
+    var coll = a
+    val coll1 = b
+    var i = 0
+    while(i < 10) {
+      coll = coll.appendedAll(coll1)
+      i += 1
+    }
+    bh.consume(coll)
+  }
+
+  @Benchmark def concatAlignedAligned(bh: Blackhole): Any =
+    concat(bh, vAligned, vAligned)
+
+  @Benchmark def concatAlignedShifted(bh: Blackhole): Any =
+    concat(bh, vShifted, vShifted)
+
+
+  @Benchmark def concatMisalignedAligned(bh: Blackhole): Any =
+    concat(bh, vAligned, vShifted)
+
+  @Benchmark def concatMisalignedShifted(bh: Blackhole): Any =
+    concat(bh, vShifted, vAligned)
+}

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/VectorConcatBigVectorsBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/VectorConcatBigVectorsBenchmark.scala
@@ -1,0 +1,45 @@
+package scala.collection.immutable
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(1)
+@Threads(1)
+@Warmup(iterations = 4)
+@Measurement(iterations = 5)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class VectorConcatBigVectorsBenchmark {
+  val size: Int = 1000000
+
+  @Param(Array("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"))
+  var tenthsSplit: Int = _
+  val o = new AnyRef
+
+  var l: Vector[AnyRef] = _
+  var lShifted: Vector[AnyRef] = _
+  var r: Vector[AnyRef] = _
+  var rNew: Vector[AnyRef] = _
+
+  @Setup(Level.Trial) def init(): Unit = {
+    val split = size * tenthsSplit / 10
+
+    val (a, b) = Vector.fillSparse(size)(o).splitAt(split)
+    l = a; r = b
+    rNew = Vector.fillSparse(size - split)(o)
+    lShifted = Vector.fillSparse(split + 5)(o).drop(5)
+  }
+
+  @Benchmark def concatAligned(bh: Blackhole): Any =
+    bh.consume(l ++ r)
+
+  @Benchmark def concatSemiAligned(bh: Blackhole): Any =
+    bh.consume(l ++ rNew)
+
+  @Benchmark def concatMisaligned(bh: Blackhole): Any =
+    bh.consume(lShifted ++ r)
+
+}

--- a/test/junit/scala/collection/immutable/VectorTest.scala
+++ b/test/junit/scala/collection/immutable/VectorTest.scala
@@ -47,7 +47,7 @@ class VectorTest {
 
   @Test
   def hasCorrectAppendedAndPrependedAll(): Unit = {
-    val els = Vector(1 to 1000: _*)
+    val els = Vector(1 to 1200: _*)
 
     for (i <- 0 until els.size) {
       val (prefix, suffix) = els.splitAt(i)
@@ -59,6 +59,17 @@ class VectorTest {
       assertEquals(els, prefix.toList ++: suffix)
       assertEquals(els, prefix.toList :++ suffix)
     }
+  }
+
+  @Test
+  def testBuilderInitWithLargeVector(): Unit = {
+    val v    = Vector.fillSparse(Int.MaxValue / 4 * 3)("v")
+    val copy =
+      new VectorBuilder[String]
+        .initFrom(v)
+        .result()
+    assertEquals(copy.size, v.size)
+    assertEquals(copy.take(500), v.take(500))
   }
 
   @Test


### PR DESCRIPTION
So far, concatenating two Vectors `v1` and `v2` of lengths $m$ (`v1`) and $n$ (`v2`) took $O(n)$ time.

This PR reduces the time needed to $O(\min(m, n))$.

For $m\lt n$, instead of pre-filling the `VectorBuilder` with `v1` and traversing all of `v2`, we now set an offset, such that after traversing `v1` and adding it's elements, the structure of the Builder does exactly match `v2`'s structure. This way, we can reuse arrays of `v2` and don't need to iterate over all of `v2`.

As an example, take the brown ("old misaligned") and red ("misaligned") line in the following plot. It shows times taken by concatenation of two Vectors with 1 million entries in total. The percentage states the relative size of `v1`. (So, $20\\%$ means $m=2\times 10^5, n=8\times10^5$.)
The values are in $\frac{\text{ns}}{\text{operation}}$. See also [benchmark source](https://github.com/ansvonwa/scala/blob/vector-faster-prepend/test/benchmarks/src/main/scala/scala/collection/immutable/VectorConcatBigVectorsBenchmark.scala).

The brown ("old misaligned") line shows the time for worst case (which is the case in 31 of 32 cases) of the old implementation.
The red ("misaligned") line shows times with this optimization. You see the improvement for $m\lt n$.

![s c i Vector concat](https://user-images.githubusercontent.com/9501177/192121750-9bd3795a-5625-47aa-ace4-08f401671269.png)

The way in which this optimization is implemented, yields another improvement. In special cases, time goes down to $O(\log_{32}(m+n))$, so basically zero.

In the old implementation, if the data arrays of the Vectors align (i.e. `(v1.suffix1.length + v2.prefix1.length) % 32 == 0`), there was only one call to `System.arraycopy` for each data array in `v2`, instead of two.
Thus, there was a small performance improvement for aligned Vectors (green and pale blue).

Now, we check for every slice whether it aligns to the Builder's structure. If that is the case, we reuse the old Array instead of copying it's content. We do this on every level. Thus, if the Vectors align at the lowest level (`(v1.suffix1.length + v2.prefix1.length) % WIDTH == 0`; $\frac1{32}$ chance for random vectors), we get the improvement shown by the yellow line. If the Vectors align at all levels (`(v1.suffix1…X.length + v2.prefix1…X.length) % WIDTHX == 0`), we get the dark blue times, so just a hand full of operations.

----

In short, the four commits do
1. fix old issues, mostly related to large Vectors,
2. detect where slices align and reuse arrays,
3. add a method (`alignTo`) to set the offset and another one to drop leading `null`s in Arrays before constructing the result,
4. change bit-arithmetics to a switch with hardcoded values.
   This should improve performance slightly, but I did not really get significantly shorter times in the benchmarks.
   It's mostly a matter of taste, but with the switch, it looks and feels more like the rest of the Vector class.


closes scala/bug#4442