### PR TITLE
[SUPERSEDED] Inherited members can induce ambiguity

### DIFF
--- a/spec/02-identifiers-names-and-scopes.md
+++ b/spec/02-identifiers-names-and-scopes.md
@@ -7,7 +7,7 @@ chapter: 2
 # Identifiers, Names and Scopes
 
 Names in Scala identify types, values, methods, and classes which are
-collectively called _entities_. Names are introduced by local
+collectively called _entities_. Names are introduced by
 [definitions and declarations](04-basic-declarations-and-definitions.html#basic-declarations-and-definitions),
 [inheritance](05-classes-and-objects.html#class-members),
 [import clauses](04-basic-declarations-and-definitions.html#import-clauses), or
@@ -17,14 +17,16 @@ which are collectively called _bindings_.
 Bindings of each kind are assigned a precedence which determines
 whether one binding can shadow another:
 
-1. Definitions and declarations that are local, inherited, or made
-   available by a package clause and also defined in the same compilation unit
-   as the reference to them, have the highest precedence.
+1. Definitions and declarations in lexical scope that are not [top-level](09-top-level-definitions.html)
+   have the highest precedence.
+1. Definitions and declarations that are either inherited,
+   or made available by a package clause and also defined in the same compilation unit as the reference to them,
+   have the next highest precedence.
 1. Explicit imports have the next highest precedence.
 1. Wildcard imports have the next highest precedence.
-1. Bindings made available by a package clause, but not also defined in the
-   same compilation unit as the reference to them, as well as bindings
-   supplied by the compiler but not explicitly written in source code,
+1. Bindings made available by a package clause,
+   but not also defined in the same compilation unit as the reference to them,
+   as well as bindings supplied by the compiler but not explicitly written in source code,
    have the lowest precedence.
 
 There are two different name spaces, one for [types](03-types.html#types)

--- a/src/compiler/scala/reflect/quasiquotes/Parsers.scala
+++ b/src/compiler/scala/reflect/quasiquotes/Parsers.scala
@@ -92,7 +92,7 @@ trait Parsers { self: Quasiquotes =>
               case _ => gen.mkBlock(stats, doFlatten = true)
             }
           case nme.unapply => gen.mkBlock(stats, doFlatten = false)
-          case other       => global.abort("unreachable")
+          case other       => this.global.abort("unreachable")
         }
 
         // tq"$a => $b"

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2098,7 +2098,7 @@ self =>
             if (in.token == SUBTYPE || in.token == SUPERTYPE) wildcardType(start, scala3Wildcard)
             else atPos(start) { Bind(tpnme.WILDCARD, EmptyTree) }
         } else {
-          typ() match {
+          this.typ() match {
             case Ident(name: TypeName) if nme.isVariableName(name) =>
               atPos(start) { Bind(name, EmptyTree) }
             case t => t
@@ -2289,7 +2289,7 @@ self =>
     }
     /** The implementation of the context sensitive methods for parsing outside of patterns. */
     final val outPattern = new PatternContextSensitive {
-      def argType(): Tree = typ()
+      def argType(): Tree = this.typ()
       def functionArgType(): Tree = paramType(repeatedParameterOK = false, useStartAsPosition = true)
     }
     /** The implementation for parsing inside of patterns at points where sequences are allowed. */

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -267,6 +267,8 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
   val exposeEmptyPackage = BooleanSetting ("-Yexpose-empty-package", "Internal only: expose the empty package.").internalOnly()
   val Ydelambdafy        = ChoiceSetting  ("-Ydelambdafy", "strategy", "Strategy used for translating lambdas into JVM code.", List("inline", "method"), "method")
 
+  val legacyBinding = BooleanSetting("-Ylegacy-binding", "Observe legacy name binding preference for inherited member competing with local definition.")
+
   // Allows a specialised jar to be written. For instance one that provides stable hashing of content, or customisation of the file storage
   val YjarFactory = StringSetting   ("-YjarFactory", "classname", "factory for jar files", classOf[DefaultJarFactory].getName)
   val YaddBackendThreads = IntSetting   ("-Ybackend-parallelism", "maximum worker threads for backend", 1, Some((1,16)), (x: String) => None )

--- a/src/compiler/scala/tools/nsc/typechecker/MacroAnnotationNamers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MacroAnnotationNamers.scala
@@ -386,7 +386,7 @@ trait MacroAnnotationNamers { self: Analyzer =>
       sym.setInfo(new MaybeExpandeeCompleter(tree) {
         override def kind = s"maybeExpandeeCompleter for ${sym.accurateKindString} ${sym.rawname}#${sym.id}"
         override def maybeExpand(): Unit = {
-          val companion = if (tree.isInstanceOf[ClassDef]) patchedCompanionSymbolOf(sym, context) else NoSymbol
+          val companion = if (this.tree.isInstanceOf[ClassDef]) patchedCompanionSymbolOf(sym, context) else NoSymbol
 
           def maybeExpand(annotation: Tree, annottee: Tree, maybeExpandee: Tree): Option[List[Tree]] =
             if (context.macrosEnabled) { // TODO: when is this bit flipped -- can we pull this check out farther?
@@ -395,7 +395,7 @@ trait MacroAnnotationNamers { self: Analyzer =>
               if (mann.isClass && mann.hasFlag(MACRO)) {
                 assert(!currentRun.compiles(mann), mann)
                 val annm = prepareAnnotationMacro(annotation, mann, sym, annottee, maybeExpandee)
-                expandAnnotationMacro(tree, annm)
+                expandAnnotationMacro(this.tree, annm)
                 // if we encounter an error, we just return None, so that other macro annotations can proceed
                 // this is unlike macroExpand1 when any error in an expandee blocks expansions
                 // there it's necessary in order not to exacerbate typer errors
@@ -424,7 +424,7 @@ trait MacroAnnotationNamers { self: Analyzer =>
               enterSyms(expanded) // TODO: we can't reliably expand into imports, because they won't be accounted by definitions below us
             case None =>
               markNotExpandable(sym)
-              finishSymbolNotExpandee(tree)
+              finishSymbolNotExpandee(this.tree)
           }
 
           // take care of the companion if it's no longer needed

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -772,8 +772,8 @@ trait Types
     def withFilter(p: Type => Boolean) = new FilterMapForeach(p)
 
     class FilterMapForeach(p: Type => Boolean) extends FilterTypeCollector(p){
-      def foreach[U](f: Type => U): Unit = collect(Type.this) foreach f
-      def map[T](f: Type => T): List[T]  = collect(Type.this) map f
+      def foreach[U](f: Type => U): Unit = this.collect(Type.this).foreach(f)
+      def map[T](f: Type => T): List[T]  = this.collect(Type.this).map(f)
     }
 
     @inline final def orElse(alt: => Type): Type = if (this ne NoType) this else alt

--- a/src/reflect/scala/reflect/io/ZipArchive.scala
+++ b/src/reflect/scala/reflect/io/ZipArchive.scala
@@ -392,7 +392,7 @@ final class ManifestResources(val url: URL) extends ZipArchive(null) {
       if (!zipEntry.isDirectory) {
         class FileEntry() extends Entry(zipEntry.getName) {
           override def lastModified = zipEntry.getTime()
-          override def input        = resourceInputStream(path)
+          override def input        = resourceInputStream(this.path)
           override def sizeOption   = None
         }
         val f = new FileEntry()

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
@@ -927,7 +927,7 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
         }
         else None
       def resultType =
-        makeTypeInTemplateContext(aSym.tpe, inTpl, aSym)
+        makeTypeInTemplateContext(aSym.tpe, this.inTpl, aSym)
       def isImplicit = aSym.isImplicit
     }
 

--- a/test/files/neg/t11921.check
+++ b/test/files/neg/t11921.check
@@ -1,0 +1,8 @@
+t11921.scala:6: error: reference to coll is ambiguous;
+it is both defined in method lazyMap and available as method coll in trait Iterable
+Since 2.13.11, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+If shadowing was intended, write `this.coll`.
+Or use `-Ylegacy-binding` to enable the previous behavior everywhere.
+      def iterator = coll.iterator.map(f)    // coll is ambiguous
+                     ^
+1 error

--- a/test/files/neg/t11921.scala
+++ b/test/files/neg/t11921.scala
@@ -1,0 +1,16 @@
+
+
+class C {
+  def lazyMap[A, B](coll: Iterable[A], f: A => B) =
+    new Iterable[B] {
+      def iterator = coll.iterator.map(f)    // coll is ambiguous
+    }
+}
+
+/* was:
+t11921.scala:5: error: type mismatch;
+ found   : A => B
+ required: B => B
+      def iterator = coll.iterator.map(f)
+                                       ^
+*/

--- a/test/files/neg/t11921b.check
+++ b/test/files/neg/t11921b.check
@@ -1,0 +1,29 @@
+t11921b.scala:11: error: reference to x is ambiguous;
+it is both defined in object Test and available as value x in class C
+Since 2.13.11, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+If shadowing was intended, write `this.x`.
+Or use `-Ylegacy-binding` to enable the previous behavior everywhere.
+      println(x)  // error
+              ^
+t11921b.scala:15: error: reference to x is ambiguous;
+it is both defined in object Test and available as value x in class C
+Since 2.13.11, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+If shadowing was intended, write `this.x`.
+Or use `-Ylegacy-binding` to enable the previous behavior everywhere.
+        println(x)  // error
+                ^
+t11921b.scala:26: error: reference to y is ambiguous;
+it is both defined in method c and available as value y in class D
+Since 2.13.11, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+If shadowing was intended, write `this.y`.
+Or use `-Ylegacy-binding` to enable the previous behavior everywhere.
+      println(y)  // error
+              ^
+t11921b.scala:38: error: reference to y is ambiguous;
+it is both defined in method c and available as value y in class D
+Since 2.13.11, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+If shadowing was intended, write `this.y`.
+Or use `-Ylegacy-binding` to enable the previous behavior everywhere.
+        println(y)  // error
+                ^
+4 errors

--- a/test/files/neg/t11921b.scala
+++ b/test/files/neg/t11921b.scala
@@ -1,0 +1,66 @@
+
+
+object test1 {
+
+  class C {
+    val x = 0
+  }
+  object Test {
+    val x = 1
+    class D extends C {
+      println(x)  // error
+    }
+    def f() =
+      new C {
+        println(x)  // error
+      }
+  }
+}
+
+object test2 {
+  def c(y: Float) = {
+    class D {
+      val y = 2
+    }
+    new D {
+      println(y)  // error
+    }
+  }
+}
+
+object test3 {
+  def c(y: Float) = {
+    class D {
+      val y = 2
+    }
+    class E extends D {
+      class F {
+        println(y)  // error
+      }
+    }
+  }
+}
+
+object test4 {
+
+  class C {
+    val x = 0
+  }
+  object Test {
+    val x = 1
+    class D extends C {
+      def x(y: Int) = 3
+      val y: Int = this.x // OK
+      val z: Int = x      // OK
+    }
+  }
+}
+
+object global
+
+class C {
+  val global = 42
+}
+object D extends C {
+  println(global)    // OK, since global is defined in package
+}

--- a/test/files/neg/t11921c.check
+++ b/test/files/neg/t11921c.check
@@ -1,0 +1,6 @@
+t11921c.scala:7: error: type mismatch;
+ found   : A => B
+ required: B => B
+      def iterator = coll.iterator.map(f)    // coll is ambiguous
+                                       ^
+1 error

--- a/test/files/neg/t11921c.scala
+++ b/test/files/neg/t11921c.scala
@@ -1,0 +1,17 @@
+
+// scalac: -Ylegacy-binding
+
+class C {
+  def lazyMap[A, B](coll: Iterable[A], f: A => B) =
+    new Iterable[B] {
+      def iterator = coll.iterator.map(f)    // coll is ambiguous
+    }
+}
+
+/* was:
+t11921.scala:5: error: type mismatch;
+ found   : A => B
+ required: B => B
+      def iterator = coll.iterator.map(f)
+                                       ^
+*/

--- a/test/files/neg/t1477.check
+++ b/test/files/neg/t1477.check
@@ -1,5 +1,5 @@
 t1477.scala:13: error: volatile type member cannot override type member with non-volatile upper bound:
 type V <: Middle.this.D (defined in trait C)
-    type V <: (D with U)
+    type V <: (this.D with U)
          ^
 1 error

--- a/test/files/neg/t1477.scala
+++ b/test/files/neg/t1477.scala
@@ -10,7 +10,7 @@ object Test extends App {
   }
 
   trait Middle extends C {
-    type V <: (D with U)
+    type V <: (this.D with U)
   }
 
   class D extends Middle {

--- a/test/files/pos/t0165.scala
+++ b/test/files/pos/t0165.scala
@@ -4,7 +4,7 @@ import scala.collection.mutable.LinkedHashMap
 trait Main {
   def asMany : ArrayResult = {
     object result extends LinkedHashMap[String,String] with ArrayResult {
-      def current = result
+      def current = this.result
     }
     result
   }

--- a/test/files/pos/t11921a.scala
+++ b/test/files/pos/t11921a.scala
@@ -1,0 +1,18 @@
+
+class C(x: Int) {
+  class D extends C(42) {
+    def f() = println(x)
+  }
+}
+
+trait T {
+  val t: Int
+}
+trait U extends T {
+  val t: Int
+  import t._
+}
+trait V { this: T =>
+  val t: Int
+  import t._
+}

--- a/test/files/pos/t11921b.scala
+++ b/test/files/pos/t11921b.scala
@@ -1,0 +1,67 @@
+
+// scalac: -Werror -Ylegacy-binding
+
+object test1 {
+
+  class C {
+    val x = 0
+  }
+  object Test {
+    val x = 1
+    class D extends C {
+      println(x)  // error
+    }
+    def f() =
+      new C {
+        println(x)  // error
+      }
+  }
+}
+
+object test2 {
+  def c(y: Float) = {
+    class D {
+      val y = 2
+    }
+    new D {
+      println(y)  // error
+    }
+  }
+}
+
+object test3 {
+  def c(y: Float) = {
+    class D {
+      val y = 2
+    }
+    class E extends D {
+      class F {
+        println(y)  // error
+      }
+    }
+  }
+}
+
+object test4 {
+
+  class C {
+    val x = 0
+  }
+  object Test {
+    val x = 1
+    class D extends C {
+      def x(y: Int) = 3
+      val y: Int = this.x // OK
+      val z: Int = x      // OK
+    }
+  }
+}
+
+object global
+
+class C {
+  val global = 42
+}
+object D extends C {
+  println(global)    // OK, since global is defined in package
+}

--- a/test/files/pos/t11921c.scala
+++ b/test/files/pos/t11921c.scala
@@ -1,0 +1,23 @@
+
+// test/scaladoc/resources/t5784.scala
+
+package test.templates {
+  object `package` {
+    type String = java.lang.String
+    val String = new StringCompanion
+    class StringCompanion { def boo = ??? }
+  }
+
+  trait Base {
+    type String = test.templates.String
+    type T <: Foo
+    val T: FooExtractor
+    trait Foo { def foo: Int }
+    trait FooExtractor { def apply(foo: Int): Unit; def unapply(t: Foo): Option[Int] }
+  }
+
+  trait Api extends Base {
+    override type T <: FooApi
+    trait FooApi extends Foo { def bar: String }
+  }
+}

--- a/test/files/run/macroPlugins-macroExpand/Plugin_1.scala
+++ b/test/files/run/macroPlugins-macroExpand/Plugin_1.scala
@@ -18,7 +18,7 @@ class Plugin(val global: Global) extends NscPlugin {
       object expander extends DefMacroExpander(typer, expandee, mode, pt) {
         override def onSuccess(expanded: Tree) = {
           val message = s"expanded into ${expanded.toString}"
-          typer.typed(q"println($message)")
+          this.typer.typed(q"println($message)")
         }
       }
       Some(expander(expandee))

--- a/test/junit/scala/collection/mutable/HashSetTest.scala
+++ b/test/junit/scala/collection/mutable/HashSetTest.scala
@@ -86,28 +86,19 @@ class HashSetTest {
   }
 
   class OnceOnly extends IterableOnce[Int] {
-    override def knownSize: Int = 1
+    var iterated = false
 
-    var iterated:Boolean = false
-
-    override def iterator: Iterator[Int] = {
-      new Iterator[Int] {
-        assert(!iterated)
-        iterated = true
-        private var v = Option(42)
-        override def hasNext: Boolean = v.nonEmpty && knownSize > 0
-        override def next(): Int = {
-          val res = v.get
-          v = None
-          res
-        }
-      }
+    override def iterator = {
+      assertFalse("Attempt to re-iterate!", iterated)
+      iterated = true
+      Iterator.single(42)
     }
   }
 
   @Test
-  def addAllTest2(): Unit = {
+  def `addAll adds exactly once`: Unit = {
     val hs = HashSet.empty[Int]
     hs.addAll(new OnceOnly)
+    assertEquals(1, hs.size)
   }
 }

--- a/test/junit/scala/math/BigDecimalTest.scala
+++ b/test/junit/scala/math/BigDecimalTest.scala
@@ -273,12 +273,12 @@ class BigDecimalTest {
   }
 
   @Test
-  def testIsComparable(): Unit = {
+  def testIsComparable(): Unit =
     assertTrue(BigDecimal(0.1).isInstanceOf[java.lang.Comparable[_]])
-  }
 
   // trick sum into using foldLeft, viz, because the size is unknown
-  @Test def testBigDecimalSumInList(): Unit = {
+  @Test
+  def testBigDecimalSumInList(): Unit = {
     val bds = List(
       BigDecimal("1000000000000000000000000.1", MC.UNLIMITED),
       BigDecimal("9.0000000000000000000000009", MC.UNLIMITED))


### PR DESCRIPTION
The language specification is clarified so that an inherited class member cannot shadow a local definition.

The following reference `m` is ambiguous:
```
class C { def m = ??? }
def f(m: Int) = new C {
  def g = m   // use this.m
}
```
The previous behavior is available under `-Ylegacy-binding`.

Fixes scala/bug#11921
