### PR TITLE
Tweak missing arg message with more names

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -689,11 +689,10 @@ trait ContextErrors extends splain.SplainErrors {
       def NotEnoughArgsError(tree: Tree, fun: Tree, missing: List[Symbol]) = {
         val notEnoughArgumentsMsg = {
           val suffix = if (missing.isEmpty) "" else {
-            val keep = missing take 3 map (_.name)
+            val keep = missing.take(3).map(_.name)
             val ess  = if (missing.tail.isEmpty) "" else "s"
-            f".%nUnspecified value parameter$ess ${
-              keep.mkString("", ", ", if ((missing drop 3).nonEmpty) "..." else ".")
-            }"
+            val dots = if (missing.drop(3).nonEmpty) "..." else "."
+            keep.mkString(s".\nUnspecified value parameter$ess ", ", ", dots)
           }
           s"not enough arguments for ${ treeSymTypeMsg(fun) }$suffix"
         }

--- a/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
@@ -405,7 +405,7 @@ trait NamesDefaults { self: Analyzer =>
    */
   def missingParams[T](args: List[T], params: List[Symbol], argName: T => Option[Name]): (List[Symbol], Boolean) = {
     // The argument list contains first a mix of positional args and named args that are on the
-    // right parameter position, and then a number or named args on different positions.
+    // right parameter position, and then a number of named args on different positions.
 
     // collect all named arguments whose position does not match the parameter they define
     val namedArgsOnChangedPosition = args.zip(params) dropWhile {
@@ -413,9 +413,8 @@ trait NamesDefaults { self: Analyzer =>
         val n = argName(arg)
         // drop the argument if
         //  - it's not named, or
-        //  - it's named, but defines the parameter on its current position, or
-        //  - it's named, but none of the parameter names matches (treated as a positional argument, an assignment expression)
-        n.isEmpty || n.get == param.name || params.forall(_.name != n.get)
+        //  - it's named, but defines the parameter on its current position
+        n.isEmpty || n.get == param.name
     } map (_._1)
 
     val paramsWithoutPositionalArg = params.drop(args.length - namedArgsOnChangedPosition.length)
@@ -433,6 +432,8 @@ trait NamesDefaults { self: Analyzer =>
    * Extend the argument list `givenArgs` with default arguments. Defaults are added
    * as named arguments calling the corresponding default getter.
    *
+   * Returns the extended arg list and missing parameters if any.
+   *
    * Example: given
    *   def foo(x: Int = 2, y: String = "def")
    *   foo(y = "lt")
@@ -443,8 +444,8 @@ trait NamesDefaults { self: Analyzer =>
                   pos: scala.reflect.internal.util.Position, context: Context): (List[Tree], List[Symbol]) = {
     if (givenArgs.length < params.length) {
       val (missing, positional) = missingParams(givenArgs, params, nameOfNamedArg)
-      if (missing forall (_.hasDefault)) {
-        val defaultArgs = missing flatMap (p => {
+      if (missing.forall(_.hasDefault)) {
+        val defaultArgs = missing flatMap { p =>
           val defGetter = defaultGetter(p, context)
           // TODO #3649 can create spurious errors when companion object is gone (because it becomes unlinked from scope)
           if (defGetter == NoSymbol) None // prevent crash in erroneous trees, #3649
@@ -463,9 +464,9 @@ trait NamesDefaults { self: Analyzer =>
               else NamedArg(Ident(p.name), default2)
             })
           }
-        })
+        }
         (givenArgs ::: defaultArgs, Nil)
-      } else (givenArgs, missing filterNot (_.hasDefault))
+      } else (givenArgs, missing.filterNot(_.hasDefault))
     } else (givenArgs, Nil)
   }
 
@@ -551,7 +552,7 @@ trait NamesDefaults { self: Analyzer =>
       var positionalAllowed = true
       def stripNamedArg(arg: NamedArg, argIndex: Int): Tree = {
         val NamedArg(Ident(name), rhs) = arg: @unchecked
-        params indexWhere (p => matchesName(p, name, argIndex)) match {
+        params.indexWhere(p => matchesName(p, name, argIndex)) match {
           case -1 =>
             val warnVariableInScope = !currentRun.isScala3 && context0.lookupSymbol(name, _.isVariable).isSuccess
             UnknownParameterNameNamesDefaultError(arg, name, warnVariableInScope)

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3735,7 +3735,10 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                   doTypedApply(tree, if (blockIsEmpty) fun else fun1, allArgs, mode, pt).tap(checkRecursive)
                 } else {
                   rollbackNamesDefaultsOwnerChanges()
-                  tryTupleApply orElse duplErrorTree(NotEnoughArgsError(tree, fun, missing))
+                  tryTupleApply orElse {
+                    removeNames(Typer.this)(allArgs, params) // report bad names
+                    duplErrorTree(NotEnoughArgsError(tree, fun, missing))
+                  }
                 }
               }
             }

--- a/test/files/neg/t8667.check
+++ b/test/files/neg/t8667.check
@@ -127,4 +127,20 @@ t8667.scala:76: error: can't supply unit value with infix notation because nulla
 t8667.scala:77: error: no arguments allowed for nullary method f0: (): Int
     x.f0(())
          ^
-43 errors
+t8667.scala:89: error: unknown parameter name: k
+    f2(k = 42)
+         ^
+t8667.scala:89: error: not enough arguments for method f2: (i: Int, j: Int): Unit.
+Unspecified value parameters i, j.
+    f2(k = 42)
+      ^
+t8667.scala:90: error: unknown parameter name: k
+    f2(17, k = 42)
+             ^
+t8667.scala:91: error: unknown parameter name: k
+    f2(17, 27, k = 42)
+                 ^
+t8667.scala:91: error: too many arguments (found 3, expected 2) for method f2: (i: Int, j: Int): Unit
+    f2(17, 27, k = 42)
+      ^
+48 errors

--- a/test/files/neg/t8667.scala
+++ b/test/files/neg/t8667.scala
@@ -82,3 +82,12 @@ object app {
     x f0
   }
 }
+
+trait Nuance {
+  def f2(i: Int, j: Int) = ()
+  def `always report bad named arg`: Unit = {
+    f2(k = 42)
+    f2(17, k = 42)
+    f2(17, 27, k = 42)
+  }
+}


### PR DESCRIPTION
If not enough args, also report bad named args.
Don't take leading bad named arg as positional,
since assignment is no longer supported; instead,
report the bad name.