### PR TITLE
Faulty implementation of method `diff` in subclass `BitSetN` of `scala.collection.immutable.BitSet`

### DIFF
--- a/src/library/scala/collection/immutable/BitSet.scala
+++ b/src/library/scala/collection/immutable/BitSet.scala
@@ -244,36 +244,45 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
             anyChanges ||= currentWord != oldWord
             i -= 1
           }
-          if (i < 0) {
-            // all indices >= 0 have had result 0, so the bitset is empty
-            this.empty
-          } else {
-            val minimumNonZeroIndex: Int = i + 1
-            while (!anyChanges && i >= 0) {
-              val oldWord = word(i)
-              currentWord = oldWord & ~bs.word(i)
-              anyChanges ||= currentWord != oldWord
-              i -= 1
-            }
-            if (anyChanges) {
-              if (minimumNonZeroIndex == -1) {
-                this.empty
-              } else if (minimumNonZeroIndex == 0) {
-                new BitSet1(currentWord)
-              } else if (minimumNonZeroIndex == 1) {
-                new BitSet2(word(0) & ~bs.word(0), currentWord)
+          i match {
+            case -1 =>
+              if (anyChanges) {
+                if (currentWord == 0) {
+                  this.empty
+                } else {
+                  new BitSet1(currentWord)
+                }
               } else {
+                this
+              }
+            case 0 =>
+              val oldFirstWord = word(0)
+              val firstWord = oldFirstWord & ~bs.word(0)
+              anyChanges ||= firstWord != oldFirstWord
+              if (anyChanges) {
+                new BitSet2(firstWord, currentWord)
+              } else {
+                this
+              }
+            case _ =>
+              val minimumNonZeroIndex: Int = i + 1
+              while (!anyChanges && i >= 0) {
+                val oldWord = word(i)
+                currentWord = oldWord & ~bs.word(i)
+                anyChanges ||= currentWord != oldWord
+                i -= 1
+              }
+              if (anyChanges) {
                 val newArray = elems.take(minimumNonZeroIndex + 1)
                 newArray(i + 1) = currentWord
                 while (i >= 0) {
                   newArray(i) = word(i) & ~bs.word(i)
                   i -= 1
                 }
-                this.fromBitMaskNoCopy(newArray)
+                new BitSetN(newArray)
+              } else {
+                this
               }
-            } else {
-              this
-            }
           }
         } else {
           var i = bsnwords - 1
@@ -314,36 +323,45 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
         anyChanges ||= currentWord != oldWord
         i -= 1
       }
-      if (i < 0) {
-        // all indices >= 0 have had result 0, so the bitset is empty
-        if (currentWord == 0) this.empty else this.fromBitMaskNoCopy(Array(currentWord))
-      } else {
-        val minimumNonZeroIndex: Int = i + 1
-        while (!anyChanges && i >= 0) {
-          val oldWord = word(i)
-          currentWord = BitSetOps.computeWordForFilter(pred, isFlipped, oldWord, i)
-          anyChanges ||= currentWord != oldWord
-          i -= 1
-        }
-        if (anyChanges) {
-          if (minimumNonZeroIndex == -1) {
-            this.empty
-          } else if (minimumNonZeroIndex == 0) {
-            new BitSet1(currentWord)
-          } else if (minimumNonZeroIndex == 1) {
-            new BitSet2(BitSetOps.computeWordForFilter(pred, isFlipped, word(0), 0), currentWord)
+      i match {
+        case -1 =>
+          if (anyChanges) {
+            if (currentWord == 0) {
+              this.empty
+            } else {
+              new BitSet1(currentWord)
+            }
           } else {
+            this
+          }
+        case 0 =>
+          val oldFirstWord = word(0)
+          val firstWord = BitSetOps.computeWordForFilter(pred, isFlipped, oldFirstWord, 0)
+          anyChanges ||= firstWord != oldFirstWord
+          if (anyChanges) {
+            new BitSet2(firstWord, currentWord)
+          } else {
+            this
+          }
+        case _ =>
+          val minimumNonZeroIndex: Int = i + 1
+          while (!anyChanges && i >= 0) {
+            val oldWord = word(i)
+            currentWord = BitSetOps.computeWordForFilter(pred, isFlipped, oldWord, i)
+            anyChanges ||= currentWord != oldWord
+            i -= 1
+          }
+          if (anyChanges) {
             val newArray = elems.take(minimumNonZeroIndex + 1)
             newArray(i + 1) = currentWord
             while (i >= 0) {
               newArray(i) = BitSetOps.computeWordForFilter(pred, isFlipped, word(i), i)
               i -= 1
             }
-            this.fromBitMaskNoCopy(newArray)
+            new BitSetN(newArray)
+          } else {
+            this
           }
-        } else {
-          this
-        }
       }
     }
 

--- a/test/junit/scala/collection/immutable/SetTest.scala
+++ b/test/junit/scala/collection/immutable/SetTest.scala
@@ -160,4 +160,17 @@ class SetTest {
     testCorrectness()
     testNoHashCodeInvocationsDuringSubsetOf()
   }
+
+  @Test def pr10238(): Unit = {
+    assertEquals(BitSet(0), BitSet(0, 128) diff BitSet(128))
+
+    val us = scala.collection.immutable.BitSet(39, 41, 44, 46, 256)
+    val vs = scala.collection.immutable.BitSet(39, 41, 44, 46, 64, 256)
+    val xs = scala.collection.immutable.BitSet.fromBitMask(us.toBitMask.take(3))
+    val ys = scala.collection.immutable.BitSet.fromBitMask(vs.toBitMask.take(3))
+    val diff = ys diff xs
+    val expected = scala.collection.immutable.BitSet(64)
+    assertEquals(diff, expected)
+  }
+
 }


### PR DESCRIPTION
The implementation of the method `diff` in class `BitSetN` is faulty.  It returns an empty BitSet for non-equal sets if the differences all occur in the first word.  As an example consider the following code.
```
    val mutableBitSet1 = scala.collection.mutable.BitSet(0, 128)
    val mutableBitSet2 = scala.collection.mutable.BitSet(128)
    val mutableDiff = mutableBitSet1 diff mutableBitSet2
    println("mutable diff: " + mutableDiff)

    val immutableBitSet1 = scala.collection.immutable.BitSet(0, 128)
    val immutableBitSet2 = scala.collection.immutable.BitSet(128)
    val immutableDiff = immutableBitSet1 diff immutableBitSet2
    println("immutable diff: " + immutableDiff)
```

While `mutableDiff` contains the correct result, namely a singleton BitSet containing 0, `immutableDiff` is empty.

The error is still present in Scala 3.2.1, which I use.  It would be great if this bug can be resolved in all affected versions.