### PR TITLE
Do not embed absolute path into class files when -Xcheckinit flag is used

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/AccessorSynthesis.scala
+++ b/src/compiler/scala/tools/nsc/transform/AccessorSynthesis.scala
@@ -357,7 +357,7 @@ trait AccessorSynthesis extends Transform with ast.TreeDSL {
         else rhs
 
       private def mkCheckedAccessorRhs(retVal: Tree, pos: Position, bitmap: BitmapInfo): Tree = {
-        val msg = s"Uninitialized field: ${clazz.sourceFile}: ${pos.line}"
+        val msg = s"Uninitialized field: ${clazz.sourceFile.name}: ${pos.line}"
         val result =
           IF(mkTest(bitmap, equalToZero = false)).
             THEN(retVal).


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/12698

It changes the code emitted when ` -Xcheckinit` flag is used. The result of this fix will be that instead of emitting something like this:
```
ldc 'Uninitialized field: /home/ruslan/xcheckinit/CheckInit.scala: 2'
```
The following code will be emitted:
```
ldc 'Uninitialized field: CheckInit.scala: 2'
```
This will make sure that the classes do not contain absolute path embedded into them anymore.

It will allow to build such objects on another machine, with different directory structure, without changing the resulting artifact.

**The potential issues**
- The error message will change, and might not be as easy to digest for IDE when running tests.
- I did not check if there any other places under other flags embedding the absolute path in a similar manner. It might be worth to check if there are other places.

**Possible alternatives**
It might be possible to introduce the flag changing the behavior and, potentially, controlling other places if such issue to occur in these places. I.e. `-Xreproducible` or `-Xstripabsolutepaths`, or something like that.

Also see https://github.com/scala/scala-dev/issues/405 for more discussion on why having reproducible builds is good.