### PR TITLE
Test for conversion before eta expansion

### DIFF
--- a/test/files/pos/t3218.scala
+++ b/test/files/pos/t3218.scala
@@ -1,0 +1,41 @@
+
+import java.util.{List => JList}
+import scala.collection.mutable
+import scala.collection.JavaConverters.asScalaBuffer
+import scala.language.existentials
+import scala.language.implicitConversions
+
+object Test extends App {
+
+  def fromJava[T](li: JList[T]): List[T] = asScalaBuffer(li).toList
+
+  implicit def `list asScalaBuffer`[A](l: JList[A]): mutable.Buffer[A] = asScalaBuffer(l)
+
+  // implicit conversion - ok
+  def test1(jList:JList[_]) = jList.filter(_.isInstanceOf[java.lang.Object])
+
+  // explicit conversion - ok
+  def test2(jList:JList[_]) = {
+    val f = fromJava(jList).filter _
+    f(_.isInstanceOf[java.lang.Object])
+  }
+
+  // implicit conversion - error
+  def test3(jList:JList[_]) = {
+    val f = jList.filter _
+    f(_.isInstanceOf[java.lang.Object])
+  }
+
+  val ss: JList[String] = {
+    val res = new java.util.ArrayList[String]
+    res.add("hello, world")
+    res
+  }
+
+  println {(
+    test1(ss),
+    test2(ss),
+    test3(ss),
+  )}
+
+}

--- a/test/files/pos/t3218b.scala
+++ b/test/files/pos/t3218b.scala
@@ -1,0 +1,35 @@
+
+import language.implicitConversions
+
+trait T
+trait U {
+  def u(x: Any) = x.toString * 2
+}
+class C {
+  implicit def cv(t: T): U = new U {}
+  def f(t: T): Any => String = cv(t).u _
+  def g(t: T): Any => String = t.u _
+  def h(t: T) = t.u _
+}
+
+object Test extends App {
+  val c = new C
+  val t = new T {}
+  println {(
+    c.f(t)("f"),
+    c.g(t)("g"),
+    c.h(t)("h"),
+  )}
+}
+
+/*
+2.11, 2.12 say:
+t3218b.scala:11: error: _ must follow method; cannot follow Any => String
+  def g(t: T): Any => String = t.u _
+                                   ^
+t3218b.scala:12: error: missing argument list for method u in trait U
+Unapplied methods are only converted to functions when a function type is expected.
+You can make this conversion explicit by writing `u _` or `u(_)` instead of `u`.
+  def h(t: T) = t.u _
+                    ^
+*/


### PR DESCRIPTION
Closes scala/bug#3218

```
    def test3(jList: java.util.List[_]): scala.collection.mutable.Buffer[_] = {
      val f: (_$3 => Boolean) => scala.collection.mutable.Buffer[_$3] forSome { type _$3 } = {
        <synthetic> val eta$0$1: scala.collection.mutable.Buffer[_$3] = Main.this.list asScalaBuffer[_$3](jList);
        ((pred: _$3 => Boolean) => eta$0$1.filter(pred))
      };
      f.apply(((x$3: _$3) => x$3.isInstanceOf[Object]))
    };
```
The test could be better isolated from collections converterings.

Worth noting that dotty warns on the import instead of the use site.
```
4 |import scala.collection.JavaConverters.asScalaBuffer
  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |object JavaConverters in package scala.collection is deprecated since 2.13.0: Use `scala.jdk.CollectionConverters` instead
```
I thought that was attempted on Scala 2 but can't locate a branch.

