### PR TITLE
Tweak compatible implicit check for refined type

### DIFF
--- a/test/files/pos/t12666.scala
+++ b/test/files/pos/t12666.scala
@@ -1,0 +1,32 @@
+
+package foo {
+
+  trait Baz[A]
+  object Baz {
+    implicit def instance[A]: Baz[A] = ???
+  }
+
+  package syntax {
+    object all {
+      implicit def ops1[A: Baz](a: A): BarOps1 = new BarOps1(a)
+      implicit def ops2[A: Baz](a: A): BarOps2 = new BarOps2(a)
+    }
+
+    class BarOps1(val a: Any) extends AnyVal {
+      def bar(x: Int): String = ???
+    }
+
+    class BarOps2(val a: Any) extends AnyVal {
+      private[syntax] def bar(x: Int): String = ???
+    }
+  }
+}
+
+import foo.syntax.all._
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    val a = new Object
+    a.bar(42)
+  }
+}


### PR DESCRIPTION
Move the test for "accessible member in refinement" from where the compatibility check is looking at a method type `(x)R` to where it is looking at the result only.

Conceptually, the fix was intended to target the search for conversions. In that case, the refinement has one member (the prototype expresses the missing member). The general case might be that all members must be accessible to pass compatibility.

Fixes scala/bug#12666