### PR TITLE
[nomerge] Use newer dist on travis for spec build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,8 @@ jobs:
 
       # build the spec using jekyll
       - stage: build
+        # bionic for newer ruby ("bundler requires Ruby version >= 2.6.0")
+        dist: bionic
         language: ruby
         install:
           - ruby -v


### PR DESCRIPTION
Recent builds failed with

```
$ ruby -v
ruby 2.5.3p105 (2018-10-18 revision 65156) [x86_64-linux]
$ gem install bundler
ERROR:  Error installing bundler:
	The last version of bundler (>= 0) to support your Ruby & RubyGems was 2.3.26. Try installing it with `gem install bundler -v 2.3.26`
	bundler requires Ruby version >= 2.6.0. The current ruby version is 2.5.3.105.
```

We have the same in 2.13.x already for a different reason.