### PR TITLE
Test for old crasher

### DIFF
--- a/test/files/pos/t7481.scala
+++ b/test/files/pos/t7481.scala
@@ -1,0 +1,10 @@
+
+// scalac: -no-specialization
+
+object Test {
+  // val fixesCompile = Array(1, 2, 3)
+
+  def foo: Any = new Array[Byte](0)
+
+  def f[@specialized(Int) A](a: A): A = a
+}


### PR DESCRIPTION
Fixed in 2.12.0 which was quite an amazing release.

Closes scala/bug#7481
