### PR TITLE
Fix sealed suptype enumeration in match analysis

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -110,7 +110,7 @@ trait TreeAndTypeAnalysis extends Debugging {
 
     private def enumerateSealed(tp: Type, grouped: Boolean): List[List[Type]] = {
       val tpApprox = analyzer.approximateAbstracts(tp)
-      val pre      = tpApprox.prefix
+      val pre      = tp.prefix
       val sym      = tp.typeSymbol
 
       def subclassesToSubtypes(syms: List[Symbol]): List[Type] = syms.flatMap { sym =>
@@ -120,7 +120,7 @@ trait TreeAndTypeAnalysis extends Debugging {
         //    sealed trait X[T]; class XInt extends X[Int]
         // XInt not valid when enumerating X[String]
         // however, must also approximate abstract types
-        val memberType  = nestedMemberType(sym, pre, tpApprox.typeSymbol.owner)
+        val memberType  = nestedMemberType(sym, pre, tp.typeSymbol.owner)
         val subTp       = appliedType(memberType, WildcardType.fillList(sym.typeParams.length))
         val subTpApprox = analyzer.approximateAbstracts(subTp)
         if (subTpApprox <:< tpApprox) Some(checkableType(subTp)) else None

--- a/test/files/neg/t12704.check
+++ b/test/files/neg/t12704.check
@@ -1,0 +1,7 @@
+t12704.scala:13: warning: match may not be exhaustive.
+It would fail on the following input: L(_)
+  def t2(t: P) = t match {
+                 ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/t12704.scala
+++ b/test/files/neg/t12704.scala
@@ -1,0 +1,16 @@
+// scalac: -Werror
+class Out {
+  sealed trait P
+  case class K(x: Int) extends P
+  case class L(x: Int) extends P
+}
+class C[O <: Out](val o: O) {
+  import o._
+  def t1(t: P) = t match {
+    case _: K => 0
+    case _: L => 0
+  }
+  def t2(t: P) = t match {
+    case _: K => 0
+  }
+}


### PR DESCRIPTION
Use the the approximated scrutinee type only to compare possible subtypes, but don't extract the prefix from it.

Fixes https://github.com/scala/bug/issues/12704