### PR TITLE
Avoid deprecation in run/analyzerPlugins

### DIFF
--- a/test/files/run/analyzerPlugins.check
+++ b/test/files/run/analyzerPlugins.check
@@ -1,4 +1,3 @@
-warning: 1 deprecation (since 2.13.0); re-run with -deprecation for details
 adaptBoundsToAnnots(List( <: Int), List(type T), List(Int @testAnn)) [2]
 annotationsConform(Boolean @testAnn, Boolean @testAnn) [2]
 annotationsConform(Boolean @testAnn, Boolean) [1]

--- a/test/files/run/analyzerPlugins.scala
+++ b/test/files/run/analyzerPlugins.scala
@@ -2,6 +2,7 @@ import scala.tools.partest._
 import scala.tools.nsc._
 
 object Test extends DirectTest {
+  override def extraSettings: String = s"${super.extraSettings} '-Wconf:cat=deprecation&msg=early initializers:s'"
 
   def code = """
     class testAnn extends annotation.TypeConstraint


### PR DESCRIPTION
Otherwise it's difficult to tell if the warning is from the test or the sample corpus.

The sample triggers a couple of lints that may be part of the test.