### PR TITLE
Find more doc vars and distinguish C from CC [ci: last-only]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -206,6 +206,7 @@ lazy val commonSettings = instanceSettings ++ clearSourceAndResourceDirectories 
     "-Wconf:cat=optimizer:is",
     // we use @nowarn for methods that are deprecated in JDK > 8, but CI/release is under JDK 8
     "-Wconf:cat=unused-nowarn:s",
+    "-Wconf:cat=deprecation&msg=in class Thread :s",
     "-Wunnamed-boolean-literal-strict",
     ),
   Compile / doc / scalacOptions ++= Seq(
@@ -502,9 +503,12 @@ lazy val reflect = configureAsSubproject(project)
     Osgi.bundleName := "Scala Reflect",
     Compile / scalacOptions ++= Seq(
       "-Wconf:cat=deprecation&msg=early initializers:s", // compiler heavily relies upon early initializers
+      "-Xlint",
+      "-feature",
     ),
     Compile / doc / scalacOptions ++= Seq(
-      "-skip-packages", "scala.reflect.macros.internal:scala.reflect.internal:scala.reflect.io"
+      "-skip-packages", "scala.reflect.macros.internal:scala.reflect.internal:scala.reflect.io",
+      "-Xlint:-doc-detached,_",
     ),
     Osgi.headers +=
       "Import-Package" -> (raw"""scala.*;version="$${range;[==,=+);$${ver}}",""" +
@@ -650,6 +654,8 @@ lazy val scaladoc = configureAsSubproject(project)
     libraryDependencies ++= ScaladocSettings.webjarResources,
     Compile / resourceGenerators += ScaladocSettings.extractResourcesFromWebjar,
     Compile / scalacOptions ++= Seq(
+      "-Xlint:-doc-detached,_",
+      "-feature",
       "-Wconf:cat=deprecation&msg=early initializers:s",
     ),
   )

--- a/src/library/scala/collection/Factory.scala
+++ b/src/library/scala/collection/Factory.scala
@@ -90,7 +90,7 @@ trait IterableFactory[+CC[_]] extends Serializable {
     */
   def from[A](source: IterableOnce[A]): CC[A]
 
-  /** An empty collection
+  /** An empty $coll
     * @tparam A      the type of the ${coll}'s elements
     */
   def empty[A]: CC[A]

--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -127,7 +127,7 @@ trait Iterable[+A] extends IterableOnce[A]
   * @define willNotTerminateInf
   *
   *    Note: will not terminate for infinite-sized collections.
-  *  @define undefinedorder
+  * @define undefinedorder
   *  The order in which operations are performed on elements is unspecified
   *  and may be nondeterministic.
   */
@@ -140,9 +140,9 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
   def toIterable: Iterable[A]
 
   /** Converts this $coll to an unspecified Iterable.  Will return
-    *  the same collection if this instance is already Iterable.
-    *  @return An Iterable containing all elements of this $coll.
-    */
+   *  the same collection if this instance is already Iterable.
+   *  @return An Iterable containing all elements of this $coll.
+   */
   @deprecated("toTraversable is internal and will be made protected; its name is similar to `toList` or `toSeq`, but it doesn't copy non-immutable collections", "2.13.0")
   final def toTraversable: Traversable[A] = toIterable
 
@@ -208,24 +208,24 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
     */
   protected def newSpecificBuilder: Builder[A @uncheckedVariance, C]
 
-  /** The empty iterable of the same type as this iterable.
+  /** The empty $coll.
     *
-    * @return an empty iterable of type `C`.
+    * @return an empty iterable of type $Coll.
     */
   def empty: C = fromSpecific(Nil)
 
   /** Selects the first element of this $coll.
-    *  $orderDependent
-    *  @return  the first element of this $coll.
-    *  @throws NoSuchElementException if the $coll is empty.
-    */
+   *  $orderDependent
+   *  @return  the first element of this $coll.
+   *  @throws NoSuchElementException if the $coll is empty.
+   */
   def head: A = iterator.next()
 
   /** Optionally selects the first element.
-    *  $orderDependent
-    *  @return  the first element of this $coll if it is nonempty,
-    *           `None` if it is empty.
-    */
+   *  $orderDependent
+   *  @return  the first element of this $coll if it is nonempty,
+   *           `None` if it is empty.
+   */
   def headOption: Option[A] = {
     val it = iterator
     if (it.hasNext) Some(it.next()) else None
@@ -244,32 +244,32 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
   }
 
   /** Optionally selects the last element.
-    *  $orderDependent
-    *  @return  the last element of this $coll$ if it is nonempty,
-    *           `None` if it is empty.
-    */
+   *  $orderDependent
+   *  @return  the last element of this $coll if it is nonempty,
+   *           `None` if it is empty.
+   */
   def lastOption: Option[A] = if (isEmpty) None else Some(last)
 
   /** A view over the elements of this collection. */
   def view: View[A] = View.fromIteratorProvider(() => iterator)
 
   /** Compares the size of this $coll to a test value.
-    *
-    *   @param   otherSize the test value that gets compared with the size.
-    *   @return  A value `x` where
-    *   {{{
-    *        x <  0       if this.size <  otherSize
-    *        x == 0       if this.size == otherSize
-    *        x >  0       if this.size >  otherSize
-    *   }}}
-    *
-    *  The method as implemented here does not call `size` directly; its running time
-    *  is `O(size min otherSize)` instead of `O(size)`. The method should be overridden
-    *  if computing `size` is cheap and `knownSize` returns `-1`.
-    *
-    *  @see [[sizeIs]]
-    */
-  def sizeCompare(otherSize: Int): Int = {
+   *
+   *  @param   otherSize the test value that gets compared with the size.
+   *  @return  A value `x` where
+   *  {{{
+   *       x <  0       if this.size <  otherSize
+   *       x == 0       if this.size == otherSize
+   *       x >  0       if this.size >  otherSize
+   *  }}}
+   *
+   *  The method as implemented here does not call `size` directly; its running time
+   *  is `O(size min otherSize)` instead of `O(size)`. The method should be overridden
+   *  if computing `size` is cheap and `knownSize` returns `-1`.
+   *
+   *  @see [[sizeIs]]
+   */
+  def sizeCompare(otherSize: Int): Int =
     if (otherSize < 0) 1
     else {
       val known = knownSize
@@ -285,7 +285,6 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
         i - otherSize
       }
     }
-  }
 
   /** Returns a value class containing operations for comparing the size of this $coll to a test value.
     *
@@ -304,19 +303,19 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
   @inline final def sizeIs: IterableOps.SizeCompareOps = new IterableOps.SizeCompareOps(this)
 
   /** Compares the size of this $coll to the size of another `Iterable`.
-    *
-    *   @param   that the `Iterable` whose size is compared with this $coll's size.
-    *   @return  A value `x` where
-    *   {{{
-    *        x <  0       if this.size <  that.size
-    *        x == 0       if this.size == that.size
-    *        x >  0       if this.size >  that.size
-    *   }}}
-    *
-    *  The method as implemented here does not call `size` directly; its running time
-    *  is `O(this.size min that.size)` instead of `O(this.size + that.size)`.
-    *  The method should be overridden if computing `size` is cheap and `knownSize` returns `-1`.
-    */
+   *
+   *  @param   that the `Iterable` whose size is compared with this $coll's size.
+   *  @return  A value `x` where
+   *  {{{
+   *       x <  0       if this.size <  that.size
+   *       x == 0       if this.size == that.size
+   *       x >  0       if this.size >  that.size
+   *  }}}
+   *
+   *  The method as implemented here does not call `size` directly; its running time
+   *  is `O(this.size min that.size)` instead of `O(this.size + that.size)`.
+   *  The method should be overridden if computing `size` is cheap and `knownSize` returns `-1`.
+   */
   def sizeCompare(that: Iterable[_]): Int = {
     val thatKnownSize = that.knownSize
 
@@ -345,39 +344,39 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
   def view(from: Int, until: Int): View[A] = view.slice(from, until)
 
   /** Transposes this $coll of iterable collections into
-    *  a $coll of ${coll}s.
-    *
-    *    The resulting collection's type will be guided by the
-    *    static type of $coll. For example:
-    *
-    *    {{{
-    *    val xs = List(
-    *               Set(1, 2, 3),
-    *               Set(4, 5, 6)).transpose
-    *    // xs == List(
-    *    //         List(1, 4),
-    *    //         List(2, 5),
-    *    //         List(3, 6))
-    *
-    *    val ys = Vector(
-    *               List(1, 2, 3),
-    *               List(4, 5, 6)).transpose
-    *    // ys == Vector(
-    *    //         Vector(1, 4),
-    *    //         Vector(2, 5),
-    *    //         Vector(3, 6))
-    *    }}}
-    *
-    *  $willForceEvaluation
-    *
-    *  @tparam B the type of the elements of each iterable collection.
-    *  @param  asIterable an implicit conversion which asserts that the
-    *          element type of this $coll is an `Iterable`.
-    *  @return a two-dimensional $coll of ${coll}s which has as ''n''th row
-    *          the ''n''th column of this $coll.
-    *  @throws IllegalArgumentException if all collections in this $coll
-    *          are not of the same size.
-    */
+   *  a $coll of ${coll}s.
+   *
+   *  The resulting collection's type will be guided by the
+   *  static type of $coll. For example:
+   *
+   *  {{{
+   *  val xs = List(
+   *             Set(1, 2, 3),
+   *             Set(4, 5, 6)).transpose
+   *  // xs == List(
+   *  //         List(1, 4),
+   *  //         List(2, 5),
+   *  //         List(3, 6))
+   *
+   *  val ys = Vector(
+   *             List(1, 2, 3),
+   *             List(4, 5, 6)).transpose
+   *  // ys == Vector(
+   *  //         Vector(1, 4),
+   *  //         Vector(2, 5),
+   *  //         Vector(3, 6))
+   *  }}}
+   *
+   *  $willForceEvaluation
+   *
+   *  @tparam B the type of the elements of each iterable collection.
+   *  @param  asIterable an implicit conversion which asserts that the
+   *          element type of this $coll is an `Iterable`.
+   *  @return a two-dimensional $coll of ${coll}s which has as ''n''th row
+   *          the ''n''th column of this $coll.
+   *  @throws IllegalArgumentException if all collections in this $coll
+   *          are not of the same size.
+   */
   def transpose[B](implicit asIterable: A => /*<:<!!!*/ Iterable[B]): CC[CC[B] @uncheckedVariance] = {
     if (isEmpty)
       return iterableFactory.empty[CC[B]]
@@ -718,31 +717,31 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
   }
 
   /** Returns a new $ccoll containing the elements from the left hand operand followed by the elements from the
-    *  right hand operand. The element type of the $ccoll is the most specific superclass encompassing
-    *  the element types of the two operands.
-    *
-    *  @param suffix   the iterable to append.
-    *  @tparam B     the element type of the returned collection.
-    *  @return       a new $coll which contains all elements
-    *                of this $coll followed by all elements of `suffix`.
-    */
+   *  right hand operand. The element type of the $ccoll is the most specific superclass encompassing
+   *  the element types of the two operands.
+   *
+   *  @param suffix   the iterable to append.
+   *  @tparam B     the element type of the returned collection.
+   *  @return       a new $coll which contains all elements
+   *                of this $coll followed by all elements of `suffix`.
+   */
   def concat[B >: A](suffix: IterableOnce[B]): CC[B] = iterableFactory.from(suffix match {
     case xs: Iterable[B] => new View.Concat(this, xs)
     case xs => iterator ++ suffix.iterator
   })
 
   /** Alias for `concat` */
-  @`inline` final def ++ [B >: A](suffix: IterableOnce[B]): CC[B] = concat(suffix)
+  @inline final def ++ [B >: A](suffix: IterableOnce[B]): CC[B] = concat(suffix)
 
-  /** Returns a $coll formed from this $coll and another iterable collection
-    *  by combining corresponding elements in pairs.
-    *  If one of the two collections is longer than the other, its remaining elements are ignored.
-    *
-    *  @param   that  The iterable providing the second half of each result pair
-    *  @tparam  B     the type of the second half of the returned pairs
-    *  @return        a new $coll containing pairs consisting of corresponding elements of this $coll and `that`.
-    *                 The length of the returned collection is the minimum of the lengths of this $coll and `that`.
-    */
+  /** Returns a $ccoll formed from this $coll and another iterable collection
+   *  by combining corresponding elements in pairs.
+   *  If one of the two collections is longer than the other, its remaining elements are ignored.
+   *
+   *  @param   that  The iterable providing the second half of each result pair
+   *  @tparam  B     the type of the second half of the returned pairs
+   *  @return        a new $ccoll containing pairs consisting of corresponding elements of this $coll and `that`.
+   *                 The length of the returned collection is the minimum of the lengths of this $coll and `that`.
+   */
   def zip[B](that: IterableOnce[B]): CC[(A @uncheckedVariance, B)] = iterableFactory.from(that match { // sound bcs of VarianceNote
     case that: Iterable[B] => new View.Zip(this, that)
     case _ => iterator.zip(that)

--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -717,8 +717,8 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
     (iterableFactory.from(left), iterableFactory.from(right))
   }
 
-  /** Returns a new $coll containing the elements from the left hand operand followed by the elements from the
-    *  right hand operand. The element type of the $coll is the most specific superclass encompassing
+  /** Returns a new $ccoll containing the elements from the left hand operand followed by the elements from the
+    *  right hand operand. The element type of the $ccoll is the most specific superclass encompassing
     *  the element types of the two operands.
     *
     *  @param suffix   the iterable to append.
@@ -862,7 +862,7 @@ object IterableOps {
   /** Operations for comparing the size of a collection to a test value.
     *
     * These operations are implemented in terms of
-    * [[scala.collection.IterableOps.sizeCompare(Int) `sizeCompare(Int)`]].
+    * [[scala.collection.IterableOps!.sizeCompare(Int):Int* `sizeCompare(Int)`]]
     */
   final class SizeCompareOps private[collection](val it: IterableOps[_, AnyConstr, _]) extends AnyVal {
     /** Tests if the size of the collection is less than some value. */

--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -453,36 +453,35 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
    *    For example:
    *
    *    {{{
-   *      def getWords(lines: Seq[String]): Seq[String] = lines flatMap (line => line split "\\W+")
+   *      def getWords(lines: Seq[String]): Seq[String] = lines.flatMap(line => line.split("\\W+"))
    *    }}}
    *
-   *    The type of the resulting collection is guided by the static type of $coll. This might
+   *    The type of the resulting collection is guided by the static type of this $coll. This might
    *    cause unexpected results sometimes. For example:
    *
    *    {{{
    *      // lettersOf will return a Seq[Char] of likely repeated letters, instead of a Set
-   *      def lettersOf(words: Seq[String]) = words flatMap (word => word.toSet)
+   *      def lettersOf(words: Seq[String]) = words.flatMap(word => word.toSet)
    *
    *      // lettersOf will return a Set[Char], not a Seq
-   *      def lettersOf(words: Seq[String]) = words.toSet flatMap ((word: String) => word.toSeq)
+   *      def lettersOf(words: Seq[String]) = words.toSet.flatMap(word => word.toSeq)
    *
    *      // xs will be an Iterable[Int]
-   *      val xs = Map("a" -> List(11,111), "b" -> List(22,222)).flatMap(_._2)
+   *      val xs = Map("a" -> List(11, 111), "b" -> List(22, 222)).flatMap(_._2)
    *
    *      // ys will be a Map[Int, Int]
-   *      val ys = Map("a" -> List(1 -> 11,1 -> 111), "b" -> List(2 -> 22,2 -> 222)).flatMap(_._2)
+   *      val ys = Map("a" -> List(1 -> 11, 1 -> 111), "b" -> List(2 -> 22, 2 -> 222)).flatMap(_._2)
    *    }}}
    *
    *  @param f      the function to apply to each element.
    *  @tparam B     the element type of the returned collection.
-   *  @return       a new $coll resulting from applying the given collection-valued function
+   *  @return       a new $ccoll resulting from applying the given collection-valued function
    *                `f` to each element of this $coll and concatenating the results.
    */
   def flatMap[B](f: A => IterableOnce[B]): CC[B]
 
-  /** Converts this $coll of iterable collections into
-   *  a $coll formed by the elements of these iterable
-   *  collections.
+  /** Given that the elements of this collection are themselves iterable collections,
+   *  converts this $coll into a $ccoll comprising the elements of these iterable collections.
    *
    *    The resulting collection's type will be guided by the
    *    type of $coll. For example:
@@ -504,16 +503,16 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
    *  @tparam B the type of the elements of each iterable collection.
    *  @param asIterable an implicit conversion which asserts that the element
    *          type of this $coll is an `Iterable`.
-   *  @return a new $coll resulting from concatenating all element ${coll}s.
+   *  @return a new $ccoll resulting from concatenating all element collections.
    */
   def flatten[B](implicit asIterable: A => IterableOnce[B]): CC[B]
 
-  /** Builds a new $coll by applying a partial function to all elements of this $coll
+  /** Builds a new $ccoll by applying a partial function to all elements of this $coll
    *  on which the function is defined.
    *
    *  @param pf     the partial function which filters and maps the $coll.
    *  @tparam B     the element type of the returned $coll.
-   *  @return       a new $coll resulting from applying the given partial function
+   *  @return       a new $ccoll resulting from applying the given partial function
    *                `pf` to each element on which it is defined and collecting the results.
    *                The order of the elements is preserved.
    */
@@ -521,7 +520,7 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
 
   /** Zips this $coll with its indices.
    *
-   *  @return        A new $coll containing pairs consisting of all elements of this $coll paired with their index.
+   *  @return        A new $ccoll containing pairs consisting of all elements of this $coll paired with their index.
    *                 Indices start at `0`.
    *  @example
    *    `List("a", "b", "c").zipWithIndex == List(("a", 0), ("b", 1), ("c", 2))`
@@ -532,7 +531,7 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
    *
    *  Note: `c span p`  is equivalent to (but possibly more efficient than)
    *  `(c takeWhile p, c dropWhile p)`, provided the evaluation of the
-   *  predicate `p` does not cause any side-effects.
+   *  predicate `p` does not cause any side effects.
    *  $orderDependent
    *
    *  @param p the test predicate

--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -40,6 +40,7 @@ import scala.runtime.{AbstractFunction1, AbstractFunction2}
   * without inheriting unwanted implementations.
   *
   * @define coll collection
+  * @define ccoll $coll
   */
 trait IterableOnce[+A] extends Any {
 
@@ -318,8 +319,6 @@ object IterableOnce {
   *              The order of applications of the operator is unspecified and may be nondeterministic.
   * @define exactlyOnce
   *              Each element appears exactly once in the computation.
-  * @define coll collection
-  *
   */
 trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
   /////////////////////////////////////////////////////////////// Abstract methods that must be implemented
@@ -439,16 +438,16 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
    */
   def slice(from: Int, until: Int): C
 
-  /** Builds a new $coll by applying a function to all elements of this $coll.
+  /** Builds a new $ccoll by applying a function to all elements of this $coll.
    *
    *  @param f      the function to apply to each element.
-   *  @tparam B     the element type of the returned $coll.
-   *  @return       a new $coll resulting from applying the given function
+   *  @tparam B     the element type of the returned $ccoll.
+   *  @return       a new $ccoll resulting from applying the given function
    *                `f` to each element of this $coll and collecting the results.
    */
   def map[B](f: A => B): CC[B]
 
-  /** Builds a new $coll by applying a function to all elements of this $coll
+  /** Builds a new $ccoll by applying a function to all elements of this $coll
    *  and using the elements of the resulting collections.
    *
    *    For example:

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -844,17 +844,14 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
    *  @param that  the collection to compare
    *  @tparam B    the type of the elements of collection `that`.
    *  @return `true` if both collections contain equal elements in the same order, `false` otherwise.
-   *
-   *    @inheritdoc
    */
   def sameElements[B >: A](that: IterableOnce[B]): Boolean = {
     val those = that.iterator
-    while (hasNext && those.hasNext)
-      if (next() != those.next())
-        return false
-    // At that point we know that *at least one* iterator has no next element
-    // If *both* of them have no elements then the collections are the same
-    hasNext == those.hasNext
+    while (hasNext) {
+      if (!those.hasNext) return false
+      if (next() != those.next()) return false
+    }
+    !those.hasNext
   }
 
   /** Creates two new iterators that both iterate over the same elements

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -843,16 +843,23 @@ trait SeqOps[+A, +CC[_], +C] extends Any
 
   override def isEmpty: Boolean = lengthCompare(0) == 0
 
-  /** Tests whether the elements of this collection are the same (and in the same order)
-    * as those of `that`.
-    */
+  /** Checks whether corresponding elements of the given iterable collection
+   *  compare equal (with respect to `==`) to elements of this $coll.
+   *
+   *  @param that  the collection to compare
+   *  @tparam B    the type of the elements of collection `that`.
+   *  @return `true` if both collections contain equal elements in the same order, `false` otherwise.
+   */
   def sameElements[B >: A](that: IterableOnce[B]): Boolean = {
     val thisKnownSize = knownSize
-    val knownSizeDifference = thisKnownSize != -1 && {
+    if (thisKnownSize != -1) {
       val thatKnownSize = that.knownSize
-      thatKnownSize != -1 && thisKnownSize != thatKnownSize
+      if (thatKnownSize != -1) {
+        if (thisKnownSize != thatKnownSize) return false
+        if (thisKnownSize == 0) return true
+      }
     }
-    !knownSizeDifference && iterator.sameElements(that)
+    iterator.sameElements(that)
   }
 
   /** Tests whether every element of this $coll relates to the

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -180,11 +180,11 @@ trait SeqOps[+A, +CC[_], +C] extends Any
   def appendedAll[B >: A](suffix: IterableOnce[B]): CC[B] = super.concat(suffix)
 
   /** Alias for `appendedAll`. */
-  @`inline` final def :++ [B >: A](suffix: IterableOnce[B]): CC[B] = appendedAll(suffix)
+  @inline final def :++ [B >: A](suffix: IterableOnce[B]): CC[B] = appendedAll(suffix)
 
   // Make `concat` an alias for `appendedAll` so that it benefits from performance
   // overrides of this method
-  @`inline` final override def concat[B >: A](suffix: IterableOnce[B]): CC[B] = appendedAll(suffix)
+  @inline final override def concat[B >: A](suffix: IterableOnce[B]): CC[B] = appendedAll(suffix)
 
  /** Produces a new sequence which contains all elements of this $coll and also all elements of
    *  a given sequence. `xs union ys`  is equivalent to `xs ++ ys`.
@@ -286,7 +286,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
    *  @param   len   the target length
    *  @param   elem  the padding value
    *  @tparam B      the element type of the returned $coll.
-   *  @return a new $coll consisting of
+   *  @return a new $ccoll consisting of
    *          all elements of this $coll followed by the minimal number of occurrences of `elem` so
    *          that the resulting collection has a length of at least `len`.
    */

--- a/src/library/scala/collection/Set.scala
+++ b/src/library/scala/collection/Set.scala
@@ -210,9 +210,7 @@ trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
   @deprecated("Use &- with an explicit collection argument instead of - with varargs", "2.13.0")
   def - (elem1: A, elem2: A, elems: A*): C = diff(elems.toSet + elem1 + elem2)
 
-  /** Creates a new $coll by adding all elements contained in another collection to this $coll, omitting duplicates.
-    *
-    * This method takes a collection of elements and adds all elements, omitting duplicates, into $coll.
+  /** Creates a new $ccoll by adding all elements contained in another collection to this $coll, omitting duplicates.
     *
     * Example:
     *  {{{

--- a/src/library/scala/collection/SortedSet.scala
+++ b/src/library/scala/collection/SortedSet.scala
@@ -57,6 +57,7 @@ trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
     */
   def sortedIterableFactory: SortedIterableFactory[CC]
 
+  /** Widens the type of this set to its unsorted counterpart. */
   def unsorted: Set[A]
 
   /**

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -21,60 +21,60 @@ import scala.collection.generic.{CommonErrors, DefaultSerializable}
 import scala.runtime.Statics.releaseFence
 
 /** A class for immutable linked lists representing ordered collections
-  *  of elements of type `A`.
-  *
-  *  This class comes with two implementing case classes `scala.Nil`
-  *  and `scala.::` that implement the abstract members `isEmpty`,
-  *  `head` and `tail`.
-  *
-  *  This class is optimal for last-in-first-out (LIFO), stack-like access patterns. If you need another access
-  *  pattern, for example, random access or FIFO, consider using a collection more suited to this than `List`.
-  *
-  *  ==Performance==
-  *  '''Time:''' `List` has `O(1)` prepend and head/tail access. Most other operations are `O(n)` on the number of elements in the list.
-  *  This includes the index-based lookup of elements, `length`, `append` and `reverse`.
-  *
-  *  '''Space:''' `List` implements '''structural sharing''' of the tail list. This means that many operations are either
-  *  zero- or constant-memory cost.
-  *  {{{
-  *  val mainList = List(3, 2, 1)
-  *  val with4 =    4 :: mainList  // re-uses mainList, costs one :: instance
-  *  val with42 =   42 :: mainList // also re-uses mainList, cost one :: instance
-  *  val shorter =  mainList.tail  // costs nothing as it uses the same 2::1::Nil instances as mainList
-  *  }}}
-  *
-  *  @example {{{
-  *  // Make a list via the companion object factory
-  *  val days = List("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday")
-  *
-  *  // Make a list element-by-element
-  *  val when = "AM" :: "PM" :: Nil
-  *
-  *  // Pattern match
-  *  days match {
-  *    case firstDay :: otherDays =>
-  *      println("The first day of the week is: " + firstDay)
-  *    case Nil =>
-  *      println("There don't seem to be any week days.")
-  *  }
-  *  }}}
-  *
-  *  @note The functional list is characterized by persistence and structural sharing, thus offering considerable
-  *        performance and space consumption benefits in some scenarios if used correctly.
-  *        However, note that objects having multiple references into the same functional list (that is,
-  *        objects that rely on structural sharing), will be serialized and deserialized with multiple lists, one for
-  *        each reference to it. I.e. structural sharing is lost after serialization/deserialization.
-  *
-  *  @see  [[https://docs.scala-lang.org/overviews/collections-2.13/concrete-immutable-collection-classes.html#lists "Scala's Collection Library overview"]]
-  *  section on `Lists` for more information.
-  *
-  *  @define coll list
-  *  @define Coll `List`
-  *  @define orderDependent
-  *  @define orderDependentFold
-  *  @define mayNotTerminateInf
-  *  @define willNotTerminateInf
-  */
+ *  of elements of type `A`.
+ *
+ *  This class comes with two implementing case classes `scala.Nil`
+ *  and `scala.::` that implement the abstract members `isEmpty`,
+ *  `head` and `tail`.
+ *
+ *  This class is optimal for last-in-first-out (LIFO), stack-like access patterns. If you need another access
+ *  pattern, for example, random access or FIFO, consider using a collection more suited to this than `List`.
+ *
+ *  ==Performance==
+ *  '''Time:''' `List` has `O(1)` prepend and head/tail access. Most other operations are `O(n)` on the number of elements in the list.
+ *  This includes the index-based lookup of elements, `length`, `append` and `reverse`.
+ *
+ *  '''Space:''' `List` implements '''structural sharing''' of the tail list. This means that many operations are either
+ *  zero- or constant-memory cost.
+ *  {{{
+ *  val mainList = List(3, 2, 1)
+ *  val with4 =    4 :: mainList  // re-uses mainList, costs one :: instance
+ *  val with42 =   42 :: mainList // also re-uses mainList, cost one :: instance
+ *  val shorter =  mainList.tail  // costs nothing as it uses the same 2::1::Nil instances as mainList
+ *  }}}
+ *
+ *  @example {{{
+ *  // Make a list via the companion object factory
+ *  val days = List("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday")
+ *
+ *  // Make a list element-by-element
+ *  val when = "AM" :: "PM" :: Nil
+ *
+ *  // Pattern match
+ *  days match {
+ *    case firstDay :: otherDays =>
+ *      println("The first day of the week is: " + firstDay)
+ *    case Nil =>
+ *      println("There don't seem to be any week days.")
+ *  }
+ *  }}}
+ *
+ *  @note The functional list is characterized by persistence and structural sharing, thus offering considerable
+ *        performance and space consumption benefits in some scenarios if used correctly.
+ *        However, note that objects having multiple references into the same functional list (that is,
+ *        objects that rely on structural sharing), will be serialized and deserialized with multiple lists, one for
+ *        each reference to it. I.e. structural sharing is lost after serialization/deserialization.
+ *
+ *  @see  [[https://docs.scala-lang.org/overviews/collections-2.13/concrete-immutable-collection-classes.html#lists "Scala's Collection Library overview"]]
+ *  section on `Lists` for more information.
+ *
+ *  @define coll list
+ *  @define Coll `List`
+ *  @define orderDependent
+ *  @define orderDependentFold
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
 @SerialVersionUID(3L)
 sealed abstract class List[+A]
   extends AbstractSeq[A]

--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -20,42 +20,43 @@ import scala.collection.{AbstractIterator, AnyStepper, IterableFactoryDefaults, 
 import scala.util.hashing.MurmurHash3
 
 /** The `Range` class represents integer values in range
-  *  ''[start;end)'' with non-zero step value `step`.
-  *  It's a special case of an indexed sequence.
-  *  For example:
-  *
-  *  {{{
-  *     val r1 = 0 until 10
-  *     val r2 = r1.start until r1.end by r1.step + 1
-  *     println(r2.length) // = 5
-  *  }}}
-  *
-  *  Ranges that contain more than `Int.MaxValue` elements can be created, but
-  *  these overfull ranges have only limited capabilities. Any method that
-  *  could require a collection of over `Int.MaxValue` length to be created, or
-  *  could be asked to index beyond `Int.MaxValue` elements will throw an
-  *  exception. Overfull ranges can safely be reduced in size by changing
-  *  the step size (e.g. `by 3`) or taking/dropping elements. `contains`,
-  *  `equals`, and access to the ends of the range (`head`, `last`, `tail`,
-  *  `init`) are also permitted on overfull ranges.
-  *
-  *  @param start       the start of this range.
-  *  @param end         the end of the range.  For exclusive ranges, e.g.
-  *                     `Range(0,3)` or `(0 until 3)`, this is one
-  *                     step past the last one in the range.  For inclusive
-  *                     ranges, e.g. `Range.inclusive(0,3)` or `(0 to 3)`,
-  *                     it may be in the range if it is not skipped by the step size.
-  *                     To find the last element inside a non-empty range,
-  *                     use `last` instead.
-  *  @param step        the step for the range.
-  *
-  *  @define coll range
-  *  @define mayNotTerminateInf
-  *  @define willNotTerminateInf
-  *  @define doesNotUseBuilders
-  *    '''Note:''' this method does not use builders to construct a new range,
-  *         and its complexity is O(1).
-  */
+ *  ''[start;end)'' with non-zero step value `step`.
+ *  It's a special case of an indexed sequence.
+ *  For example:
+ *
+ *  {{{
+ *     val r1 = 0 until 10
+ *     val r2 = r1.start until r1.end by r1.step + 1
+ *     println(r2.length) // = 5
+ *  }}}
+ *
+ *  Ranges that contain more than `Int.MaxValue` elements can be created, but
+ *  these overfull ranges have only limited capabilities. Any method that
+ *  could require a collection of over `Int.MaxValue` length to be created, or
+ *  could be asked to index beyond `Int.MaxValue` elements will throw an
+ *  exception. Overfull ranges can safely be reduced in size by changing
+ *  the step size (e.g. `by 3`) or taking/dropping elements. `contains`,
+ *  `equals`, and access to the ends of the range (`head`, `last`, `tail`,
+ *  `init`) are also permitted on overfull ranges.
+ *
+ *  @param start       the start of this range.
+ *  @param end         the end of the range.  For exclusive ranges, e.g.
+ *                     `Range(0,3)` or `(0 until 3)`, this is one
+ *                     step past the last one in the range.  For inclusive
+ *                     ranges, e.g. `Range.inclusive(0,3)` or `(0 to 3)`,
+ *                     it may be in the range if it is not skipped by the step size.
+ *                     To find the last element inside a non-empty range,
+ *                     use `last` instead.
+ *  @param step        the step for the range.
+ *
+ *  @define coll range
+ *  @define ccoll indexed sequence
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ *  @define doesNotUseBuilders
+ *    '''Note:''' this method does not use builders to construct a new range,
+ *         and its complexity is O(1).
+ */
 @SerialVersionUID(3L)
 sealed abstract class Range(
   val start: Int,
@@ -522,11 +523,7 @@ sealed abstract class Range(
     }
 }
 
-/**
-  * Companion object for ranges.
-  *  @define Coll `Range`
-  *  @define coll range
-  */
+/** Companion object for ranges. */
 object Range {
 
   /** Counts the number of range elements.

--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -19,12 +19,12 @@ import scala.annotation.tailrec
 import scala.runtime.Statics.releaseFence
 
 /** An object containing the RedBlack tree implementation used by for `TreeMaps` and `TreeSets`.
-  *
-  *  Implementation note: since efficiency is important for data structures this implementation
-  *  uses `null` to represent empty trees. This also means pattern matching cannot
-  *  easily be used. The API represented by the RedBlackTree object tries to hide these
-  *  optimizations behind a reasonably clean API.
-  */
+ *
+ *  Implementation note: since efficiency is important for data structures this implementation
+ *  uses `null` to represent empty trees. This also means pattern matching cannot
+ *  easily be used. The API represented by the RedBlackTree object tries to hide these
+ *  optimizations behind a reasonably clean API.
+ */
 private[collection] object RedBlackTree {
   def validate[A](tree: Tree[A, _])(implicit ordering: Ordering[A]): tree.type = {
     def impl(tree: Tree[A, _], keyProp: A => Boolean): Int = {

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -21,23 +21,22 @@ import scala.collection.generic.{CommonErrors, DefaultSerializable}
 import scala.runtime.PStatics.VM_MaxArraySize
 
 /** An implementation of the `Buffer` class using an array to
-  *  represent the assembled sequence internally. Append, update and random
-  *  access take constant time (amortized time). Prepends and removes are
-  *  linear in the buffer size.
-  *
-  *  @see [[https://docs.scala-lang.org/overviews/collections-2.13/concrete-mutable-collection-classes.html#array-buffers "Scala's Collection Library overview"]]
-  *  section on `Array Buffers` for more information.
-
-  *
-  *  @tparam A    the type of this arraybuffer's elements.
-  *
-  *  @define Coll `mutable.ArrayBuffer`
-  *  @define coll array buffer
-  *  @define orderDependent
-  *  @define orderDependentFold
-  *  @define mayNotTerminateInf
-  *  @define willNotTerminateInf
-  */
+ *  represent the assembled sequence internally. Append, update and random
+ *  access take constant time (amortized time). Prepends and removes are
+ *  linear in the buffer size.
+ *
+ *  @see [[https://docs.scala-lang.org/overviews/collections-2.13/concrete-mutable-collection-classes.html#array-buffers "Scala's Collection Library overview"]]
+ *  section on `Array Buffers` for more information.
+ *
+ *  @tparam A    the type of this arraybuffer's elements.
+ *
+ *  @define Coll `mutable.ArrayBuffer`
+ *  @define coll array buffer
+ *  @define orderDependent
+ *  @define orderDependentFold
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
 @SerialVersionUID(-1582447879429021880L)
 class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
   extends AbstractBuffer[A]

--- a/src/library/scala/collection/mutable/Buffer.scala
+++ b/src/library/scala/collection/mutable/Buffer.scala
@@ -16,7 +16,11 @@ package mutable
 import scala.annotation.nowarn
 
 
-/** A `Buffer` is a growable and shrinkable `Seq`. */
+/** A `Buffer` is a growable and shrinkable `Seq`.
+ *
+ *  @define coll buffer
+ *  @define Coll `Buffer`
+ */
 trait Buffer[A]
   extends Seq[A]
     with SeqOps[A, Buffer, Buffer[A]]

--- a/src/library/scala/collection/mutable/Shrinkable.scala
+++ b/src/library/scala/collection/mutable/Shrinkable.scala
@@ -16,30 +16,30 @@ package collection.mutable
 import scala.annotation.tailrec
 
 /** This trait forms part of collections that can be reduced
-  *  using a `-=` operator.
-  *
-  *  @define coll shrinkable collection
-  *  @define Coll `Shrinkable`
-  */
+ *  using a `-=` operator.
+ *
+ *  @define coll shrinkable collection
+ *  @define Coll `Shrinkable`
+ */
 trait Shrinkable[-A] {
 
   /** Removes a single element from this $coll.
-    *
-    *  @param elem  the element to remove.
-    *  @return the $coll itself
-    */
+   *
+   *  @param elem  the element to remove.
+   *  @return the $coll itself
+   */
   def subtractOne(elem: A): this.type
 
   /** Alias for `subtractOne` */
   @`inline` final def -= (elem: A): this.type = subtractOne(elem)
 
   /** Removes two or more elements from this $coll.
-    *
-    *  @param elem1 the first element to remove.
-    *  @param elem2 the second element to remove.
-    *  @param elems the remaining elements to remove.
-    *  @return the $coll itself
-    */
+   *
+   *  @param elem1 the first element to remove.
+   *  @param elem2 the second element to remove.
+   *  @param elems the remaining elements to remove.
+   *  @return the $coll itself
+   */
   @deprecated("Use `--=` aka `subtractAll` instead of varargs `-=`; infix operations with an operand of multiple args will be deprecated", "2.13.3")
   def -= (elem1: A, elem2: A, elems: A*): this.type = {
     this -= elem1
@@ -48,10 +48,10 @@ trait Shrinkable[-A] {
   }
 
   /** Removes all elements produced by an iterator from this $coll.
-    *
-    *  @param xs   the iterator producing the elements to remove.
-    *  @return the $coll itself
-    */
+   *
+   *  @param xs   the iterator producing the elements to remove.
+   *  @return the $coll itself
+   */
   def subtractAll(xs: collection.IterableOnce[A]): this.type = {
     @tailrec def loop(xs: collection.LinearSeq[A]): Unit = {
       if (xs.nonEmpty) {

--- a/src/library/scala/collection/mutable/SortedSet.scala
+++ b/src/library/scala/collection/mutable/SortedSet.scala
@@ -39,9 +39,7 @@ trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
 }
 
 /**
-  * $factoryInfo
-  * @define xcoll mutable sorted set
-  * @define xColl `mutable.SortedSet`
-  */
+ *  $factoryInfo
+ */
 @SerialVersionUID(3L)
 object SortedSet extends SortedIterableFactory.Delegate[SortedSet](TreeSet)

--- a/src/library/scala/collection/mutable/SortedSet.scala
+++ b/src/library/scala/collection/mutable/SortedSet.scala
@@ -14,9 +14,8 @@ package scala
 package collection
 package mutable
 
-/**
-  * Base type for mutable sorted set collections
-  */
+/** Base type for mutable sorted set collections
+ */
 trait SortedSet[A]
   extends Set[A]
     with collection.SortedSet[A]
@@ -30,7 +29,7 @@ trait SortedSet[A]
 
 /**
   * @define coll mutable sorted set
-  * @define Coll `mutable.Sortedset`
+  * @define Coll `mutable.SortedSet`
   */
 trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
   extends SetOps[A, Set, C]
@@ -41,8 +40,8 @@ trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
 
 /**
   * $factoryInfo
-  * @define coll mutable sorted set
-  * @define Coll `mutable.Sortedset`
+  * @define xcoll mutable sorted set
+  * @define xColl `mutable.SortedSet`
   */
 @SerialVersionUID(3L)
 object SortedSet extends SortedIterableFactory.Delegate[SortedSet](TreeSet)

--- a/test/junit/scala/collection/SeqTest.scala
+++ b/test/junit/scala/collection/SeqTest.scala
@@ -1,9 +1,9 @@
 package scala.collection
 
-import org.junit.Assert._
+import org.junit.Assert.{assertThrows => _, _}
 import org.junit.Test
 
-import scala.tools.testkit.{AllocationTest, CompileTime}
+import scala.tools.testkit.{AllocationTest, AssertUtil, CompileTime}, AssertUtil.assertThrows
 
 class SeqTest extends AllocationTest {
 
@@ -113,5 +113,25 @@ class SeqTest extends AllocationTest {
       Seq("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"))
     exactAllocates(expected(20), "collection seq size 20")(
       Seq("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"))
+  }
+
+  /** A sequence of no consequence. */
+  class Inconsequential[+A](n: Int) extends AbstractSeq[A] {
+    def iterator: Iterator[A] = ???
+    def apply(i: Int): A = ???
+    def length: Int = knownSize
+    override def knownSize = n
+  }
+  object Inconsequential {
+    def apply(n: Int) = new Inconsequential(n)
+  }
+  type ??? = NotImplementedError
+
+  @Test def `sameElements by size`: Unit = {
+    assertFalse(Inconsequential(0).sameElements(Inconsequential(1)))
+    assertFalse(Inconsequential(1).sameElements(Inconsequential(2)))
+    assertTrue(Inconsequential(0).sameElements(Inconsequential(0)))
+    assertThrows[???](Inconsequential(1).sameElements(Inconsequential(1)))
+    assertThrows[???](Inconsequential(-1).sameElements(Inconsequential(-1)))
   }
 }


### PR DESCRIPTION
Look up doc vars in self-types to facilitate collection trait culture.

Introduce ccoll for natural language phrase for `CC`, alongside coll for `C` and Coll for the `CC` type.

Fixes scala/bug#12681
Fixes scala/bug#12908
