### PR TITLE
Report total errors on stderr

### DIFF
--- a/src/compiler/scala/tools/nsc/reporters/ConsoleReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/ConsoleReporter.scala
@@ -27,9 +27,10 @@ class ConsoleReporter(val settings: Settings, val reader: BufferedReader, val wr
   override def finish(): Unit = {
     import reflect.internal.util.StringOps.countElementsAsString
     if (!settings.nowarn.value && hasWarnings)
-      echo(countElementsAsString(warningCount, WARNING.toString.toLowerCase))
+      writer.println(countElementsAsString(warningCount, WARNING.toString.toLowerCase))
     if (hasErrors)
-      echo(countElementsAsString(errorCount, ERROR.toString.toLowerCase))
+      writer.println(countElementsAsString(errorCount, ERROR.toString.toLowerCase))
+    writer.flush()
     super.finish()
   }
 }


### PR DESCRIPTION
cherry-plucked from https://github.com/scala/scala/pull/10262

The warning and error diagnostic summary goes to stderr, like in javac.