### PR TITLE
[REVISIT] Robust stringOf [ci: last-only]

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -35,6 +35,8 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.ScalaRunTime._toString0"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.ScalaRunTime.stringOf"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.ScalaRunTime.replStringOf"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.ScalaRunTime.DefaultMaxElements"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.ScalaRunTime.DefaultMaxLength"),
   )
 
   override val buildSettings = Seq(

--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -31,6 +31,10 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.Predef#ArrayCharSequence.isEmpty"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.ArrayCharSequence.isEmpty"),
 
+    // internal use
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.ScalaRunTime._toString0"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.ScalaRunTime.stringOf"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.ScalaRunTime.replStringOf"),
   )
 
   override val buildSettings = Seq(

--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -1187,7 +1187,7 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
     *          of all elements of this $coll follow each other without any
     *          separator string.
     */
-  @inline final def mkString: String = mkString("")
+  @inline final def mkString: String = mkString("", "", "")
 
   /** Appends all elements of this $coll to a string builder using start, end, and separator strings.
     *  The written text begins with the string `start` and ends with the string `end`.
@@ -1215,7 +1215,7 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
     */
   def addString(b: StringBuilder, start: String, sep: String, end: String): b.type = {
     val jsb = b.underlying
-    if (start.length != 0) jsb.append(start)
+    if (!start.isEmpty) jsb.append(start)
     val it = iterator
     if (it.hasNext) {
       jsb.append(it.next())
@@ -1224,7 +1224,7 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
         jsb.append(it.next())
       }
     }
-    if (end.length != 0) jsb.append(end)
+    if (!end.isEmpty) jsb.append(end)
     b
   }
 

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -178,6 +178,7 @@ trait Definitions extends api.StandardDefinitions {
         }
         false
       }
+      override def toString = syms.toString
     }
     def ScalaPrimitiveValueClasses: List[ClassSymbol] = ScalaValueClasses
 
@@ -695,16 +696,16 @@ trait Definitions extends api.StandardDefinitions {
         else nme.genericWrapArray
     }
 
-    def isTupleSymbol(sym: Symbol) = TupleClass contains unspecializedSymbol(sym)
-    def isFunctionSymbol(sym: Symbol) = FunctionClass contains unspecializedSymbol(sym)
-    def isAbstractFunctionSymbol(sym: Symbol) = AbstractFunctionClass contains unspecializedSymbol(sym)
-    def isProductNSymbol(sym: Symbol) = ProductClass contains unspecializedSymbol(sym)
+    def isTupleSymbol(sym: Symbol)            = TupleClass.contains(unspecializedSymbol(sym))
+    def isFunctionSymbol(sym: Symbol)         = FunctionClass.contains(unspecializedSymbol(sym))
+    def isAbstractFunctionSymbol(sym: Symbol) = AbstractFunctionClass.contains(unspecializedSymbol(sym))
+    def isProductNSymbol(sym: Symbol)         = ProductClass.contains(unspecializedSymbol(sym))
 
-    lazy val TryClass = requiredClass[scala.util.Try[_]]
-    lazy val FailureClass = requiredClass[scala.util.Failure[_]]
-    lazy val SuccessClass = requiredClass[scala.util.Success[_]]
-    lazy val FutureClass = requiredClass[scala.concurrent.Future[_]]
-    lazy val PromiseClass = requiredClass[scala.concurrent.Promise[_]]
+    lazy val TryClass      = requiredClass[scala.util.Try[_]]
+    lazy val FailureClass  = requiredClass[scala.util.Failure[_]]
+    lazy val SuccessClass  = requiredClass[scala.util.Success[_]]
+    lazy val FutureClass   = requiredClass[scala.concurrent.Future[_]]
+    lazy val PromiseClass  = requiredClass[scala.concurrent.Promise[_]]
     lazy val NonFatalClass = requiredClass[scala.util.control.NonFatal.type]
 
     def unspecializedSymbol(sym: Symbol): Symbol = {

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
@@ -989,7 +989,7 @@ object ILoop {
     override val colorOk = delegate.colorOk
 
     // No truncated output, because the result changes on Windows because of line endings
-    override val maxPrintString = sys.Prop[Int]("wtf").tap(_.set("0"))
+    override val maxPrintString = 0
   }
   object TestConfig {
     def apply(settings: Settings) = new TestConfig(ShellConfig(settings))

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/Reporter.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/Reporter.scala
@@ -31,8 +31,18 @@ class ReplReporterImpl(val config: ShellConfig, val settings: Settings = new Set
 
   val out: PrintWriter = new ReplStrippingWriter(writer)
   private class ReplStrippingWriter(out: PrintWriter) extends PrintWriter(out) {
-    override def write(str: String): Unit =
-      super.write(unmangleInterpreterOutput(str))
+    override def write(str0: String): Unit = {
+      val str = unmangleInterpreterOutput(str0)
+      // rendering already accounts for maxPrintString, but avoid huge total string (val x = v with color escapes)
+      val margin = Option(str.indexOf(" = ")).filter(_ > 0).map(_ + 3).getOrElse(0)
+      val limit = maxPrintString + margin
+      if (truncationOK && maxPrintString != 0 && str.length > limit) {
+        super.append(str, 0, limit)
+        super.append("...")
+      }
+      else
+        super.write(str)
+    }
   }
 
   override def flush() = out.flush()
@@ -92,7 +102,7 @@ class ReplReporterImpl(val config: ShellConfig, val settings: Settings = new Set
     *  more than this number of characters, then the printout is
     *  truncated.
     */
-  var maxPrintString = config.maxPrintString.option getOrElse 800
+  var maxPrintString = config.maxPrintString
 
   /** Whether very long lines can be truncated.  This exists so important
     *  debugging information (like printing the classpath) is not rendered
@@ -123,7 +133,7 @@ class ReplReporterImpl(val config: ShellConfig, val settings: Settings = new Set
     if (unwrapStrings) Naming.unmangle(str)
     else str
 
-  def unmangleInterpreterOutput(str: String): String = truncate(unwrap(str))
+  def unmangleInterpreterOutput(str: String): String = unwrap(str)
 
   var currentRequest: ReplRequest = _
 

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/ShellConfig.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/ShellConfig.scala
@@ -127,7 +127,7 @@ trait ShellConfig {
   val powerInitCode   = Prop[File]("scala.repl.power.initcode")
   val powerBanner     = Prop[File]("scala.repl.power.banner")
 
-  val maxPrintString = int("scala.repl.maxprintstring")
+  val maxPrintString = int("scala.repl.maxprintstring").option.getOrElse(800)
 
   def isReplInfo: Boolean  = info || isReplDebug
   def replinfo(msg: => String)   = if (isReplInfo)  echo(msg)

--- a/src/repl/scala/tools/nsc/interpreter/Interface.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Interface.scala
@@ -229,6 +229,9 @@ trait ScriptedRepl extends Repl {
 trait ReplReporter extends FilteringReporter with ReplStrings {
   def out: PrintWriter
 
+  /* String length limiter. */
+  def maxPrintString: Int
+
   /**
     * Print message (info/warning/error).
     * By default, messages beyond a certain length are truncated (see `withoutTruncating`),

--- a/src/repl/scala/tools/nsc/interpreter/ReplStrings.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplStrings.scala
@@ -43,8 +43,8 @@ object ReplStrings {
   def string2codeQuoted(str: String) =
     quotedString(string2code(str))
 
-  def any2stringOf(x: Any, maxlen: Int) =
-    s"_root_.scala.runtime.ScalaRunTime.replStringOf($x, $maxlen)"
+  def any2stringOf(x: Any, maxlen: Int, verboseProduct: Boolean) =
+    s"_root_.scala.runtime.ScalaRunTime.replStringOf($x, $maxlen, $verboseProduct)"
 
   // no escaped or nested quotes
   private[this] val inquotes = """(['"])(.*?)\1""".r

--- a/test/files/jvm/scala-concurrent-tck.scala
+++ b/test/files/jvm/scala-concurrent-tck.scala
@@ -1,3 +1,4 @@
+// scalac: -feature -Xlint -Werror -Wconf:cat=deprecation&msg="method getId in class Thread":s
 import scala.concurrent.{
   Future,
   Promise,
@@ -7,11 +8,11 @@ import scala.concurrent.{
   CanAwait,
   Await,
   Awaitable,
-  blocking
+  BlockContext,
+  blocking,
 }
 import scala.annotation.tailrec
 import scala.concurrent.duration._
-import scala.reflect.{classTag, ClassTag}
 import scala.tools.testkit.AssertUtil.{Fast, Slow, assertThrows, waitFor, waitForIt}
 import scala.util.{Try, Success, Failure}
 import scala.util.chaining._
@@ -747,7 +748,6 @@ class Blocking extends TestBase {
 
 class BlockContexts extends TestBase {
   import ExecutionContext.Implicits._
-  import scala.concurrent.{ Await, Awaitable, BlockContext }
 
   private def getBlockContext(body: => BlockContext): BlockContext = await(Future(body))
 
@@ -846,7 +846,7 @@ class Exceptions extends TestBase {
     Thread.sleep(20)
     e.shutdownNow()
 
-    val Failure(ee: ExecutionException) = Await.ready(f, 2.seconds).value.get
+    val Failure(ee: ExecutionException) = Await.ready(f, 2.seconds).value.get: @unchecked
     assert(ee.getCause.isInstanceOf[InterruptedException])
   }
 
@@ -855,7 +855,7 @@ class Exceptions extends TestBase {
     val p = Promise[String]()
     p.success("foo")
     val f = p.future.map(identity)
-    val Failure(t: RejectedExecutionException) = Await.ready(f, 2.seconds).value.get
+    val Failure(t: RejectedExecutionException) = Await.ready(f, 2.seconds).value.get: @unchecked
   }
 
   test("interruptHandling")(interruptHandling())
@@ -863,7 +863,6 @@ class Exceptions extends TestBase {
 }
 
 class GlobalExecutionContext extends TestBase {
-  import ExecutionContext.Implicits._
   
   def testNameOfGlobalECThreads(): Unit = once {
     done => Future({
@@ -876,7 +875,6 @@ class GlobalExecutionContext extends TestBase {
 }
 
 class CustomExecutionContext extends TestBase {
-  import scala.concurrent.{ ExecutionContext, Awaitable }
 
   def defaultEC = ExecutionContext.global
 

--- a/test/files/run/t7747-repl.check
+++ b/test/files/run/t7747-repl.check
@@ -268,7 +268,7 @@ object $eval {
   lazy val $print: _root_.java.lang.String =  {
     val _ = $line10.$read.INSTANCE.$iw
 
-""  + "val res3: List[Product with java.io.Serializable]" + " = " + _root_.scala.runtime.ScalaRunTime.replStringOf($line10.$read.INSTANCE.$iw.res3, 1000)
+""  + "val res3: List[Product with java.io.Serializable]" + " = " + { val s = _root_.scala.runtime.ScalaRunTime.replStringOf($line10.$read.INSTANCE.$iw.res3, 0, false) ; (if (s.indexOf('\n') >= 0) "\n" else "") + s + "\n" }
 
   }
 }}

--- a/test/instrumented/srt.patch
+++ b/test/instrumented/srt.patch
@@ -1,15 +1,12 @@
 --- src/library/scala/runtime/ScalaRunTime.scala	2018-03-22 12:22:03.000000000 +0100
 +++ test/instrumented/library/scala/runtime/ScalaRunTime.scala	2018-04-05 22:52:10.000000000 +0200
-@@ -10,6 +10,8 @@
-  * additional information regarding copyright ownership.
-  */
-
+@@ -1,3 +1,5 @@
 +/* INSTRUMENTED VERSION */
 +
- package scala
- package runtime
-
-@@ -52,8 +54,11 @@
+ /*
+  * Scala (https://www.scala-lang.org)
+  *
+@@ -53,8 +55,11 @@
    def anyValClass[T <: AnyVal : ClassTag](value: T): jClass[T] =
      classTag[T].runtimeClass.asInstanceOf[jClass[T]]
 
@@ -21,7 +18,7 @@
      (xs: @unchecked) match {
        case x: Array[AnyRef]  => x(idx).asInstanceOf[Any]
        case x: Array[Int]     => x(idx).asInstanceOf[Any]
-@@ -68,8 +73,11 @@
+@@ -69,8 +74,11 @@
      }
    }
 

--- a/test/junit/scala/runtime/ScalaRunTimeTest.scala
+++ b/test/junit/scala/runtime/ScalaRunTimeTest.scala
@@ -1,105 +1,150 @@
-package scala.runtime
-
 import org.junit.Assert._
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
-/** Tests for the runtime object ScalaRunTime */
-@RunWith(classOf[JUnit4])
-class ScalaRunTimeTest {
+import scala.runtime.ScalaRunTime.{replStringOf, stringOf}
+
+package scala.runtime {
+
+  /** Tests for the runtime object ScalaRunTime */
+  class ScalaRunTimeTest {
+    import test.stuff._
+
+    @Test def testStringOf(): Unit = {
+
+      def verboseStringOf(s: String): String = stringOf(s, maxLength = 0, verboseProduct = true)
+
+      assertEquals("null", stringOf(null))
+      assertEquals("\"\"", stringOf(""))
+
+      assertEquals("X", stringOf(Strung(1)))
+      assertEquals("X"*2, stringOf(Strung(2)))
+      assertEquals("X"*3, stringOf(Strung(3)))
+      assertEquals("X"*4, stringOf(Strung(4)))
+      assertEquals("XX...", stringOf(Strung(10), 5))
+      assertEquals("...", stringOf(Strung(10), 2))
+      assertEquals(s"Li...", stringOf(List(Strung(10), Strung(20)), 5))
+
+      assertEquals("abc", stringOf("abc"))
+      assertEquals("\"abc\"", stringOf("abc", maxLength = 0, verboseProduct = true))
+      assertEquals("\" abc\"", stringOf(" abc"))
+      assertEquals("\"abc \"", stringOf("abc "))
+
+      assertEquals("""Array()""", stringOf(Array.empty[AnyRef]))
+      assertEquals("""Array()""", stringOf(Array.empty[Int]))
+      assertEquals("""Array(1, 2, 3)""", stringOf(Array(1, 2, 3)))
+      assertEquals("""Array(a, "", " c", null)""", stringOf(Array("a", "", " c", null)))
+      assertEquals("""Array("a", "", " c", null)""", stringOf(Array("a", "", " c", null), maxLength = 0, verboseProduct = true))
+      assertEquals("""Array(Array("", 1, Array(5)), Array(1))""",
+          stringOf(Array(Array("", 1, Array(5)), Array(1))))
+
+      val map = Map(1->"", 2->"a", 3->" a", 4->null)
+      assertEquals("""Map(1 -> "", 2 -> a, 3 -> " a", 4 -> null)""", stringOf(map))
+      assertEquals("""Map(1 -> "", 2 -> "a", 3 -> " a", 4 -> null)""", stringOf(map, maxLength = 0, verboseProduct = true))
+      assertEquals("""Map(1 -> "", ...)""", stringOf(map, 20))
+
+      val iterable = Iterable("a", "", " c", null)
+      assertEquals("""List(a, "", " c", null)""", stringOf(iterable))
+      assertEquals("""List("a", "", " c", null)""", stringOf(iterable, maxLength = 0, verboseProduct = true))
+      assertEquals("""List(a, ...)""", stringOf(iterable, 15))
+      assertEquals("""List("a", "", ...)""", stringOf(iterable, maxLength = 20, verboseProduct = true))
+
+      val tuple1 = Tuple1(0)
+      assertEquals("(0,)", stringOf(tuple1))
+      assertEquals("(0,)", stringOf(tuple1, 0))
+      assertEquals("(Array(0),)", stringOf(Tuple1(Array(0))))
+
+      val tuple2 = Tuple2(0, 1)
+      assertEquals("(0,1)", stringOf(tuple2))
+      assertEquals("(0,1)", stringOf(tuple2, 0))
+      assertEquals("(Array(0),1)", stringOf((Array(0), 1)))
+
+      val tuple3 = Tuple3(0, 1, 2)
+      assertEquals("(0,1,2)", stringOf(tuple3))
+      assertEquals("(0,1,2)", stringOf(tuple3, 0))
+      assertEquals("(Array(0),1,2)", stringOf((Array(0), 1, 2)))
+
+      val x = new Object {
+        override def toString(): String = "this is the stringOf string"
+      }
+      assertEquals("this is the stringOf string", stringOf(x))
+      assertEquals("...", stringOf(x, maxLength = 2))
+
+      val tpolecat = new Object {
+        override def toString(): String = null
+      }
+      assertEquals(null, stringOf(tpolecat))
+      assertEquals("null // non-null reference has null-valued toString", replStringOf(tpolecat, maxLength = 100, verboseProduct = false))
+
+      val TQ = "\"" * 3
+      val abcdef =
+        s"""abc
+           |def""".stripMargin
+      def q(s: String) = "\"" + s + "\""
+      def escq(s: String) = "\\\"" + s + "\\\""
+      def tq(s: String) = TQ + s + TQ
+      // escape the quote then wrap in triple quotes and prepend with interpolator
+      assertEquals(
+        "s" + tq(escq(abcdef)),
+        verboseStringOf(q(abcdef))
+      )
+      // escape ALL the quotes
+      assertEquals(
+        "s" + tq(escq(escq(escq(escq(abcdef))))),
+        verboseStringOf(tq(q(abcdef)))
+      )
+      // ordinary single quote and no interpolator needed for \t
+      assertEquals(q("a\\tb"), verboseStringOf("a\tb"))
+    }
+    @Test def `stringOf handles recursive-traversable`: Unit = {
+      val vs =
+        new Iterable[_] {
+          def iterator = Iterator.continually(this)
+          override def toString = "ha, you caught me"
+        }
+      assertEquals("ha, you caught me", stringOf(vs))
+    }
+    // not traversble again means always use toString
+    @Test def `stringOf avoids once-traversable`: Unit = {
+      val vs =
+        new Iterable[Int] {
+          var i = 0
+          def iterator = Iterator.continually { i+=1; i }
+          override def isTraversableAgain = false
+        }
+      assertEquals("<iterable>", stringOf(vs))
+    }
+    @Test def `stringOf avoids mystery iterable`: Unit = {
+      assertEquals("mystery", stringOf(Mystery))
+    }
+    @Test def `stringOf handles infinite iterable`: Unit = {
+      assertEquals("Custom(42, 42, 42, 42, 42, 42, 42, 42, 42, 42)", stringOf(Custom, maxLength = Int.MaxValue, verboseProduct = false, maxElements = 10))
+    }
+    @Test def `stringOf draws a line somewhere`: Unit = {
+      assertEquals("Iterable(42, 42, 42, 42, 42, 42, 42, 42, 42, 42)", stringOf(Danger, maxLength = Int.MaxValue, verboseProduct = false, maxElements = 10))
+    }
+  }
+}
+
+package test.stuff {
+  import scala.collection.AbstractIterable
+
   class Strung(n: Int) {
     override def toString = "X" * n
   }
-  def Strung(n: Int) = new Strung(n)
-  @Test
-  def testStringOf(): Unit = {
-    import ScalaRunTime.{replStringOf, stringOf}
-    import scala.collection._
-
-    def verboseStringOf(s: String): String = stringOf(s, maxLength = 0, verboseProduct = true)
-
-    assertEquals("null", stringOf(null))
-    assertEquals("\"\"", stringOf(""))
-
-    assertEquals("X", stringOf(Strung(1)))
-    assertEquals("X"*2, stringOf(Strung(2)))
-    assertEquals("X"*3, stringOf(Strung(3)))
-    assertEquals("X"*4, stringOf(Strung(4)))
-    assertEquals("XX...", stringOf(Strung(10), 5))
-    assertEquals("...", stringOf(Strung(10), 2))
-    assertEquals(s"Li...", stringOf(List(Strung(10), Strung(20)), 5))
-
-    assertEquals("abc", stringOf("abc"))
-    assertEquals("\"abc\"", stringOf("abc", maxLength = 0, verboseProduct = true))
-    assertEquals("\" abc\"", stringOf(" abc"))
-    assertEquals("\"abc \"", stringOf("abc "))
-
-    assertEquals("""Array()""", stringOf(Array.empty[AnyRef]))
-    assertEquals("""Array()""", stringOf(Array.empty[Int]))
-    assertEquals("""Array(1, 2, 3)""", stringOf(Array(1, 2, 3)))
-    assertEquals("""Array(a, "", " c", null)""", stringOf(Array("a", "", " c", null)))
-    assertEquals("""Array("a", "", " c", null)""", stringOf(Array("a", "", " c", null), maxLength = 0, verboseProduct = true))
-    assertEquals("""Array(Array("", 1, Array(5)), Array(1))""",
-        stringOf(Array(Array("", 1, Array(5)), Array(1))))
-
-    val map = Map(1->"", 2->"a", 3->" a", 4->null)
-    assertEquals(s"""Map(1 -> "", 2 -> a, 3 -> " a", 4 -> null)""", stringOf(map))
-    assertEquals(s"""Map(1 -> "", 2 -> "a", 3 -> " a", 4 -> null)""", stringOf(map, maxLength = 0, verboseProduct = true))
-    assertEquals(s"""Map(1 -> "", ...)""", stringOf(map, 20))
-
-    val iterable = Iterable("a", "", " c", null)
-    assertEquals(s"""List(a, "", " c", null)""", stringOf(iterable))
-    assertEquals(s"""List("a", "", " c", null)""", stringOf(iterable, maxLength = 0, verboseProduct = true))
-    assertEquals(s"""List(a, ...)""", stringOf(iterable, 15))
-    assertEquals(s"""List("a", "", ...)""", stringOf(iterable, maxLength = 20, verboseProduct = true))
-
-    val tuple1 = Tuple1(0)
-    assertEquals("(0,)", stringOf(tuple1))
-    assertEquals("(0,)", stringOf(tuple1, 0))
-    assertEquals("(Array(0),)", stringOf(Tuple1(Array(0))))
-
-    val tuple2 = Tuple2(0, 1)
-    assertEquals("(0,1)", stringOf(tuple2))
-    assertEquals("(0,1)", stringOf(tuple2, 0))
-    assertEquals("(Array(0),1)", stringOf((Array(0), 1)))
-
-    val tuple3 = Tuple3(0, 1, 2)
-    assertEquals("(0,1,2)", stringOf(tuple3))
-    assertEquals("(0,1,2)", stringOf(tuple3, 0))
-    assertEquals("(Array(0),1,2)", stringOf((Array(0), 1, 2)))
-
-    val x = new Object {
-      override def toString(): String = "this is the stringOf string"
-    }
-    assertEquals("this is the stringOf string", stringOf(x))
-    assertEquals("this is...", stringOf(x, 10))
-    assertEquals("...", stringOf(x, 2))
-
-    val tpolecat = new Object {
-      override def toString(): String = null
-    }
-    assertEquals(null, stringOf(tpolecat))
-    assertEquals("null // non-null reference has null-valued toString", replStringOf(tpolecat, maxLength = 100, verboseProduct = false))
-
-    val TQ = "\"" * 3
-    val abcdef =
-      s"""abc
-         |def""".stripMargin
-    def q(s: String) = "\"" + s + "\""
-    def escq(s: String) = "\\\"" + s + "\\\""
-    def tq(s: String) = TQ + s + TQ
-    // escape the quote then wrap in triple quotes and prepend with interpolator
-    assertEquals(
-      "s" + tq(escq(abcdef)),
-      verboseStringOf(q(abcdef))
-    )
-    // escape ALL the quotes
-    assertEquals(
-      "s" + tq(escq(escq(escq(escq(abcdef))))),
-      verboseStringOf(tq(q(abcdef)))
-    )
-    // ordinary single quote and no interpolator needed for \t
-    assertEquals(q("a\\tb"), verboseStringOf("a\tb"))
+  object Strung {
+    def apply(n: Int) = new Strung(n)
+  }
+  // Is not AbstractIterable, so don't expect a legit toString like it's a thing.
+  object Custom extends Iterable[Int] {
+    def iterator = Iterator.continually(42)
+    override def className = "Custom" // signal that I expect mkString, but REPL can pretty-print elements
+  }
+  object Mystery extends AbstractIterable[Int] {
+    def iterator = Iterator.continually(42)
+    override def toString = "mystery" // doesn't supply className so intends to use toString, not mkString
+  }
+  object Danger extends Iterable[Int] {
+    def iterator = Iterator.continually(42)
+    override def toString = "toxic"  // too dangerous
   }
 }


### PR DESCRIPTION
Use `maxElements` to limit elements of collections.

Use `isInstanceOf[AbstractIterable]` to judge whether a thing is not a trivial iterable. Use `collectionClassName` to judge whether the iterable expects the default `toString` using `mkString` (or the equivalent `stringify`) or its own custom `toString`.

Fixes scala/bug#11785
