### PR TITLE
`-Xsource:3` now respects refinements by whitebox macro overrides

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1127,7 +1127,7 @@ trait Namers extends MethodSynthesis {
         case _ => defnTyper.computeType(tree.rhs, pt)
       }
       tree.tpt.defineType {
-        if (currentRun.isScala3 && !pt.isWildcard && pt != NoType && !pt.isErroneous) pt
+        if (currentRun.isScala3 && !pt.isWildcard && pt != NoType && !pt.isErroneous && openMacros.isEmpty) pt
         else dropIllegalStarTypes(widenIfNecessary(tree.symbol, rhsTpe, pt))
       }.setPos(tree.pos.focus)
       tree.tpt.tpe
@@ -1319,7 +1319,6 @@ trait Namers extends MethodSynthesis {
       val tparamSyms = typer.reenterTypeParams(tparams)
       val tparamSkolems = tparams.map(_.symbol)
 
-
       /*
        * Creates a method type using tparamSyms and vparamsSymss as argument symbols and `respte` as result type.
        * All typeRefs to type skolems are replaced by references to the corresponding non-skolem type parameter,
@@ -1330,7 +1329,6 @@ trait Namers extends MethodSynthesis {
        */
       def deskolemizedPolySig(vparamSymss: List[List[Symbol]], restpe: Type) =
         GenPolyType(tparamSyms, methodTypeFor(meth, vparamSymss, restpe).substSym(tparamSkolems, tparamSyms))
-
 
       if (tpt.isEmpty && meth.name == nme.CONSTRUCTOR) {
         tpt defineType context.enclClass.owner.tpe_*
@@ -1350,7 +1348,6 @@ trait Namers extends MethodSynthesis {
           context.unit.transformed(tpt) = tptTyped
           tptTyped.tpe
         }
-
 
       // ignore missing types unless we can look to overridden method to recover the missing information
       val canOverride = methOwner.isClass && !meth.isConstructor

--- a/test/files/pos/t12645/Macro_1.scala
+++ b/test/files/pos/t12645/Macro_1.scala
@@ -1,0 +1,20 @@
+
+// scalac: -Xsource:3
+
+import language.experimental.macros
+import scala.reflect.macros.whitebox.Context
+
+trait Greeter {
+  def greeting: Option[Any] = Some("Take me to your leader, Greeter.")
+}
+
+class Welcomer {
+  def greeter: Greeter = macro Macros.impl
+}
+
+object Macros {
+  def impl(c: Context) = {
+    import c.universe._
+    q"""new Greeter { override def greeting = Some("hello, quoted world") }"""
+  }
+}

--- a/test/files/pos/t12645/Test_2.scala
+++ b/test/files/pos/t12645/Test_2.scala
@@ -1,0 +1,8 @@
+
+// scalac: -Xsource:3
+
+object Test extends App {
+  def f(s: String) = println(s)
+  val welcomer = new Welcomer
+  welcomer.greeter.greeting.foreach(f)
+}

--- a/test/files/pos/t12645b/Test_2.scala
+++ b/test/files/pos/t12645b/Test_2.scala
@@ -1,0 +1,6 @@
+// scalac: -Xsource:3
+
+object Test extends App {
+  Foo.ctx.quote(42).ast.id
+}
+// was: Test_2.scala:4: error: value id is not a member of Ast

--- a/test/files/pos/t12645b/macro_1.scala
+++ b/test/files/pos/t12645b/macro_1.scala
@@ -1,0 +1,31 @@
+
+// scalac: -Xsource:3
+
+import scala.language.experimental.macros
+import scala.reflect.macros.whitebox.Context
+
+trait Ast
+case class Foo(id: Int) extends Ast
+object Foo {
+  val ctx = new Ctx {}
+}
+
+trait Ctx {
+  trait Quoted[+A] {
+    def ast: Ast
+  }
+  final def quote[A](a: A): Quoted[A] = macro QuoteMacro.quoteImpl[A]
+}
+
+class QuoteMacro(val c: Context) {
+  import c.universe.*
+
+  def quoteImpl[A](a: c.Expr[A])(implicit t: WeakTypeTag[A]) =
+    c.untypecheck {
+      q"""
+      new ${c.prefix}.Quoted[$t] {
+        def ast = Foo(42)
+      }
+      """
+    }
+}


### PR DESCRIPTION
Fixes scala/bug#12645