### PR TITLE
Fallback to paramless during overload, like Scala 3

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -107,11 +107,9 @@ trait ContextErrors extends splain.SplainErrors {
 
     def issueTypeError(err: AbsTypeError)(implicit context: Context): Unit = { context.issue(err) }
 
+    // OPT: avoid error string creation for errors that won't see the light of day
     def typeErrorMsg(context: Context, found: Type, req: Type) =
-      if (context.openImplicits.nonEmpty && !settings.Vimplicits.value)
-         // OPT: avoid error string creation for errors that won't see the light of day, but predicate
-        //       this on -Xsource:2.13 for bug compatibility with https://github.com/scala/scala/pull/7147#issuecomment-418233611
-        "type mismatch"
+      if (!context.openImplicits.isEmpty && !settings.Vimplicits.value) "type mismatch"
       else "type mismatch" + foundReqMsg(found, req)
   }
 

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -590,7 +590,7 @@ trait Contexts { self: Analyzer =>
             inSilentMode {
               try {
                 set(disable = ImplicitsEnabled | EnrichmentEnabled) // restored by inSilentMode
-                tryOnce(false)
+                tryOnce(isLastTry = false)
                 reporter.hasErrors
               } catch {
                 case ex: CyclicReference => throw ex
@@ -602,7 +602,7 @@ trait Contexts { self: Analyzer =>
         // do last try if try with implicits enabled failed
         // (or if it was not attempted because they were disabled)
         if (doLastTry)
-          tryOnce(true)
+          tryOnce(isLastTry = true)
       }
     }
 

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -1383,12 +1383,14 @@ trait Infer extends Checkable {
      *  matches prototype `pt`, if it exists.
      *  If several alternatives match `pt`, take parameterless one.
      *  If no alternative matches `pt`, take the parameterless one anyway.
+     *  (There may be more than one parameterless alternative, in particular,
+     *  badly overloaded default args or case class elements. These are detected elsewhere.)
      */
     def inferExprAlternative(tree: Tree, pt: Type): Tree = {
       val c = context
       class InferTwice(pre: Type, alts: List[Symbol]) extends c.TryTwice {
         def tryOnce(isSecondTry: Boolean): Unit = {
-          val alts0 = alts filter (alt => isWeaklyCompatible(pre memberType alt, pt))
+          val alts0 = alts.filter(alt => isWeaklyCompatible(pre.memberType(alt), pt))
           val alts1 = if (alts0.isEmpty) alts else alts0
           val bests = bestAlternatives(alts1) { (sym1, sym2) =>
             val tp1 = memberTypeForSpecificity(pre, sym1, tree)
@@ -1399,22 +1401,35 @@ trait Infer extends Checkable {
               || isStrictlyMoreSpecific(tp1, tp2, sym1, sym2)
             )
           }
-          // todo: missing test case for bests.isEmpty
+          def finish(s: Symbol): Unit = tree.setSymbol(s).setType(pre.memberType(s))
+          def paramlessOr(error: => Unit): Unit = {
+            val paramless =
+              if (isSecondTry)
+                alts.find { alt => val ps = alt.info.paramss; ps.isEmpty || ps.tail.isEmpty && ps.head.isEmpty }
+              else None
+            paramless match {
+              case Some(alt) => finish(alt)
+              case None => error
+            }
+          }
           bests match {
-            case best :: Nil                              => tree setSymbol best setType (pre memberType best)
+            case best :: Nil =>
+              finish(best)
             case best :: competing :: _ if alts0.nonEmpty =>
-              // scala/bug#6912 Don't give up and leave an OverloadedType on the tree.
-              //         Originally I wrote this as `if (secondTry) ... `, but `tryTwice` won't attempt the second try
-              //         unless an error is issued. We're not issuing an error, in the assumption that it would be
-              //         spurious in light of the erroneous expected type
-              if (pt.isErroneous) setError(tree)
-              else AmbiguousExprAlternativeError(tree, pre, best, competing, pt, isSecondTry)
-            case _                                        => if (bests.isEmpty || alts0.isEmpty) NoBestExprAlternativeError(tree, pt, isSecondTry)
+              // If erroneous expected type, don't issue spurious error and don't `tryTwice` again with implicits.
+              // scala/bug#6912 except it does not loop
+              paramlessOr {
+                if (pt.isErroneous) setError(tree)
+                else AmbiguousExprAlternativeError(tree, pre, best, competing, pt, isSecondTry)
+              }
+            case _ if bests.isEmpty || alts0.isEmpty =>
+              paramlessOr(NoBestExprAlternativeError(tree, pt, isSecondTry))
+            case _ =>
           }
         }
       }
       tree.tpe match {
-        case OverloadedType(pre, alts) => (new InferTwice(pre, alts)).apply() ; tree
+        case OverloadedType(pre, alts) => (new InferTwice(pre, alts)).apply(); tree
         case _                         => tree
       }
     }
@@ -1512,11 +1527,12 @@ trait Infer extends Checkable {
           val applicable  = overloadsToConsiderBySpecificity(alts filter isAltApplicable(pt), argtpes, varargsStar)
           // println(s"bestForExpectedType($argtpes, $pt): $alts -app-> ${alts filter isAltApplicable(pt)} -arity-> $applicable")
           val ranked      = bestAlternatives(applicable)(rankAlternatives)
+          def finish(s: Symbol): Unit = tree.setSymbol(s).setType(pre.memberType(s))
           ranked match {
             case best :: competing :: _ => AmbiguousMethodAlternativeError(tree, pre, best, competing, argtpes, pt, isLastTry) // ambiguous
-            case best :: Nil            => tree setSymbol best setType (pre memberType best)           // success
-            case Nil if pt.isWildcard   => NoBestMethodAlternativeError(tree, argtpes, pt, isLastTry)  // failed
-            case Nil                    => bestForExpectedType(WildcardType, isLastTry)                // failed, but retry with WildcardType
+            case best :: nil            => finish(best)
+            case nil if pt.isWildcard   => NoBestMethodAlternativeError(tree, argtpes, pt, isLastTry)  // failed
+            case nil                    => bestForExpectedType(WildcardType, isLastTry)                // failed, but retry with WildcardType
           }
         }
 

--- a/test/files/neg/dbldef.check
+++ b/test/files/neg/dbldef.check
@@ -6,7 +6,4 @@ dbldef.scala:1: error: type mismatch;
  required: Int
 case class test0(x: Int, x: Float)
                  ^
-dbldef.scala:1: error: in class test0, multiple overloaded alternatives of x define default arguments
-case class test0(x: Int, x: Float)
-           ^
-3 errors
+2 errors

--- a/test/files/neg/i10715a.check
+++ b/test/files/neg/i10715a.check
@@ -1,0 +1,38 @@
+i10715a.scala:16: error: type mismatch;
+ found   : Int
+ required: String
+    c.f: String // error
+      ^
+i10715a.scala:17: error: polymorphic expression cannot be instantiated to expected type;
+ found   : [A]Int
+ required: String
+    c.g: String // error
+      ^
+i10715a.scala:18: error: value bad is not a member of Int
+    c.f.bad // error
+        ^
+i10715a.scala:19: error: value bad is not a member of Int
+    c.g.bad // error
+        ^
+i10715a.scala:21: error: type mismatch;
+ found   : String("")
+ required: Int
+    c.f("") // error
+        ^
+i10715a.scala:22: error: type mismatch;
+ found   : String("")
+ required: Int
+    c.g("") // error
+        ^
+i10715a.scala:23: error: overloaded method g with alternatives:
+  (x: Int)Parent <and>
+  Int
+ cannot be applied to (String)
+    c.g[Int]("") // error
+       ^
+i10715a.scala:24: error: type mismatch;
+ found   : Int
+ required: String => String
+    c.g[Int]: (String => String) // error
+       ^
+8 errors

--- a/test/files/neg/i10715a.scala
+++ b/test/files/neg/i10715a.scala
@@ -1,0 +1,27 @@
+class Parent {
+  def f(x: Int): Parent = ???
+  def f: Int = 0
+
+  def g[A](x: Int): Parent = ???
+  def g[A]: Int = 0
+}
+
+class Sub extends Parent {
+  override def f(x: Int): Parent = ???
+  override def g[A](x: Int): Parent = ???
+}
+
+class C {
+  def bad(c: Sub): Unit = {
+    c.f: String // error
+    c.g: String // error
+    c.f.bad // error
+    c.g.bad // error
+
+    c.f("") // error
+    c.g("") // error
+    c.g[Int]("") // error
+    c.g[Int]: (String => String) // error
+    c.g[Int]: (Int => Parent) // ok
+  }
+}

--- a/test/files/neg/i10715b.check
+++ b/test/files/neg/i10715b.check
@@ -1,0 +1,7 @@
+i10715b.scala:12: error: ambiguous reference to overloaded definition,
+both method f in class Sub of type (x: Int)(implicit s: String): Unit
+and  method f in class Sub of type (x: Int): Unit
+match argument types (Int)
+  def bad(c: Sub): Unit = c.f(1) // error: ambiguous overload
+                            ^
+1 error

--- a/test/files/neg/i10715b.scala
+++ b/test/files/neg/i10715b.scala
@@ -1,0 +1,13 @@
+class Parent {
+  def f(x: Int): Unit = ()
+  def f: Int = 0
+}
+
+class Sub extends Parent {
+  override def f(x: Int): Unit = ()
+  def f(x: Int)(implicit s: String): Unit = ()
+}
+
+class C {
+  def bad(c: Sub): Unit = c.f(1) // error: ambiguous overload
+}

--- a/test/files/neg/names-defaults-neg-pu.check
+++ b/test/files/neg/names-defaults-neg-pu.check
@@ -127,6 +127,10 @@ names-defaults-neg-pu.scala:141: error: parameter 'a' is already specified at pa
 names-defaults-neg-pu.scala:142: error: missing parameter type for expanded function ((<x$4: error>) => b = x$4)
   val taf4: (Int, String) => Unit = testAnnFun(_, b = _)
                                                       ^
+names-defaults-neg-pu.scala:193: error: an expression of type Null is ineligible for implicit conversion
+Error occurred in an application involving default arguments.
+  def f = new A3[Int]()
+          ^
 names-defaults-neg-pu.scala:95: warning: the parameter name y is deprecated: use b instead
   deprNam3(y = 10, b = 2)
              ^
@@ -137,4 +141,4 @@ names-defaults-neg-pu.scala:100: warning: naming parameter deprNam5Arg is deprec
   deprNam5(deprNam5Arg = null)
                        ^
 3 warnings
-33 errors
+34 errors

--- a/test/files/neg/names-defaults-neg-pu.scala
+++ b/test/files/neg/names-defaults-neg-pu.scala
@@ -188,3 +188,7 @@ object t3685 {
   class u20 { val x: Int = u.f(x = "32") }
   class u21 { var x: Int = u.f(x = "32") }
 }
+class A3[T](x: T = null) // scala/bug#4727 cf A2
+class t4727 {
+  def f = new A3[Int]()
+}

--- a/test/files/neg/t3909.check
+++ b/test/files/neg/t3909.check
@@ -1,5 +1,4 @@
-t3909.scala:1: error: in object DO, multiple overloaded alternatives of m1 define default arguments
-Error occurred in an application involving default arguments.
+t3909.scala:1: error: in object DO, multiple overloaded alternatives of method m1 define default arguments.
 object DO {
        ^
 1 error

--- a/test/files/neg/t3909b.check
+++ b/test/files/neg/t3909b.check
@@ -1,0 +1,4 @@
+t3909b.scala:1: error: in object DO, multiple overloaded alternatives of method m1 define default arguments.
+object DO {
+       ^
+1 error

--- a/test/files/neg/t3909b.scala
+++ b/test/files/neg/t3909b.scala
@@ -1,0 +1,10 @@
+object DO {
+
+  def m1(str: String, extraStuff: String = "stuff"): Int = ???
+  def m1(i: Int, extraStuff: Int = "42".toInt): Int = ???
+
+  def main(args: Array[String]): Unit = {
+    val m1s = m1("foo")
+    val m1i = m1(42)
+  }
+}

--- a/test/files/neg/t4727.check
+++ b/test/files/neg/t4727.check
@@ -1,5 +1,0 @@
-t4727.scala:5: error: an expression of type Null is ineligible for implicit conversion
-Error occurred in an application involving default arguments.
-    new C[Int]
-    ^
-1 error

--- a/test/files/neg/t4727.scala
+++ b/test/files/neg/t4727.scala
@@ -1,7 +1,0 @@
-class C[T](x : T = null)
-
-object Test {
-  def main(args: Array[String]): Unit = {
-    new C[Int]
-  }
-}

--- a/test/files/neg/t5735.check
+++ b/test/files/neg/t5735.check
@@ -1,5 +1,5 @@
 t5735.scala:6: error: type mismatch;
- found   : (x: Int): Int <and> String
+ found   : String
  required: Int
   val z: Int = a
                ^

--- a/test/files/pos/i10715a.scala
+++ b/test/files/pos/i10715a.scala
@@ -1,0 +1,31 @@
+class Parent {
+  def f(x: Int): Parent = ???
+  def f: Int = 0
+
+  def g[A](x: Int): Parent = ???
+  def g[A]: Int = 0
+}
+
+// For the issue to show up, there must be a subclass that overrides
+// one of the two methods.
+class Sub extends Parent {
+  override def f(x: Int): Parent = ???
+  override def g[A](x: Int): Parent = ???
+}
+
+class C {
+  def test(c: Sub): Unit = {
+    c.f(1) // already worked
+    c.f
+    c.f.+(0)
+    c.f.toString
+
+    c.g(0) // already worked
+    c.g
+    c.g[Int]
+    c.g.+(0)
+    c.g.toString
+    c.g[Int].+(0)
+    c.g.toString
+  }
+}

--- a/test/files/pos/i10715b/C_1.java
+++ b/test/files/pos/i10715b/C_1.java
@@ -1,0 +1,16 @@
+class C_1 {
+
+  public int f() {
+    return 0;
+  }
+  public C_1 f(int x) {
+    return null;
+  }
+}
+
+class Child extends C_1 {
+  @Override
+  public C_1 f(int x) {
+    return null;
+  }
+}

--- a/test/files/pos/i10715b/caller_2.scala
+++ b/test/files/pos/i10715b/caller_2.scala
@@ -1,0 +1,15 @@
+class C {
+  def test(c: Child): Unit = {
+    c.f() // always ok
+    c.f // should work too
+    c.f(1)
+    c.f.toString
+  }
+
+  // The issue was first detected on NIO buffers,
+  // (on Java 11+), so these should pass now.
+  def buffer(c: java.nio.ByteBuffer): Unit = {
+    c.position
+    c.position(10).position.toString
+  }
+}

--- a/test/files/pos/i6705.scala
+++ b/test/files/pos/i6705.scala
@@ -1,0 +1,15 @@
+trait StringTempl {
+  def mkString: String
+  def mkString(x: String): String
+}
+
+object Test {
+  implicit class extension(val x: String) {
+    def shouldBe(y: String): Boolean = ???
+  }
+
+  def test(tmpl: StringTempl): Unit = {
+    tmpl.mkString shouldBe "hello"                       // error
+    tmpl.mkString(", world") shouldBe "hello, world"
+  }
+}


### PR DESCRIPTION
The ancient code comment says it used to work that way. It works that way in Dotty. What's old is new.

Note that https://github.com/lampepfl/dotty/pull/16315 applies the existing fallback to ambiguous case.

The issue with `ByteBuffer` API is at https://github.com/scala/bug/issues/10418 which was closed for fixing a different interop problem.

Overlapping test at https://github.com/scala/bug/issues/5735 is for messaging rather than overload resolution.

Opening a PR should just automatically add a He-Pin 👍 