### PR TITLE
Careful interpolating windows paths

### DIFF
--- a/test/files/run/t12390.scala
+++ b/test/files/run/t12390.scala
@@ -1,37 +1,39 @@
 import scala.tools.nsc.Settings
 import scala.tools.nsc.interpreter._, shell._
+import scala.util.Properties.lineSeparator
 
-import java.io.{PrintWriter, OutputStream}
+import java.io.{PrintWriter, StringWriter}
 
 object Test {
 
   def main(args: Array[String]): Unit = {
-    //val filename: String = ".../data/generated_01mb.base64"
-    val filename: String = sys.props("partest.test-path")
     val code: String =
-        "import scala.io.Source\n " +
-        "Source.fromFile(\"" + filename + "\").getLines().mkString(\"\\n\")"
+      s"""|import scala.io.Source
+          |import scala.util.Properties.lineSeparator
+          |import scala.util.chaining._
+          |Source.fromFile(sys.props("partest.test-path")).pipe(s => s.getLines().mkString(lineSeparator).tap(_ => s.close()))
+          |""".stripMargin.linesIterator.mkString(lineSeparator)
 
     val s = new Settings()
 
     s.processArguments(
       List(
-        //"-Xprint:typer",
         "-deprecation",
         "-Yrepl-class-based",
-        "-Yrepl-outdir", "./target"
+        "-Yrepl-outdir", "target"
       ), processAll = true)
 
-    val drain = new OutputStream { override def write(byte: Int) = () }
+    val drain = new StringWriter //new OutputStream { override def write(byte: Int) = () }
     val sinkWriter = new PrintWriter(drain)
     val reporter = new ReplReporterImpl(ShellConfig(s), s, sinkWriter)
     val repl = new IMain(s, reporter)
     repl.settings.usejavacp.value = true
-    for(i <- 1 to 65) {
+    for (i <- 1 to 65) {
       repl.interpret(code) match {
         case Results.Success =>
           assert(repl.valueOfTerm(repl.mostRecentVar).get != null)  // 2.12: null after 60
         case other =>
+          println(drain.toString)
           throw new MatchError(other)
       }
     }


### PR DESCRIPTION
Follow-up to https://github.com/scala/scala/pull/10192 to run under windows.

As a wise man once said,
```
// My god...it's full of quines
```
https://github.com/scala/scala/blob/2.13.x/test/files/run/t4671.scala