### PR TITLE
Under `-Xsource:3`, warn that inherited members no longer take precedence over outer definitions in Scala 3

### DIFF
--- a/spec/02-identifiers-names-and-scopes.md
+++ b/spec/02-identifiers-names-and-scopes.md
@@ -7,7 +7,7 @@ chapter: 2
 # Identifiers, Names and Scopes
 
 Names in Scala identify types, values, methods, and classes which are
-collectively called _entities_. Names are introduced by local
+collectively called _entities_. Names are introduced by
 [definitions and declarations](04-basic-declarations-and-definitions.html#basic-declarations-and-definitions),
 [inheritance](05-classes-and-objects.html#class-members),
 [import clauses](04-basic-declarations-and-definitions.html#import-clauses), or
@@ -17,14 +17,16 @@ which are collectively called _bindings_.
 Bindings of each kind are assigned a precedence which determines
 whether one binding can shadow another:
 
-1. Definitions and declarations that are local, inherited, or made
-   available by a package clause and also defined in the same compilation unit
-   as the reference to them, have the highest precedence.
+1. Definitions and declarations in lexical scope that are not [top-level](09-top-level-definitions.html)
+   have the highest precedence.
+1. Definitions and declarations that are either inherited,
+   or made available by a package clause and also defined in the same compilation unit as the reference to them,
+   have the next highest precedence.
 1. Explicit imports have the next highest precedence.
 1. Wildcard imports have the next highest precedence.
-1. Bindings made available by a package clause, but not also defined in the
-   same compilation unit as the reference to them, as well as bindings
-   supplied by the compiler but not explicitly written in source code,
+1. Bindings made available by a package clause,
+   but not also defined in the same compilation unit as the reference to them,
+   as well as bindings supplied by the compiler but not explicitly written in source code,
    have the lowest precedence.
 
 There are two different name spaces, one for [types](03-types.html#types)

--- a/src/compiler/scala/reflect/quasiquotes/Parsers.scala
+++ b/src/compiler/scala/reflect/quasiquotes/Parsers.scala
@@ -92,7 +92,7 @@ trait Parsers { self: Quasiquotes =>
               case _ => gen.mkBlock(stats, doFlatten = true)
             }
           case nme.unapply => gen.mkBlock(stats, doFlatten = false)
-          case other       => global.abort("unreachable")
+          case other       => this.global.abort("unreachable")
         }
 
         // tq"$a => $b"

--- a/src/compiler/scala/reflect/quasiquotes/Parsers.scala
+++ b/src/compiler/scala/reflect/quasiquotes/Parsers.scala
@@ -92,7 +92,7 @@ trait Parsers { self: Quasiquotes =>
               case _ => gen.mkBlock(stats, doFlatten = true)
             }
           case nme.unapply => gen.mkBlock(stats, doFlatten = false)
-          case other       => this.global.abort("unreachable")
+          case other       => global.abort("unreachable")
         }
 
         // tq"$a => $b"

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2098,7 +2098,7 @@ self =>
             if (in.token == SUBTYPE || in.token == SUPERTYPE) wildcardType(start, scala3Wildcard)
             else atPos(start) { Bind(tpnme.WILDCARD, EmptyTree) }
         } else {
-          typ() match {
+          this.typ() match {
             case Ident(name: TypeName) if nme.isVariableName(name) =>
               atPos(start) { Bind(name, EmptyTree) }
             case t => t
@@ -2289,7 +2289,7 @@ self =>
     }
     /** The implementation of the context sensitive methods for parsing outside of patterns. */
     final val outPattern = new PatternContextSensitive {
-      def argType(): Tree = typ()
+      def argType(): Tree = this.typ()
       def functionArgType(): Tree = paramType(repeatedParameterOK = false, useStartAsPosition = true)
     }
     /** The implementation for parsing inside of patterns at points where sequences are allowed. */

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -267,8 +267,6 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
   val exposeEmptyPackage = BooleanSetting ("-Yexpose-empty-package", "Internal only: expose the empty package.").internalOnly()
   val Ydelambdafy        = ChoiceSetting  ("-Ydelambdafy", "strategy", "Strategy used for translating lambdas into JVM code.", List("inline", "method"), "method")
 
-  val legacyBinding = BooleanSetting("-Ylegacy-binding", "Observe legacy name binding preference for inherited member competing with local definition.")
-
   // Allows a specialised jar to be written. For instance one that provides stable hashing of content, or customisation of the file storage
   val YjarFactory = StringSetting   ("-YjarFactory", "classname", "factory for jar files", classOf[DefaultJarFactory].getName)
   val YaddBackendThreads = IntSetting   ("-Ybackend-parallelism", "maximum worker threads for backend", 1, Some((1,16)), (x: String) => None )

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -267,6 +267,8 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
   val exposeEmptyPackage = BooleanSetting ("-Yexpose-empty-package", "Internal only: expose the empty package.").internalOnly()
   val Ydelambdafy        = ChoiceSetting  ("-Ydelambdafy", "strategy", "Strategy used for translating lambdas into JVM code.", List("inline", "method"), "method")
 
+  val legacyBinding = BooleanSetting("-Ylegacy-binding", "Observe legacy name binding preference for inherited member competing with local definition.")
+
   // Allows a specialised jar to be written. For instance one that provides stable hashing of content, or customisation of the file storage
   val YjarFactory = StringSetting   ("-YjarFactory", "classname", "factory for jar files", classOf[DefaultJarFactory].getName)
   val YaddBackendThreads = IntSetting   ("-Ybackend-parallelism", "maximum worker threads for backend", 1, Some((1,16)), (x: String) => None )

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1523,15 +1523,17 @@ trait Contexts { self: Analyzer =>
        *
        * Scala: Bindings of different kinds have a defined precedence order:
        *
-       *  1) Local definitions and declarations have the highest precedence.
+       *  1) Definitions and declarations in lexical scope that are not top-level have the highest precedence.
        *  1b) Definitions and declarations that are either inherited, or made
        *      available by a package clause and also defined in the same compilation unit
        *      as the reference to them, have the next highest precedence.
        *      (Only in -Xsource:3, same precedence as 1 with a warning in Scala 2.)
        *  2) Explicit imports have next highest precedence.
        *  3) Wildcard imports have next highest precedence.
-       *  4) Definitions made available by a package clause, but not also defined in the same compilation unit
-       *     as the reference, have lowest precedence. Also "root" imports added implicitly.
+       *  4) Bindings made available by a package clause,
+       *     but not also defined in the same compilation unit as the reference to them,
+       *     as well as bindings supplied by the compiler but not explicitly written in source code,
+       *     have the lowest precedence.
        */
       def foreignDefined = defSym.exists && thisContext.isPackageOwnedInDifferentUnit(defSym)  // SI-2458
 

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1468,7 +1468,8 @@ trait Contexts { self: Analyzer =>
         }
         if ((defSym.isAliasType || lastDef.isAliasType) && pre.memberType(defSym) =:= lastPre.memberType(lastDef))
           defSym = NoSymbol
-        if (defSym.isStable && lastDef.isStable && singleType(pre, defSym) =:= singleType(lastPre, lastDef))
+        if (defSym.isStable && lastDef.isStable &&
+          (lastPre.memberType(lastDef).termSymbol == defSym || pre.memberType(defSym).termSymbol == lastDef))
           defSym = NoSymbol
         foundInPrefix = inPrefix && defSym.exists
         foundInSuper  = foundInPrefix && defSym.owner != cx.owner

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -51,13 +51,6 @@ trait Contexts { self: Analyzer =>
   }
   private lazy val NoJavaMemberFound = (NoType, NoSymbol)
 
-  def ambiguousImports(imp1: ImportInfo, imp2: ImportInfo) =
-    LookupAmbiguous(s"it is imported twice in the same scope by\n$imp1\nand $imp2")
-  def ambiguousDefnAndImport(owner: Symbol, imp: ImportInfo) =
-    LookupAmbiguous(s"it is both defined in $owner and imported subsequently by \n$imp")
-  def ambiguousDefinitions(owner: Symbol, other: Symbol) =
-    LookupAmbiguous(s"it is both defined in $owner and available as ${other.fullLocationString}")
-
   private lazy val startContext = NoContext.make(
     Template(List(), noSelfType, List()) setSymbol global.NoSymbol setType global.NoType,
     rootMirror.RootClass,
@@ -1362,6 +1355,15 @@ trait Contexts { self: Analyzer =>
     private[this] var pre: Type                = _ // the prefix type of defSym, if a class member
     private[this] var cx: Context              = _ // the context under consideration
     private[this] var symbolDepth: Int         = _ // the depth of the directly found symbol
+    private[this] var foundInPrefix: Boolean   = _ // the symbol was found in pre
+    private[this] var foundInSuper: Boolean    = _ // the symbol was found super of context class (inherited)
+
+    def ambiguousImports(imp1: ImportInfo, imp2: ImportInfo) =
+      LookupAmbiguous(s"it is imported twice in the same scope by\n$imp1\nand $imp2")
+    def ambiguousDefnAndImport(owner: Symbol, imp: ImportInfo) =
+      LookupAmbiguous(s"it is both defined in $owner and imported subsequently by \n$imp")
+    def ambiguousDefinitions(owner: Symbol, other: Symbol, addendum: String) =
+      LookupAmbiguous(s"it is both defined in $owner and available as ${other.fullLocationString}$addendum")
 
     def apply(thisContext: Context, name: Name)(qualifies: Symbol => Boolean): NameLookup = {
       lookupError  = null
@@ -1370,6 +1372,8 @@ trait Contexts { self: Analyzer =>
       pre          = NoPrefix
       cx           = thisContext
       symbolDepth  = -1
+      foundInPrefix = false
+      foundInSuper = false
 
       def finish(qual: Tree, sym: Symbol): NameLookup = (
         if (lookupError ne null) lookupError
@@ -1386,8 +1390,8 @@ trait Contexts { self: Analyzer =>
         finish(qual, sym)
       }
 
-      def lookupInPrefix(name: Name): Symbol = {
-        if (thisContext.unit.isJava) {
+      def lookupInPrefix(name: Name): Symbol =
+        if (thisContext.unit.isJava)
           thisContext.javaFindMember(pre, name, qualifies) match {
             case (_, NoSymbol) =>
               NoSymbol
@@ -1395,17 +1399,16 @@ trait Contexts { self: Analyzer =>
               pre = pre1
               sym
           }
-        } else {
+        else
           pre.member(name).filter(qualifies)
-        }
-      }
+
       def accessibleInPrefix(s: Symbol) =
         thisContext.isAccessible(s, pre, superAccess = false)
 
       def searchPrefix = {
         cx = cx.enclClass
         val found0 = lookupInPrefix(name)
-        val found1 = found0 filter accessibleInPrefix
+        val found1 = found0.filter(accessibleInPrefix)
         if (found0.exists && !found1.exists && inaccessible == null)
           inaccessible = LookupInaccessible(found0, analyzer.lastAccessCheckDetails)
 
@@ -1452,15 +1455,20 @@ trait Contexts { self: Analyzer =>
       }
 
       // cx.scope eq null arises during FixInvalidSyms in Duplicators
-      def nextDefinition(): Unit =
+      def nextDefinition(): Unit = {
+        var inPrefix = false
+        defSym = NoSymbol
         while (defSym == NoSymbol && (cx ne NoContext) && (cx.scope ne null)) {
           pre    = cx.enclClass.prefix
-          defSym = lookupInScope(cx.owner, cx.enclClass.prefix, cx.scope) match {
-            case NoSymbol => searchPrefix
-            case found    => found
+          defSym = lookupInScope(cx.owner, pre, cx.scope) match {
+            case NoSymbol => inPrefix = true; searchPrefix
+            case found    => inPrefix = false; found
           }
           if (!defSym.exists) cx = cx.outer // push further outward
         }
+        foundInPrefix = inPrefix && defSym.exists
+        foundInSuper  = foundInPrefix && defSym.owner != cx.owner
+      }
       nextDefinition()
 
       if (symbolDepth < 0)
@@ -1490,8 +1498,11 @@ trait Contexts { self: Analyzer =>
        *
        * Scala: Bindings of different kinds have a defined precedence order:
        *
-       *  1) Definitions and declarations that are local, inherited, or made available by
-       *     a package clause and also defined in the same compilation unit as the reference, have highest precedence.
+       *  1) Local definitions and declarations have the highest precedence.
+       *  1b) Definitions and declarations that are either inherited, or made
+       *      available by a package clause and also defined in the same compilation unit
+       *      as the reference to them, have the next highest precedence.
+       *      (Same precedence as 1 under -Ylegacy-binding.)
        *  2) Explicit imports have next highest precedence.
        *  3) Wildcard imports have next highest precedence.
        *  4) Definitions made available by a package clause, but not also defined in the same compilation unit
@@ -1552,22 +1563,38 @@ trait Contexts { self: Analyzer =>
           return ambiguousDefnAndImport(defSym.alternatives.head.owner, imp1)
       })
 
-      // If the defSym is at 4, and there is a def at 1 in scope due to packaging, then the reference is ambiguous.
-      if (foreignDefined && !defSym.hasPackageFlag && !thisContext.unit.isJava) {
+      // If the defSym is at 4, and there is a def at 1b in scope due to packaging, then the reference is ambiguous.
+      // Also if defSym is at 1b inherited, the reference can be rendered ambiguous by a def at 1a in scope.
+      val possiblyAmbiguousDefinition =
+        foundInSuper && cx.owner.isClass && !settings.legacyBinding.value ||
+        foreignDefined && !defSym.hasPackageFlag
+      if (possiblyAmbiguousDefinition && !thisContext.unit.isJava) {
         val defSym0 = defSym
         val pre0    = pre
         val cx0     = cx
+        val wasFoundInSuper = foundInSuper
+        val foundCompetingSymbol: () => Boolean =
+          if (foreignDefined) () => !foreignDefined
+          else () => !defSym.isTopLevel && !defSym.owner.isPackageObjectOrClass && !foundInSuper && !foreignDefined
         while ((cx ne NoContext) && cx.depth >= symbolDepth) cx = cx.outer
+        if (wasFoundInSuper)
+          while ((cx ne NoContext) && (cx.owner eq cx0.owner)) cx = cx.outer
         var done = false
         while (!done) {
-          defSym = NoSymbol
           nextDefinition()
-          done = (cx eq NoContext) || defSym.exists && !foreignDefined
+          done = (cx eq NoContext) || defSym.exists && foundCompetingSymbol()
           if (!done && (cx ne NoContext)) cx = cx.outer
         }
         if (defSym.exists && (defSym ne defSym0)) {
+          val addendum =
+            if (wasFoundInSuper)
+            s"""|
+                |Since 2.13.11, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+                |If shadowing was intended, write `this.${defSym0.name}`.
+                |Or use `-Ylegacy-binding` to enable the previous behavior everywhere.""".stripMargin
+            else ""
           val ambiguity =
-            if (preferDef) ambiguousDefinitions(owner = defSym.owner, defSym0)
+            if (preferDef) ambiguousDefinitions(owner = defSym.owner, defSym0, addendum)
             else ambiguousDefnAndImport(owner = defSym.owner, imp1)
           return ambiguity
         }

--- a/src/compiler/scala/tools/nsc/typechecker/MacroAnnotationNamers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MacroAnnotationNamers.scala
@@ -386,7 +386,7 @@ trait MacroAnnotationNamers { self: Analyzer =>
       sym.setInfo(new MaybeExpandeeCompleter(tree) {
         override def kind = s"maybeExpandeeCompleter for ${sym.accurateKindString} ${sym.rawname}#${sym.id}"
         override def maybeExpand(): Unit = {
-          val companion = if (tree.isInstanceOf[ClassDef]) patchedCompanionSymbolOf(sym, context) else NoSymbol
+          val companion = if (this.tree.isInstanceOf[ClassDef]) patchedCompanionSymbolOf(sym, context) else NoSymbol
 
           def maybeExpand(annotation: Tree, annottee: Tree, maybeExpandee: Tree): Option[List[Tree]] =
             if (context.macrosEnabled) { // TODO: when is this bit flipped -- can we pull this check out farther?
@@ -395,7 +395,7 @@ trait MacroAnnotationNamers { self: Analyzer =>
               if (mann.isClass && mann.hasFlag(MACRO)) {
                 assert(!currentRun.compiles(mann), mann)
                 val annm = prepareAnnotationMacro(annotation, mann, sym, annottee, maybeExpandee)
-                expandAnnotationMacro(tree, annm)
+                expandAnnotationMacro(this.tree, annm)
                 // if we encounter an error, we just return None, so that other macro annotations can proceed
                 // this is unlike macroExpand1 when any error in an expandee blocks expansions
                 // there it's necessary in order not to exacerbate typer errors
@@ -424,7 +424,7 @@ trait MacroAnnotationNamers { self: Analyzer =>
               enterSyms(expanded) // TODO: we can't reliably expand into imports, because they won't be accounted by definitions below us
             case None =>
               markNotExpandable(sym)
-              finishSymbolNotExpandee(tree)
+              finishSymbolNotExpandee(this.tree)
           }
 
           // take care of the companion if it's no longer needed

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5501,6 +5501,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               case sym      => typed1(tree setSymbol sym, mode, pt)
             }
           case LookupSucceeded(qual, sym)   =>
+            sym.getAndRemoveAttachment[LookupAmbiguityWarning].foreach(w =>
+              runReporting.warning(tree.pos, w.msg, WarningCategory.Other, context.owner))
             (// this -> Foo.this
             if (sym.isThisSym)
               typed1(This(sym.owner) setPos tree.pos, mode, pt)

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -152,4 +152,6 @@ trait StdAttachments {
 
   /** For `val i = 42`, marks field as inferred so accessor (getter) can warn if implicit. */
   case object FieldTypeInferred extends PlainAttachment
+
+  case class LookupAmbiguityWarning(msg: String) extends PlainAttachment
 }

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -772,8 +772,8 @@ trait Types
     def withFilter(p: Type => Boolean) = new FilterMapForeach(p)
 
     class FilterMapForeach(p: Type => Boolean) extends FilterTypeCollector(p){
-      def foreach[U](f: Type => U): Unit = collect(Type.this) foreach f
-      def map[T](f: Type => T): List[T]  = collect(Type.this) map f
+      def foreach[U](f: Type => U): Unit = this.collect(Type.this).foreach(f)
+      def map[T](f: Type => T): List[T]  = this.collect(Type.this).map(f)
     }
 
     @inline final def orElse(alt: => Type): Type = if (this ne NoType) this else alt

--- a/src/reflect/scala/reflect/io/ZipArchive.scala
+++ b/src/reflect/scala/reflect/io/ZipArchive.scala
@@ -392,7 +392,7 @@ final class ManifestResources(val url: URL) extends ZipArchive(null) {
       if (!zipEntry.isDirectory) {
         class FileEntry() extends Entry(zipEntry.getName) {
           override def lastModified = zipEntry.getTime()
-          override def input        = resourceInputStream(path)
+          override def input        = resourceInputStream(this.path)
           override def sizeOption   = None
         }
         val f = new FileEntry()

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -79,6 +79,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.RootSelection
     this.TypedExpectingUnitAttachment
     this.FieldTypeInferred
+    this.LookupAmbiguityWarning
     this.noPrint
     this.typeDebug
     // inaccessible: this.posAssigner

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
@@ -927,7 +927,7 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
         }
         else None
       def resultType =
-        makeTypeInTemplateContext(aSym.tpe, inTpl, aSym)
+        makeTypeInTemplateContext(aSym.tpe, this.inTpl, aSym)
       def isImplicit = aSym.isImplicit
     }
 

--- a/test/files/neg/t11921-alias.check
+++ b/test/files/neg/t11921-alias.check
@@ -12,4 +12,11 @@ If shadowing was intended, write `this.c`.
 Or use `-Ylegacy-binding` to enable the previous behavior everywhere.
       def n = c // ambiguous
               ^
-2 errors
+t11921-alias.scala:65: error: reference to name is ambiguous;
+it is both defined in method m and available as value name in class A
+Since 2.13.11, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+If shadowing was intended, write `this.name`.
+Or use `-Ylegacy-binding` to enable the previous behavior everywhere.
+      println(name)
+              ^
+3 errors

--- a/test/files/neg/t11921-alias.check
+++ b/test/files/neg/t11921-alias.check
@@ -1,22 +1,31 @@
-t11921-alias.scala:16: error: reference to TT is ambiguous;
-it is both defined in object O and available as type TT in class C
-Since 2.13.11, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
-If shadowing was intended, write `this.TT`.
-Or use `-Ylegacy-binding` to enable the previous behavior everywhere.
+t11921-alias.scala:18: warning: reference to TT is ambiguous;
+it is both defined in the enclosing object O and available in the enclosing class D as type TT (defined in class C)
+Since 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+To continue using the symbol from the superclass, write `this.TT`.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
       def n(x: TT) = x // ambiguous
                ^
-t11921-alias.scala:36: error: reference to c is ambiguous;
-it is both defined in class B and available as value c in class A
-Since 2.13.11, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
-If shadowing was intended, write `this.c`.
-Or use `-Ylegacy-binding` to enable the previous behavior everywhere.
+t11921-alias.scala:38: warning: reference to c is ambiguous;
+it is both defined in the enclosing class B and available in the enclosing anonymous class as value c (defined in class A)
+Since 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+To continue using the symbol from the superclass, write `this.c`.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
       def n = c // ambiguous
               ^
-t11921-alias.scala:65: error: reference to name is ambiguous;
-it is both defined in method m and available as value name in class A
-Since 2.13.11, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
-If shadowing was intended, write `this.name`.
-Or use `-Ylegacy-binding` to enable the previous behavior everywhere.
+t11921-alias.scala:57: warning: reference to name is ambiguous;
+it is both defined in the enclosing method m and available in the enclosing anonymous class as value name (defined in class C)
+Since 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+To continue using the symbol from the superclass, write `this.name`.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
       println(name)
               ^
-3 errors
+t11921-alias.scala:67: warning: reference to name is ambiguous;
+it is both defined in the enclosing method m and available in the enclosing anonymous class as value name (defined in class A, inherited through parent class C)
+Since 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+To continue using the symbol from the superclass, write `this.name`.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+      println(name)
+              ^
+error: No warnings can be incurred under -Werror.
+4 warnings
+1 error

--- a/test/files/neg/t11921-alias.check
+++ b/test/files/neg/t11921-alias.check
@@ -1,0 +1,15 @@
+t11921-alias.scala:16: error: reference to TT is ambiguous;
+it is both defined in object O and available as type TT in class C
+Since 2.13.11, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+If shadowing was intended, write `this.TT`.
+Or use `-Ylegacy-binding` to enable the previous behavior everywhere.
+      def n(x: TT) = x // ambiguous
+               ^
+t11921-alias.scala:36: error: reference to c is ambiguous;
+it is both defined in class B and available as value c in class A
+Since 2.13.11, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+If shadowing was intended, write `this.c`.
+Or use `-Ylegacy-binding` to enable the previous behavior everywhere.
+      def n = c // ambiguous
+              ^
+2 errors

--- a/test/files/neg/t11921-alias.scala
+++ b/test/files/neg/t11921-alias.scala
@@ -37,3 +37,13 @@ object t4 {
     }
   }
 }
+
+object t5 {
+  trait TT
+  class K[T <: TT](val t: T)
+  class C {
+    def f(t: TT) = new K[t.type](t) {
+      def test = t
+    }
+  }
+}

--- a/test/files/neg/t11921-alias.scala
+++ b/test/files/neg/t11921-alias.scala
@@ -1,0 +1,39 @@
+object t1 {
+  class C[T] { type TT = T }
+  object O {
+    type TT = String
+    class D extends C[TT] {
+      def n(x: TT) = x // OK
+    }
+  }
+}
+
+object t2 {
+  class C[T] { type TT <: T }
+  object O {
+    type TT = String
+    class D extends C[TT] {
+      def n(x: TT) = x // ambiguous
+    }
+  }
+}
+
+object t3 {
+  trait Context
+  class A[C <: Context](val c: C)
+  class B(val c: Context) { b =>
+    val a = new A[c.type](c) {
+      def n = c // OK
+    }
+  }
+}
+
+object t4 {
+  trait Context
+  class A[C <: Context](val c: C)
+  class B(val c: Context) { b =>
+    val a = new A(c) {
+      def n = c // ambiguous
+    }
+  }
+}

--- a/test/files/neg/t11921-alias.scala
+++ b/test/files/neg/t11921-alias.scala
@@ -47,3 +47,22 @@ object t5 {
     }
   }
 }
+
+object t6 {
+  class C(val name: String)
+  object Test {
+    def m(name: String) = new C(name) {
+      println(name)
+    }
+  }
+}
+
+object t7 {
+  abstract class A(val name: String)
+  class C(name: String) extends A(name)
+  object Test {
+    def m(name: String) = new C(name) {
+      println(name)
+    }
+  }
+}

--- a/test/files/neg/t11921-alias.scala
+++ b/test/files/neg/t11921-alias.scala
@@ -1,3 +1,5 @@
+// scalac: -Werror
+
 object t1 {
   class C[T] { type TT = T }
   object O {

--- a/test/files/neg/t11921.check
+++ b/test/files/neg/t11921.check
@@ -1,0 +1,8 @@
+t11921.scala:6: error: reference to coll is ambiguous;
+it is both defined in method lazyMap and available as method coll in trait Iterable
+Since 2.13.11, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+If shadowing was intended, write `this.coll`.
+Or use `-Ylegacy-binding` to enable the previous behavior everywhere.
+      def iterator = coll.iterator.map(f)    // coll is ambiguous
+                     ^
+1 error

--- a/test/files/neg/t11921.check
+++ b/test/files/neg/t11921.check
@@ -1,8 +1,14 @@
-t11921.scala:6: error: reference to coll is ambiguous;
-it is both defined in method lazyMap and available as method coll in trait Iterable
-Since 2.13.11, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
-If shadowing was intended, write `this.coll`.
-Or use `-Ylegacy-binding` to enable the previous behavior everywhere.
+t11921.scala:6: error: type mismatch;
+ found   : A => B
+ required: B => B
+      def iterator = coll.iterator.map(f)    // coll is ambiguous
+                                       ^
+t11921.scala:6: warning: reference to coll is ambiguous;
+it is both defined in the enclosing method lazyMap and available in the enclosing anonymous class as method coll (defined in trait Iterable)
+Since 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+To continue using the symbol from the superclass, write `this.coll`.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
       def iterator = coll.iterator.map(f)    // coll is ambiguous
                      ^
+1 warning
 1 error

--- a/test/files/neg/t11921.scala
+++ b/test/files/neg/t11921.scala
@@ -1,0 +1,16 @@
+
+
+class C {
+  def lazyMap[A, B](coll: Iterable[A], f: A => B) =
+    new Iterable[B] {
+      def iterator = coll.iterator.map(f)    // coll is ambiguous
+    }
+}
+
+/* was:
+t11921.scala:5: error: type mismatch;
+ found   : A => B
+ required: B => B
+      def iterator = coll.iterator.map(f)
+                                       ^
+*/

--- a/test/files/neg/t11921b.check
+++ b/test/files/neg/t11921b.check
@@ -1,0 +1,29 @@
+t11921b.scala:11: error: reference to x is ambiguous;
+it is both defined in object Test and available as value x in class C
+Since 2.13.11, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+If shadowing was intended, write `this.x`.
+Or use `-Ylegacy-binding` to enable the previous behavior everywhere.
+      println(x)  // error
+              ^
+t11921b.scala:15: error: reference to x is ambiguous;
+it is both defined in object Test and available as value x in class C
+Since 2.13.11, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+If shadowing was intended, write `this.x`.
+Or use `-Ylegacy-binding` to enable the previous behavior everywhere.
+        println(x)  // error
+                ^
+t11921b.scala:26: error: reference to y is ambiguous;
+it is both defined in method c and available as value y in class D
+Since 2.13.11, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+If shadowing was intended, write `this.y`.
+Or use `-Ylegacy-binding` to enable the previous behavior everywhere.
+      println(y)  // error
+              ^
+t11921b.scala:38: error: reference to y is ambiguous;
+it is both defined in method c and available as value y in class D
+Since 2.13.11, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+If shadowing was intended, write `this.y`.
+Or use `-Ylegacy-binding` to enable the previous behavior everywhere.
+        println(y)  // error
+                ^
+4 errors

--- a/test/files/neg/t11921b.check
+++ b/test/files/neg/t11921b.check
@@ -1,29 +1,38 @@
-t11921b.scala:11: error: reference to x is ambiguous;
-it is both defined in object Test and available as value x in class C
-Since 2.13.11, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
-If shadowing was intended, write `this.x`.
-Or use `-Ylegacy-binding` to enable the previous behavior everywhere.
+t11921b.scala:11: warning: reference to x is ambiguous;
+it is both defined in the enclosing object Test and available in the enclosing class D as value x (defined in class C)
+Since 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+To continue using the symbol from the superclass, write `this.x`.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
       println(x)  // error
               ^
-t11921b.scala:15: error: reference to x is ambiguous;
-it is both defined in object Test and available as value x in class C
-Since 2.13.11, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
-If shadowing was intended, write `this.x`.
-Or use `-Ylegacy-binding` to enable the previous behavior everywhere.
+t11921b.scala:15: warning: reference to x is ambiguous;
+it is both defined in the enclosing object Test and available in the enclosing anonymous class as value x (defined in class C)
+Since 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+To continue using the symbol from the superclass, write `this.x`.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
         println(x)  // error
                 ^
-t11921b.scala:26: error: reference to y is ambiguous;
-it is both defined in method c and available as value y in class D
-Since 2.13.11, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
-If shadowing was intended, write `this.y`.
-Or use `-Ylegacy-binding` to enable the previous behavior everywhere.
+t11921b.scala:26: warning: reference to y is ambiguous;
+it is both defined in the enclosing method c and available in the enclosing anonymous class as value y (defined in class D)
+Since 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+To continue using the symbol from the superclass, write `this.y`.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
       println(y)  // error
               ^
-t11921b.scala:38: error: reference to y is ambiguous;
-it is both defined in method c and available as value y in class D
-Since 2.13.11, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
-If shadowing was intended, write `this.y`.
-Or use `-Ylegacy-binding` to enable the previous behavior everywhere.
+t11921b.scala:38: warning: reference to y is ambiguous;
+it is both defined in the enclosing method c and available in the enclosing class E as value y (defined in class D)
+Since 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+To continue using the symbol from the superclass, write `this.y`.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
         println(y)  // error
                 ^
-4 errors
+t11921b.scala:75: warning: reference to x is ambiguous;
+it is both defined in the enclosing object Uhu and available in the enclosing class C as value x (defined in class A, inherited through parent class B)
+Since 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+To continue using the symbol from the superclass, write `this.x`.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+        def t = x // ambiguous, message mentions parent B
+                ^
+error: No warnings can be incurred under -Werror.
+5 warnings
+1 error

--- a/test/files/neg/t11921b.scala
+++ b/test/files/neg/t11921b.scala
@@ -1,4 +1,4 @@
-
+// scalac: -Werror
 
 object test1 {
 
@@ -63,4 +63,17 @@ class C {
 }
 object D extends C {
   println(global)    // OK, since global is defined in package
+}
+
+object test5 {
+  class A { val x = 1 }
+  class B extends A
+  object Uhu {
+    val x = 2
+    class C extends B {
+      class Inner {
+        def t = x // ambiguous, message mentions parent B
+      }
+    }
+  }
 }

--- a/test/files/neg/t11921b.scala
+++ b/test/files/neg/t11921b.scala
@@ -1,0 +1,66 @@
+
+
+object test1 {
+
+  class C {
+    val x = 0
+  }
+  object Test {
+    val x = 1
+    class D extends C {
+      println(x)  // error
+    }
+    def f() =
+      new C {
+        println(x)  // error
+      }
+  }
+}
+
+object test2 {
+  def c(y: Float) = {
+    class D {
+      val y = 2
+    }
+    new D {
+      println(y)  // error
+    }
+  }
+}
+
+object test3 {
+  def c(y: Float) = {
+    class D {
+      val y = 2
+    }
+    class E extends D {
+      class F {
+        println(y)  // error
+      }
+    }
+  }
+}
+
+object test4 {
+
+  class C {
+    val x = 0
+  }
+  object Test {
+    val x = 1
+    class D extends C {
+      def x(y: Int) = 3
+      val y: Int = this.x // OK
+      val z: Int = x      // OK
+    }
+  }
+}
+
+object global
+
+class C {
+  val global = 42
+}
+object D extends C {
+  println(global)    // OK, since global is defined in package
+}

--- a/test/files/neg/t11921c.check
+++ b/test/files/neg/t11921c.check
@@ -1,0 +1,6 @@
+t11921c.scala:7: error: type mismatch;
+ found   : A => B
+ required: B => B
+      def iterator = coll.iterator.map(f)    // coll is ambiguous
+                                       ^
+1 error

--- a/test/files/neg/t11921c.check
+++ b/test/files/neg/t11921c.check
@@ -1,4 +1,4 @@
-t11921c.scala:7: error: type mismatch;
+t11921c.scala:6: error: type mismatch;
  found   : A => B
  required: B => B
       def iterator = coll.iterator.map(f)    // coll is ambiguous

--- a/test/files/neg/t11921c.scala
+++ b/test/files/neg/t11921c.scala
@@ -1,5 +1,4 @@
-
-// scalac: -Ylegacy-binding
+// scalac: -Wconf:msg=legacy-binding:s
 
 class C {
   def lazyMap[A, B](coll: Iterable[A], f: A => B) =

--- a/test/files/neg/t11921c.scala
+++ b/test/files/neg/t11921c.scala
@@ -1,0 +1,17 @@
+
+// scalac: -Ylegacy-binding
+
+class C {
+  def lazyMap[A, B](coll: Iterable[A], f: A => B) =
+    new Iterable[B] {
+      def iterator = coll.iterator.map(f)    // coll is ambiguous
+    }
+}
+
+/* was:
+t11921.scala:5: error: type mismatch;
+ found   : A => B
+ required: B => B
+      def iterator = coll.iterator.map(f)
+                                       ^
+*/

--- a/test/files/neg/t1477.check
+++ b/test/files/neg/t1477.check
@@ -1,5 +1,5 @@
 t1477.scala:13: error: volatile type member cannot override type member with non-volatile upper bound:
 type V <: Middle.this.D (defined in trait C)
-    type V <: (D with U)
+    type V <: (this.D with U)
          ^
 1 error

--- a/test/files/neg/t1477.scala
+++ b/test/files/neg/t1477.scala
@@ -10,7 +10,7 @@ object Test extends App {
   }
 
   trait Middle extends C {
-    type V <: (D with U)
+    type V <: (this.D with U)
   }
 
   class D extends Middle {

--- a/test/files/pos/t0165.scala
+++ b/test/files/pos/t0165.scala
@@ -4,7 +4,7 @@ import scala.collection.mutable.LinkedHashMap
 trait Main {
   def asMany : ArrayResult = {
     object result extends LinkedHashMap[String,String] with ArrayResult {
-      def current = result
+      def current = this.result
     }
     result
   }

--- a/test/files/pos/t11921a.scala
+++ b/test/files/pos/t11921a.scala
@@ -1,0 +1,18 @@
+
+class C(x: Int) {
+  class D extends C(42) {
+    def f() = println(x)
+  }
+}
+
+trait T {
+  val t: Int
+}
+trait U extends T {
+  val t: Int
+  import t._
+}
+trait V { this: T =>
+  val t: Int
+  import t._
+}

--- a/test/files/pos/t11921b.scala
+++ b/test/files/pos/t11921b.scala
@@ -1,5 +1,5 @@
 
-// scalac: -Werror -Ylegacy-binding
+// scalac: -Werror -Wconf:msg=legacy-binding:s
 
 object test1 {
 

--- a/test/files/pos/t11921b.scala
+++ b/test/files/pos/t11921b.scala
@@ -1,0 +1,67 @@
+
+// scalac: -Werror -Ylegacy-binding
+
+object test1 {
+
+  class C {
+    val x = 0
+  }
+  object Test {
+    val x = 1
+    class D extends C {
+      println(x)  // error
+    }
+    def f() =
+      new C {
+        println(x)  // error
+      }
+  }
+}
+
+object test2 {
+  def c(y: Float) = {
+    class D {
+      val y = 2
+    }
+    new D {
+      println(y)  // error
+    }
+  }
+}
+
+object test3 {
+  def c(y: Float) = {
+    class D {
+      val y = 2
+    }
+    class E extends D {
+      class F {
+        println(y)  // error
+      }
+    }
+  }
+}
+
+object test4 {
+
+  class C {
+    val x = 0
+  }
+  object Test {
+    val x = 1
+    class D extends C {
+      def x(y: Int) = 3
+      val y: Int = this.x // OK
+      val z: Int = x      // OK
+    }
+  }
+}
+
+object global
+
+class C {
+  val global = 42
+}
+object D extends C {
+  println(global)    // OK, since global is defined in package
+}

--- a/test/files/pos/t11921c.scala
+++ b/test/files/pos/t11921c.scala
@@ -1,0 +1,23 @@
+
+// test/scaladoc/resources/t5784.scala
+
+package test.templates {
+  object `package` {
+    type String = java.lang.String
+    val String = new StringCompanion
+    class StringCompanion { def boo = ??? }
+  }
+
+  trait Base {
+    type String = test.templates.String
+    type T <: Foo
+    val T: FooExtractor
+    trait Foo { def foo: Int }
+    trait FooExtractor { def apply(foo: Int): Unit; def unapply(t: Foo): Option[Int] }
+  }
+
+  trait Api extends Base {
+    override type T <: FooApi
+    trait FooApi extends Foo { def bar: String }
+  }
+}

--- a/test/files/run/macroPlugins-macroExpand/Plugin_1.scala
+++ b/test/files/run/macroPlugins-macroExpand/Plugin_1.scala
@@ -18,7 +18,7 @@ class Plugin(val global: Global) extends NscPlugin {
       object expander extends DefMacroExpander(typer, expandee, mode, pt) {
         override def onSuccess(expanded: Tree) = {
           val message = s"expanded into ${expanded.toString}"
-          typer.typed(q"println($message)")
+          this.typer.typed(q"println($message)")
         }
       }
       Some(expander(expandee))

--- a/test/junit/scala/collection/mutable/HashSetTest.scala
+++ b/test/junit/scala/collection/mutable/HashSetTest.scala
@@ -86,28 +86,19 @@ class HashSetTest {
   }
 
   class OnceOnly extends IterableOnce[Int] {
-    override def knownSize: Int = 1
+    var iterated = false
 
-    var iterated:Boolean = false
-
-    override def iterator: Iterator[Int] = {
-      new Iterator[Int] {
-        assert(!iterated)
-        iterated = true
-        private var v = Option(42)
-        override def hasNext: Boolean = v.nonEmpty && knownSize > 0
-        override def next(): Int = {
-          val res = v.get
-          v = None
-          res
-        }
-      }
+    override def iterator = {
+      assertFalse("Attempt to re-iterate!", iterated)
+      iterated = true
+      Iterator.single(42)
     }
   }
 
   @Test
-  def addAllTest2(): Unit = {
+  def `addAll adds exactly once`: Unit = {
     val hs = HashSet.empty[Int]
     hs.addAll(new OnceOnly)
+    assertEquals(1, hs.size)
   }
 }


### PR DESCRIPTION
Continuation of @som-snytt's work at https://github.com/scala/scala/pull/10177.

Backport from Scala 3: an inherited name no longer takes precedence over a definition in an outer scope. The following reference `m` is ambiguous:

```scala
class C { def m = ??? }
def f(m: Int) = new C {
  def g = m   // use this.m
}
```

It's an error under `-Xsource:3`, a warning otherwise.

Fixes scala/bug#11921.

Don't issue an ambiguity error if
  - a symbol is a type alias and the two types are equivalent (`=:=`)
  - both symbols are stable and their singleton types are equivalent (`=:=`)

Example:

```scala
class C
class A { val c: B.c.type = B.c }
object B {
  val c = new C
  val a = new A {
    def m = c    // not ambiguous, `this.c` vs `B.c`
  }
}
```

Type example:

```scala
class C[T] { type TT = T }
object O {
  type TT = String
  class D extends C[TT] {
    def n(x: TT) = x  // not ambiguous, `this.TT` vs `O.TT`
  }
}
```
