### PR TITLE
Fix `-Yprofile-enabled` on JDK 9+

### DIFF
--- a/src/compiler/scala/tools/nsc/profile/ExtendedThreadMxBean.java
+++ b/src/compiler/scala/tools/nsc/profile/ExtendedThreadMxBean.java
@@ -260,13 +260,14 @@ class SunThreadMxBean extends ExtendedThreadMxBean {
         super(underlying);
         this.real = underlying;
         try {
-            getThreadUserTimeMethod = real.getClass().getMethod("getThreadUserTime", long[].class);
-            isThreadAllocatedMemoryEnabledMethod = real.getClass().getMethod("isThreadAllocatedMemoryEnabled");
-            setThreadAllocatedMemoryEnabledMethod = real.getClass().getMethod("setThreadAllocatedMemoryEnabled", Boolean.TYPE);
-            getThreadAllocatedBytesMethod1 = real.getClass().getMethod("getThreadAllocatedBytes", Long.TYPE);
-            getThreadAllocatedBytesMethod2 = real.getClass().getMethod("getThreadAllocatedBytes", long[].class);
-            isThreadAllocatedMemorySupportedMethod = real.getClass().getMethod("isThreadAllocatedMemorySupported");
-            getThreadCpuTimeMethod = real.getClass().getMethod("getThreadCpuTime", long[].class);
+            Class<?> cls = Class.forName("com.sun.management.ThreadMXBean");
+            getThreadUserTimeMethod = cls.getMethod("getThreadUserTime", long[].class);
+            isThreadAllocatedMemoryEnabledMethod = cls.getMethod("isThreadAllocatedMemoryEnabled");
+            setThreadAllocatedMemoryEnabledMethod = cls.getMethod("setThreadAllocatedMemoryEnabled", Boolean.TYPE);
+            getThreadAllocatedBytesMethod1 = cls.getMethod("getThreadAllocatedBytes", Long.TYPE);
+            getThreadAllocatedBytesMethod2 = cls.getMethod("getThreadAllocatedBytes", long[].class);
+            isThreadAllocatedMemorySupportedMethod = cls.getMethod("isThreadAllocatedMemorySupported");
+            getThreadCpuTimeMethod = cls.getMethod("getThreadCpuTime", long[].class);
 
             getThreadUserTimeMethod.setAccessible(true);
             isThreadAllocatedMemoryEnabledMethod.setAccessible(true);


### PR DESCRIPTION
Starting with java 9 using `scalac` with the `-Yprofile-enabled` flag (or any other flag that enables profiling like the `-Yprofile-trace`) results in a `java.lang.ExceptionInInitializerError`.

Full stack trace (from sbt)
```
[error] java.lang.ExceptionInInitializerError
[error] 	at scala.tools.nsc.profile.RealProfiler$.<clinit>(Profiler.scala:127)
[error] 	at scala.tools.nsc.profile.RealProfiler.<init>(Profiler.scala:153)
[error] 	at scala.tools.nsc.profile.Profiler$.apply(Profiler.scala:40)
[error] 	at scala.tools.nsc.Global$Run.<init>(Global.scala:1166)
[error] 	at xsbt.ZincCompiler$ZincRun.<init>(CallbackGlobal.scala:79)
[error] 	at xsbt.CachedCompiler0.run(CompilerInterface.scala:151)
[error] 	at xsbt.CachedCompiler0.run(CompilerInterface.scala:125)
[error] 	at xsbt.CompilerInterface.run(CompilerInterface.scala:39)
[error] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[error] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[error] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[error] 	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
[error] 	at sbt.internal.inc.AnalyzingCompiler.call(AnalyzingCompiler.scala:248)
[error] 	at sbt.internal.inc.AnalyzingCompiler.compile(AnalyzingCompiler.scala:122)
[error] 	at sbt.internal.inc.AnalyzingCompiler.compile(AnalyzingCompiler.scala:95)
[error] 	at sbt.internal.inc.MixedAnalyzingCompiler.$anonfun$compile$4(MixedAnalyzingCompiler.scala:91)
[error] 	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
[error] 	at sbt.internal.inc.MixedAnalyzingCompiler.timed(MixedAnalyzingCompiler.scala:186)
[error] 	at sbt.internal.inc.MixedAnalyzingCompiler.$anonfun$compile$3(MixedAnalyzingCompiler.scala:82)
[error] 	at sbt.internal.inc.MixedAnalyzingCompiler.$anonfun$compile$3$adapted(MixedAnalyzingCompiler.scala:77)
[error] 	at sbt.internal.inc.JarUtils$.withPreviousJar(JarUtils.scala:215)
[error] 	at sbt.internal.inc.MixedAnalyzingCompiler.compileScala$1(MixedAnalyzingCompiler.scala:77)
[error] 	at sbt.internal.inc.MixedAnalyzingCompiler.compile(MixedAnalyzingCompiler.scala:146)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileInternal$1(IncrementalCompilerImpl.scala:343)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileInternal$1$adapted(IncrementalCompilerImpl.scala:343)
[error] 	at sbt.internal.inc.Incremental$.doCompile(Incremental.scala:120)
[error] 	at sbt.internal.inc.Incremental$.$anonfun$compile$4(Incremental.scala:100)
[error] 	at sbt.internal.inc.IncrementalCommon.recompileClasses(IncrementalCommon.scala:180)
[error] 	at sbt.internal.inc.IncrementalCommon.cycle(IncrementalCommon.scala:98)
[error] 	at sbt.internal.inc.Incremental$.$anonfun$compile$3(Incremental.scala:102)
[error] 	at sbt.internal.inc.Incremental$.manageClassfiles(Incremental.scala:155)
[error] 	at sbt.internal.inc.Incremental$.compile(Incremental.scala:92)
[error] 	at sbt.internal.inc.IncrementalCompile$.apply(Compile.scala:75)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.compileInternal(IncrementalCompilerImpl.scala:348)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileIncrementally$1(IncrementalCompilerImpl.scala:301)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.handleCompilationError(IncrementalCompilerImpl.scala:168)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.compileIncrementally(IncrementalCompilerImpl.scala:248)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.compile(IncrementalCompilerImpl.scala:74)
[error] 	at sbt.Defaults$.compileIncrementalTaskImpl(Defaults.scala:1765)
[error] 	at sbt.Defaults$.$anonfun$compileIncrementalTask$1(Defaults.scala:1738)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:62)
[error] 	at sbt.std.Transform$$anon$4.work(Transform.scala:67)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:281)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:19)
[error] 	at sbt.Execute.work(Execute.scala:290)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:281)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:178)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
[error] 	at java.base/java.lang.Thread.run(Thread.java:829)
[error] Caused by: java.lang.IllegalStateException: java.lang.reflect.InaccessibleObjectException: Unable to make public long[] com.sun.management.internal.HotSpotThreadImpl.getThreadUserTime(long[]) accessible: module jdk.management does not "exports com.sun.management.internal" to unnamed module @56b4fbed
[error] 	at scala.tools.nsc.profile.SunThreadMxBean.<init>(ExtendedThreadMxBean.java:279)
[error] 	at scala.tools.nsc.profile.ExtendedThreadMxBean.<clinit>(ExtendedThreadMxBean.java:31)
[error] 	at scala.tools.nsc.profile.RealProfiler$.<clinit>(Profiler.scala:127)
[error] 	at scala.tools.nsc.profile.RealProfiler.<init>(Profiler.scala:153)
[error] 	at scala.tools.nsc.profile.Profiler$.apply(Profiler.scala:40)
[error] 	at scala.tools.nsc.Global$Run.<init>(Global.scala:1166)
[error] 	at xsbt.ZincCompiler$ZincRun.<init>(CallbackGlobal.scala:79)
[error] 	at xsbt.CachedCompiler0.run(CompilerInterface.scala:151)
[error] 	at xsbt.CachedCompiler0.run(CompilerInterface.scala:125)
[error] 	at xsbt.CompilerInterface.run(CompilerInterface.scala:39)
[error] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[error] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[error] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[error] 	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
[error] 	at sbt.internal.inc.AnalyzingCompiler.call(AnalyzingCompiler.scala:248)
[error] 	at sbt.internal.inc.AnalyzingCompiler.compile(AnalyzingCompiler.scala:122)
[error] 	at sbt.internal.inc.AnalyzingCompiler.compile(AnalyzingCompiler.scala:95)
[error] 	at sbt.internal.inc.MixedAnalyzingCompiler.$anonfun$compile$4(MixedAnalyzingCompiler.scala:91)
[error] 	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
[error] 	at sbt.internal.inc.MixedAnalyzingCompiler.timed(MixedAnalyzingCompiler.scala:186)
[error] 	at sbt.internal.inc.MixedAnalyzingCompiler.$anonfun$compile$3(MixedAnalyzingCompiler.scala:82)
[error] 	at sbt.internal.inc.MixedAnalyzingCompiler.$anonfun$compile$3$adapted(MixedAnalyzingCompiler.scala:77)
[error] 	at sbt.internal.inc.JarUtils$.withPreviousJar(JarUtils.scala:215)
[error] 	at sbt.internal.inc.MixedAnalyzingCompiler.compileScala$1(MixedAnalyzingCompiler.scala:77)
[error] 	at sbt.internal.inc.MixedAnalyzingCompiler.compile(MixedAnalyzingCompiler.scala:146)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileInternal$1(IncrementalCompilerImpl.scala:343)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileInternal$1$adapted(IncrementalCompilerImpl.scala:343)
[error] 	at sbt.internal.inc.Incremental$.doCompile(Incremental.scala:120)
[error] 	at sbt.internal.inc.Incremental$.$anonfun$compile$4(Incremental.scala:100)
[error] 	at sbt.internal.inc.IncrementalCommon.recompileClasses(IncrementalCommon.scala:180)
[error] 	at sbt.internal.inc.IncrementalCommon.cycle(IncrementalCommon.scala:98)
[error] 	at sbt.internal.inc.Incremental$.$anonfun$compile$3(Incremental.scala:102)
[error] 	at sbt.internal.inc.Incremental$.manageClassfiles(Incremental.scala:155)
[error] 	at sbt.internal.inc.Incremental$.compile(Incremental.scala:92)
[error] 	at sbt.internal.inc.IncrementalCompile$.apply(Compile.scala:75)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.compileInternal(IncrementalCompilerImpl.scala:348)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileIncrementally$1(IncrementalCompilerImpl.scala:301)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.handleCompilationError(IncrementalCompilerImpl.scala:168)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.compileIncrementally(IncrementalCompilerImpl.scala:248)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.compile(IncrementalCompilerImpl.scala:74)
[error] 	at sbt.Defaults$.compileIncrementalTaskImpl(Defaults.scala:1765)
[error] 	at sbt.Defaults$.$anonfun$compileIncrementalTask$1(Defaults.scala:1738)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:62)
[error] 	at sbt.std.Transform$$anon$4.work(Transform.scala:67)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:281)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:19)
[error] 	at sbt.Execute.work(Execute.scala:290)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:281)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:178)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
[error] 	at java.base/java.lang.Thread.run(Thread.java:829)
[error] Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make public long[] com.sun.management.internal.HotSpotThreadImpl.getThreadUserTime(long[]) accessible: module jdk.management does not "exports com.sun.management.internal" to unnamed module @56b4fbed
[error] 	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:340)
[error] 	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:280)
[error] 	at java.base/java.lang.reflect.Method.checkCanSetAccessible(Method.java:198)
[error] 	at java.base/java.lang.reflect.Method.setAccessible(Method.java:192)
[error] 	at scala.tools.nsc.profile.SunThreadMxBean.<init>(ExtendedThreadMxBean.java:271)
[error] 	at scala.tools.nsc.profile.ExtendedThreadMxBean.<clinit>(ExtendedThreadMxBean.java:31)
[error] 	at scala.tools.nsc.profile.RealProfiler$.<clinit>(Profiler.scala:127)
[error] 	at scala.tools.nsc.profile.RealProfiler.<init>(Profiler.scala:153)
[error] 	at scala.tools.nsc.profile.Profiler$.apply(Profiler.scala:40)
[error] 	at scala.tools.nsc.Global$Run.<init>(Global.scala:1166)
[error] 	at xsbt.ZincCompiler$ZincRun.<init>(CallbackGlobal.scala:79)
[error] 	at xsbt.CachedCompiler0.run(CompilerInterface.scala:151)
[error] 	at xsbt.CachedCompiler0.run(CompilerInterface.scala:125)
[error] 	at xsbt.CompilerInterface.run(CompilerInterface.scala:39)
[error] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[error] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[error] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[error] 	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
[error] 	at sbt.internal.inc.AnalyzingCompiler.call(AnalyzingCompiler.scala:248)
[error] 	at sbt.internal.inc.AnalyzingCompiler.compile(AnalyzingCompiler.scala:122)
[error] 	at sbt.internal.inc.AnalyzingCompiler.compile(AnalyzingCompiler.scala:95)
[error] 	at sbt.internal.inc.MixedAnalyzingCompiler.$anonfun$compile$4(MixedAnalyzingCompiler.scala:91)
[error] 	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
[error] 	at sbt.internal.inc.MixedAnalyzingCompiler.timed(MixedAnalyzingCompiler.scala:186)
[error] 	at sbt.internal.inc.MixedAnalyzingCompiler.$anonfun$compile$3(MixedAnalyzingCompiler.scala:82)
[error] 	at sbt.internal.inc.MixedAnalyzingCompiler.$anonfun$compile$3$adapted(MixedAnalyzingCompiler.scala:77)
[error] 	at sbt.internal.inc.JarUtils$.withPreviousJar(JarUtils.scala:215)
[error] 	at sbt.internal.inc.MixedAnalyzingCompiler.compileScala$1(MixedAnalyzingCompiler.scala:77)
[error] 	at sbt.internal.inc.MixedAnalyzingCompiler.compile(MixedAnalyzingCompiler.scala:146)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileInternal$1(IncrementalCompilerImpl.scala:343)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileInternal$1$adapted(IncrementalCompilerImpl.scala:343)
[error] 	at sbt.internal.inc.Incremental$.doCompile(Incremental.scala:120)
[error] 	at sbt.internal.inc.Incremental$.$anonfun$compile$4(Incremental.scala:100)
[error] 	at sbt.internal.inc.IncrementalCommon.recompileClasses(IncrementalCommon.scala:180)
[error] 	at sbt.internal.inc.IncrementalCommon.cycle(IncrementalCommon.scala:98)
[error] 	at sbt.internal.inc.Incremental$.$anonfun$compile$3(Incremental.scala:102)
[error] 	at sbt.internal.inc.Incremental$.manageClassfiles(Incremental.scala:155)
[error] 	at sbt.internal.inc.Incremental$.compile(Incremental.scala:92)
[error] 	at sbt.internal.inc.IncrementalCompile$.apply(Compile.scala:75)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.compileInternal(IncrementalCompilerImpl.scala:348)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileIncrementally$1(IncrementalCompilerImpl.scala:301)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.handleCompilationError(IncrementalCompilerImpl.scala:168)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.compileIncrementally(IncrementalCompilerImpl.scala:248)
[error] 	at sbt.internal.inc.IncrementalCompilerImpl.compile(IncrementalCompilerImpl.scala:74)
[error] 	at sbt.Defaults$.compileIncrementalTaskImpl(Defaults.scala:1765)
[error] 	at sbt.Defaults$.$anonfun$compileIncrementalTask$1(Defaults.scala:1738)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:62)
[error] 	at sbt.std.Transform$$anon$4.work(Transform.scala:67)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:281)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:19)
[error] 	at sbt.Execute.work(Execute.scala:290)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:281)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:178)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
[error] 	at java.base/java.lang.Thread.run(Thread.java:829)
```

The issue is caused by the Java Platform Module System (aka jigsaw). There are three classes at play:
- java.lang.management.ThreadMXBean - a statically known type of `SunThreadMxBean#real`
- com.sun.management.ThreadMXBean - a subtype of the above type. `SunThreadMxBean#real` is known to be of this type thanks to runtime check performed [here](https://github.com/scala/scala/blob/2.13.x/src/compiler/scala/tools/nsc/profile/ExtendedThreadMxBean.java#L30)
- com.sun.management.internal.HotSpotThreadImpl - a subtype of the above type. This is the actuall class of the `SunThreadMxBean#real`. This type is inaccessable (jigsaw-wise) due to residing in the `internal` package.

Current implementation attempts to get access to methods of `com.sun.management.internal.HotSpotThreadImpl` which violates the rules enforced by the module system. These methods are implementations of methods defined in `com.sun.management.ThreadMXBean`. The fixed implementation accesses methods defined in `com.sun.management.ThreadMXBean` instead, resolving the problem.