### PR TITLE
Deprecate infix type args, as they are dropped in Scala 3

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -986,10 +986,15 @@ self =>
 
     def finishBinaryOp(isExpr: Boolean, opinfo: OpInfo, rhs: Tree): Tree = {
       import opinfo._
+      if (targs.nonEmpty)
+        if (currentRun.isScala3)
+          syntaxError(offset, "type application is not allowed for infix operators")
+        else
+          deprecationWarning(offset, "type application will be disallowed for infix operators", "2.13.11")
       val operatorPos: Position = Position.range(rhs.pos.source, offset, offset, offset + operator.length)
       val pos                   = lhs.pos.union(rhs.pos).union(operatorPos).withEnd(in.lastOffset).withPoint(offset)
 
-      atPos(pos)(makeBinop(isExpr, lhs, operator, rhs, operatorPos, opinfo.targs))
+      atPos(pos)(makeBinop(isExpr, lhs, operator, rhs, operatorPos, targs))
     }
 
     def reduceExprStack(base: List[OpInfo], top: Tree): Tree    = reduceStack(isExpr = true, base, top)

--- a/test/files/neg/dotless-targs-a.check
+++ b/test/files/neg/dotless-targs-a.check
@@ -1,0 +1,15 @@
+dotless-targs-a.scala:4: warning: type application will be disallowed for infix operators
+  def fn2 = List apply[Int] 2
+                 ^
+dotless-targs-a.scala:9: warning: type application will be disallowed for infix operators
+  def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
+                ^
+dotless-targs-a.scala:9: warning: type application will be disallowed for infix operators
+  def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
+                                                    ^
+dotless-targs-a.scala:9: warning: multiarg infix syntax looks like a tuple and will be deprecated
+  def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
+                ^
+error: No warnings can be incurred under -Werror.
+4 warnings
+1 error

--- a/test/files/neg/dotless-targs-a.scala
+++ b/test/files/neg/dotless-targs-a.scala
@@ -1,0 +1,10 @@
+// scalac: -Werror -Xlint -Yrangepos:false
+class A {
+  def fn1 = List apply 1
+  def fn2 = List apply[Int] 2
+
+  def g1: Char = "g1" toList 0
+  def g2: Char = "g2" apply 1
+
+  def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
+}

--- a/test/files/neg/dotless-targs-b.check
+++ b/test/files/neg/dotless-targs-b.check
@@ -1,0 +1,10 @@
+dotless-targs-b.scala:4: error: type application is not allowed for infix operators
+  def fn2 = List apply[Int] 2
+                 ^
+dotless-targs-b.scala:9: error: type application is not allowed for infix operators
+  def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
+                ^
+dotless-targs-b.scala:9: error: type application is not allowed for infix operators
+  def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
+                                                    ^
+3 errors

--- a/test/files/neg/dotless-targs-b.scala
+++ b/test/files/neg/dotless-targs-b.scala
@@ -1,0 +1,10 @@
+// scalac: -Werror -Xlint -Xsource:3 -Yrangepos:false
+class A {
+  def fn1 = List apply 1
+  def fn2 = List apply[Int] 2
+
+  def g1: Char = "g1" toList 0
+  def g2: Char = "g2" apply 1
+
+  def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
+}

--- a/test/files/neg/dotless-targs-ranged-a.check
+++ b/test/files/neg/dotless-targs-ranged-a.check
@@ -1,0 +1,16 @@
+dotless-targs-ranged-a.scala:4: error: type application is not allowed for infix operators
+  def fn2 = List apply[Int] 2
+                 ^
+dotless-targs-ranged-a.scala:9: error: type application is not allowed for infix operators
+  def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
+                ^
+dotless-targs-ranged-a.scala:9: error: type application is not allowed for infix operators
+  def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
+                                                    ^
+dotless-targs-ranged-a.scala:13: error: type application is not allowed for infix operators
+  def eval = 1 ->[Int] 2
+               ^
+dotless-targs-ranged-a.scala:14: error: type application is not allowed for infix operators
+  def evil = new A() op  [Int,   String     ]  42
+                     ^
+5 errors

--- a/test/files/neg/dotless-targs-ranged-a.scala
+++ b/test/files/neg/dotless-targs-ranged-a.scala
@@ -1,0 +1,16 @@
+// scalac: -Xlint -Xsource:3 -Yrangepos:true
+class A {
+  def fn1 = List apply 1
+  def fn2 = List apply[Int] 2
+
+  def g1: Char = "g1" toList 0
+  def g2: Char = "g2" apply 1
+
+  def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
+
+  def op[A, B](i: Int): Int = 2*i
+
+  def eval = 1 ->[Int] 2
+  def evil = new A() op  [Int,   String     ]  42
+}
+

--- a/test/files/neg/dotless-targs.check
+++ b/test/files/neg/dotless-targs.check
@@ -1,4 +1,4 @@
-dotless-targs.scala:2: error: type application is not allowed for postfix operators
+dotless-targs.scala:4: error: type application is not allowed for postfix operators
   def f1 = "f1" isInstanceOf[String] // not ok
                 ^
 1 error

--- a/test/files/neg/dotless-targs.scala
+++ b/test/files/neg/dotless-targs.scala
@@ -1,3 +1,5 @@
+// scalac: -Xsource:3 -language:postfixOps
+//
 class A {
   def f1 = "f1" isInstanceOf[String] // not ok
   def f2 = "f2".isInstanceOf[String] // ok

--- a/test/files/run/t10751.check
+++ b/test/files/run/t10751.check
@@ -35,3 +35,4 @@
   }
 }
 
+warning: 4 deprecations (since 2.13.11); re-run with -deprecation for details

--- a/test/files/run/t1980.check
+++ b/test/files/run/t1980.check
@@ -1,3 +1,4 @@
+warning: 1 deprecation (since 2.13.11); re-run with -deprecation for details
 1. defining
 foo 1
 foo 2


### PR DESCRIPTION
Type arguments for infix expressions were added but never included in the specification and never received any support in Scala 3. They are now deprecated in Scala 2 and error under `-Xsource:3`.

For example, the 4th expression below is deprecated. In general, Scala 3 encourages only symbolic operators as infix operators, and never allows type arguments.
```
scala> xs.map(_ + 1)
val res1: List[Int] = List(43)

scala> xs map (_ + 1)
val res2: List[Int] = List(43)

scala> xs.map[Int](_ + 1)
val res3: List[Int] = List(43)

scala> xs map[Int] (_ + 1)
val res4: List[Int] = List(43)
```