### PR TITLE
Forward port minor ListSetTest tweak

### DIFF
--- a/test/junit/scala/collection/immutable/ListSetTest.scala
+++ b/test/junit/scala/collection/immutable/ListSetTest.scala
@@ -1,6 +1,8 @@
 package scala.collection.immutable
 
-import org.junit.Assert._
+import scala.tools.testkit.AssertUtil.{assertSameElements, fail}
+
+import org.junit.Assert.{assertEquals, assertSame, fail => _}
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -79,6 +81,17 @@ class ListSetTest {
 
     bar = foo ++ ListSet(1, 2, 3, 4, 5, 6)
     assertEquals(List(1, 2, 3, 4, 5, 6), bar.iterator.toList)
+    assertSameElements(List(1, 2, 3, 4, 5, 6), bar.iterator)
+
+    assertSame(foo, foo ++ foo)
+    assertSame(foo, foo ++ ListSet.empty)
+    assertSame(foo, foo ++ Nil)
+  }
+
+  @Test def `t12316 ++ is correctly ordered`: Unit = {
+    // was: ListSet(1, 2, 3, 42, 43, 44, 29, 28, 27, 12, 11, 10)
+    assertEquals(ListSet(1,2,3,42,43,44,10,11,12,27,28,29), ListSet(1,2,3,42,43,44) ++ ListSet(10,11,12,42,43,44,27,28,29))
+    assertSameElements(List(1,2,3,42,43,44,10,11,12,27,28,29), ListSet(1,2,3,42,43,44) ++ ListSet(10,11,12,42,43,44,27,28,29))
   }
 
   @Test

--- a/test/junit/scala/tools/nsc/backend/jvm/PerRunInitTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/PerRunInitTest.scala
@@ -77,6 +77,7 @@ abstract class PerRunInitTest {
 
   def clearCaches() = underTest.global.perRunCaches.clearAll()
 
+  @annotation.nowarn("cat=deprecation")
   def doGc() = {
     System.gc()
     System.runFinalization()

--- a/test/junit/scala/tools/testkit/AssertUtilTest.scala
+++ b/test/junit/scala/tools/testkit/AssertUtilTest.scala
@@ -122,4 +122,25 @@ class AssertUtilTest {
     assertEquals("00000000  f0 90 90 80                                       |𐐀.|", hexdump("\ud801\udc00").next())
   }
   */
+
+  @Test def `assertSameElements reports fail of IterableOnce`: Unit = {
+    assertFails(_ == "expected:<List(1, 2, 3)> but was:<List(1, 2, 3, 4)>") {
+      assertSameElements(List(1, 2, 3), Iterator(1, 2, 3, 4))
+    }
+    assertFails(_ == "expected:<List(1, 2, 3)> but was:<List(1, 2, 3, 4)>") {
+      assertSameElements(List(1, 2, 3), Set(1, 2, 3, 4))
+    }
+    assertFails(_ == "expected:<Vector(1, 2, 3)> but was:<List(1, 2, 3, 4)>") {
+      assertSameElements(Vector(1, 2, 3), Iterator(1, 2, 3, 4))
+    }
+    assertFails(_ == "force use of canonical method expected:<Vector(1, 2, 3)> but was:<List(1, 2, 3, 4)>") {
+      assertSameElements(Vector(1, 2, 3), Iterator(1, 2, 3, 4).to(Iterable), message = "force use of canonical method")
+    }
+  }
+  @Test def `assertSameElements supports Array directly`: Unit = {
+    assertSameElements(Array(42), Array(42))
+    assertFails(_ == "expected:<ArraySeq(17)> but was:<ArraySeq(42)>") {
+      assertSameElements(Array(17), Array(42))
+    }
+  }
 }


### PR DESCRIPTION
Also observe that `sameElements` is provided on`Seq` and `Iterator`. It is deprecated as an extension for `IterableOnce`.

Cater to testing an expected that is a `Seq`. The actual can be an `IterableOnce`, but must be converted "in case" it must be re-iterated for reporting. (This could be improved with a few more LOC.)

Provide methods just for arrays, which would otherwise warn about the conversion.

Addresses the road bump at https://github.com/scala/scala/pull/10270