### PR TITLE
restore a bit of spec language that went missing

### DIFF
--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -1526,7 +1526,9 @@ question: given
 
 - A parameterized method ´m´ of type `(´p_1:T_1, \ldots , p_n:T_n´)´U´` is
   _as specific as_ some other member ´m'´ of type ´S´ if ´m'´ is [applicable](#function-applications)
-  to arguments `(´p_1 , \ldots , p_n´)` of types ´T_1 , \ldots , T_n´.
+  to arguments `(´p_1 , \ldots , p_n´)` of types ´T_1 , \ldots , T_last´;
+  if ´T_n´ denotes a repeated parameter (it has shape ´T*´), and so does ´m'´'s last parameter,
+  ´T_last´ is taken as ´T´, otherwise ´T_n´ is used directly.
 - A polymorphic method of type `[´a_1´ >: ´L_1´ <: ´U_1 , \ldots , a_n´ >: ´L_n´ <: ´U_n´]´T´` is
   as specific as some other member of type ´S´ if ´T´ is as specific as ´S´
   under the assumption that for ´i = 1 , \ldots , n´ each ´a_i´ is an abstract type name


### PR DESCRIPTION
This came up during some Scala 3 work. "I could have sworn the spec said something about this," I thought, and I was right — it did, before it didn't again.

A little digging revealed that the language in question was added by Adriaan in #7680 but then accidentally got removed in 2020 by #7432.

I looked through other spec commits in that date span and didn't find anything else that went missing