### PR TITLE
Don't catch UnsupportedOperationException in IterableOnce.reduceRight

### DIFF
--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -783,12 +783,7 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
   def reduceRight[B >: A](op: (A, B) => B): B = this match {
     case seq: IndexedSeq[A @unchecked] if seq.length > 0 => foldr[A, B](seq, op)
     case _ if knownSize == 0 => throw new UnsupportedOperationException("empty.reduceRight")
-    case _ =>
-      try reversed.reduceLeft[B]((x, y) => op(y, x))    // reduceLeftIterator
-      catch {
-        case e: UnsupportedOperationException if e.getMessage == "empty.reduceLeft" =>
-          throw new UnsupportedOperationException("empty.reduceRight")
-      }
+    case _ => reversed.reduceLeft[B]((x, y) => op(y, x)) // reduceLeftIterator
   }
 
   /** Optionally applies a binary operator to all elements of this $coll, going left to right.

--- a/test/junit/scala/collection/IterableTest.scala
+++ b/test/junit/scala/collection/IterableTest.scala
@@ -463,7 +463,7 @@ class IterableTest {
 
   @Test def `IterableOnceOps.reduceRight consumes one iterator`: Unit = assertEquals(106, SingleUseIterable(42, 27, 37).reduceRight(_ + _))
   @Test def `IterableOnceOps.reduceRight of empty iterator`: Unit =
-    assertThrows[UnsupportedOperationException](SingleUseIterable[Int]().reduceRight(_ + _), _.contains("reduceRight"))
+    assertThrows[UnsupportedOperationException](SingleUseIterable[Int]().reduceRight(_ + _), _.contains("reduceLeft"))
   @Test def `IterableOnceOps.reduceRight consumes no iterator`: Unit =
     assertThrows[UnsupportedOperationException](ZeroUseIterable[Int]().reduceRight(_ + _), _.contains("reduceRight"))
 


### PR DESCRIPTION
Follow-up for https://github.com/scala/scala/pull/10211, in the spirit of https://github.com/scala/scala/pull/10230#discussion_r1034460225