### PR TITLE
Thread.getId is deprecated in JVM19

### DIFF
--- a/src/compiler/scala/tools/nsc/PipelineMain.scala
+++ b/src/compiler/scala/tools/nsc/PipelineMain.scala
@@ -325,6 +325,7 @@ class PipelineMainClass(argFiles: Seq[Path], pipelineSettings: PipelineMain.Pipe
     trace.append("""{"traceEvents": [""")
     val sb = new mutable.StringBuilder(trace)
 
+    @annotation.nowarn("cat=deprecation")
     def durationEvent(name: String, cat: String, t: Timer): String = {
       s"""{"name": "$name", "cat": "$cat", "ph": "X", "ts": ${(t.startMicros).toLong}, "dur": ${(t.durationMicros).toLong}, "pid": 0, "tid": ${t.thread.getId}}"""
     }

--- a/src/compiler/scala/tools/nsc/profile/Profiler.scala
+++ b/src/compiler/scala/tools/nsc/profile/Profiler.scala
@@ -129,6 +129,7 @@ private [profile] object RealProfiler {
   private val idGen = new AtomicInteger()
   lazy val allPlugins = ServiceLoader.load(classOf[ProfilerPlugin]).iterator.asScala.toList
 
+  @annotation.nowarn("cat=deprecation")
   private[profile] def snapThread(idleTimeNanos: Long): ProfileSnap = {
     val current = Thread.currentThread()
     val allocatedBytes = threadMx.getThreadAllocatedBytes(Thread.currentThread().getId)
@@ -403,6 +404,7 @@ class StreamProfileReporter(out:PrintWriter) extends ProfileReporter {
   override def reportForeground(profiler: RealProfiler, threadRange: ProfileRange): Unit = {
     reportCommon(EventType.MAIN, profiler, threadRange)
   }
+  @annotation.nowarn("cat=deprecation")
   private def reportCommon(tpe:EventType.value, profiler: RealProfiler, threadRange: ProfileRange): Unit = {
     out.println(s"$tpe,${threadRange.start.snapTimeNanos},${threadRange.end.snapTimeNanos},${profiler.id},${threadRange.phase.id},${threadRange.phase.name},${threadRange.purpose},${threadRange.taskCount},${threadRange.thread.getId},${threadRange.thread.getName},${threadRange.runNs},${threadRange.idleNs},${threadRange.cpuNs},${threadRange.userNs},${threadRange.allocatedBytes},${threadRange.end.heapBytes} ")
   }

--- a/src/library/scala/concurrent/impl/ExecutionContextImpl.scala
+++ b/src/library/scala/concurrent/impl/ExecutionContextImpl.scala
@@ -35,6 +35,7 @@ private[concurrent] object ExecutionContextImpl {
 
     private final val blockerPermits = new Semaphore(maxBlockers)
 
+    @annotation.nowarn("cat=deprecation")
     def wire[T <: Thread](thread: T): T = {
       thread.setDaemon(daemonic)
       thread.setUncaughtExceptionHandler(uncaught)

--- a/src/reflect/scala/reflect/internal/util/ChromeTrace.scala
+++ b/src/reflect/scala/reflect/internal/util/ChromeTrace.scala
@@ -43,6 +43,7 @@ final class ChromeTrace(f: Path) extends Closeable {
   private val traceWriter = FileUtils.newAsyncBufferedWriter(f)
   private val context = mutable.Stack[JsonContext](TopContext)
   private val tidCache = new ThreadLocal[String]() {
+    @annotation.nowarn("cat=deprecation")
     override def initialValue(): String = f"${Thread.currentThread().getId}%05d"
   }
   objStart()

--- a/src/testkit/scala/tools/testkit/AllocationTest.scala
+++ b/src/testkit/scala/tools/testkit/AllocationTest.scala
@@ -132,6 +132,7 @@ trait AllocationTest {
   private[AllocationTest] def calcAllocationInfo[T](fn: => T, cost: Long, text: String, ignoreEqualCheck: Boolean)(implicit execution: AllocationExecution = AllocationExecution()): AllocationInfo[T] = {
     val expected  = fn
     val extraText = if (text.isEmpty) "" else s" -- $text"
+    @annotation.nowarn("cat=deprecation")
     val id        = Thread.currentThread().getId
     val counts    = new Array[Long](execution.executionCount)
 


### PR DESCRIPTION
I think it doesn't warn for unused nowarn under old JDK?