### PR TITLE
Run delayed checks in `unit.toCheck` after typer finished all units

### DIFF
--- a/src/compiler/scala/tools/nsc/CompilationUnits.scala
+++ b/src/compiler/scala/tools/nsc/CompilationUnits.scala
@@ -127,7 +127,9 @@ trait CompilationUnits { global: Global =>
     val transformed = new mutable.AnyRefMap[Tree, Tree]
 
     /** things to check at end of compilation unit */
-    val toCheck = new ListBuffer[() => Unit]
+    val toCheck = new ListBuffer[CompilationUnit.ToCheck]
+    private[nsc] def addPostUnitCheck(check: CompilationUnit.ToCheckAfterUnit): Unit = toCheck += check
+    private[nsc] def addPostTyperCheck(check: CompilationUnit.ToCheckAfterTyper): Unit = toCheck += check
 
     /** The features that were already checked for this unit */
     var checkedFeatures = Set[Symbol]()
@@ -148,5 +150,11 @@ trait CompilationUnits { global: Global =>
     val isJava: Boolean = source.isJava
 
     override def toString() = source.toString()
+  }
+
+  object CompilationUnit {
+    sealed trait ToCheck
+    trait ToCheckAfterUnit extends ToCheck { def apply(): Unit }
+    trait ToCheckAfterTyper extends ToCheck { def apply(): Unit }
   }
 }

--- a/src/compiler/scala/tools/nsc/typechecker/Checkable.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Checkable.scala
@@ -371,7 +371,7 @@ trait Checkable {
               val Xsym = X.typeSymbol
               val Psym = P.typeSymbol
               if (isSealedOrFinal(Xsym) && isSealedOrFinal(Psym) && (currentRun.compiles(Xsym) || currentRun.compiles(Psym)))
-                context.unit.toCheck += (() => recheckFruitless())
+                context.unit.addPostTyperCheck(() => recheckFruitless())
             }
         }
       }

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1487,7 +1487,7 @@ trait Namers extends MethodSynthesis {
             context.warning(ddef.pos, msg, WarningCategory.OtherNullaryOverride)
             meth.updateAttachment(NullaryOverrideAdapted)
           }
-          context.unit.toCheck += (if (currentRun.isScala3) error _ else warn _)
+          context.unit.addPostUnitCheck(() => if (currentRun.isScala3) error() else warn())
           ListOfNil
         } else vparamSymss
       }


### PR DESCRIPTION
`unit.toCheck` is used for various checks that need to be delayed,
either to avoid cyclic references by forcing too much, or to
wait for information to be populated (`symbol.children`).

Instead of running a compilation unit's checks right when that unit
is done type checking, run some checks after typer is done with all
compilation units. This makes sure delayed checks see the post-typer
symbol table (consistent children, no matter of compilation order).

Don't delay all checks to keep messages for a unit together. Also,
unused imports warnings are reported at the end of a unit, and the
language flag check (in `unit.toCheck`) marks language imports as
used.

Fixes https://github.com/scala/bug/issues/12703