### PR TITLE
Require element copies succeed

### DIFF
--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -197,7 +197,8 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
           //   - `copyElemsToArray` will call `System.arraycopy`
           //   - `System.arraycopy` will effectively "read" all the values before
           //     overwriting any of them when two arrays are the the same reference
-          IterableOnce.copyElemsToArray(elems, array.asInstanceOf[Array[Any]], index, elemsLength)
+          val actual = IterableOnce.copyElemsToArray(elems, array.asInstanceOf[Array[Any]], index, elemsLength)
+          if (actual != elemsLength) throw new IllegalStateException(s"Copied $actual of $elemsLength")
           size0 = len + elemsLength // update size AFTER the copy, in case we're inserting a proxy
         }
       case _ => insertAll(index, ArrayBuffer.from(elems))

--- a/src/library/scala/collection/mutable/ArrayBuilder.scala
+++ b/src/library/scala/collection/mutable/ArrayBuilder.scala
@@ -61,7 +61,8 @@ sealed abstract class ArrayBuilder[T]
     val k = xs.knownSize
     if (k > 0) {
       ensureSize(this.size + k)
-      IterableOnce.copyElemsToArray(xs, elems, this.size)
+      val actual = IterableOnce.copyElemsToArray(xs, elems, this.size)
+      if (actual != k) throw new IllegalStateException(s"Copied $actual of $k")
       size += k
     } else if (k < 0) super.addAll(xs)
     this

--- a/src/library/scala/collection/mutable/ArrayDeque.scala
+++ b/src/library/scala/collection/mutable/ArrayDeque.scala
@@ -529,7 +529,8 @@ object ArrayDeque extends StrictOptimizedSeqFactory[ArrayDeque] {
     val s = coll.knownSize
     if (s >= 0) {
       val array = alloc(s)
-      IterableOnce.copyElemsToArray(coll, array.asInstanceOf[Array[Any]])
+      val actual = IterableOnce.copyElemsToArray(coll, array.asInstanceOf[Array[Any]])
+      if (actual != s) throw new IllegalStateException(s"Copied $actual of $s")
       new ArrayDeque[B](array, start = 0, end = s)
     } else new ArrayDeque[B]() ++= coll
   }

--- a/test/junit/scala/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBufferTest.scala
@@ -7,20 +7,17 @@ import java.lang.reflect.InvocationTargetException
 import scala.annotation.nowarn
 import scala.tools.testkit.AssertUtil.{assertSameElements, assertThrows, fail}
 import scala.tools.testkit.ReflectUtil.{getMethodAccessible, _}
+import scala.util.chaining._
 
 class ArrayBufferTest {
 
   /* Test for scala/bug#9043 */
   @Test
-  def testInsertAll(): Unit = {
-    val traver = ArrayBuffer(2, 4, 5, 7)
+  def testInsertAll: Unit = {
+    def traver = ArrayBuffer(2, 4, 5, 7)
     val testSeq = List(1, 3, 6, 9)
 
-    def insertAt(x: Int) = {
-      val clone = traver.clone()
-      clone.insertAll(x, testSeq)
-      clone
-    }
+    def insertAt(x: Int) = traver.tap(_.insertAll(x, testSeq))
 
     // Just insert some at position 0
     assertEquals(ArrayBuffer(1, 3, 6, 9, 2, 4, 5, 7), insertAt(0))
@@ -34,6 +31,9 @@ class ArrayBufferTest {
     // Overflow is caught
     assertThrows[IndexOutOfBoundsException] { insertAt(-1) }
     assertThrows[IndexOutOfBoundsException] { insertAt(traver.size + 10) }
+
+    val xs = new Iterable[Int] { def iterator = Iterator(42); override def knownSize = 10 }
+    assertThrows[IllegalStateException] { traver.tap(_.insertAll(0, xs)) }
   }
 
   @Test


### PR DESCRIPTION
Do something if knownSize is inconsistent with iterator.

Previously, if the iterator terminates early, the underlying array contains nulls.

Filling the array if the iterator.hasNext may be deemed benign.

Alternatively, it could just close the gap instead of failing fast.