### PR TITLE
Avoid name check when loading repl products

### DIFF
--- a/test/files/run/t12705.check
+++ b/test/files/run/t12705.check
@@ -1,0 +1,11 @@
+
+scala> case class Person(name: String)
+class Person
+
+scala> $intp.classLoader.getResource("Person.class")
+val res0: java.net.URL = memory:(memory)/Person.class
+
+scala> $intp.classLoader.loadClass("Person")
+val res1: Class[_] = class Person
+
+scala> :quit

--- a/test/files/run/t12705.scala
+++ b/test/files/run/t12705.scala
@@ -1,0 +1,20 @@
+
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  def code =
+    """|case class Person(name: String)
+       |$intp.classLoader.getResource("Person.class")
+       |$intp.classLoader.loadClass("Person")""".stripMargin
+       //|classOf[Person].getClassLoader.loadClass("Person")""".stripMargin
+}
+
+/*
+java.lang.NoClassDefFoundError: Person (wrong name: Person)
+  at java.base/java.lang.ClassLoader.defineClass1(Native Method)
+  at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1013)
+  at scala.reflect.internal.util.AbstractFileClassLoader.findClass(AbstractFileClassLoader.scala:77)
+  at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:588)
+  at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
+  ... 76 elided
+*/


### PR DESCRIPTION
Supplying the name to `defineClass` means the name is checked, but if REPL found the class for a "translated" name, the name will never match. So REPL's class loader supplies `null` to mean DK. Some extra code could be added to preserve the translation and the name check, but for the REPL that might be unnecessary.

Fixes scala/bug#12705