### PR TITLE
Offer “did you mean” for assignment ops

### DIFF
--- a/src/compiler/scala/tools/nsc/util/StringUtil.scala
+++ b/src/compiler/scala/tools/nsc/util/StringUtil.scala
@@ -15,15 +15,12 @@ package util
 
 import scala.collection.immutable.Seq
 
-trait StringUtil {
-  def oxford(vs: Seq[String], conj: String): String = {
+object StringUtil {
+  def oxford(vs: Seq[String], conj: String): String =
     vs match {
       case Seq()     => ""
       case Seq(a)    => a
       case Seq(a, b) => s"$a $conj $b"
-      case xs        => xs.dropRight(1).mkString(", ") + s", $conj " + xs.last
+      case xs        => xs.init.mkString("", ", ", s", $conj ${xs.last}")
     }
-  }
 }
-
-object StringUtil extends StringUtil

--- a/test/files/neg/suggest-similar.check
+++ b/test/files/neg/suggest-similar.check
@@ -10,7 +10,7 @@ did you mean Weehawken?
   new example.Eeehawken
               ^
 suggest-similar.scala:16: error: value readline is not a member of object scala.io.StdIn
-did you mean readLine?
+did you mean readLine? or perhaps readByte, readInt, or readLong?
   import scala.io.StdIn.{readline, readInt}
          ^
 suggest-similar.scala:20: error: object stdin is not a member of package io
@@ -18,11 +18,68 @@ did you mean StdIn?
   import scala.io.stdin.{readLine => line}
                   ^
 suggest-similar.scala:37: error: value foo is not a member of object example.Hohokus
-did you mean foo1, foo2, foo3, or foo4?
+did you mean foo1, foo2, foo3, or foo4? or...?
   Hohokus.foo
           ^
 suggest-similar.scala:41: error: value bar is not a member of example.Hohokus
 did you mean bar2?
   new Hohokus().bar // don't suggest bar1
                 ^
-7 errors
+suggest-similar.scala:54: error: value acb is not a member of example.assignments.C
+did you mean abc?
+  def f = c.acb(42)
+            ^
+suggest-similar.scala:55: error: value ++- is not a member of example.assignments.C
+did you mean +++?
+  def g = c.++-(42)
+            ^
+suggest-similar.scala:56: error: value ++= is not a member of example.assignments.C
+did you mean +++?
+  def h = c.++=(42)
+            ^
+suggest-similar.scala:57: error: value ++= is not a member of example.assignments.C
+did you mean +++?
+  Expression does not convert to assignment because receiver is not assignable.
+  def i = c ++= 42
+            ^
+suggest-similar.scala:59: error: value y_= is not a member of example.assignments.C
+  def v = c y_= 1
+            ^
+suggest-similar.scala:60: error: value y is not a member of example.assignments.C
+  def v2 = c.y = 1
+             ^
+suggest-similar.scala:61: error: value x_== is not a member of example.assignments.C
+  def w = c x_== 1
+            ^
+suggest-similar.scala:62: error: value xx_= is not a member of example.assignments.C
+did you mean x_=?
+  def y = c.xx_=(1)
+            ^
+suggest-similar.scala:63: error: reassignment to val
+  def y2 = c.xx = 1
+                ^
+suggest-similar.scala:65: error: value zzz_= is not a member of example.assignments.C
+did you mean zz_=? or perhaps z_=?
+  def z2 = c.zzz_=(1)
+             ^
+suggest-similar.scala:66: error: value ++++ is not a member of example.assignments.C
+did you mean +++?
+  def z3 = c.++++(1)
+             ^
+suggest-similar.scala:67: error: value xxx is not a member of example.assignments.C
+did you mean xx? or perhaps x?
+  def legacy_duple = c.xxx  // did not suggest c.xx as too short
+                       ^
+suggest-similar.scala:76: error: value missN is not a member of example.MaxAlt
+did you mean miss0, miss1, miss2, or miss3? or...?
+  def test: Int = new MaxAlt().missN
+                               ^
+suggest-similar.scala:83: error: value missN is not a member of example.MissAlt
+did you mean miss0, miss1, or miss2?
+  def test: Int = new MissAlt().missN
+                                ^
+suggest-similar.scala:94: error: value missN is not a member of example.MoreAlt
+did you mean miss0, miss1, miss2, or miss3? or...?
+  def test: Int = new MoreAlt().missN
+                                ^
+22 errors

--- a/test/files/neg/suggest-similar.scala
+++ b/test/files/neg/suggest-similar.scala
@@ -21,8 +21,8 @@ object C {
 }
 
 class Hohokus {
-  protected def bar1
-  protected[example] def bar2
+  protected def bar1: Unit = ()
+  protected[example] def bar2: Unit = ()
 }
 object Hohokus {
   def foo1 = 1
@@ -39,4 +39,57 @@ object D {
 
 object E {
   new Hohokus().bar // don't suggest bar1
+}
+
+object assignments {
+  class C {
+    def abc(i: Int) = i
+    def +++(i: Int) = i
+    var x = 42
+    val xx = 42
+    var z = 42
+    var zz = 42
+  }
+  val c = new C
+  def f = c.acb(42)
+  def g = c.++-(42)
+  def h = c.++=(42)
+  def i = c ++= 42
+  def u = c x_= 1
+  def v = c y_= 1
+  def v2 = c.y = 1
+  def w = c x_== 1
+  def y = c.xx_=(1)
+  def y2 = c.xx = 1
+  def z = c.zz_=(1)
+  def z2 = c.zzz_=(1)
+  def z3 = c.++++(1)
+  def legacy_duple = c.xxx  // did not suggest c.xx as too short
+}
+
+class MaxAlt {
+  def miss0 = 42
+  def miss1 = 42
+  def miss2 = 42
+  def miss3 = 42
+  def miss33 = 42
+  def test: Int = new MaxAlt().missN
+}
+
+class MissAlt {
+  def miss0 = 42
+  def miss1 = 42
+  def miss2 = 42
+  def test: Int = new MissAlt().missN
+}
+
+class MoreAlt {
+  def miss0 = 42
+  def miss1 = 42
+  def miss2 = 42
+  def miss3 = 42
+  def miss4 = 42
+  def miss5 = 42
+  def miss6 = 42
+  def test: Int = new MoreAlt().missN
 }

--- a/test/files/neg/t11843.check
+++ b/test/files/neg/t11843.check
@@ -1,17 +1,17 @@
 t11843.scala:6: error: value $isInstanceOf is not a member of String
-did you mean asInstanceOf or isInstanceOf?
+did you mean isInstanceOf? or perhaps asInstanceOf?
   "".$isInstanceOf[Int]
      ^
 t11843.scala:7: error: value $asInstanceOf is not a member of String
-did you mean asInstanceOf or isInstanceOf?
+did you mean asInstanceOf? or perhaps isInstanceOf?
   "".$asInstanceOf[Int]
      ^
 t11843.scala:10: error: value $isInstanceOf is not a member of Symbol
-did you mean asInstanceOf or isInstanceOf?
+did you mean isInstanceOf? or perhaps asInstanceOf?
   ss.$isInstanceOf[String]
      ^
 t11843.scala:11: error: value $asInstanceOf is not a member of Symbol
-did you mean asInstanceOf or isInstanceOf?
+did you mean asInstanceOf? or perhaps isInstanceOf?
   ss.$asInstanceOf[String]
      ^
 t11843.scala:8: warning: fruitless type test: a value of type Symbol cannot also be a String (the underlying of String)

--- a/test/files/neg/t3346c.check
+++ b/test/files/neg/t3346c.check
@@ -1,5 +1,4 @@
 t3346c.scala:65: error: value bar is not a member of Either[Int,String]
-did you mean map?
   eii.bar
       ^
 1 error

--- a/test/files/neg/t4271.check
+++ b/test/files/neg/t4271.check
@@ -1,11 +1,12 @@
 t4271.scala:9: error: value to is not a member of Int
+did you mean toInt?
   3 to 5
     ^
 t4271.scala:10: error: value ensuring is not a member of Int
   5 ensuring true
     ^
 t4271.scala:11: error: value -> is not a member of Int
-did you mean >>>?
+did you mean >>?
   3 -> 5
     ^
 t4271.scala:3: warning: Implicit definition should have explicit type (inferred foo.Donotuseme.type)

--- a/test/files/neg/t5801.check
+++ b/test/files/neg/t5801.check
@@ -1,5 +1,4 @@
 t5801.scala:1: error: object sth is not a member of package scala
-did you mean math or sys?
 import scala.sth
        ^
 t5801.scala:4: error: not found: value sth

--- a/test/files/neg/t7475f.check
+++ b/test/files/neg/t7475f.check
@@ -5,6 +5,7 @@ t7475f.scala:13: error: not found: value c2
   c2 // a member, but inaccessible.
   ^
 t7475f.scala:26: error: value d2 is not a member of D[Any]
+did you mean d1?
     other.d2 // not a member
           ^
 3 errors

--- a/test/files/run/macro-typecheck-implicitsdisabled.check
+++ b/test/files/run/macro-typecheck-implicitsdisabled.check
@@ -1,3 +1,3 @@
 scala.Predef.ArrowAssoc[Int](1).->[Int](2)
 scala.reflect.macros.TypecheckException: value -> is not a member of Int
-did you mean >>>?
+did you mean >>?

--- a/test/files/run/repl-no-imports-no-predef.check
+++ b/test/files/run/repl-no-imports-no-predef.check
@@ -21,7 +21,7 @@ val res5: (Int, Int) = (1,2)
 scala> 1 -> 2
          ^
        error: value -> is not a member of Int
-       did you mean >>>?
+       did you mean >>?
 
 scala> 
 

--- a/test/files/run/toolbox_typecheck_implicitsdisabled.check
+++ b/test/files/run/toolbox_typecheck_implicitsdisabled.check
@@ -3,4 +3,4 @@
   scala.Predef.ArrowAssoc[Int](1).->[Int](2)
 }
 scala.tools.reflect.ToolBoxError: reflective typecheck has failed: value -> is not a member of Int
-did you mean >>>?
+did you mean >>?

--- a/test/tasty/neg/src-2/TestInvisibleDefs.check
+++ b/test/tasty/neg/src-2/TestInvisibleDefs.check
@@ -8,6 +8,7 @@ TestInvisibleDefs_fail.scala:11: error: value getStatus is not a member of tasty
     mybean.getStatus() // error
            ^
 TestInvisibleDefs_fail.scala:12: error: value setStatus is not a member of tastytest.InvisibleDefs.MyBean
+did you mean status?
     mybean.setStatus("closed") // error
            ^
 4 errors


### PR DESCRIPTION
Backport the latest Dotty research on recommending members of nearly identical spelling. (MONIS.)

Bumps the edit distance to consider, sorts the result, and presents up to 4 suggestions. Those that are not first-rank receive a qualifying, "or perhaps?" An ellipsis indicates when there are other candidates not presented to the user.

Avoid suggesting `wait` for `priv` or `name` (that is more of a Wordle move). The tweaked restriction is that the edit distance cannot exceed half the word length (for either user identifier or candidate), but if all the chars written by the user appear in the candidate string, then use it, since swaps and repetitions are common typos. For example, for `acb` suggest `abc` but not for `ade`. (Tempted to take `ade` because of the common prefix.)

Sample dotty:
```
scala> c.priv
-- [E008] Not Found Error: ---------------------------------------------------------------------------------------------
1 |c.priv
  |^^^^^^
  |value priv is not a member of C - did you mean c.wait?
1 error found
```

Avoid offering advice for setter, as in this dotty message:
```
1 |def v = c y_= 1
  |        ^^^^^
  |        value y_= is not a member of C - did you mean c.x_=?
```
but do advise on `++=`.

It is slightly incongruous to suggest `did you mean +++ or x_=?` probably because the shared element is the suffix `_=` or just `=`. Maybe edit distance should be 1 for the shortest identifiers. More precisely, when comparing two setters, strip the suffix first. Then normal criterion says don't recommend `x` for `y`, which would be tedious.

Dotty offers only one suggestion:
```
scala> "xyz".lengt
-- [E008] Not Found Error: ---------------------------------------------------------------------------------------------
1 |"xyz".lengt
  |^^^^^^^^^^^
  |value lengt is not a member of String - did you mean ("xyz" : String).length?
1 error found

scala> "xyz".lgnet
-- [E008] Not Found Error: ---------------------------------------------------------------------------------------------
1 |"xyz".lgnet
  |^^^^^^^^^^^
  |value lgnet is not a member of String - did you mean ("xyz" : String).lines?
1 error found
```
now we exclude `lines` in the first case (edit distance compared to token length) but include `length` in the second (because it is a word scramble):
```
scala> "xyz".lengt
             ^
       error: value lengt is not a member of String
       did you mean length?

scala> "xyz".lgnet
             ^
       error: value lgnet is not a member of String
       did you mean lines? or perhaps length?
```