### PR TITLE
{get=>find}Resource in some tests

### DIFF
--- a/test/junit/scala/reflect/io/ZipArchiveTest.scala
+++ b/test/junit/scala/reflect/io/ZipArchiveTest.scala
@@ -8,7 +8,6 @@ import java.util.jar.{Attributes, Manifest, JarEntry, JarOutputStream}
 import org.junit.Assert._
 import org.junit.Test
 
-import scala.reflect.internal.util.ScalaClassLoader
 import scala.tools.testkit.AssertUtil._
 import scala.tools.testkit.ForDeletion
 import scala.tools.testkit.Releasables._
@@ -50,12 +49,12 @@ class ZipArchiveTest {
     assertThrown[IOException](_.getMessage.contains(f.toString))(fza.iterator)
   }
 
-  private def manifestAt(location: URI): URL = ScalaClassLoader.fromURLs(List(location.toURL), null).getResource("META-INF/MANIFEST.MF");
+  private def manifestAt(location: Path): URL = URI.create(s"jar:file:$location!/META-INF/MANIFEST.MF").toURL
 
   // ZipArchive.fromManifestURL(URL)
   @Test def `manifest resources just works`(): Unit = {
     val jar = createTestJar()
-    Using.resources(ForDeletion(jar), new ManifestResources(manifestAt(jar.toUri))) { (_, archive) =>
+    Using.resources(ForDeletion(jar), new ManifestResources(manifestAt(jar.toAbsolutePath))) { (_, archive) =>
       val it = archive.iterator
       assertTrue(it.hasNext)
       val f = it.next()

--- a/test/junit/scala/tools/nsc/classpath/ZipAndJarFileLookupFactoryTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/ZipAndJarFileLookupFactoryTest.scala
@@ -6,7 +6,6 @@ import org.junit.Test
 import java.net.{URI, URL}
 import java.nio.file._
 import java.nio.file.attribute.FileTime
-import scala.reflect.internal.util.ScalaClassLoader
 import scala.reflect.io.AbstractFile
 import scala.tools.testkit.ForDeletion
 import scala.tools.testkit.Releasables._
@@ -82,10 +81,10 @@ class ZipAndJarFileLookupFactoryTest {
         ()
       }
     }
-    def manifestAt(location: URI): URL = ScalaClassLoader.fromURLs(List(location.toURL), null).getResource("META-INF/MANIFEST.MF");
+    def manifestAt(location: Path): URL = URI.create(s"jar:file:$location!/META-INF/MANIFEST.MF").toURL
 
     val j = createTestJar();
-    Using.resources(ForDeletion(j), new ManifestResources(manifestAt(j.toUri)), new CloseableRegistry) { (_, archive, closeableRegistry) =>
+    Using.resources(ForDeletion(j), new ManifestResources(manifestAt(j.toAbsolutePath)), new CloseableRegistry) { (_, archive, closeableRegistry) =>
       val settings = new Settings
       val cp = ZipAndJarClassPathFactory.create(archive, settings, closeableRegistry)
       assertTrue(cp.findClass("foo").isDefined)


### PR DESCRIPTION
This does not call the parent class loader first, which may return different resources if they're on classpath.

fixes scala/bug#12677