### PR TITLE
Preserve tree attachment in the typer's Block/Apply inversion transform

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4919,8 +4919,10 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       }
 
       def typedApply(tree: Apply) = tree match {
-        case Apply(Block(stats, expr), args) =>
-          typed1(atPos(tree.pos)(Block(stats, Apply(expr, args) setPos tree.pos.makeTransparent)), mode, pt)
+        case Apply(blk @ Block(stats, expr), args) =>
+          val ap1 = treeCopy.Apply(tree, expr, args).clearType().setPos(tree.pos.makeTransparent)
+          val blk1 = treeCopy.Block(blk, stats, ap1).clearType()
+          typed1(blk1, mode, pt)
         case Apply(fun, args) =>
           normalTypedApply(tree, fun, args) match {
             case treeInfo.ArrayInstantiation(level, componentType, arg) =>

--- a/test/junit/scala/tools/nsc/typechecker/TreeAttachmentTest.scala
+++ b/test/junit/scala/tools/nsc/typechecker/TreeAttachmentTest.scala
@@ -1,0 +1,46 @@
+package scala.tools.nsc.typechecker
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+import scala.tools.testing.BytecodeTesting
+
+@RunWith(classOf[JUnit4])
+class TreeAttachmentTest extends BytecodeTesting {
+
+  import compiler.global._
+
+  override def compilerArgs: String = "-Ystop-after:typer"
+
+  @Test
+  def namedApplyInfoAttachmentPreserved(): Unit = {
+    def compile(testMethodCode: String, call: String): Option[analyzer.NamedApplyInfo] = {
+      val code =
+        s"""
+          |class C {
+          |  $testMethodCode
+          |  def s = ""
+          |  def useTest = $call
+          |}
+          |""".stripMargin
+
+      compiler.compileClasses(code)
+      val run = compiler.newRun
+      run.compileUnits(newCompilationUnit(code) :: Nil, run.parserPhase)
+      val tree : Tree = run.units.next.body
+      val block: Tree = tree.collect { case b: Block => b }.last
+      block.attachments.get[analyzer.NamedApplyInfo]
+    }
+
+
+    def vargss(x: Option[analyzer.NamedApplyInfo]): List[List[String]] = x.map(x => mmap(x.vargss)(_.symbol.name.toString)).getOrElse(Nil)
+
+    assertEquals(None, compile("def test(a: Any, b: Any)(c: Any)(implicit d: DummyImplicit) = 0", "test(s, s)(s)"))
+
+    val expected = List(List("x$2", "x$1"), List("x$3"))
+    assertEquals(expected, vargss(compile("def test(a: Any, b: Any)(c:    Any)                            = 0", "test(b = s, a = s)(s)")))
+    assertEquals(expected, vargss(compile("def test(a: Any, b: Any)(c:    Any)(implicit d: DummyImplicit) = 0", "test(b = s, a = s)(s)")))
+  }
+}


### PR DESCRIPTION
This keeps NamedApplyInfo attachment in place for downstream analysis
by compiler plugins.

Fixes scala/bug#12659
