### PR TITLE
Honor more deprecations under separate compilation

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -826,6 +826,7 @@ abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
 
         case tpnme.DeprecatedATTR =>
           in.skip(attrLen)
+          sym.addAnnotation(JavaDeprecatedAttr)
           if (sym == clazz)
             staticModule.addAnnotation(JavaDeprecatedAttr)
 

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -1423,7 +1423,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
       override def enterSyntheticSym(tree: Tree): Symbol = tree.symbol
     }
 
-    protected override def newBodyDuplicator(context: Context): SpecializeBodyDuplicator =
+    override protected def newBodyDuplicator(context: Context): SpecializeBodyDuplicator =
       new SpecializeBodyDuplicator(context)
 
     override def newNamer(context: Context): Namer =

--- a/src/compiler/scala/tools/nsc/typechecker/Duplicators.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Duplicators.scala
@@ -58,7 +58,7 @@ abstract class Duplicators extends Analyzer {
   private var envSubstitution: SubstTypeMap = _
 
   private class SubstSkolemsTypeMap(from: List[Symbol], to: List[Type]) extends SubstTypeMap(from, to) {
-    protected override def matches(sym1: Symbol, sym2: Symbol) =
+    override protected def matches(sym1: Symbol, sym2: Symbol) =
       if (sym2.isTypeSkolem) sym2.deSkolemize eq sym1
       else sym1 eq sym2
   }

--- a/src/library/scala/collection/mutable/ArrayDeque.scala
+++ b/src/library/scala/collection/mutable/ArrayDeque.scala
@@ -434,7 +434,7 @@ class ArrayDeque[A] protected (
 
   override def isEmpty = start == end
 
-  protected override def klone(): ArrayDeque[A] = new ArrayDeque(array.clone(), start = start, end = end)
+  override protected def klone(): ArrayDeque[A] = new ArrayDeque(array.clone(), start = start, end = end)
 
   override def iterableFactory: SeqFactory[ArrayDeque] = ArrayDeque
 

--- a/src/library/scala/collection/mutable/Queue.scala
+++ b/src/library/scala/collection/mutable/Queue.scala
@@ -110,7 +110,7 @@ class Queue[A] protected (array: Array[AnyRef], start: Int, end: Int)
     */
   @`inline` final def front: A = head
 
-  protected override def klone(): Queue[A] = {
+  override protected def klone(): Queue[A] = {
     val bf = newSpecificBuilder
     bf ++= this
     bf.result()

--- a/src/library/scala/collection/mutable/Stack.scala
+++ b/src/library/scala/collection/mutable/Stack.scala
@@ -114,7 +114,7 @@ class Stack[A] protected (array: Array[AnyRef], start: Int, end: Int)
     */
   @`inline` final def top: A = head
 
-  protected override def klone(): Stack[A] = {
+  override protected def klone(): Stack[A] = {
     val bf = newSpecificBuilder
     bf ++= this
     bf.result()

--- a/src/library/scala/collection/mutable/UnrolledBuffer.scala
+++ b/src/library/scala/collection/mutable/UnrolledBuffer.scala
@@ -438,5 +438,5 @@ object UnrolledBuffer extends StrictOptimizedClassTagSeqFactory[UnrolledBuffer] 
 // Todo -- revisit whether inheritance is the best way to achieve this functionality
 private[collection] class DoublingUnrolledBuffer[T](implicit t: ClassTag[T]) extends UnrolledBuffer[T]()(t) {
   override def calcNextLength(sz: Int) = if (sz < 10000) sz * 2 else sz
-  protected override def newUnrolled = new UnrolledBuffer.Unrolled[T](0, new Array[T](4), null, this)
+  override protected def newUnrolled = new UnrolledBuffer.Unrolled[T](0, new Array[T](4), null, this)
 }

--- a/src/partest/scala/tools/partest/nest/DirectCompiler.scala
+++ b/src/partest/scala/tools/partest/nest/DirectCompiler.scala
@@ -122,7 +122,7 @@ class DirectCompiler(val runner: Runner) {
       if (command.files.nonEmpty) reportError(command.files.mkString("flags file may only contain compiler options, found: ", space, ""))
     }
 
-    suiteRunner.verbose(s"% compiling ${ sources.map(_.testIdent).mkString(space) }${ if (suiteRunner.debug) " -d " + outDir else ""}")
+    suiteRunner.verbose(sources.map(_.testIdent).mkString("% compiling ", space, if (suiteRunner.debug) s" -d $outDir" else ""))
 
     def execCompile() =
       if (command.shouldStopWithInfo) {

--- a/src/partest/scala/tools/partest/nest/Runner.scala
+++ b/src/partest/scala/tools/partest/nest/Runner.scala
@@ -418,18 +418,15 @@ class Runner(val testInfo: TestInfo, val suiteRunner: AbstractRunner) {
    *  2. Runs script function, providing log file and output directory as arguments.
    *     2b. or, just run the script without context and return a new context
    */
-  def runInContext(body: => TestState): TestState = {
-    body
-  }
+  def runInContext(body: => TestState): TestState = body
 
   /** Grouped files in group order, and lex order within each group. */
-  def groupedFiles(sources: List[File]): List[List[File]] = (
+  def groupedFiles(sources: List[File]): List[List[File]] =
     if (sources.sizeIs > 1) {
-      val grouped = sources groupBy (_.group)
-      grouped.keys.toList.sorted map (k => grouped(k) sortBy (_.getName))
+      val grouped = sources.groupBy(_.group)
+      grouped.keys.toList.sorted.map(grouped(_).sortBy(_.getName))
     }
     else List(sources)
-  )
 
   /** Source files for the given test file. */
   def sources(file: File): List[File] = if (file.isDirectory) file.listFiles.toList.filter(_.isJavaOrScala) else List(file)
@@ -483,31 +480,31 @@ class Runner(val testInfo: TestInfo, val suiteRunner: AbstractRunner) {
     files.flatMap(argsFor)
   }
 
-  abstract class CompileRound {
-    def fs: List[File]
-    def result: TestState
+  sealed abstract class CompileRound {
+    def files: List[File]
     def description: String
+    protected def computeResult: TestState
 
-    def fsString = fs map (_.toString stripPrefix parentFile.toString + "/") mkString " "
-    def isOk = result.isOk
-    def mkScalacString(): String = s"""scalac $fsString"""
-    override def toString = description + ( if (result.isOk) "" else "\n" + result.status )
+    final lazy val result: TestState = { pushTranscript(description); computeResult }
+
+    final protected def fsString = files.map(_.toString.stripPrefix(s"$parentFile/")).mkString(" ")
+    final override def toString = description + ( if (result.isOk) "" else "\n" + result.status )
   }
-  case class OnlyJava(fs: List[File]) extends CompileRound {
+  final case class OnlyJava(files: List[File]) extends CompileRound {
     def description = s"""javac $fsString"""
-    lazy val result = { pushTranscript(description) ; javac(fs) }
+    override protected def computeResult = javac(files)
   }
-  case class OnlyScala(fs: List[File]) extends CompileRound {
-    def description = mkScalacString()
-    lazy val result = { pushTranscript(description) ; attemptCompile(fs) }
+  final case class OnlyScala(files: List[File]) extends CompileRound {
+    def description = s"""scalac $fsString"""
+    override protected def computeResult = attemptCompile(files)
   }
-  case class ScalaAndJava(fs: List[File]) extends CompileRound {
-    def description = mkScalacString()
-    lazy val result = { pushTranscript(description) ; attemptCompile(fs) }
+  final case class ScalaAndJava(files: List[File]) extends CompileRound {
+    def description = s"""scalac $fsString"""
+    override protected def computeResult = attemptCompile(files)
   }
-  case class SkipRound(fs: List[File], state: TestState) extends CompileRound {
+  final case class SkipRound(files: List[File], state: TestState) extends CompileRound {
     def description: String = state.status
-    lazy val result = { pushTranscript(description); state }
+    override protected def computeResult = state
   }
 
   def compilationRounds(file: File): List[CompileRound] = {
@@ -535,7 +532,7 @@ class Runner(val testInfo: TestInfo, val suiteRunner: AbstractRunner) {
   }
 
   def mixedCompileGroup(allFiles: List[File]): List[CompileRound] = {
-    val (scalaFiles, javaFiles) = allFiles partition (_.isScala)
+    val (scalaFiles, javaFiles) = allFiles.partition(_.isScala)
     val round1                  = if (scalaFiles.isEmpty) None else Some(ScalaAndJava(allFiles))
     val round2                  = if (javaFiles.isEmpty) None else Some(OnlyJava(javaFiles))
 

--- a/src/partest/scala/tools/partest/package.scala
+++ b/src/partest/scala/tools/partest/package.scala
@@ -58,6 +58,12 @@ package object partest {
 
   /** Sources have a numerical group, specified by name_7 and so on. */
   private val GroupPattern = """.*_(\d+)""".r
+  private object IntOf {
+    def unapply(ds: String): Some[Int] = Some {
+      try ds.toInt
+      catch { case _: NumberFormatException => -1 }
+    }
+  }
 
   implicit class `special string ops`(private val s: String) extends AnyVal {
     def linesIfNonEmpty: Iterator[String] = if (!s.isEmpty) s.linesIterator else Iterator.empty
@@ -85,11 +91,11 @@ package object partest {
     def hasExtension(ext: String) = sf hasExtension ext
     def changeExtension(ext: String): File = (sf changeExtension ext).jfile
 
-    /** The group number for this source file, or -1 for no group. */
+    /** The group number for this source file, or -1 for no group or out of range. */
     def group: Int =
       sf.stripExtension match {
-        case GroupPattern(g) if g.toInt >= 0 => g.toInt
-        case _                               => -1
+        case GroupPattern(IntOf(g)) => g
+        case _                      => -1
       }
 
     // Files.readString on jdk 11

--- a/test/files/jvm/deprecation.check
+++ b/test/files/jvm/deprecation.check
@@ -1,2 +1,28 @@
-Note: deprecation/Use_2.java uses or overrides a deprecated API.
-Note: Recompile with -Xlint:deprecation for details.
+Test_1.scala:7: warning: variable i in class Defs is deprecated
+    val u = d.i + 1
+              ^
+Test_1.scala:8: warning: variable i in class Defs is deprecated
+    d.i = 2
+      ^
+Test_1.scala:9: warning: method bar in class Defs is deprecated
+    val v = d.bar()
+              ^
+Test_1.scala:10: warning: class Inner in class Defs is deprecated
+    val i = new d.Inner
+                  ^
+deprecation/Use_2.java:7: warning: [deprecation] Test.Inner in Test has been deprecated
+        Test.Inner a = u.new Inner();
+            ^
+deprecation/Use_2.java:7: warning: [deprecation] Test.Inner in Test has been deprecated
+        Test.Inner a = u.new Inner();
+                             ^
+deprecation/Use_2.java:8: warning: [deprecation] f() in Test.Inner has been deprecated
+        int i = a.f();
+                 ^
+deprecation/Use_2.java:9: warning: [deprecation] g() in Test.Inner has been deprecated
+        int j = a.g();
+                 ^
+deprecation/Use_2.java:10: warning: [deprecation] g_$eq(int) in Test.Inner has been deprecated
+        a.g_$eq(5);
+         ^
+5 warnings

--- a/test/files/jvm/deprecation/Test_1.scala
+++ b/test/files/jvm/deprecation/Test_1.scala
@@ -1,3 +1,6 @@
+
+// scalac: -Xlint:deprecation
+
 class Test {
   def test: Unit = {
     val d = new Defs

--- a/test/files/jvm/deprecation/Use_2.java
+++ b/test/files/jvm/deprecation/Use_2.java
@@ -1,3 +1,6 @@
+
+// javac: -Xlint:deprecation
+
 class Use_2 {
     public int test() {
         Test u = new Test();

--- a/test/files/neg/t10752.check
+++ b/test/files/neg/t10752.check
@@ -1,3 +1,6 @@
+Test_2.scala:2: warning: class DeprecatedClass in package p1 is deprecated
+object Test extends p1.DeprecatedClass {
+                       ^
 Test_2.scala:3: warning: class DeprecatedClass in package p1 is deprecated
   def useC = p1.DeprecatedClass.foo
                 ^
@@ -5,5 +8,5 @@ Test_2.scala:4: warning: method foo in class DeprecatedMethod is deprecated
   def useM = p1.DeprecatedMethod.foo
                                  ^
 error: No warnings can be incurred under -Werror.
-2 warnings
+3 warnings
 1 error

--- a/test/files/neg/t10752/Test_2.scala
+++ b/test/files/neg/t10752/Test_2.scala
@@ -1,5 +1,5 @@
 // scalac: -Xlint:deprecation -Werror
-object Test {
+object Test extends p1.DeprecatedClass {
   def useC = p1.DeprecatedClass.foo
   def useM = p1.DeprecatedMethod.foo
 }

--- a/test/files/neg/t9617.check
+++ b/test/files/neg/t9617.check
@@ -1,3 +1,6 @@
+Test.scala:4: warning: class DeprecatedClass in package p1 is deprecated
+object Test extends p1.DeprecatedClass {
+                       ^
 Test.scala:5: warning: class DeprecatedClass in package p1 is deprecated
   def useC = p1.DeprecatedClass.foo
                 ^
@@ -5,5 +8,5 @@ Test.scala:6: warning: method foo in class DeprecatedMethod is deprecated
   def useM = p1.DeprecatedMethod.foo
                                  ^
 error: No warnings can be incurred under -Werror.
-2 warnings
+3 warnings
 1 error

--- a/test/files/neg/t9617/Test.scala
+++ b/test/files/neg/t9617/Test.scala
@@ -1,7 +1,7 @@
-// scalac: -Xfatal-warnings -deprecation
+// scalac: -Werror -Xlint:deprecation
 
 // Joint-compilation copy of test/files/neg/t10752/Test_2.scala
-object Test {
+object Test extends p1.DeprecatedClass {
   def useC = p1.DeprecatedClass.foo
   def useM = p1.DeprecatedMethod.foo
 }


### PR DESCRIPTION
Honor more deprecations under separate compilation.

Fixes scala/bug#12714

Restore that the symbol gets deprecation directly in classfile parser.

Partest files without a group are in group -1, not group 0 or a last group. (I assumed last round.)

The loose partitioning between `jvm` tests and `run` is unfortunate.

I could not decipher the change that is reverted here. That change is also seen in the `jvm` test.