### PR TITLE
[backport] Under `-Xsource:2.13`, don't GLB binders of type patterns, use the type directly

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
@@ -75,7 +75,7 @@ trait MatchTranslation {
         case TypeBound(tpe) => tpe
         case tree           => tree.tpe
       }
-      def glbWith(other: Type) = glb(tpe :: other :: Nil).normalize
+      def glbWith(other: Type) = if (currentRun.isScala213) other else glb(tpe :: other :: Nil).normalize
 
       object SymbolAndTypeBound {
         def unapply(tree: Tree): Option[(Symbol, Type)] = tree match {

--- a/test/files/run/t12702.check
+++ b/test/files/run/t12702.check
@@ -1,0 +1,2 @@
+warning: one feature warning; re-run with -feature for details
+IOS

--- a/test/files/run/t12702.scala
+++ b/test/files/run/t12702.scala
@@ -1,0 +1,19 @@
+// scalac: -Xsource:2.13
+
+object Test {
+  trait MFSS[X <: MFSS[_]]
+  trait CS extends MFSS[CS]
+  trait MFI { type ST }
+  case class MFSD[S](mFI: MFI {type ST = S})
+  case object IOS extends MFI { type ST = CS }
+  type SD = MFSD[S] forSome {
+    type S <: MFSS[S]
+  }
+  def bad(sd: SD) = sd.mFI match {
+    case ios: IOS.type => println(ios)
+  }
+  def main(args: Array[String]): Unit = {
+    val x = MFSD(IOS)
+    bad(x)
+  }
+}

--- a/test/junit/scala/tools/nsc/symtab/SymbolTableTest.scala
+++ b/test/junit/scala/tools/nsc/symtab/SymbolTableTest.scala
@@ -49,4 +49,33 @@ class SymbolTableTest {
     import symbolTable._
     assert(NoSymbol.outerClass == NoSymbol)
   }
+
+  @Test def t12702_glb(): Unit = {
+    import symbolTable._
+    import SymbolTableTest.t12702._
+    val t1 = typeOf[IOS.type]
+    val t2 = {
+      val sd = typeOf[SD]
+      sd.memberType(sd.member(TermName("mFI"))).finalResultType
+    }
+    // t1: Test.IOS.type
+    // t2: Test.MFI{type +ST = S}
+
+    // Ends up in `throw GlbFailure` in glb => Null
+    assertTrue(definitions.NullTpe =:= glb(t1 :: t2 :: Nil))
+  }
+}
+
+object SymbolTableTest {
+  object t12702 {
+    import scala.language.existentials
+    trait MFSS[X <: MFSS[_]]
+    trait CS extends MFSS[CS]
+    trait MFI { type ST }
+    case class MFSD[S](mFI: MFI {type ST = S})
+    case object IOS extends MFI { type ST = CS }
+    type SD = MFSD[S] forSome {
+      type S <: MFSS[S]
+    }
+  }
 }


### PR DESCRIPTION
Backport of https://github.com/scala/scala/pull/10247 under `-Xsource:2.13`.