### PR TITLE
fix ValueOf can't specialized 

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -506,8 +506,15 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
       else if (!args.isEmpty)
         enteringTyper {
           foreach2(sym.typeParams, args) { (tp, arg) =>
-            if (tp.isSpecialized)
+            if (tp.isSpecialized) {
               specializedTypeVarsBuffer(arg, result)
+            } else if (sym == ValueOfClass) { // scala/bug#11489, we only update it for ValueOf 
+              arg.typeSymbol.annotations.foreach {
+                case lzai: LazyAnnotationInfo if lzai.symbol == SpecializedClass =>
+                  specializedTypeVarsBuffer(arg, result)
+                case _                                                           =>
+              }
+            }
           }
         }
     case PolyType(tparams, resTpe)   => specializedTypeVarsBuffer(resTpe, result);  tparams.foreach(sym => specializedTypeVarsBuffer(sym.info, result))

--- a/test/files/specialized/t11489.scala
+++ b/test/files/specialized/t11489.scala
@@ -1,0 +1,8 @@
+class Parent {
+  def twice[@scala.specialized(Int) I <: Int : ValueOf]: Int = valueOf[I] * 2
+}
+
+object Test extends App {
+  val actualMethods = (new Parent).getClass.getDeclaredMethods
+  assert(actualMethods.count(_.getName == "twice$mIc$sp") == 1)
+}


### PR DESCRIPTION
scala/bug#11489

This is a new pr for 11489, Old pr and discussion: https://github.com/scala/scala/pull/9787/files

The constraint type of the type parameter supports specialization, and there are `specialized` annotation. It should support specialization. 
