### PR TITLE
Fix test that compared ints and strings

### DIFF
--- a/test/files/jvm/t7253.check
+++ b/test/files/jvm/t7253.check
@@ -1,1 +1,0 @@
-bytecode identical

--- a/test/files/jvm/t7253/test.scala
+++ b/test/files/jvm/t7253/test.scala
@@ -1,29 +1,20 @@
-import scala.tools.partest.BytecodeTest
-import scala.tools.testkit.ASMConverters
+// scalac: -Werror -Xlint
 
-import scala.tools.nsc.util.JavaClassPath
-import java.io.InputStream
-import scala.tools.asm
-import asm.ClassReader
-import asm.tree.{ClassNode, InsnList}
-import scala.collection.JavaConverters._
+import scala.tools.asm.Opcodes
+import scala.tools.partest.BytecodeTest
+import scala.tools.testkit.ASMConverters._
 
 object Test extends BytecodeTest {
-  import ASMConverters._
 
-  def show: Unit = {
-    val instrBaseSeqs = Seq("ScalaClient_1", "JavaClient_1") map (name => instructionsFromMethod(getMethod(loadClassNode(name), "foo")))
-    val instrSeqs = instrBaseSeqs map (_ filter isInvoke)
-    cmpInstructions(instrSeqs(0), instrSeqs(1))
+  def show(): Unit = {
+    def fooOf(name: String) = instructionsFromMethod(getMethod(loadClassNode(name), "foo")).filter(isInvoke)
+    cmpInstructions(fooOf("ScalaClient_1"), fooOf("JavaClient_1"))
   }
 
-  def cmpInstructions(isa: List[Instruction], isb: List[Instruction]) = {
-    if (isa == isb) println("bytecode identical")
-    else diffInstructions(isa, isb)
-  }
+  def cmpInstructions(isa: List[Instruction], isb: List[Instruction]) =
+    if (!isa.sameElements(isb))
+      diffInstructions(isa, isb)
 
-  def isInvoke(node: Instruction): Boolean = {
-    val opcode = node.opcode
-    (opcode == "INVOKEVIRTUAL") || (opcode == "INVOKEINTERFACE")
-  }
+  def isInvoke(node: Instruction): Boolean =
+    node.opcode == Opcodes.INVOKEVIRTUAL || node.opcode == Opcodes.INVOKEINTERFACE
 }


### PR DESCRIPTION
The test was filtering for invoke instructions but tested `(opcode == "INVOKEVIRTUAL")` where opcode is an int. As a result, it compared only two empty lists of instructions, which succeeds trivially.

The underlying issue is that partest does not report warnings when there is more than one "compilation round" for the test. So even if you're watching for warnings, you will see none. Linting and `-Werror` added here, and test cleaned up.