### PR TITLE
Accept `-Vprint:all`, `-Vprint:~tailcalls`

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -945,14 +945,19 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
 
     def clear(): Unit = (v = Nil)
 
-    // we slightly abuse the usual meaning of "contains" here by returning
-    // true if our phase list contains "_", regardless of the incoming argument
+    /* True if the named phase is selected.
+     *
+     * A setting value "_" or "all" selects all phases by name.
+     */
     def contains(phName: String)     = doAllPhases || containsName(phName)
-    def containsName(phName: String) = stringValues exists (phName startsWith _)
+    /* True if the given phase name matches the selection, possibly as prefixed "~name". */
+    def containsName(phName: String) = stringValues.exists(phName.startsWith(_))
     def containsId(phaseId: Int)     = phaseIdTest(phaseId)
-    def containsPhase(ph: Phase)     = contains(ph.name) || containsId(ph.id)
+    /* True if the phase is selected by name or "all", or by id, or by prefixed "~name". */
+    def containsPhase(ph: Phase)     = contains(ph.name) || containsId(ph.id) || containsName(s"~${ph.name}") ||
+      ph.next != null && containsName(s"~${ph.next.name}")  // null if called during construction
 
-    def doAllPhases = stringValues.contains("_")
+    def doAllPhases = stringValues.exists(s => s == "_" || s == "all")
     def unparse: List[String] = value.map(v => s"$name:$v")
 
     withHelpSyntax(

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -499,7 +499,7 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
   val showPhases         = BooleanSetting("-Vphases", "Print a synopsis of compiler phases.")
     .withAbbreviation("-Xshow-phases")
   val Yposdebug          = BooleanSetting("-Vpos", "Trace position validation.") withAbbreviation "-Ypos-debug"
-  val Xprint             = PhasesSetting("-Vprint", "Print out program after")
+  val Xprint             = PhasesSetting("-Vprint", "Print out program after (or ~phase for before and after)", "typer")
     .withAbbreviation("-Xprint")
   val Xprintpos          = BooleanSetting("-Vprint-pos", "Print tree positions, as offsets.")
     .withAbbreviation("-Xprint-pos")

--- a/test/junit/scala/tools/nsc/settings/SettingsTest.scala
+++ b/test/junit/scala/tools/nsc/settings/SettingsTest.scala
@@ -354,6 +354,54 @@ class SettingsTest {
     assertFalse(s.isInfo)
     assertTrue(s.printArgs.isSetByUser)
   }
+  @Test def `name-based phases setting accepts tilde prefix`: Unit = {
+    val start = new Phase(null) { def name = "start"; def run() = () }
+    val chunk = new Phase(start) { def name = "chunker"; def run() = () }
+    val clean = new Phase(chunk) { def name = "clean"; def run() = () }
+    val go    = new Phase(clean) { def name = "go"; def run() = () }
+    val end   = new Phase(go) { def name = "end"; def run() = () }
+    val s = new MutableSettings(msg => throw new IllegalArgumentException(msg))
+    val ps = new s.PhasesSetting("-Yp", descr="", default="")
+    s.allSettings(ps.name) = ps
+    val args = List("-Yp:clean,~chunker,3")
+    val (ok, residual) = s.processArguments(args, processAll = true)
+    assertTrue(ok)
+    assertTrue(residual.isEmpty)
+    assertTrue(ps.contains("clean"))
+    assertFalse(ps.contains("chunker"))
+    assertTrue(ps.contains("~chunker"))
+    assertFalse(ps.contains("start"))
+    assertFalse(ps.contains("end"))
+    assertTrue(ps.containsPhase(clean))
+    assertTrue(ps.containsPhase(chunk))
+    assertTrue(ps.containsPhase(start))
+    assertTrue(ps.containsPhase(start.next))
+    assertTrue(ps.contains(s"~${start.next.name}"))
+    assertTrue(ps.containsPhase(go))
+    assertTrue(ps.containsId(go.id))
+    assertFalse(ps.containsPhase(end))
+    assertFalse(ps.containsId(end.id))
+  }
+  @Test def `phases setting accepts all or underscore`: Unit = {
+    val start = new Phase(null) { def name = "start"; def run() = () }
+    def check(args: String*): MutableSettings#PhasesSetting = {
+      val s = new MutableSettings(msg => throw new IllegalArgumentException(msg))
+      val ps = new s.PhasesSetting("-Yp", descr="", default="")
+      s.allSettings(ps.name) = ps
+      val (ok, residual) = s.processArguments(args.toList, processAll = true)
+      assertTrue(ok)
+      assertTrue(residual.isEmpty)
+      ps
+    }
+    assertTrue(check("-Yp:start").containsPhase(start))
+    assertTrue(check("-Yp:start").contains("start"))
+    assertTrue(check("-Yp:start").containsName("start"))
+    assertTrue(check("-Yp:all").containsPhase(start))
+    assertTrue(check("-Yp:all").contains("start"))
+    assertFalse(check("-Yp:all").containsName("start"))
+    assertTrue(check("-Yp:_").containsPhase(start))
+    assertTrue(check("-Yp:junk,_").containsPhase(start))
+  }
 }
 object SettingsTest {
   import language.implicitConversions


### PR DESCRIPTION
Because Scala 3 uses "all", it would be easier if Scala 2 regressed to also accepting all in `-Vprint:all`.

Often, one wishes to see both incoming and outgoing trees.

It is verbose and cumbersome to determine which phase precedes `tailcalls`, for instance, in order to `-Vprint:fields,tailcalls`.

The updated syntax is `-Vprint:~tailcalls`.

Since settings are not aware of phase order, semantics are the onus of the feature. The syntax is not supported automatically by `-Vshow`, for example.

Note that id syntax is `-Vprint:12-13` and tilde is not supported for id. It is trivial to compute the predecessor of phase 13 (unlucky phase!).

`~all` does not mean before and after every phase, i.e., twice.