### PR TITLE
fix typo in recently added ambiguity message

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1369,7 +1369,7 @@ trait Contexts { self: Analyzer =>
         val inherit = if (parent.exists && parent != other.owner) s", inherited through parent $parent" else ""
         val message =
           s"""it is both defined in the enclosing ${sym.owner} and available in the enclosing $enclDesc as $other (defined in ${other.ownsString}$inherit)
-             |Since 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+             |Since Scala 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
              |To continue using the symbol from the superclass, write `this.${sym.name}`.""".stripMargin
         if (currentRun.isScala3)
           Some(LookupAmbiguous(message))

--- a/test/files/neg/t11921-alias.check
+++ b/test/files/neg/t11921-alias.check
@@ -1,27 +1,27 @@
 t11921-alias.scala:18: warning: reference to TT is ambiguous;
 it is both defined in the enclosing object O and available in the enclosing class D as type TT (defined in class C)
-Since 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+Since Scala 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
 To continue using the symbol from the superclass, write `this.TT`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
       def n(x: TT) = x // ambiguous
                ^
 t11921-alias.scala:38: warning: reference to c is ambiguous;
 it is both defined in the enclosing class B and available in the enclosing anonymous class as value c (defined in class A)
-Since 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+Since Scala 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
 To continue using the symbol from the superclass, write `this.c`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
       def n = c // ambiguous
               ^
 t11921-alias.scala:57: warning: reference to name is ambiguous;
 it is both defined in the enclosing method m and available in the enclosing anonymous class as value name (defined in class C)
-Since 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+Since Scala 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
 To continue using the symbol from the superclass, write `this.name`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
       println(name)
               ^
 t11921-alias.scala:67: warning: reference to name is ambiguous;
 it is both defined in the enclosing method m and available in the enclosing anonymous class as value name (defined in class A, inherited through parent class C)
-Since 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+Since Scala 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
 To continue using the symbol from the superclass, write `this.name`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
       println(name)

--- a/test/files/neg/t11921.check
+++ b/test/files/neg/t11921.check
@@ -5,7 +5,7 @@ t11921.scala:6: error: type mismatch;
                                        ^
 t11921.scala:6: warning: reference to coll is ambiguous;
 it is both defined in the enclosing method lazyMap and available in the enclosing anonymous class as method coll (defined in trait Iterable)
-Since 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+Since Scala 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
 To continue using the symbol from the superclass, write `this.coll`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
       def iterator = coll.iterator.map(f)    // coll is ambiguous

--- a/test/files/neg/t11921b.check
+++ b/test/files/neg/t11921b.check
@@ -1,34 +1,34 @@
 t11921b.scala:11: warning: reference to x is ambiguous;
 it is both defined in the enclosing object Test and available in the enclosing class D as value x (defined in class C)
-Since 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+Since Scala 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
 To continue using the symbol from the superclass, write `this.x`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
       println(x)  // error
               ^
 t11921b.scala:15: warning: reference to x is ambiguous;
 it is both defined in the enclosing object Test and available in the enclosing anonymous class as value x (defined in class C)
-Since 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+Since Scala 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
 To continue using the symbol from the superclass, write `this.x`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
         println(x)  // error
                 ^
 t11921b.scala:26: warning: reference to y is ambiguous;
 it is both defined in the enclosing method c and available in the enclosing anonymous class as value y (defined in class D)
-Since 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+Since Scala 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
 To continue using the symbol from the superclass, write `this.y`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
       println(y)  // error
               ^
 t11921b.scala:38: warning: reference to y is ambiguous;
 it is both defined in the enclosing method c and available in the enclosing class E as value y (defined in class D)
-Since 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+Since Scala 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
 To continue using the symbol from the superclass, write `this.y`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
         println(y)  // error
                 ^
 t11921b.scala:75: warning: reference to x is ambiguous;
 it is both defined in the enclosing object Uhu and available in the enclosing class C as value x (defined in class A, inherited through parent class B)
-Since 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+Since Scala 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
 To continue using the symbol from the superclass, write `this.x`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
         def t = x // ambiguous, message mentions parent B


### PR DESCRIPTION
Follow-up for https://github.com/scala/scala/pull/10220