### PR TITLE
GitHub Actions: update actions/checkout to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - run: git config --global core.autocrlf false
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Java
         uses: actions/setup-java@v3


### PR DESCRIPTION
at e.g. https://github.com/scala/scala/actions/runs/4130256541 GitHub is telling us:

> Node.js 12 actions are deprecated. Please update the following
> actions to use Node.js 16: actions/checkout@v2. For more information
> see:
> https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

I eyeballed https://github.com/actions/checkout/releases but didn't see any compatibility concerns