### PR TITLE
Replace removeFirst with removeHead in ArrayDeque documentation

### DIFF
--- a/src/library/scala/collection/mutable/ArrayDeque.scala
+++ b/src/library/scala/collection/mutable/ArrayDeque.scala
@@ -21,7 +21,7 @@ import scala.reflect.ClassTag
 
 /** An implementation of a double-ended queue that internally uses a resizable circular buffer.
   *
-  *  Append, prepend, removeFirst, removeLast and random-access (indexed-lookup and indexed-replacement)
+  *  Append, prepend, removeHead, removeLast and random-access (indexed-lookup and indexed-replacement)
   *  take amortized constant time. In general, removals and insertions at i-th index are O(min(i, n-i))
   *  and thus insertions and removals from end/beginning are fast.
   *


### PR DESCRIPTION
The `ArrayDeque` documentation mentions:

> Append, prepend, removeFirst, removeLast and random-access (indexed-lookup and indexed-replacement) take amortized constant time.

However, `removeFirst` is defined as: `def removeFirst(p: A => Boolean, from: Int): Option[A]` (which obviously won't take constant time).
This should have been `removeHead`, which mirrors `removeLast` (including the `*Option` and `*While` variants).