### PR TITLE
Restore `-Vprint-args`, for echoing arguments provided to compiler

### DIFF
--- a/src/compiler/scala/tools/nsc/CompilerCommand.scala
+++ b/src/compiler/scala/tools/nsc/CompilerCommand.scala
@@ -126,11 +126,11 @@ class CompilerCommand(arguments: List[String], val settings: Settings) {
   def expandArg(arg: String): List[String] = {
     import java.nio.file.{Files, Paths}
     import scala.jdk.CollectionConverters._
-    def stripComment(s: String) = s.takeWhile(_ != '#')
-    val file = Paths.get(arg stripPrefix "@")
+    def stripComment(s: String) = s.takeWhile(_ != '#').trim()  // arg can be "" but not " "
+    val file = Paths.get(arg.stripPrefix("@"))
     if (!Files.exists(file))
       throw new java.io.FileNotFoundException(s"argument file $file could not be found")
-    settings.splitParams(Files.readAllLines(file).asScala.map(stripComment).mkString(" "))
+    Files.readAllLines(file).asScala.filter(!_.startsWith("#")).map(stripComment).toList
   }
 
   // override this if you don't want arguments processed here

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1491,23 +1491,19 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
         }
       }
 
-    /** Compile list of source files,
-     *  unless there is a problem already,
-     *  such as a plugin was passed a bad option.
+    /** Compile a list of source files, unless there is a problem already, e.g., a plugin was passed a bad option.
      */
     def compileSources(sources: List[SourceFile]): Unit = if (!reporter.hasErrors) {
       printArgs(sources)
-
       def checkDeprecations() = {
         warnDeprecatedAndConflictingSettings()
         reporting.summarizeErrors()
       }
-
-      val units = sources map scripted map (file => new CompilationUnit(file, warningFreshNameCreator))
-
-      units match {
+      sources match {
         case Nil => checkDeprecations()   // nothing to compile, report deprecated options
-        case _   => compileUnits(units)
+        case _   =>
+          val units = sources.map(src => new CompilationUnit(scripted(src), warningFreshNameCreator))
+          compileUnits(units)
       }
     }
 

--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -973,5 +973,5 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
 }
 
 private object Optionlike {
-  def unapply(s: String): Boolean = s.startsWith("-")
+  def unapply(s: String): Boolean = s.startsWith("-") && s != "-"
 }

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -39,7 +39,7 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
   protected def defaultClasspath = Option(System.getenv("CLASSPATH")).getOrElse(".")
 
   /** If any of these settings is enabled, the compiler should print a message and exit.  */
-  def infoSettings = List[Setting](version, help, Vhelp, Whelp, Xhelp, Yhelp, showPlugins, showPhases, genPhaseGraph, printArgs)
+  def infoSettings = List[Setting](version, help, Vhelp, Whelp, Xhelp, Yhelp, showPlugins, showPhases, genPhaseGraph)
 
   /** Is an info setting set? Any -option:help? */
   def isInfo = infoSettings.exists(_.isSetByUser) || allSettings.valuesIterator.exists(_.isHelping)

--- a/test/files/run/argfile.check
+++ b/test/files/run/argfile.check
@@ -1,0 +1,1 @@
+Compiler arguments written to: argfile-run.obj/print-args.txt

--- a/test/files/run/argfile.scala
+++ b/test/files/run/argfile.scala
@@ -1,0 +1,39 @@
+
+import java.nio.file.Files
+
+import scala.jdk.CollectionConverters._
+import scala.reflect.internal.util._
+import scala.tools.nsc.{CompilerCommand, Settings}
+import scala.tools.partest.DirectTest
+import scala.util.chaining._
+
+object Test extends DirectTest {
+  var count = 0
+  lazy val argfile = testOutput.jfile.toPath().resolve("print-args.txt")
+  lazy val goodarg = testOutput.jfile.toPath().resolve("print-args2.txt")
+  override def extraSettings =
+    if (count == 0) s"""${super.extraSettings} -Xsource:3 -Vprint-args $argfile "-Wconf:cat=unused-nowarn&msg=does not suppress&site=C:s""""
+    else s"@$goodarg"
+    
+  // Use CompilerCommand for expanding the args file.
+  override def newSettings(args: List[String]) = (new Settings).tap { s =>
+    val cc = new CompilerCommand(args, s)
+    assert(cc.ok)
+    assert(cc.files.isEmpty)
+  }
+  def code =
+    sm"""
+    |@annotation.nowarn
+    |final class C {
+    |  def f: Int = "42".toInt
+    |}
+    """
+  def show() = {
+    assert(compile())
+    // drop "-Vprint-args .../print-args.txt newSource1.scala"
+    val args = Files.readAllLines(argfile).asScala.toList.dropRight(3)
+    Files.write(goodarg, args.asJava)
+    count += 1
+    assert(compile())
+  }
+}

--- a/test/files/run/print-args.check
+++ b/test/files/run/print-args.check
@@ -1,0 +1,6 @@
+Compiler arguments written to: print-args-run.obj/print-args.txt
+newSource1.scala:3: error: type mismatch;
+ found   : String("42")
+ required: Int
+  def f: Int = "42"
+               ^

--- a/test/files/run/print-args.scala
+++ b/test/files/run/print-args.scala
@@ -1,0 +1,31 @@
+
+import java.nio.file.Files
+
+import scala.jdk.CollectionConverters._
+import scala.reflect.internal.util._
+import scala.tools.partest.DirectTest
+
+object Test extends DirectTest {
+  lazy val argfile = testOutput.jfile.toPath().resolve("print-args.txt")
+  override def extraSettings = s"${super.extraSettings} -Xsource:3 -Vprint-args ${argfile}"
+  def expected =
+    sm"""
+    |-usejavacp
+    |-d
+    |${testOutput.jfile.toPath()}
+    |-Xsource:3.0.0
+    |-Vprint-args
+    |${testOutput.jfile.toPath().resolve(argfile)}
+    |newSource1.scala
+    """
+  def code =
+    sm"""
+    |class C {
+    |  def f: Int = "42"
+    |}
+    """
+  def show() = {
+    assert(!compile())
+    assert(expected.linesIterator.toList.tail.init.sameElements(Files.readAllLines(argfile).asScala))
+  }
+}

--- a/test/junit/scala/tools/nsc/settings/SettingsTest.scala
+++ b/test/junit/scala/tools/nsc/settings/SettingsTest.scala
@@ -345,6 +345,15 @@ class SettingsTest {
     assertFalse(s.optInlinerEnabled)
     assertTrue(s.optBoxUnbox)
   }
+  @Test def `print args to reporter`: Unit = {
+    val s = settings
+    val args = "-Vprint-args" :: "-" :: Nil
+    val (ok, rest) = s.processArguments(args, processAll = true)
+    assertTrue(ok)
+    assertTrue(rest.isEmpty)
+    assertFalse(s.isInfo)
+    assertTrue(s.printArgs.isSetByUser)
+  }
 }
 object SettingsTest {
   import language.implicitConversions


### PR DESCRIPTION
It was accidentally put back on the info arg list. Insult to injury, its "-" arg was no longer parsed.

Unreverts and improves https://github.com/scala/scala/pull/10123

Note that this is irrespective of how "command lines" are tokenized, as arg files are no longer tokenized.

Apologies to retronym, who set up the current facility in 2018, which I broke in 2019 (but only on 2.13, which must be why retronym didn't notice).
