### PR TITLE
Improve message for implicit object

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1265,7 +1265,7 @@ trait Implicits extends splain.SplainData {
 
           if (invalidImplicits.nonEmpty)
             setAddendum(pos, () =>
-              s"\n Note: implicit ${invalidImplicits.head} is not applicable here because it comes after the application point and it lacks an explicit result type"
+              s"\n Note: implicit ${invalidImplicits.head} is not applicable here because it comes after the application point and it lacks an explicit result type.${if (invalidImplicits.head.isModule) " An object can be written as a lazy val with an explicit type." else ""}"
             )
         }
 

--- a/test/files/neg/t2206.check
+++ b/test/files/neg/t2206.check
@@ -1,5 +1,5 @@
 t2206.scala:10: error: value f is not a member of o.A
- Note: implicit method ax is not applicable here because it comes after the application point and it lacks an explicit result type
+ Note: implicit method ax is not applicable here because it comes after the application point and it lacks an explicit result type.
   a.f()
     ^
 t2206.scala:13: warning: Implicit definition should have explicit type (inferred o.AX)

--- a/test/files/neg/t5197.check
+++ b/test/files/neg/t5197.check
@@ -1,0 +1,7 @@
+t5197.scala:12: error: type mismatch;
+ found   : List[String]
+ required: Int
+ Note: implicit object O2 is not applicable here because it comes after the application point and it lacks an explicit result type. An object can be written as a lazy val with an explicit type.
+  val y: Int = List("b")
+                   ^
+1 error

--- a/test/files/neg/t5197.scala
+++ b/test/files/neg/t5197.scala
@@ -1,0 +1,14 @@
+
+// scalac: -Werror -feature
+
+// Periodic reminder that the feature is not required for implicit function values.
+//import scala.language.implicitConversions
+
+object A {
+  val x: Int = List("a")
+  implicit lazy val O1: (List[String] => Int) = _.head.toInt
+}
+object B {
+  val y: Int = List("b")
+  implicit object O2 extends (List[String] => Int) { def apply(ss: List[String]): Int = ss.head.toInt }
+}

--- a/test/files/neg/t7131.check
+++ b/test/files/neg/t7131.check
@@ -1,7 +1,7 @@
 t7131.scala:21: error: type mismatch;
  found   : Iterable[U]
  required: That
- Note: implicit method convertToSimpleMappable is not applicable here because it comes after the application point and it lacks an explicit result type
+ Note: implicit method convertToSimpleMappable is not applicable here because it comes after the application point and it lacks an explicit result type.
         x.value.map(f)
                    ^
 t7131.scala:28: warning: Implicit definition should have explicit type (inferred ObservableValue.TraversableMappable[T,Container])


### PR DESCRIPTION
It's unlikely that "explicit type for object" will be proposed for dotty, which has decided that matter of explicit types for implicits.

I expected to see this case more exercised in neg tests, given the amount of attention over the years.

This commit says "try lazy val instead".

Fixes scala/bug#5197
