### PR TITLE
Scaladoc tool: fix parsing bug which could cause very slow performance or incorrect output

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
@@ -267,7 +267,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
       case CodeBlockEndRegex(before, marker, after) :: ls =>
         if (!before.trim.isEmpty && !after.trim.isEmpty)
           parse0(docBody, tags, lastTagKey, before :: marker :: after :: ls, inCodeBlock = true)
-        if (!before.trim.isEmpty)
+        else if (!before.trim.isEmpty)
           parse0(docBody, tags, lastTagKey, before :: marker :: ls, inCodeBlock = true)
         else if (!after.trim.isEmpty)
           parse0(docBody, tags, lastTagKey, marker :: after :: ls, inCodeBlock = false)


### PR DESCRIPTION
Fix scala/bug#12509

I think I found the root cause.  I used a simple test case to debug this issue:
```
/**
* {{{foo}}}}
*/
```
Not sure the fix and/or commit message is completely correct.
So please give comment.