### PR TITLE
Fix `take` and `drop` on very large `NumericRange`s

### DIFF
--- a/src/library/scala/collection/immutable/NumericRange.scala
+++ b/src/library/scala/collection/immutable/NumericRange.scala
@@ -142,11 +142,15 @@ sealed class NumericRange[T](
   // because the length of the range cannot be represented with Int numbers.
   // This method tries to compare the length of this with the given Int number.
   private def compareLength(n: Int): Int = {
-    val diff = num.minus(end, start)
-    val quotient = num.quot(diff, step)
-    val remainder = num.minus(diff, num.times(quotient, step))
-    val thisLength = if (!isInclusive && zero == remainder) quotient else num.plus(quotient, num.one)
-    num.compare(num.fromInt(n), thisLength)
+    num match {
+      case _: Numeric.ByteIsIntegral | _: Numeric.ShortIsIntegral => n compare length
+      case _ =>
+        val diff = num.minus(end, start)
+        val quotient = num.quot(diff, step)
+        val remainder = num.minus(diff, num.times(quotient, step))
+        val thisLength = if (!isInclusive && zero == remainder) quotient else num.plus(quotient, num.one)
+        num.compare(num.fromInt(n), thisLength)
+    }
   }
 
   override def take(n: Int): NumericRange[T] = {

--- a/src/library/scala/collection/immutable/NumericRange.scala
+++ b/src/library/scala/collection/immutable/NumericRange.scala
@@ -138,31 +138,16 @@ sealed class NumericRange[T](
   // based on the given value.
   private def newEmptyRange(value: T) = NumericRange(value, value, step)
 
-  // Calling length when a range contains more than Int.MaxValue causes IllegalArgumentException
-  // because the length of the range cannot be represented with Int numbers.
-  // This method tries to compare the length of this with the given Int number.
-  private def compareLength(n: Int): Int = {
-    num match {
-      case _: Numeric.ByteIsIntegral | _: Numeric.ShortIsIntegral => n compare length
-      case _ =>
-        val diff = num.minus(end, start)
-        val quotient = num.quot(diff, step)
-        val remainder = num.minus(diff, num.times(quotient, step))
-        val thisLength = if (!isInclusive && zero == remainder) quotient else num.plus(quotient, num.one)
-        num.compare(num.fromInt(n), thisLength)
-    }
-  }
-
   override def take(n: Int): NumericRange[T] = {
     if (n <= 0 || isEmpty) newEmptyRange(start)
-    else if (compareLength(n) < 0)
+    else if (num.lt(locationAfterN(n - 1), end))
       new NumericRange.Inclusive(start, locationAfterN(n - 1), step)
     else this
   }
 
   override def drop(n: Int): NumericRange[T] = {
     if (n <= 0 || isEmpty) this
-    else if (compareLength(n) < 0)
+    else if (num.lt(locationAfterN(n), end))
       copy(locationAfterN(n), end, step)
     else newEmptyRange(end)
   }

--- a/src/library/scala/collection/immutable/NumericRange.scala
+++ b/src/library/scala/collection/immutable/NumericRange.scala
@@ -143,7 +143,9 @@ sealed class NumericRange[T](
   // This method tries to compare the length of this with the given Int number.
   private def compareLength(n: Int): Int = {
     val diff = num.minus(end, start)
-    val thisLength = num.quot(diff, step)
+    val quotient = num.quot(diff, step)
+    val remainder = num.minus(diff, num.times(quotient, step))
+    val thisLength = if (!isInclusive && zero == remainder) quotient else num.plus(quotient, num.one)
     num.compare(num.fromInt(n), thisLength)
   }
 

--- a/src/library/scala/collection/immutable/NumericRange.scala
+++ b/src/library/scala/collection/immutable/NumericRange.scala
@@ -147,7 +147,7 @@ sealed class NumericRange[T](
 
   override def drop(n: Int): NumericRange[T] = {
     if (n <= 0 || isEmpty) this
-    else if (num.lt(locationAfterN(n), end))
+    else if (num.lt(locationAfterN(n - 1), end))
       copy(locationAfterN(n), end, step)
     else newEmptyRange(end)
   }

--- a/test/junit/scala/collection/immutable/NumericRangeTest.scala
+++ b/test/junit/scala/collection/immutable/NumericRangeTest.scala
@@ -195,4 +195,49 @@ class NumericRangeTest {
     assertTrue(smallChunkOfRange equals expected)
     assertTrue(smallChunkOfRange.length == toAddToMaxInt)
   }
+
+  @Test
+  def numericRangeSmallTypesDrop() = {
+    val byteStart: Byte = Byte.MinValue
+    val byteEnd: Byte = Byte.MaxValue
+    val drop = scala.util.Random.nextInt(Byte.MaxValue)
+
+    val byteRange = NumericRange(byteStart, byteEnd, (1: Byte))
+    val byteRangeChunk = byteRange.drop(drop)
+    assertTrue(byteRangeChunk.length == byteRange.length - drop)
+    assertTrue(byteRangeChunk.end == byteEnd)
+    assertTrue(byteRangeChunk.start == (byteStart + drop.toByte))
+
+    val shortStart: Short = Short.MinValue
+    val shortEnd: Short = Short.MaxValue
+
+    val shortRange = NumericRange(shortStart, shortEnd, (1: Short))
+    val shortRangeChunk = shortRange.drop(drop)
+    assertTrue(shortRangeChunk.length == shortRange.length - drop)
+    assertTrue(shortRangeChunk.end == shortEnd)
+    assertTrue(shortRangeChunk.start == (shortStart + drop.toShort))
+  }
+
+  @Test
+  def numericRangeSmallTypesTake() = {
+    val byteStart: Byte = Byte.MinValue
+    val byteEnd: Byte = Byte.MaxValue
+    val take = scala.util.Random.nextInt(Byte.MaxValue)
+
+    val byteRange = NumericRange(byteStart, byteEnd, (1: Byte))
+    val byteRangeChunk = byteRange.take(take)
+    assertTrue(byteRangeChunk.length == take)
+    assertTrue(byteRangeChunk.end == byteStart + take.toByte - 1)
+    assertTrue(byteRangeChunk.start == byteStart)
+
+    val shortStart: Short = Short.MinValue
+    val shortEnd: Short = Short.MaxValue
+
+    val shortRange = NumericRange(shortStart, shortEnd, (1: Short))
+    val shortRangeChunk = shortRange.take(take)
+    assertTrue(shortRangeChunk.length == take)
+    assertTrue(shortRangeChunk.end == shortStart + take.toShort - 1)
+    assertTrue(shortRangeChunk.start == shortStart)
+  }
+
 }

--- a/test/junit/scala/collection/immutable/NumericRangeTest.scala
+++ b/test/junit/scala/collection/immutable/NumericRangeTest.scala
@@ -157,4 +157,42 @@ class NumericRangeTest {
     assertEquals(Nil, check(testDecreaseCase.start to testIncreaseCase.last by testIncreaseCase.step))
     assertEquals(Nil, check(testDecreaseCase.inclusive))
   }
+
+  @Test
+  def numericRangeWithMoreThanMaxIntTake() = {
+    val start = BigInt(0)
+    val step = BigInt(1)
+    val end = BigInt(Int.MaxValue) * 5
+
+    // evaluation of length causes IllegalArgumentException because it cannot be represented as Int number
+    // Yet using `take` should be independent of evaluating length when it's not necessary.
+    assertThrows[IllegalArgumentException]((start until end by step).length)
+    val range = start until end by step
+
+    val take = 100
+    val smallChunkOfRange = range.take(take)
+    val expected = start until BigInt(100) by step
+    assertTrue(smallChunkOfRange equals expected)
+    assertTrue(smallChunkOfRange.length == take)
+  }
+
+  @Test
+  def numericRangeWithMoreThanMaxIntDrop() = {
+    val start = BigInt(0)
+    val step = BigInt(1)
+    val toAddToMaxInt = 50
+    val end = BigInt(Int.MaxValue) + toAddToMaxInt
+
+    val drop = Int.MaxValue
+
+    // evaluation of length causes IllegalArgumentException because it cannot be represented as Int number
+    // Yet using `drop` should be independent of evaluating length when it's not necessary.
+    assertThrows[IllegalArgumentException]((start until end by step).length)
+    val range = start until end by step
+
+    val smallChunkOfRange = range.drop(drop)
+    val expected = BigInt(Int.MaxValue) until end by step
+    assertTrue(smallChunkOfRange equals expected)
+    assertTrue(smallChunkOfRange.length == toAddToMaxInt)
+  }
 }


### PR DESCRIPTION
Use length compare of Integral instead of evaluating `length` on `NumericRange`, to avoid IllegalArgumentException when using `drop` and `take`.

Fixes scala/bug#12706