### PR TITLE
Unused warning shows uniqid

### DIFF
--- a/src/partest/scala/tools/partest/nest/AbstractRunner.scala
+++ b/src/partest/scala/tools/partest/nest/AbstractRunner.scala
@@ -188,12 +188,12 @@ class AbstractRunner(val config: RunnerSpec.Config, protected final val testSour
         echo(message)
         levyJudgment()
       }
-      if (realeasy) {
-        runGit("status --porcelain")(_.filter(_.endsWith(".check")).map(_.drop(3)).mkString("\n")).foreach { danger =>
+      if (realeasy)
+        for (lines <- runGit("status --porcelain")(_.filter(_.endsWith(".check")).map(_.drop(3))) if lines.nonEmpty) {
           echo(bold(red("# There are uncommitted check files!")))
-          echo(s"$danger\n")
+          for (file <- lines)
+            echo(s"$file\n")
         }
-      }
     }
   }
 

--- a/test/files/neg/macro-annot-unused-param.check
+++ b/test/files/neg/macro-annot-unused-param.check
@@ -1,4 +1,4 @@
-Test_2.scala:2: warning: parameter value x in anonymous function is never used
+Test_2.scala:2: warning: parameter x in anonymous function is never used
 @mymacro
  ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/patmat-exprs-b.check
+++ b/test/files/neg/patmat-exprs-b.check
@@ -1,10 +1,10 @@
-patmat-exprs-b.scala:42: warning: parameter value num in class Add is never used
+patmat-exprs-b.scala:42: warning: parameter num in class Add is never used
   case class Add[T](args: Iterable[Expr[T]])(implicit @nowarn num: NumericOps[T]) extends ManyArg[T] {
                                                               ^
-patmat-exprs-b.scala:46: warning: parameter value num in class Add2 is never used
+patmat-exprs-b.scala:46: warning: parameter num in class Add2 is never used
   case class Add2[T](left: Expr[T], right: Expr[T])(implicit @nowarn num: NumericOps[T]) extends TwoArg[T] {
                                                                      ^
-patmat-exprs-b.scala:49: warning: parameter value num in class Add3 is never used
+patmat-exprs-b.scala:49: warning: parameter num in class Add3 is never used
   case class Add3[T](a1: Expr[T], a2: Expr[T], a3: Expr[T])(implicit @nowarn num: NumericOps[T]) extends ManyArg[T] {
                                                                              ^
 patmat-exprs-b.scala:42: warning: @nowarn annotation does not suppress any warnings

--- a/test/files/neg/t10790.check
+++ b/test/files/neg/t10790.check
@@ -4,7 +4,7 @@ t10790.scala:13: warning: private val y in class X is never used
 t10790.scala:10: warning: private class C in class X is never used
   private class C                  // warn
                 ^
-t10790.scala:8: warning: parameter value x in method control is never used
+t10790.scala:8: warning: parameter x in method control is never used
   def control(x: Int) = answer         // warn to verify control
               ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t12720.check
+++ b/test/files/neg/t12720.check
@@ -1,0 +1,40 @@
+t12720.scala:15: error: missing argument list for method f*** in class D***
+Unapplied methods are only converted to functions when a function type is expected.
+You can make this conversion explicit by writing `f _` or `f(_)` instead of `f`.
+  def f = d.f
+            ^
+t12720.scala:10: warning: private constructor in class Test*** is never used
+  private def this(stuff: Int) = this()
+              ^
+t12720.scala:20: warning: local method m*** in method forgone*** is never used
+    def m = 17
+        ^
+t12720.scala:21: warning: local object j*** in method forgone*** is never used
+    object j
+           ^
+t12720.scala:22: warning: local var totally*** in method forgone*** is never used
+    var totally = 27
+        ^
+t12720.scala:24: warning: local val z*** in method forgone*** is never used
+    val z = unset
+        ^
+t12720.scala:28: warning: private var misbegotten*** in class Test*** is never used
+  private var misbegotten: Int = 42
+              ^
+t12720.scala:30: warning: private var forgotten (forgotten_=***) in class Test*** is never updated: consider using immutable val
+  private var forgotten: Int = 42
+              ^
+t12720.scala:12: warning: private class Subtle*** in class Test*** is never used
+  private class Subtle
+                ^
+t12720.scala:23: warning: local var unset*** in method forgone*** is never updated: consider using immutable val
+    var unset: Int = 0
+        ^
+t12720.scala:16: warning: parameter x*** in method g*** is never used
+  def g(x: Int) = println("error")
+        ^
+t12720.scala:25: warning: parameter y*** in anonymous function is never used
+    for (x <- Option(42); y <- Option(27) if x < i; res = x - y) yield res
+                          ^
+11 warnings
+1 error

--- a/test/files/neg/t12720.scala
+++ b/test/files/neg/t12720.scala
@@ -1,0 +1,32 @@
+// scalac: -uniqid -Werror -Wunused
+// hide: #\d+
+class C {
+  def f(x: Int) = ""
+}
+class D extends C {
+  def f(x: String) = ""
+}
+final class Test {
+  private def this(stuff: Int) = this()
+
+  private class Subtle
+
+  val d = new D
+  def f = d.f
+  def g(x: Int) = println("error")
+
+  // -Vprint shows two symbols `y`
+  def forgone(i: Int) = {
+    def m = 17
+    object j
+    var totally = 27
+    var unset: Int = 0
+    val z = unset
+    for (x <- Option(42); y <- Option(27) if x < i; res = x - y) yield res
+  }
+
+  private var misbegotten: Int = 42
+  def touch() = misbegotten = 17
+  private var forgotten: Int = 42
+  def fetch   = forgotten
+}

--- a/test/files/neg/warn-unused-explicits.check
+++ b/test/files/neg/warn-unused-explicits.check
@@ -1,4 +1,4 @@
-warn-unused-explicits.scala:9: warning: parameter value x in method warn is never used
+warn-unused-explicits.scala:9: warning: parameter x in method warn is never used
   def warn(x: Int) = answer
            ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/warn-unused-implicits.check
+++ b/test/files/neg/warn-unused-implicits.check
@@ -1,7 +1,7 @@
-warn-unused-implicits.scala:13: warning: parameter value s in method f is never used
+warn-unused-implicits.scala:13: warning: parameter s in method f is never used
        )(implicit s: String): Int = {  // warn
                   ^
-warn-unused-implicits.scala:33: warning: parameter value s in method i is never used
+warn-unused-implicits.scala:33: warning: parameter s in method i is never used
   def i(implicit s: String, t: Int) = t           // yes, warn
                  ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/warn-unused-params.check
+++ b/test/files/neg/warn-unused-params.check
@@ -1,34 +1,34 @@
-warn-unused-params.scala:13: warning: parameter value b in method f is never used
+warn-unused-params.scala:13: warning: parameter b in method f is never used
         b: String,               // warn
         ^
-warn-unused-params.scala:36: warning: parameter value s in method i is never used
+warn-unused-params.scala:36: warning: parameter s in method i is never used
   def i(implicit s: String) = answer           // yes, warn
                  ^
-warn-unused-params.scala:53: warning: parameter value u in class Unusing is never used
+warn-unused-params.scala:53: warning: parameter u in class Unusing is never used
 class Unusing(u: Int) {       // warn
               ^
-warn-unused-params.scala:63: warning: parameter value s in class CaseyAtTheBat is never used
+warn-unused-params.scala:63: warning: parameter s in class CaseyAtTheBat is never used
 case class CaseyAtTheBat(k: Int)(s: String)        // warn
                                  ^
-warn-unused-params.scala:66: warning: parameter value readResolve in method f is never used
+warn-unused-params.scala:66: warning: parameter readResolve in method f is never used
   def f(readResolve: Int) = answer           // warn
         ^
-warn-unused-params.scala:81: warning: parameter value dummy in method g is never used
+warn-unused-params.scala:81: warning: parameter dummy in method g is never used
   def g(dummy: DummyImplicit) = answer
         ^
-warn-unused-params.scala:86: warning: parameter value ev in method f2 is never used
+warn-unused-params.scala:86: warning: parameter ev in method f2 is never used
   def f2[A, B](ev: A =:= B) = answer
                ^
-warn-unused-params.scala:87: warning: parameter value ev in method g2 is never used
+warn-unused-params.scala:87: warning: parameter ev in method g2 is never used
   def g2[A, B](ev: A <:< B) = answer
                ^
-warn-unused-params.scala:91: warning: parameter value i in anonymous function is never used
+warn-unused-params.scala:91: warning: parameter i in anonymous function is never used
   def f = (i: Int) => answer      // warn
             ^
-warn-unused-params.scala:97: warning: parameter value i in anonymous function is never used
+warn-unused-params.scala:97: warning: parameter i in anonymous function is never used
   def g = for (i <- List(1)) yield answer    // warn map.(i => 42)
                ^
-warn-unused-params.scala:101: warning: parameter value ctx in method f is never used
+warn-unused-params.scala:101: warning: parameter ctx in method f is never used
   def f[A](implicit ctx: Context[A]) = answer
                     ^
 warn-unused-params.scala:102: warning: evidence parameter evidence$1 of type Context[A] in method g is never used


### PR DESCRIPTION
The edge cases are how to name setters,
and for some reason parameter was using
toString, so now instead of `parameter value p`
it says simply `parameter p`.

Fixes scala/bug#12720