### PR TITLE
[SUPERSEDED] Use ellipsis instead of silent truncation in stringOf

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -31,6 +31,10 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.Predef#ArrayCharSequence.isEmpty"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.ArrayCharSequence.isEmpty"),
 
+    // internal use
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.ScalaRunTime._toString0"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.ScalaRunTime.stringOf"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.ScalaRunTime.replStringOf"),
   )
 
   override val buildSettings = Seq(

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -178,6 +178,7 @@ trait Definitions extends api.StandardDefinitions {
         }
         false
       }
+      override def toString = syms.toString
     }
     def ScalaPrimitiveValueClasses: List[ClassSymbol] = ScalaValueClasses
 
@@ -695,16 +696,16 @@ trait Definitions extends api.StandardDefinitions {
         else nme.genericWrapArray
     }
 
-    def isTupleSymbol(sym: Symbol) = TupleClass contains unspecializedSymbol(sym)
-    def isFunctionSymbol(sym: Symbol) = FunctionClass contains unspecializedSymbol(sym)
-    def isAbstractFunctionSymbol(sym: Symbol) = AbstractFunctionClass contains unspecializedSymbol(sym)
-    def isProductNSymbol(sym: Symbol) = ProductClass contains unspecializedSymbol(sym)
+    def isTupleSymbol(sym: Symbol)            = TupleClass.contains(unspecializedSymbol(sym))
+    def isFunctionSymbol(sym: Symbol)         = FunctionClass.contains(unspecializedSymbol(sym))
+    def isAbstractFunctionSymbol(sym: Symbol) = AbstractFunctionClass.contains(unspecializedSymbol(sym))
+    def isProductNSymbol(sym: Symbol)         = ProductClass.contains(unspecializedSymbol(sym))
 
-    lazy val TryClass = requiredClass[scala.util.Try[_]]
-    lazy val FailureClass = requiredClass[scala.util.Failure[_]]
-    lazy val SuccessClass = requiredClass[scala.util.Success[_]]
-    lazy val FutureClass = requiredClass[scala.concurrent.Future[_]]
-    lazy val PromiseClass = requiredClass[scala.concurrent.Promise[_]]
+    lazy val TryClass      = requiredClass[scala.util.Try[_]]
+    lazy val FailureClass  = requiredClass[scala.util.Failure[_]]
+    lazy val SuccessClass  = requiredClass[scala.util.Success[_]]
+    lazy val FutureClass   = requiredClass[scala.concurrent.Future[_]]
+    lazy val PromiseClass  = requiredClass[scala.concurrent.Promise[_]]
     lazy val NonFatalClass = requiredClass[scala.util.control.NonFatal.type]
 
     def unspecializedSymbol(sym: Symbol): Symbol = {

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
@@ -989,7 +989,7 @@ object ILoop {
     override val colorOk = delegate.colorOk
 
     // No truncated output, because the result changes on Windows because of line endings
-    override val maxPrintString = sys.Prop[Int]("wtf").tap(_.set("0"))
+    override val maxPrintString = 0
   }
   object TestConfig {
     def apply(settings: Settings) = new TestConfig(ShellConfig(settings))

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/Reporter.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/Reporter.scala
@@ -31,8 +31,18 @@ class ReplReporterImpl(val config: ShellConfig, val settings: Settings = new Set
 
   val out: PrintWriter = new ReplStrippingWriter(writer)
   private class ReplStrippingWriter(out: PrintWriter) extends PrintWriter(out) {
-    override def write(str: String): Unit =
-      super.write(unmangleInterpreterOutput(str))
+    override def write(str0: String): Unit = {
+      val str = unmangleInterpreterOutput(str0)
+      // rendering already accounts for maxPrintString, but avoid huge total string (val x = v with color escapes)
+      val margin = Option(str.indexOf(" = ")).filter(_ > 0).map(_ + 3).getOrElse(0)
+      val limit = maxPrintString + margin
+      if (truncationOK && maxPrintString != 0 && str.length > limit) {
+        super.append(str, 0, limit)
+        super.append("...")
+      }
+      else
+        super.write(str)
+    }
   }
 
   override def flush() = out.flush()
@@ -92,7 +102,7 @@ class ReplReporterImpl(val config: ShellConfig, val settings: Settings = new Set
     *  more than this number of characters, then the printout is
     *  truncated.
     */
-  var maxPrintString = config.maxPrintString.option getOrElse 800
+  var maxPrintString = config.maxPrintString
 
   /** Whether very long lines can be truncated.  This exists so important
     *  debugging information (like printing the classpath) is not rendered
@@ -123,7 +133,7 @@ class ReplReporterImpl(val config: ShellConfig, val settings: Settings = new Set
     if (unwrapStrings) Naming.unmangle(str)
     else str
 
-  def unmangleInterpreterOutput(str: String): String = truncate(unwrap(str))
+  def unmangleInterpreterOutput(str: String): String = unwrap(str)
 
   var currentRequest: ReplRequest = _
 

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/ShellConfig.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/ShellConfig.scala
@@ -127,7 +127,7 @@ trait ShellConfig {
   val powerInitCode   = Prop[File]("scala.repl.power.initcode")
   val powerBanner     = Prop[File]("scala.repl.power.banner")
 
-  val maxPrintString = int("scala.repl.maxprintstring")
+  val maxPrintString = int("scala.repl.maxprintstring").option.getOrElse(800)
 
   def isReplInfo: Boolean  = info || isReplDebug
   def replinfo(msg: => String)   = if (isReplInfo)  echo(msg)

--- a/src/repl/scala/tools/nsc/interpreter/Interface.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Interface.scala
@@ -229,6 +229,9 @@ trait ScriptedRepl extends Repl {
 trait ReplReporter extends FilteringReporter with ReplStrings {
   def out: PrintWriter
 
+  /* String length limiter. */
+  def maxPrintString: Int
+
   /**
     * Print message (info/warning/error).
     * By default, messages beyond a certain length are truncated (see `withoutTruncating`),

--- a/src/repl/scala/tools/nsc/interpreter/ReplStrings.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplStrings.scala
@@ -43,8 +43,8 @@ object ReplStrings {
   def string2codeQuoted(str: String) =
     quotedString(string2code(str))
 
-  def any2stringOf(x: Any, maxlen: Int) =
-    s"_root_.scala.runtime.ScalaRunTime.replStringOf($x, $maxlen)"
+  def any2stringOf(x: Any, maxlen: Int, verboseProduct: Boolean) =
+    s"_root_.scala.runtime.ScalaRunTime.replStringOf($x, $maxlen, $verboseProduct)"
 
   // no escaped or nested quotes
   private[this] val inquotes = """(['"])(.*?)\1""".r

--- a/test/files/jvm/scala-concurrent-tck.scala
+++ b/test/files/jvm/scala-concurrent-tck.scala
@@ -1,3 +1,4 @@
+// scalac: -feature -Xlint -Werror -Wconf:cat=deprecation&msg="method getId in class Thread":s
 import scala.concurrent.{
   Future,
   Promise,
@@ -7,11 +8,11 @@ import scala.concurrent.{
   CanAwait,
   Await,
   Awaitable,
-  blocking
+  BlockContext,
+  blocking,
 }
 import scala.annotation.tailrec
 import scala.concurrent.duration._
-import scala.reflect.{classTag, ClassTag}
 import scala.tools.testkit.AssertUtil.{Fast, Slow, assertThrows, waitFor, waitForIt}
 import scala.util.{Try, Success, Failure}
 import scala.util.chaining._
@@ -747,7 +748,6 @@ class Blocking extends TestBase {
 
 class BlockContexts extends TestBase {
   import ExecutionContext.Implicits._
-  import scala.concurrent.{ Await, Awaitable, BlockContext }
 
   private def getBlockContext(body: => BlockContext): BlockContext = await(Future(body))
 
@@ -846,7 +846,7 @@ class Exceptions extends TestBase {
     Thread.sleep(20)
     e.shutdownNow()
 
-    val Failure(ee: ExecutionException) = Await.ready(f, 2.seconds).value.get
+    val Failure(ee: ExecutionException) = Await.ready(f, 2.seconds).value.get: @unchecked
     assert(ee.getCause.isInstanceOf[InterruptedException])
   }
 
@@ -855,7 +855,7 @@ class Exceptions extends TestBase {
     val p = Promise[String]()
     p.success("foo")
     val f = p.future.map(identity)
-    val Failure(t: RejectedExecutionException) = Await.ready(f, 2.seconds).value.get
+    val Failure(t: RejectedExecutionException) = Await.ready(f, 2.seconds).value.get: @unchecked
   }
 
   test("interruptHandling")(interruptHandling())
@@ -863,7 +863,6 @@ class Exceptions extends TestBase {
 }
 
 class GlobalExecutionContext extends TestBase {
-  import ExecutionContext.Implicits._
   
   def testNameOfGlobalECThreads(): Unit = once {
     done => Future({
@@ -876,7 +875,6 @@ class GlobalExecutionContext extends TestBase {
 }
 
 class CustomExecutionContext extends TestBase {
-  import scala.concurrent.{ ExecutionContext, Awaitable }
 
   def defaultEC = ExecutionContext.global
 

--- a/test/files/run/t7747-repl.check
+++ b/test/files/run/t7747-repl.check
@@ -268,7 +268,7 @@ object $eval {
   lazy val $print: _root_.java.lang.String =  {
     val _ = $line10.$read.INSTANCE.$iw
 
-""  + "val res3: List[Product with java.io.Serializable]" + " = " + _root_.scala.runtime.ScalaRunTime.replStringOf($line10.$read.INSTANCE.$iw.res3, 1000)
+""  + "val res3: List[Product with java.io.Serializable]" + " = " + { val s = _root_.scala.runtime.ScalaRunTime.replStringOf($line10.$read.INSTANCE.$iw.res3, 0, false) ; (if (s.indexOf('\n') >= 0) "\n" else "") + s + "\n" }
 
   }
 }}


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/12337

```
➜  ~ scala -Dscala.repl.maxprintstring=50
Welcome to Scala 2.13.10-20221005-211743-e04f32b (OpenJDK 64-Bit Server VM, Java 19).
Type in expressions for evaluation. Or try :help.

scala> (1 to 1000).map(i => "X"*5).toList
val res0: List[String] = List(XXXXX, XXXXX, XXXXX, XXXXX, XXXXX, ...)

scala> (1 to 1000).map(i => "X"*50).toList
val res1: List[String] = List(XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX...)

scala> "List(XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX...)".length
val res2: Int = 50

scala> "X"*50
val res3: String = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

scala> "X"*51
val res4: String = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX...
```