### PR TITLE
=lib Make use of CompletionStage#handle instead of whenComplete

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -31,6 +31,13 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.Predef#ArrayCharSequence.isEmpty"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.ArrayCharSequence.isEmpty"),
 
+    // KEEP: make use of CompletionStage#handle to get a better performance than CompletionStage#whenComplete.
+    ProblemFilters.exclude[MissingTypesProblem]("scala.concurrent.impl.FutureConvertersImpl$P"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.concurrent.impl.FutureConvertersImpl#P.andThen"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.concurrent.impl.FutureConvertersImpl#P.apply"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.concurrent.impl.FutureConvertersImpl#P.andThen"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.concurrent.impl.FutureConvertersImpl#P.accept"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.concurrent.impl.FutureConvertersImpl#P.andThen"),
   )
 
   override val buildSettings = Seq(

--- a/src/library/scala/concurrent/impl/FutureConvertersImpl.scala
+++ b/src/library/scala/concurrent/impl/FutureConvertersImpl.scala
@@ -91,8 +91,8 @@ private[scala] object FutureConvertersImpl {
     override def toString(): String = super[CompletableFuture].toString
   }
 
-  final class P[T](val wrapped: CompletionStage[T]) extends DefaultPromise[T] with BiConsumer[T, Throwable] {
-    override def accept(v: T, e: Throwable): Unit = {
+  final class P[T](val wrapped: CompletionStage[T]) extends DefaultPromise[T] with BiFunction[T, Throwable, Unit] {
+    override def apply(v: T, e: Throwable): Unit = {
       if (e == null) success(v)
       else failure(e)
     }


### PR DESCRIPTION
Which has better performance.

@lrytz Would you like to give some input, thanks.

Another one was :
https://github.com/line/armeria/pull/1440
https://github.com/line/armeria/pull/1444
https://github.com/akka/akka/pull/31283

I think this will help especially when the CompletionStage was failed already.
