### PR TITLE
fix and expand testing of signature polymorphic methods

### DIFF
--- a/test/files/run/dotty-i11332.scala
+++ b/test/files/run/dotty-i11332.scala
@@ -1,0 +1,67 @@
+import java.lang.invoke._, MethodType.methodType
+
+class Foo {
+  def neg(x: Int): Int = -x
+  def rev(s: String): String = s.reverse
+  def over(l: Long): String = "long"
+  def over(i: Int): String  = "int"
+  def unit(s: String): Unit = ()
+  def obj(s: String): Object = s
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val l = MethodHandles.lookup()
+    val self    = new Foo()
+    val mhNeg   = l.findVirtual(classOf[Foo], "neg", methodType(classOf[Int], classOf[Int]))
+    val mhRev   = l.findVirtual(classOf[Foo], "rev", methodType(classOf[String], classOf[String]))
+    val mhOverL = l.findVirtual(classOf[Foo], "over", methodType(classOf[String], classOf[Long]))
+    val mhOverI = l.findVirtual(classOf[Foo], "over", methodType(classOf[String], classOf[Int]))
+    val mhUnit  = l.findVirtual(classOf[Foo], "unit", methodType(classOf[Unit], classOf[String]))
+    val mhObj   = l.findVirtual(classOf[Foo], "obj", methodType(classOf[Any], classOf[String]))
+
+    assert(-42 == (mhNeg.invokeExact(self, 42): Int))
+    assert(-33 == (mhNeg.invokeExact(self, 33): Int))
+
+    assert("oof" == (mhRev.invokeExact(self, "foo"): String))
+    assert("rab" == (mhRev.invokeExact(self, "bar"): String))
+
+    assert("long" == (mhOverL.invokeExact(self, 1L): String))
+    assert("int" == (mhOverI.invokeExact(self, 1): String))
+
+    assert(-3 == (id(mhNeg.invokeExact(self, 3)): Int))
+    expectWrongMethod(mhNeg.invokeExact(self, 4))
+
+    { mhUnit.invokeExact(self, "hi"): Unit; () } // explicit block
+    val hi2: Unit = mhUnit.invokeExact(self, "hi2")
+    assert((()) == (hi2: Any))
+    def hi3: Unit = mhUnit.invokeExact(self, "hi3")
+    assert((()) == (hi3: Any))
+
+    { mhObj.invokeExact(self, "any"); () } // explicit block
+    val any2 = mhObj.invokeExact(self, "any2")
+    assert("any2" == any2)
+    def any3 = mhObj.invokeExact(self, "any3")
+    assert("any3" == any3)
+
+    expectWrongMethod {
+      l // explicit chain method call
+        .findVirtual(classOf[Foo], "neg", methodType(classOf[Int], classOf[Int]))
+        .invokeExact(self, 3)
+    }
+    val res4 = {
+      l // explicit chain method call
+        .findVirtual(classOf[Foo], "neg", methodType(classOf[Int], classOf[Int]))
+        .invokeExact(self, 4): Int
+    }
+    assert(-4 == res4)
+  }
+
+  def id[T](x: T): T = x
+
+  def expectWrongMethod(op: => Any) = try {
+    op
+    throw new AssertionError("expected operation to fail but it didn't")
+  } catch { case expected: WrongMethodTypeException => () }
+
+}

--- a/test/files/run/dotty-i11332b.scala
+++ b/test/files/run/dotty-i11332b.scala
@@ -1,0 +1,20 @@
+// javaVersion: 11+
+// scalac: -release:11
+
+import java.lang.invoke._, MethodType.methodType
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val l = MethodHandles.lookup()
+    val mhCL = l.findStatic(classOf[ClassLoader], "getPlatformClassLoader", methodType(classOf[ClassLoader]))
+    // sanity check that the non-signature-polymorphic invocations work as expected
+    assert(null != (mhCL.invoke(): ClassLoader))
+    assert(null != (mhCL.invoke().asInstanceOf[ClassLoader]: ClassLoader))
+    // now go signature polymorphic
+    assert(null != (mhCL.invokeExact(): ClassLoader))
+    // I've commented out this part of the Dotty test because here in Scala 2,
+    // we didn't implement specifying a signature polymorphic method's return type
+    // via `asInstanceOf`; we only implemented specifying it via type ascription
+    // assert(null != (mhCL.invokeExact().asInstanceOf[ClassLoader]: ClassLoader))
+  }
+}

--- a/test/files/run/dotty-t12348.scala
+++ b/test/files/run/dotty-t12348.scala
@@ -1,0 +1,23 @@
+// javaVersion: 11+
+// scalac: -release:11
+
+import java.lang.invoke._
+import scala.runtime.IntRef
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val ref = new scala.runtime.IntRef(0)
+    val varHandle = MethodHandles.lookup()
+      .in(classOf[IntRef])
+      .findVarHandle(classOf[IntRef], "elem", classOf[Int])
+    assert(0 == (varHandle.getAndSet(ref, 1): Int))
+    assert(1 == (varHandle.getAndSet(ref, 2): Int))
+    assert(2 == ref.elem)
+
+    assert((()) == (varHandle.set(ref, 3): Any))
+    assert(3 == (varHandle.get(ref): Int))
+
+    assert(true == (varHandle.compareAndSet(ref, 3, 4): Any))
+    assert(4 == (varHandle.get(ref): Int))
+  }
+}

--- a/test/files/run/t12348.scala
+++ b/test/files/run/t12348.scala
@@ -1,0 +1,18 @@
+// javaVersion: 11+
+// scalac: -release:11
+
+// this a sequel to t7965. that one only tests MethodHandle. JDK 11 added
+// signature polymorphic methods to VarHandle, so let's test that too
+
+// the reason to include `-release:11` is the problem Jason noticed and fixed in
+// scala/scala#9930
+
+object Test extends App {
+  import java.lang.invoke._
+  import scala.runtime.IntRef
+  val ref = new scala.runtime.IntRef(0)
+  val varHandle = MethodHandles.lookup().in(classOf[IntRef]).findVarHandle(classOf[IntRef], "elem", classOf[Int])
+  assert(0 == (varHandle.getAndSet(ref, 1): Int))
+  assert(1 == (varHandle.getAndSet(ref, 2): Int))
+  assert(2 == ref.elem)
+}

--- a/test/files/run/t7965.scala
+++ b/test/files/run/t7965.scala
@@ -1,7 +1,5 @@
 // Test that scala doesn't apply boxing or varargs conversions to the
 // @PolymorphicSignature magical methods, MethodHandle#{invoke, invokeExact}
-object Test {
-  val code = """
 
 object O {
   private def foo = "foo"
@@ -13,42 +11,24 @@ object O {
 import java.lang.invoke._
 class Box(var a: Any)
 
-object Test {
-  def main(args: Array[String]): Unit = {
-    def lookup(name: String, params: Array[Class[_]], ret: Class[_]) = {
-      val mt = MethodType.methodType(ret, params)
-      O.lookup.findVirtual(O.getClass, name, mt)
-    }
-    val fooResult = (lookup("foo", Array(), classOf[String]).invokeExact(O): Int)
-    assert(fooResult == "foo")
-
-    val barResult = (lookup("bar", Array(classOf[Int]), classOf[Int]).invokeExact(O, 42): Int)
-    assert(barResult == -42)
-
-    val box = new Box(null)
-    (lookup("baz", Array(classOf[Box]), Void.TYPE).invokeExact(O, box) : Unit)
-    assert(box.a == "present")
-
-    // Note: Application in statement position in a block in Java also infers return type of Unit,
-    // but we don't support that, ascribe the type to Unit as above.
-    // as done in Java.
-    // lookup("baz", Array(classOf[Box]), Void.TYPE).invokeExact(O, box)
-    ()
+object Test extends App {
+  def lookup(name: String, params: Array[Class[_]], ret: Class[_]) = {
+    val mt = MethodType.methodType(ret, params)
+    O.lookup.findVirtual(O.getClass, name, mt)
   }
-}
+  val fooResult = (lookup("foo", Array(), classOf[String]).invokeExact(O): String)
+  assert(fooResult == "foo")
 
-"""
-  def main(args: Array[String]): Unit = {
-    if (util.Properties.isJavaAtLeast("1.7")) test()
-  }
+  val barResult = (lookup("bar", Array(classOf[Int]), classOf[Int]).invokeExact(O, 42): Int)
+  assert(barResult == -42)
 
-  def test() {
-    import scala.reflect.runtime._
-    import scala.tools.reflect.ToolBox
+  val box = new Box(null)
+  (lookup("baz", Array(classOf[Box]), Void.TYPE).invokeExact(O, box) : Unit)
+  assert(box.a == "present")
 
-    val m = currentMirror
-    val tb = m.mkToolBox()
-    import tb._
-    eval(parse(code))
-  }
+  // Note: Application in statement position in a block in Java also infers return type of Unit,
+  // but we don't support that, ascribe the type to Unit as above.
+  // as done in Java.
+  // lookup("baz", Array(classOf[Box]), Void.TYPE).invokeExact(O, box)
+
 }


### PR DESCRIPTION
* fix `MethodHandle` test which wasn't testing anything
* add `VarHandle` test, now that it's easy to make the test run on JDK 11+ only

this came up as part of the work we're doing on porting signature polymorphic method support to Scala 3