### PR TITLE
Document: don't allow characters with unicode property Bidi_Class in source files

### DIFF
--- a/spec/01-lexical-syntax.md
+++ b/spec/01-lexical-syntax.md
@@ -8,6 +8,11 @@ chapter: 1
 
 Scala source code consists of Unicode text.
 
+The nine [Bidirectional explicit formatting](https://www.unicode.org/reports/tr9/#Bidirectional_Character_Types)
+characters `\u202a - \u202e` and `\u2066 - \u2069` (inclusive) are forbidden 
+from appearing in source files. Note that they can be represented using 
+unicode escapes in string and character literals.
+
 The program text is tokenized as described in this chapter.
 See the last section for special support for XML literals,
 which are parsed in _XML mode_.

--- a/spec/13-syntax-summary.md
+++ b/spec/13-syntax-summary.md
@@ -8,6 +8,11 @@ chapter: 13
 
 The following descriptions of Scala tokens uses literal characters `‘c’` when referring to the ASCII fragment `\u0000` – `\u007F`.
 
+The nine [Bidirectional explicit formatting](https://www.unicode.org/reports/tr9/#Bidirectional_Character_Types)
+characters `\u202a - \u202e` and `\u2066 - \u2069` (inclusive) are forbidden 
+from appearing in source files. Note that they can be represented using 
+unicode escapes in string and character literals.
+
 ## Lexical Syntax
 
 The lexical syntax of Scala is given by the following grammar in EBNF form:


### PR DESCRIPTION
Update documentation with changes made in #10017. Previously [discussed on scala-contributors](https://contributors.scala-lang.org/t/scala-3-syntax-reference-disallows-unicode-string-literals/5963/8).

This is my first PR and there are some things I'm not sure about:
* The EBNF uses several CharNoXxxOrYyy constructions that are not explicitly defined. Since I couldn't update the definition I had to add ...OrZzz to their names. Zzz is here "BidiFormatting" which makes the names annoyingly long, and you can't keep adding exceptions this way. Is that alright? I considered shorter names but just "bidi" is misleading.
* I linked to the Unicode standard definition of these codepoints. Is that a good thing? Should I additionally or instead explain why these particular characters are forbidden, linking to the CVE or some other discussion? (As for the Unicode link, I could make it even more explicit by explaining that these are the codepoints whose Bidi_Class has 'explicit strength' but most readers won't benefit from that.)
* I noted that Scala 12 forbids these characters anywhere in the source file (e.g. comments, identifiers) - is that useful? It's an implementation restriction. Should I mark the PR [nomerge] and edit out that part in the 2.13 version?