### PR TITLE
[REJECTED] Nullary override check only current sources

### DIFF
--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -385,6 +385,7 @@ object Reporting {
     object LintAdaptedArgs extends Lint; add(LintAdaptedArgs)
     object LintNullaryUnit extends Lint; add(LintNullaryUnit)
     object LintInaccessible extends Lint; add(LintInaccessible)
+    object LintNullaryOverride extends Lint; add(LintNullaryOverride)
     object LintInferAny extends Lint; add(LintInferAny)
     object LintMissingInterpolator extends Lint; add(LintMissingInterpolator)
     object LintDocDetached extends Lint; add(LintDocDetached)

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -187,6 +187,7 @@ trait Warnings {
     val AdaptedArgs            = LintWarning("adapted-args",              "An argument list was modified to match the receiver.")
     val NullaryUnit            = LintWarning("nullary-unit",              "`def f: Unit` looks like an accessor; add parens to look side-effecting.")
     val Inaccessible           = LintWarning("inaccessible",              "Warn about inaccessible types in method signatures.")
+    val NullaryOverride        = LintWarning("nullary-override",          "Non-nullary `def f()` overrides nullary `def f`.")
     val InferAny               = LintWarning("infer-any",                 "A type argument was inferred as Any.")
     val MissingInterpolator    = LintWarning("missing-interpolator",      "A string literal appears to be missing an interpolator id.")
     val DocDetached            = LintWarning("doc-detached",              "When running scaladoc, warn if a doc comment is discarded.")
@@ -221,6 +222,7 @@ trait Warnings {
   def warnAdaptedArgs            = lint contains AdaptedArgs
   def warnNullaryUnit            = lint contains NullaryUnit
   def warnInaccessible           = lint contains Inaccessible
+  def warnNullaryOverride        = lint contains NullaryOverride
   def warnInferAny               = lint contains InferAny
   def warnMissingInterpolator    = lint contains MissingInterpolator
   def warnDocDetached            = lint contains DocDetached

--- a/test/files/neg/nullary-override-3c.check
+++ b/test/files/neg/nullary-override-3c.check
@@ -1,0 +1,5 @@
+B_2.scala:7: error: method with a single empty parameter list overrides method without any parameter list
+def x: String (defined in trait T1)
+class Mix12b extends T1 with T2 { override def x() = "12b" }
+                                               ^
+1 error

--- a/test/files/neg/nullary-override-3c/A_1.scala
+++ b/test/files/neg/nullary-override-3c/A_1.scala
@@ -1,0 +1,3 @@
+// scalac: -Werror -Xsource:3
+//
+class A { def x: Int = 3 }

--- a/test/files/neg/nullary-override-3c/B_2.scala
+++ b/test/files/neg/nullary-override-3c/B_2.scala
@@ -1,0 +1,7 @@
+// scalac: -Werror -Xsource:3
+//
+class B extends A { override def x(): Int = 4 }
+
+trait T1 { def x: String   = "1" }
+trait T2 { def x(): String = "2" }
+class Mix12b extends T1 with T2 { override def x() = "12b" }

--- a/test/files/neg/nullary-override-3d.check
+++ b/test/files/neg/nullary-override-3d.check
@@ -1,0 +1,9 @@
+B_2.scala:3: warning: method with a single empty parameter list overrides method without any parameter list
+class B extends A { override def x(): Int = 4 }
+                                 ^
+B_2.scala:7: error: method with a single empty parameter list overrides method without any parameter list
+def x: String (defined in trait T1)
+class Mix12b extends T1 with T2 { override def x() = "12b" }
+                                               ^
+1 warning
+1 error

--- a/test/files/neg/nullary-override-3d/A_1.scala
+++ b/test/files/neg/nullary-override-3d/A_1.scala
@@ -1,0 +1,3 @@
+// scalac: -Werror -Xsource:3 -Xlint:nullary-override
+//
+class A { def x: Int = 3 }

--- a/test/files/neg/nullary-override-3d/B_2.scala
+++ b/test/files/neg/nullary-override-3d/B_2.scala
@@ -1,0 +1,7 @@
+// scalac: -Werror -Xsource:3 -Xlint:nullary-override
+//
+class B extends A { override def x(): Int = 4 }
+
+trait T1 { def x: String   = "1" }
+trait T2 { def x(): String = "2" }
+class Mix12b extends T1 with T2 { override def x() = "12b" }

--- a/test/files/pos/nullary-override-3e.scala
+++ b/test/files/pos/nullary-override-3e.scala
@@ -1,0 +1,11 @@
+// scalac: -Werror -Xsource:3
+
+import collection.AbstractIterable
+
+abstract class LIterable[+A] extends AbstractIterable[A] {
+  def iterator(): Iterator[A]
+}
+
+object Test extends App {
+  val chars: LIterable[Char] = () => "hello, world".iterator
+}


### PR DESCRIPTION
Scala 3 does not enforce the override check for Scala 2 definitions. To enable compiling under both regimes, restrict the check to when the overrides are in the current run. Restore the lint option to warn for the remaining cases.

Fixes scala/bug#12695