### PR TITLE
Lint eta-expansions with impure subexpressions

### DIFF
--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -380,6 +380,7 @@ object Reporting {
     object LintSerial extends Lint; add(LintSerial)
     object LintEtaZero extends Lint; add(LintEtaZero)
     object LintEtaSam extends Lint; add(LintEtaSam)
+    object LintEtaImpure extends Lint; add(LintEtaImpure)
     object LintDeprecation extends Lint; add(LintDeprecation)
     object LintBynameImplicit extends Lint; add(LintBynameImplicit)
     object LintRecurseWithDefault extends Lint; add(LintRecurseWithDefault)

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -182,6 +182,7 @@ trait Warnings {
     val StarsAlign             = LintWarning("stars-align",               "Pattern sequence wildcard must align with sequence component.")
     val Constant               = LintWarning("constant",                  "Evaluation of a constant arithmetic expression results in an error.")
     val Unused                 = LintWarning("unused",                    "Enable -Ywarn-unused:imports,privates,locals,implicits,nowarn.")
+    val EtaImpure              = LintWarning("eta-impure",                "The qualifier in an eta-expansion `qual.foo _` is impure (evaluated eagerly, not part of the function).")
     val Deprecation            = LintWarning("deprecation",               "Enable -deprecation and also check @deprecated annotations.")
 
     def allLintWarnings = values.toSeq.asInstanceOf[Seq[LintWarning]]
@@ -206,6 +207,7 @@ trait Warnings {
   def warnStarsAlign             = lint contains StarsAlign
   def warnConstant               = lint contains Constant
   def lintUnused                 = lint contains Unused
+  def lintEtaImpure              = lint contains EtaImpure
   def lintDeprecation            = lint contains Deprecation
 
   // Lint warnings that are currently -Y, but deprecated in that usage

--- a/src/compiler/scala/tools/nsc/typechecker/EtaExpansion.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/EtaExpansion.scala
@@ -14,6 +14,7 @@ package scala.tools.nsc
 package typechecker
 
 import scala.collection.mutable.ListBuffer
+import scala.tools.nsc.Reporting.WarningCategory
 import symtab.Flags._
 
 /** This trait ...
@@ -67,7 +68,11 @@ trait EtaExpansion { self: Analyzer =>
               val res = typer.typed(Function(List(), tree))
               new ChangeOwnerTraverser(typer.context.owner, res.symbol) traverse tree // scala/bug#6274
               res
-            } else tree
+            } else {
+              if (settings.lintEtaImpure)
+                typer.context.warning(tree.pos, "impure expression as part of an eta-expansion. The expression is evaluated eagerly, before the function is created, not when the function is evaluated.", WarningCategory.LintEtaImpure)
+              tree
+            }
             ValDef(Modifiers(SYNTHETIC), vname.toTermName, TypeTree(), rhs)
           }
           atPos(tree.pos.focus) {

--- a/test/files/neg/lint-eta-impure.check
+++ b/test/files/neg/lint-eta-impure.check
@@ -1,0 +1,12 @@
+lint-eta-impure.scala:10: warning: impure expression as part of an eta-expansion. The expression is evaluated eagerly, before the function is created, not when the function is evaluated.
+  def t1 = (new C).g _           // warn
+            ^
+lint-eta-impure.scala:11: warning: impure expression as part of an eta-expansion. The expression is evaluated eagerly, before the function is created, not when the function is evaluated.
+  def t2: Int => Int = (new C).g // warn
+                        ^
+lint-eta-impure.scala:15: warning: impure expression as part of an eta-expansion. The expression is evaluated eagerly, before the function is created, not when the function is evaluated.
+  def t6(c: C) = c.h(c.f) _      // warn
+                       ^
+error: No warnings can be incurred under -Xfatal-warnings.
+three warnings found
+one error found

--- a/test/files/neg/lint-eta-impure.scala
+++ b/test/files/neg/lint-eta-impure.scala
@@ -1,0 +1,17 @@
+// scalac: -Xlint -Xfatal-warnings
+
+class C {
+  def f = 1
+  def g(x: Int) = 0
+  def h(x: Int)(y: Int) = 0
+  def i(x: => Int)(y: Int) = 0
+}
+object Test {
+  def t1 = (new C).g _           // warn
+  def t2: Int => Int = (new C).g // warn
+  def t3(c: C) = c.g _           // ok
+  def t4(c: C): Int => Int = c.g // ok
+  def t5(c: C) = c.h(1) _        // ok
+  def t6(c: C) = c.h(c.f) _      // warn
+  def t7(c: C) = c.i(c.f) _      // ok (by-name)
+}


### PR DESCRIPTION
In an eta-expansion `foo.bar(baz) _`, `foo` and `baz` are evaluated eagerly, so the entire expression is equivalent to

```
{
  val eta$0 = foo
  val eta$1 = baz
  xs... => eta$0.bar(eta$1)(xs...)
}
```

which is different from `xs... => foo.bar(baz)(xs...)`. I belive not many users are aware of this and it's a pitfall that can lead to bugs that are difficult to track down.

The lint warning is not issued if `foo` and `baz` are pure.