### PR TITLE
Fix accessibility case for static java members

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -896,7 +896,9 @@ trait Contexts { self: Analyzer =>
     private def isSubClassOrCompanion(sub: Symbol, base: Symbol) =
       sub.isNonBottomSubClass(base) ||
         (sub.isModuleClass && sub.linkedClassOfClass.isNonBottomSubClass(base)) ||
-        (base.isJavaDefined && base.isModuleClass && sub.isNonBottomSubClass(base.linkedClassOfClass))
+        (base.isJavaDefined && base.isModuleClass && (
+          sub.isNonBottomSubClass(base.linkedClassOfClass) ||
+            sub.isModuleClass && sub.linkedClassOfClass.isNonBottomSubClass(base.linkedClassOfClass)))
 
     /** Return the closest enclosing context that defines a subclass of `clazz`
      *  or a companion object thereof, or `NoContext` if no such context exists.

--- a/test/files/pos/t12673/A.java
+++ b/test/files/pos/t12673/A.java
@@ -1,0 +1,4 @@
+package compiletest.a;
+public class A {
+  protected static class InnerParent { }
+}

--- a/test/files/pos/t12673/B.java
+++ b/test/files/pos/t12673/B.java
@@ -1,0 +1,6 @@
+package compiletest.b;
+import compiletest.a.A;
+
+public class B extends A {
+  public static class InnerChild extends InnerParent { }
+}

--- a/test/files/pos/t12673/Test.scala
+++ b/test/files/pos/t12673/Test.scala
@@ -1,0 +1,5 @@
+package client
+
+object Client {
+  new compiletest.b.B.InnerChild
+}


### PR DESCRIPTION
Given

```
public class A {
  protected static class AI { }
}
public class B extends A {
  public static class BI extends AI { }
}
```

The owner of `AI` is the module class `A$`, the owner of `BI` is the module class `B$`. When checking if the protected `AI` can be accessed in `B$`, we need to navigate from `B$` to `B`. The inheritance chain is not reflected in the module classes.

Fixes https://github.com/scala/bug/issues/12673