### PR TITLE
[WIP] Enforce stable id patterns conform under Xsource:3

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -1315,8 +1315,11 @@ trait Infer extends Checkable {
       else intersect(pt, pattp)
     }
 
-    def inferModulePattern(pat: Tree, pt: Type) =
-      if ((pat.symbol ne null) && pat.symbol.isModule && !(pat.tpe <:< pt)) {
+    def inferStableIdPattern(pat: Tree, pt: Type) = {
+      val check =
+        if (currentRun.isScala3) treeInfo.isStableIdentifier(pat, allowVolatile = true) && !pat.tpe.weak_<:<(pt)
+        else (pat.symbol ne null) && pat.symbol.isModule && !(pat.tpe <:< pt)
+      if (check) {
         val ptparams = freeTypeParamsOfTerms(pt)
         debuglog("free type params (2) = " + ptparams)
         val ptvars = ptparams map freshVar
@@ -1326,6 +1329,7 @@ trait Infer extends Checkable {
         else
           PatternTypeIncompatibleWithPtError2(pat, pt1, pt)
       }
+    }
 
     /** Collects type parameters referred to in a type.
      */

--- a/test/files/neg/t12722.check
+++ b/test/files/neg/t12722.check
@@ -1,0 +1,7 @@
+t12722.scala:7: error: pattern type is incompatible with expected type;
+ found   : Int(2147483647)
+ required: Short
+Note: if you intended to match against the class, try `case _: Int`
+      case 2147483647 => true
+           ^
+1 error

--- a/test/files/neg/t12722.scala
+++ b/test/files/neg/t12722.scala
@@ -1,0 +1,10 @@
+
+// scalac: -Werror -Xsource:3
+
+class C {
+  def f(n: Short) =
+    n match {
+      case 2147483647 => true
+      case _ => false
+    }
+}

--- a/test/files/neg/t7211.check
+++ b/test/files/neg/t7211.check
@@ -1,0 +1,7 @@
+t7211.scala:11: error: pattern type is incompatible with expected type;
+ found   : C
+ required: D
+Note: if you intended to match against the class, try `case _: C`
+    case `c` => true
+         ^
+1 error

--- a/test/files/neg/t7211.scala
+++ b/test/files/neg/t7211.scala
@@ -1,0 +1,14 @@
+
+// scalac: -Werror -Xsource:3
+
+class C
+class D
+
+object Test extends App {
+  val c = new C
+  val d = new D
+  d match {
+    case `c` => true
+    case _ => false
+  }
+}

--- a/test/files/neg/t7655.check
+++ b/test/files/neg/t7655.check
@@ -1,0 +1,11 @@
+t7655.scala:12: error: pattern type is incompatible with expected type;
+ found   : Test.Other.type
+ required: Test.Foo
+    case Other => true // warns
+         ^
+t7655.scala:17: error: pattern type is incompatible with expected type;
+ found   : Test.Other.type
+ required: Test.Foo
+    case OtherAlias => true // no warning.
+         ^
+2 errors

--- a/test/files/neg/t7655.scala
+++ b/test/files/neg/t7655.scala
@@ -1,0 +1,21 @@
+//
+// scalac: -Werror -Xsource:3
+
+object Test {
+  sealed trait Foo
+  object Bar extends Foo
+
+  object Other
+  val OtherAlias = Other
+
+  def f(x: Foo) = x match {
+    case Other => true // warns
+    case _     => false
+  }
+
+  def g(x: Foo) = x match {
+    case OtherAlias => true // no warning.
+    case _          => false
+  }
+}
+

--- a/test/files/pos/t12722.scala
+++ b/test/files/pos/t12722.scala
@@ -1,0 +1,10 @@
+
+// scalac: -Werror
+
+class C {
+  def f(n: Short) =
+    n match {
+      case -1 => true
+      case _ => false
+    }
+}


### PR DESCRIPTION
Stable identifier pattern has always required, per spec, that the type of the pattern conform to the scrutinee. Although matching is determined by universal equals, it is intended that the pattern case narrow the broader expected type. Extraction of values of arbitrary type is provided by extractor patterns.

Relatedly, literal pattern must also conform,
and literal pattern must be typed with the expected type.

Fixes scala/bug#7211
Fixes scala/bug#7655
Fixes scala/bug#12722

uses https://github.com/scala/scala/pull/2742