### PR TITLE
Under `-Xsource:3`, adjust 2.13.9 change to ignore override type for whitebox macro expansion

### DIFF
--- a/test/files/neg/t12647.check
+++ b/test/files/neg/t12647.check
@@ -1,0 +1,4 @@
+Test_3.scala:6: error: value value is not a member of Result
+  println(resolver.resolve.value)
+                           ^
+1 error

--- a/test/files/neg/t12647/Macro_1.scala
+++ b/test/files/neg/t12647/Macro_1.scala
@@ -1,0 +1,13 @@
+
+// scalac: -Xsource:3
+
+import scala.reflect.macros.blackbox.Context
+
+trait Result
+
+object Macros {
+  def impl(c: Context) = {
+    import c.universe._
+    q"""new Result { def value = "Was this the answer you sought?" }"""
+  }
+}

--- a/test/files/neg/t12647/Resolve_2.scala
+++ b/test/files/neg/t12647/Resolve_2.scala
@@ -1,0 +1,13 @@
+
+// scalac: -Xsource:3
+
+import language.experimental.macros
+
+trait Resolver {
+  def resolve: Result = ???
+}
+
+class ValueResolver extends Resolver {
+  override def resolve = valueResult
+  def valueResult: Result = macro Macros.impl
+}

--- a/test/files/neg/t12647/Test_3.scala
+++ b/test/files/neg/t12647/Test_3.scala
@@ -1,0 +1,7 @@
+
+// scalac: -Xsource:3
+
+object Test extends App {
+  val resolver = new ValueResolver
+  println(resolver.resolve.value)
+}

--- a/test/files/pos/t12647/Macro_1.scala
+++ b/test/files/pos/t12647/Macro_1.scala
@@ -1,0 +1,13 @@
+
+// scalac: -Xsource:3
+
+import scala.reflect.macros.whitebox.Context
+
+trait Result
+
+object Macros {
+  def impl(c: Context) = {
+    import c.universe._
+    q"""new Result { def value = "Was this the answer you sought?" }"""
+  }
+}

--- a/test/files/pos/t12647/Resolve_2.scala
+++ b/test/files/pos/t12647/Resolve_2.scala
@@ -1,0 +1,13 @@
+
+// scalac: -Xsource:3
+
+import language.experimental.macros
+
+trait Resolver {
+  def resolve: Result = ???
+}
+
+class ValueResolver extends Resolver {
+  override def resolve = valueResult
+  def valueResult: Result = macro Macros.impl
+}

--- a/test/files/pos/t12647/Test_3.scala
+++ b/test/files/pos/t12647/Test_3.scala
@@ -1,0 +1,7 @@
+
+// scalac: -Xsource:3
+
+object Test extends App {
+  val resolver = new ValueResolver
+  println(resolver.resolve.value)
+}

--- a/test/files/pos/t12647b/Macro_1.scala
+++ b/test/files/pos/t12647b/Macro_1.scala
@@ -1,0 +1,11 @@
+
+import scala.reflect.macros.whitebox.Context
+
+trait Result
+
+object Macros {
+  def impl(c: Context): c.Tree = {
+    import c.universe._
+    q"""new Result { def value = "Was this the answer you sought?" }"""
+  }
+}

--- a/test/files/pos/t12647b/Resolve_2.scala
+++ b/test/files/pos/t12647b/Resolve_2.scala
@@ -1,0 +1,11 @@
+
+import language.experimental.macros
+
+abstract class Resolver {
+  def resolve: Result = ???
+}
+
+class ValueResolver extends Resolver {
+  override def resolve = valueResult
+  def valueResult: Result = macro Macros.impl
+}

--- a/test/files/pos/t12647b/Test_3.scala
+++ b/test/files/pos/t12647b/Test_3.scala
@@ -1,0 +1,5 @@
+
+object Test extends App {
+  val resolver = new ValueResolver
+  println(resolver.resolve.value)
+}


### PR DESCRIPTION
Improve the condition for inferring the type of an overriding def under `-Xsource:3`: use the precise type of the RHS if the RHS is the expansion of a whitebox macro.

Adjusts scala/scala#9891
Fixes scala/bug#12647
