### PR TITLE
spec and test tweaks for signature polymorphic methods

### DIFF
--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -411,9 +411,10 @@ undefined then `$U$` is `scala.AnyRef`. The parameter names `$p_1 , \ldots , p_n
 
 ###### Note
 
-On the Java platform version 11 and later, signature polymorphic methods are native,
-members of `java.lang.invoke.MethodHandle` or `java.lang.invoke.VarHandle`, and have a single
-repeated parameter of type `java.lang.Object*`.
+On the Java platform version 11 and later, a method is signature polymorphic if it is native,
+a member of `java.lang.invoke.MethodHandle` or `java.lang.invoke.VarHandle`, and has a single
+repeated parameter of type `java.lang.Object*`. (These requirements also work for Java 8,
+which had fewer such methods.)
 
 
 ## Method Values

--- a/test/files/run/dotty-i11332.scala
+++ b/test/files/run/dotty-i11332.scala
@@ -7,6 +7,7 @@ class Foo {
   def over(i: Int): String  = "int"
   def unit(s: String): Unit = ()
   def obj(s: String): Object = s
+  def void(v: Void): String = "void"
 }
 
 object Test {
@@ -19,6 +20,7 @@ object Test {
     val mhOverI = l.findVirtual(classOf[Foo], "over", methodType(classOf[String], classOf[Int]))
     val mhUnit  = l.findVirtual(classOf[Foo], "unit", methodType(classOf[Unit], classOf[String]))
     val mhObj   = l.findVirtual(classOf[Foo], "obj", methodType(classOf[Any], classOf[String]))
+    val mhVoid  = l.findVirtual(classOf[Foo], "void", methodType(classOf[String], classOf[Void]))
 
     assert(-42 == (mhNeg.invokeExact(self, 42): Int))
     assert(-33 == (mhNeg.invokeExact(self, 33): Int))
@@ -43,6 +45,8 @@ object Test {
     assert("any2" == any2)
     def any3 = mhObj.invokeExact(self, "any3")
     assert("any3" == any3)
+
+    assert("void" == (mhVoid.invokeExact(self, null: Void): String))
 
     expectWrongMethod {
       l // explicit chain method call

--- a/test/files/run/dotty-i11332b.scala
+++ b/test/files/run/dotty-i11332b.scala
@@ -7,10 +7,9 @@ object Test {
   def main(args: Array[String]): Unit = {
     val l = MethodHandles.lookup()
     val mhCL = l.findStatic(classOf[ClassLoader], "getPlatformClassLoader", methodType(classOf[ClassLoader]))
-    // sanity check that the non-signature-polymorphic invocations work as expected
+    // `invoke` and `invokeExact` are both signature polymorphic
     assert(null != (mhCL.invoke(): ClassLoader))
     assert(null != (mhCL.invoke().asInstanceOf[ClassLoader]: ClassLoader))
-    // now go signature polymorphic
     assert(null != (mhCL.invokeExact(): ClassLoader))
     // I've commented out this part of the Dotty test because here in Scala 2,
     // we didn't implement specifying a signature polymorphic method's return type


### PR DESCRIPTION
sequel to #10195
references scala/bug#12678

review by @dwijnand -- please read my recent remarks on 12678 as part of your review