### PR TITLE
Disallow mixins where super calls bind to vals

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Mixin.scala
+++ b/src/compiler/scala/tools/nsc/transform/Mixin.scala
@@ -357,6 +357,8 @@ abstract class Mixin extends Transform with ast.TreeDSL with AccessorSynthesis {
             case alias1 =>
               registerRequiredDirectInterface(alias1, clazz, parent =>
                 s"Unable to implement a super accessor required by trait ${mixinClass.name} unless $parent is directly extended by $clazz.")
+              if (alias1.isValue && !alias1.isMethod || alias1.isAccessor)
+                reporter.error(clazz.pos, s"parent $mixinClass has a super call to method ${mixinMember.alias.fullNameString}, which binds to the value ${alias1.fullNameString}. Super calls can only target methods.")
               superAccessor.asInstanceOf[TermSymbol] setAlias alias1
           }
         }

--- a/test/files/neg/t12715.check
+++ b/test/files/neg/t12715.check
@@ -1,0 +1,7 @@
+t12715.scala:21: error: parent trait E has a super call to method B.f, which binds to the value D.f. Super calls can only target methods.
+object O1 extends B with C with D with E
+       ^
+t12715.scala:22: error: parent trait E has a super call to method B.f, which binds to the value C.f. Super calls can only target methods.
+object O2 extends B with C with E with D
+       ^
+2 errors

--- a/test/files/neg/t12715.scala
+++ b/test/files/neg/t12715.scala
@@ -1,0 +1,23 @@
+trait A {
+  def f: String
+}
+
+trait B extends A {
+  def f = "B";
+}
+
+trait C extends A {
+  override val f = "C"
+}
+
+trait D extends C {
+  override val f = "D"
+}
+
+trait E extends A with B {
+  def d = super.f
+}
+
+object O1 extends B with C with D with E
+object O2 extends B with C with E with D
+object O3 extends B with E with C with D

--- a/test/files/neg/t12715b.check
+++ b/test/files/neg/t12715b.check
@@ -1,0 +1,4 @@
+t12715b.scala:17: error: parent trait D has a super call to method B.f, which binds to the value C.f. Super calls can only target methods.
+    new A(10.0f) with C with D {}
+        ^
+1 error

--- a/test/files/neg/t12715b.scala
+++ b/test/files/neg/t12715b.scala
@@ -1,0 +1,19 @@
+trait B {
+ def f: Float = 1.0f
+}
+
+class A(override val f: Float) extends B
+
+trait C extends B {
+ abstract override val f = super.f + 100.0f
+}
+
+trait D extends B {
+ abstract override val f = super.f + 1000.0f
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    new A(10.0f) with C with D {}
+  }
+}


### PR DESCRIPTION
Super calls in traits are bound when the trait is mixed into a class. Disallow mixin compositions where the target of a super call is a value (not a method).

Fixes https://github.com/scala/bug/issues/12715. Fixes https://github.com/scala/bug/issues/10308.