### PR TITLE
IterableOnce.isEmpty uses knownSize, sum is reduce

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -41,6 +41,9 @@ object MimaFilters extends AutoPlugin {
 
     // private class used by methods
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.IterableOnceOps$Maximized"),
+
+    // private object used by methods
+    ProblemFilters.exclude[MissingClassProblem]("scala.math.Numeric$BigDecimalIsConflicted$"),
   )
 
   override val buildSettings = Seq(

--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -936,11 +936,7 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
 
   /** Sums the elements of this collection.
    *
-   *  The default implementation uses `reduce` for a known non-empty collection,
-   *  `foldLeft` otherwise.
-   *
-   *  If `foldLeft` is used, this implementation works around pollution of the math context
-   *  by ignoring the identity element.
+   *  The default implementation uses `reduce` for a known non-empty collection, `foldLeft` otherwise.
    *
    *   $willNotTerminateInf
    *
@@ -951,24 +947,14 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
    */
   def sum[B >: A](implicit num: Numeric[B]): B =
     knownSize match {
-      case -1 =>
-        val z = num.zero
-        if ((num eq Numeric.BigDecimalIsFractional) || (num eq Numeric.BigDecimalAsIfIntegral)) {
-          def nonPollutingPlus(x: B, y: B): B = if (x.asInstanceOf[AnyRef] eq z.asInstanceOf[AnyRef]) y else num.plus(x, y)
-          foldLeft(z)(nonPollutingPlus)
-        }
-        else foldLeft(z)(num.plus)
+      case -1 => foldLeft(num.zero)(num.plus)
       case  0 => num.zero
       case  _ => reduce(num.plus)
     }
 
   /** Multiplies together the elements of this collection.
    *
-   *  The default implementation uses `reduce` for a known non-empty collection,
-   *  `foldLeft` otherwise.
-   *
-   *  If `foldLeft` is used, this implementation works around pollution of the math context
-   *  by ignoring the identity element.
+   *  The default implementation uses `reduce` for a known non-empty collection, `foldLeft` otherwise.
    *
    *  $willNotTerminateInf
    *
@@ -979,13 +965,7 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
    */
   def product[B >: A](implicit num: Numeric[B]): B =
     knownSize match {
-      case -1 =>
-        val u = num.one
-        if ((num eq Numeric.BigDecimalIsFractional) || (num eq Numeric.BigDecimalAsIfIntegral)) {
-          def nonPollutingProd(x: B, y: B): B = if (x.asInstanceOf[AnyRef] eq u.asInstanceOf[AnyRef]) y else num.times(x, y)
-          foldLeft(u)(nonPollutingProd)
-        }
-        else foldLeft(u)(num.times)
+      case -1 => foldLeft(num.one)(num.times)
       case  0 => num.one
       case  _ => reduce(num.times)
     }

--- a/src/library/scala/math/Numeric.scala
+++ b/src/library/scala/math/Numeric.scala
@@ -177,9 +177,20 @@ object Numeric {
   implicit object DoubleIsFractional extends DoubleIsFractional with Ordering.Double.IeeeOrdering
 
   trait BigDecimalIsConflicted extends Numeric[BigDecimal] {
-    def plus(x: BigDecimal, y: BigDecimal): BigDecimal = x + y
-    def minus(x: BigDecimal, y: BigDecimal): BigDecimal = x - y
-    def times(x: BigDecimal, y: BigDecimal): BigDecimal = x * y
+    // works around pollution of math context by ignoring identity element
+    def plus(x: BigDecimal, y: BigDecimal): BigDecimal = {
+      import BigDecimalIsConflicted._0
+      if (x eq _0) y else x + y
+    }
+    def minus(x: BigDecimal, y: BigDecimal): BigDecimal = {
+      import BigDecimalIsConflicted._0
+      if (x eq _0) -y else x - y
+    }
+    // works around pollution of math context by ignoring identity element
+    def times(x: BigDecimal, y: BigDecimal): BigDecimal = {
+      import BigDecimalIsConflicted._1
+      if (x eq _1) y else x * y
+    }
     def negate(x: BigDecimal): BigDecimal = -x
     def fromInt(x: Int): BigDecimal = BigDecimal(x)
     def parseString(str: String): Option[BigDecimal] = Try(BigDecimal(str)).toOption
@@ -187,6 +198,10 @@ object Numeric {
     def toLong(x: BigDecimal): Long = x.longValue
     def toFloat(x: BigDecimal): Float = x.floatValue
     def toDouble(x: BigDecimal): Double = x.doubleValue
+  }
+  private object BigDecimalIsConflicted {
+    private val _0 = BigDecimal(0)   // cached zero is ordinarily cached for default math context
+    private val _1 = BigDecimal(1)   // cached one is ordinarily cached for default math context
   }
 
   trait BigDecimalIsFractional extends BigDecimalIsConflicted with Fractional[BigDecimal] {

--- a/test/junit/scala/collection/IterableTest.scala
+++ b/test/junit/scala/collection/IterableTest.scala
@@ -470,4 +470,20 @@ class IterableTest {
   @Test def `IterableOnceOps.reduceRightOption consumes one iterator`: Unit = assertEquals(Some(10), SingleUseIterable(1, 2, 3, 4).reduceRightOption(_ + _))
   @Test def `IterableOnceOps.reduceRightOption of empty iterator`: Unit = assertEquals(None, SingleUseIterable[Int]().reduceRightOption(_ + _))
   @Test def `IterableOnceOps.reduceRightOption consumes no iterator`: Unit = assertEquals(None, ZeroUseIterable[Int]().reduceRightOption(_ + _))
+
+  @Test def `IterableOnceOps.isEmpty consumes no iterator`: Unit = assertTrue(ZeroUseIterable[Int]().isEmpty)
+
+  @Test def `sum uses my reduce if knownSize > 0`: Unit = {
+    val reductive = new AbstractIterable[Int] {
+      val values = List(1, 2, 3, 4, 32)
+      override def iterator = Iterator.empty
+      override def reduce[B >: Int](op: (B, B) => B): B = values.reduce(op)             // sum, produce
+      override def reduceLeft[B >: Int](op: (B, Int) => B): B = values.reduceLeft(op)   // min, max
+      override def knownSize = values.size
+    }
+    assertEquals(42,  reductive.sum)
+    assertEquals(768, reductive.product)
+    assertEquals(1,   reductive.min)
+    assertEquals(32,  reductive.max)
+  }
 }

--- a/test/junit/scala/collection/SeqViewTest.scala
+++ b/test/junit/scala/collection/SeqViewTest.scala
@@ -1,14 +1,51 @@
 package scala.collection
 
-import org.junit.Assert._
+import org.junit.Assert.{assertThrows => _, _}
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+
+import scala.tools.testkit.AssertUtil.assertThrows
 
 @RunWith(classOf[JUnit4])
 class SeqViewTest {
   @Test
   def _toString(): Unit = {
     assertEquals("SeqView(<not computed>)", Seq(1, 2, 3).view.toString)
+  }
+
+  private def seq(n: Int, maxIterate: Int = -1): Seq[Int] =
+    new AbstractSeq[Int] {
+      val values = 1 to n
+      var remaining = maxIterate
+      def iterator = {
+        if (remaining == 0) throw new IllegalStateException()
+        if (remaining > 0) remaining -= 1
+        values.iterator
+      }
+      def apply(i: Int) = values(i)
+      def length = values.length
+    }
+  private def seqk(n: Int, maxIterate: Int): Seq[Int] =
+    new AbstractSeq[Int] {
+      val values = 1 to n
+      var remaining = maxIterate
+      def iterator = {
+        if (remaining == 0) throw new IllegalStateException()
+        if (remaining > 0) remaining -= 1
+        values.iterator
+      }
+      def apply(i: Int) = values(i)
+      def length = values.length
+      override def knownSize = length
+    }
+
+  @Test def `sum of seq view`: Unit = {
+    assertEquals(10, seq(4).view.sum)
+  }
+  @Test def `sum of seq view iterates once`: Unit = {
+    val sut = seqk(4, 1).view
+    assertEquals(10, sut.sum)
+    assertThrows[IllegalStateException](sut.sum)
   }
 }


### PR DESCRIPTION
`isEmpty` uses `knownSize` if known.

`BigDecimal`'s `Numeric` intercepts ops on identity to fix pollution of math context. Ugly but desired semantics.

Follow-up to https://github.com/scala/scala/pull/10211/files#r1032418501



