### PR TITLE
Clarify spec of root contexts

### DIFF
--- a/test/files/neg/t12513.check
+++ b/test/files/neg/t12513.check
@@ -1,0 +1,4 @@
+predefer_2.scala:10: error: not found: value x
+    println((x,y))
+             ^
+1 error

--- a/test/files/neg/t12513/predefer_2.scala
+++ b/test/files/neg/t12513/predefer_2.scala
@@ -1,0 +1,12 @@
+// scalac: -Yimports:p.MyPredef,scala.Predef,scala
+
+package p {
+  object Test extends App {
+    println((x,y))
+  }
+}
+package q {
+  object Test extends App {
+    println((x,y))
+  }
+}

--- a/test/files/neg/t12513/predefined_1.scala
+++ b/test/files/neg/t12513/predefined_1.scala
@@ -1,0 +1,7 @@
+
+package p
+
+object MyPredef {
+  private [p] def x = 27
+  def y = 42
+}

--- a/test/files/neg/t12513b.check
+++ b/test/files/neg/t12513b.check
@@ -1,0 +1,4 @@
+t12513b.scala:8: error: could not optimize @tailrec annotated method f: it contains a recursive call not in tail position
+  @T def f: Int = { f ; 42 }  // the annotation worked: error, f is not tail recursive
+         ^
+1 error

--- a/test/files/neg/t12513b.scala
+++ b/test/files/neg/t12513b.scala
@@ -1,0 +1,9 @@
+
+// scalac: -Werror -Xsource:3
+
+object X { type T = annotation.tailrec }
+object Y { type T = annotation.tailrec }
+object Z {
+  import X.*, Y.*             // OK, both T mean tailrec
+  @T def f: Int = { f ; 42 }  // the annotation worked: error, f is not tail recursive
+}

--- a/test/files/pos/t12513c/c.scala
+++ b/test/files/pos/t12513c/c.scala
@@ -1,0 +1,1 @@
+package p { class C }

--- a/test/files/pos/t12513c/xy.scala
+++ b/test/files/pos/t12513c/xy.scala
@@ -1,0 +1,3 @@
+import p._
+package p { class X extends C } // not ambiguous (compiles without the import)
+package q { class Y extends C } // requires the import


### PR DESCRIPTION
Fixes scala/bug#12513

Improved word choices. Changed explanation from analogy to mechanism.

Added test showing spec change that a root context binding is available if access permits (just like an import).
