### PR TITLE
Test roundtrips path.toUri.getPath for windows

### DIFF
--- a/test/junit/scala/reflect/io/ZipArchiveTest.scala
+++ b/test/junit/scala/reflect/io/ZipArchiveTest.scala
@@ -49,7 +49,7 @@ class ZipArchiveTest {
     assertThrown[IOException](_.getMessage.contains(f.toString))(fza.iterator)
   }
 
-  private def manifestAt(location: Path): URL = URI.create(s"jar:file:$location!/META-INF/MANIFEST.MF").toURL
+  private def manifestAt(location: Path): URL = URI.create(s"jar:file:${location.toUri.getPath}!/META-INF/MANIFEST.MF").toURL
 
   // ZipArchive.fromManifestURL(URL)
   @Test def `manifest resources just works`(): Unit = {

--- a/test/junit/scala/tools/nsc/classpath/ZipAndJarFileLookupFactoryTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/ZipAndJarFileLookupFactoryTest.scala
@@ -81,7 +81,7 @@ class ZipAndJarFileLookupFactoryTest {
         ()
       }
     }
-    def manifestAt(location: Path): URL = URI.create(s"jar:file:$location!/META-INF/MANIFEST.MF").toURL
+    def manifestAt(location: Path): URL = URI.create(s"jar:file:${location.toUri.getPath}!/META-INF/MANIFEST.MF").toURL
 
     val j = createTestJar();
     Using.resources(ForDeletion(j), new ManifestResources(manifestAt(j.toAbsolutePath)), new CloseableRegistry) { (_, archive, closeableRegistry) =>


### PR DESCRIPTION
Follow-up fix for windows.