### PR TITLE
Unused diagnostics includes original of const-fold

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -562,6 +562,8 @@ trait TypeDiagnostics extends splain.SplainDiagnostics {
         case Assign(lhs, _) if isExisting(lhs.symbol) => setVars += lhs.symbol
         case Function(ps, _) if settings.warnUnusedParams && !t.isErrorTyped => params ++=
           ps.filterNot(p => atBounded(p) || p.symbol.isSynthetic).map(_.symbol)
+        case Literal(_) =>
+          t.attachments.get[OriginalTreeAttachment].foreach(ota => traverse(ota.original))
         case _                                        =>
       }
 

--- a/test/files/neg/t12590.check
+++ b/test/files/neg/t12590.check
@@ -1,0 +1,6 @@
+t12590.scala:4: warning: local val a in method unusedLocal is never used
+    val a = 27
+        ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/t12590.scala
+++ b/test/files/neg/t12590.scala
@@ -1,0 +1,7 @@
+// scalac: -Werror -Wunused:locals
+class C {
+  def unusedLocal = {
+    val a = 27
+    42
+  }
+}

--- a/test/files/run/repl-replay.check
+++ b/test/files/run/repl-replay.check
@@ -6,6 +6,8 @@ scala> :replay -Xlint
 replay> locally { val x = 42 ; "$x" }
                                ^
         warning: possible missing interpolator: detected interpolated identifier `$x`
+                      ^
+        warning: local val x in value res0 is never used
 val res0: String = $x
 
 


### PR DESCRIPTION
Trees munged by adaptConstant are preserved in an attachment. Traverse the original looking for unused grunge.

Co-authored-by: jxnu-liguobin <dreamylost@outlook.com>

Fixes scala/bug#12590