### PR TITLE
[backport] warn when inherited takes precedence over outer definitions

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5275,6 +5275,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               case sym      => typed1(tree setSymbol sym, mode, pt)
                 }
           case LookupSucceeded(qual, sym)   =>
+            sym.getAndRemoveAttachment[LookupAmbiguityWarning].foreach(w =>
+              runReporting.warning(tree.pos, w.msg, WarningCategory.Other, context.owner))
             (// this -> Foo.this
             if (sym.isThisSym)
               typed1(This(sym.owner) setPos tree.pos, mode, pt)

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -131,4 +131,6 @@ trait StdAttachments {
 
   // When typing a Def with this attachment, change the owner of its RHS from origalOwner to the symbol of the Def
   case class ChangeOwnerAttachment(originalOwner: Symbol)
+
+  case class LookupAmbiguityWarning(msg: String) extends PlainAttachment
 }

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -68,6 +68,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.TypeParamVarargsAttachment
     this.KnownDirectSubclassesCalled
     this.ChangeOwnerAttachment
+    this.LookupAmbiguityWarning
     this.noPrint
     this.typeDebug
     // inaccessible: this.posAssigner

--- a/test/files/neg/t11921-alias.check
+++ b/test/files/neg/t11921-alias.check
@@ -1,0 +1,31 @@
+t11921-alias.scala:18: warning: reference to TT is ambiguous;
+it is both defined in the enclosing object O and available in the enclosing class D as type TT (defined in class C)
+Since Scala 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+To continue using the symbol from the superclass, write `this.TT`.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+      def n(x: TT) = x // ambiguous
+               ^
+t11921-alias.scala:38: warning: reference to c is ambiguous;
+it is both defined in the enclosing class B and available in the enclosing anonymous class as value c (defined in class A)
+Since Scala 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+To continue using the symbol from the superclass, write `this.c`.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+      def n = c // ambiguous
+              ^
+t11921-alias.scala:57: warning: reference to name is ambiguous;
+it is both defined in the enclosing method m and available in the enclosing anonymous class as value name (defined in class C)
+Since Scala 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+To continue using the symbol from the superclass, write `this.name`.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+      println(name)
+              ^
+t11921-alias.scala:67: warning: reference to name is ambiguous;
+it is both defined in the enclosing method m and available in the enclosing anonymous class as value name (defined in class A, inherited through parent class C)
+Since Scala 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+To continue using the symbol from the superclass, write `this.name`.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+      println(name)
+              ^
+error: No warnings can be incurred under -Xfatal-warnings.
+four warnings found
+one error found

--- a/test/files/neg/t11921-alias.scala
+++ b/test/files/neg/t11921-alias.scala
@@ -1,0 +1,70 @@
+// scalac: -Xfatal-warnings -Xsource:2.13
+
+object t1 {
+  class C[T] { type TT = T }
+  object O {
+    type TT = String
+    class D extends C[TT] {
+      def n(x: TT) = x // OK
+    }
+  }
+}
+
+object t2 {
+  class C[T] { type TT <: T }
+  object O {
+    type TT = String
+    class D extends C[TT] {
+      def n(x: TT) = x // ambiguous
+    }
+  }
+}
+
+object t3 {
+  trait Context
+  class A[C <: Context](val c: C)
+  class B(val c: Context) { b =>
+    val a = new A[c.type](c) {
+      def n = c // OK
+    }
+  }
+}
+
+object t4 {
+  trait Context
+  class A[C <: Context](val c: C)
+  class B(val c: Context) { b =>
+    val a = new A(c) {
+      def n = c // ambiguous
+    }
+  }
+}
+
+object t5 {
+  trait TT
+  class K[T <: TT](val t: T)
+  class C {
+    def f(t: TT) = new K[t.type](t) {
+      def test = t
+    }
+  }
+}
+
+object t6 {
+  class C(val name: String)
+  object Test {
+    def m(name: String) = new C(name) {
+      println(name)
+    }
+  }
+}
+
+object t7 {
+  abstract class A(val name: String)
+  class C(name: String) extends A(name)
+  object Test {
+    def m(name: String) = new C(name) {
+      println(name)
+    }
+  }
+}

--- a/test/files/neg/t11921b.check
+++ b/test/files/neg/t11921b.check
@@ -1,0 +1,45 @@
+t11921b.scala:11: warning: reference to x is ambiguous;
+it is both defined in the enclosing object Test and available in the enclosing class D as value x (defined in class C)
+Since Scala 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+To continue using the symbol from the superclass, write `this.x`.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+      println(x)  // error
+              ^
+t11921b.scala:15: warning: reference to x is ambiguous;
+it is both defined in the enclosing object Test and available in the enclosing anonymous class as value x (defined in class C)
+Since Scala 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+To continue using the symbol from the superclass, write `this.x`.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+        println(x)  // error
+                ^
+t11921b.scala:26: warning: reference to y is ambiguous;
+it is both defined in the enclosing method c and available in the enclosing anonymous class as value y (defined in class D)
+Since Scala 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+To continue using the symbol from the superclass, write `this.y`.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+      println(y)  // error
+              ^
+t11921b.scala:38: warning: reference to y is ambiguous;
+it is both defined in the enclosing method c and available in the enclosing class E as value y (defined in class D)
+Since Scala 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+To continue using the symbol from the superclass, write `this.y`.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+        println(y)  // error
+                ^
+t11921b.scala:65: warning: reference to global is ambiguous;
+it is both defined in the enclosing package <empty> and available in the enclosing object D as value global (defined in class C)
+Since Scala 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+To continue using the symbol from the superclass, write `this.global`.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+  println(global)    // error
+          ^
+t11921b.scala:75: warning: reference to x is ambiguous;
+it is both defined in the enclosing object Uhu and available in the enclosing class C as value x (defined in class A, inherited through parent class B)
+Since Scala 3, symbols inherited from a superclass no longer shadow symbols defined in an outer scope.
+To continue using the symbol from the superclass, write `this.x`.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+        def t = x // ambiguous, message mentions parent B
+                ^
+error: No warnings can be incurred under -Xfatal-warnings.
+6 warnings found
+one error found

--- a/test/files/neg/t11921b.scala
+++ b/test/files/neg/t11921b.scala
@@ -1,0 +1,79 @@
+// scalac: -Xfatal-warnings -Xsource:2.13
+
+object test1 {
+
+  class C {
+    val x = 0
+  }
+  object Test {
+    val x = 1
+    class D extends C {
+      println(x)  // error
+    }
+    def f() =
+      new C {
+        println(x)  // error
+      }
+  }
+}
+
+object test2 {
+  def c(y: Float) = {
+    class D {
+      val y = 2
+    }
+    new D {
+      println(y)  // error
+    }
+  }
+}
+
+object test3 {
+  def c(y: Float) = {
+    class D {
+      val y = 2
+    }
+    class E extends D {
+      class F {
+        println(y)  // error
+      }
+    }
+  }
+}
+
+object test4 {
+
+  class C {
+    val x = 0
+  }
+  object Test {
+    val x = 1
+    class D extends C {
+      def x(y: Int) = 3
+      val y: Int = this.x // OK
+      val z: Int = x      // OK
+    }
+  }
+}
+
+object global
+
+class C {
+  val global = 42
+}
+object D extends C {
+  println(global)    // error
+}
+
+object test5 {
+  class A { val x = 1 }
+  class B extends A
+  object Uhu {
+    val x = 2
+    class C extends B {
+      class Inner {
+        def t = x // ambiguous, message mentions parent B
+      }
+    }
+  }
+}

--- a/test/files/pos/t11921b.scala
+++ b/test/files/pos/t11921b.scala
@@ -1,0 +1,66 @@
+// scalac: -Xfatal-warnings -Xsource:2.13 -Wconf:msg=legacy-binding:s
+
+object test1 {
+
+  class C {
+    val x = 0
+  }
+  object Test {
+    val x = 1
+    class D extends C {
+      println(x)  // error
+    }
+    def f() =
+      new C {
+        println(x)  // error
+      }
+  }
+}
+
+object test2 {
+  def c(y: Float) = {
+    class D {
+      val y = 2
+    }
+    new D {
+      println(y)  // error
+    }
+  }
+}
+
+object test3 {
+  def c(y: Float) = {
+    class D {
+      val y = 2
+    }
+    class E extends D {
+      class F {
+        println(y)  // error
+      }
+    }
+  }
+}
+
+object test4 {
+
+  class C {
+    val x = 0
+  }
+  object Test {
+    val x = 1
+    class D extends C {
+      def x(y: Int) = 3
+      val y: Int = this.x // OK
+      val z: Int = x      // OK
+    }
+  }
+}
+
+object global
+
+class C {
+  val global = 42
+}
+object D extends C {
+  println(global)    // error
+}

--- a/test/files/pos/t11921c.scala
+++ b/test/files/pos/t11921c.scala
@@ -1,0 +1,22 @@
+// scalac: -Xfatal-warnings -Xsource:2.13
+
+package test.templates {
+  object `package` {
+    type String = java.lang.String
+    val String = new StringCompanion
+    class StringCompanion { def boo = ??? }
+  }
+
+  trait Base {
+    type String = test.templates.String
+    type T <: Foo
+    val T: FooExtractor
+    trait Foo { def foo: Int }
+    trait FooExtractor { def apply(foo: Int): Unit; def unapply(t: Foo): Option[Int] }
+  }
+
+  trait Api extends Base {
+    override type T <: FooApi
+    trait FooApi extends Foo { def bar: String }
+  }
+}


### PR DESCRIPTION
Under `-Xsource:2.13`, warn when an inherited member takes precedence over an outer definition.

Backport of https://github.com/scala/scala/pull/10220.