### PR TITLE
Fix interaction between string switching and async

### DIFF
--- a/test/async/run/string-switch-async.scala
+++ b/test/async/run/string-switch-async.scala
@@ -1,0 +1,19 @@
+// scalac: -Xasync
+
+import scala.tools.partest.async.OptionAwait._
+import org.junit.Assert._
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    assertEquals(Some(""), testSwitch(""))
+    assertEquals(Some("aa"), testSwitch("a"))
+  }
+
+  private def testSwitch(s: String) = optionally {
+    s match {
+      case "" => ""
+      case p =>
+        value(Some(p)) + p
+    }
+  }
+}


### PR DESCRIPTION
```
def testSwitch(s: String) = optionally {
  s match {
    case "" => ""
    case p =>
      value(Some(p))
      p
  }
}
```

Pattern translation introduces a local for the scrutinee (`x1`) and replaces uses of `p` in the default case by `x1`. After patmat:

```
case <synthetic> val x1: String = s;
x1 match {
  case "" => ""
  case _ => {
    scala.tools.partest.async.OptionAwait.value[String](new Some[String](x1));
    x1
  }
}
```

The `x1` variable is accessed in different async stages, and therefore transformed into a state machine field. After async:

```
(stateMachine$async.this.x1: String) match {
case "" => ...
  ...
case _ => ...
}
```

This breaks the translation of string switches in `CleanUp`, which assumes the scrutinee AST is a `Literal` or an `Ident`. The fix is to introduce another local variable if needed.

Fixes https://github.com/scala/bug/issues/12686