### PR TITLE
Tweak t12201 to run unoptimized

### DIFF
--- a/test/files/instrumented/t12201.check
+++ b/test/files/instrumented/t12201.check
@@ -1,3 +1,0 @@
-Method call statistics:
-    1  scala/runtime/BoxedUnit.<clinit>()V
-    1  scala/runtime/BoxedUnit.<init>()V

--- a/test/files/instrumented/t12201.scala
+++ b/test/files/instrumented/t12201.scala
@@ -1,7 +1,10 @@
 import scala.tools.partest.instrumented.Instrumentation._
 
 object Test {
+  @noinline def discard(x: Any) = ()
+
   def main(args: Array[String]): Unit = {
+    discard((): Any)  // ensure BoxedUnit is loaded; only under -opt is it not loaded before this method
     startProfiling()
 
     // to optimized
@@ -24,6 +27,6 @@ object Test {
     val k                = Array[Unit](())
 
     stopProfiling()
-    printStatistics()
+    assert(getStatistics.isEmpty)
   }
 }


### PR DESCRIPTION
When running unoptimized, a random early ref to `BoxedUnit` in `SetBuilderImpl#addOne` would make this test fail because the static init would not be recorded.

Instead, ensure `BoxedUnit` is loaded before turning on profiling.

Could also filter for methods of interest. But this is more robust against sneaky changes in implementation. Or filter out known uninteresting calls as they pop up.