### PR TITLE
Revert exclusion of companion for reporting deprecation

### DIFF
--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -204,7 +204,7 @@ trait Reporting extends internal.Reporting { self: ast.Positions with Compilatio
     def deprecationWarning(pos: Position, origin: Symbol, site: Symbol): Unit = {
       val version = origin.deprecationVersion.getOrElse("")
       val since   = if (version.isEmpty) version else s" (since $version)"
-      val message = origin.deprecationMessage.map(": " + _).getOrElse("")
+      val message = origin.deprecationMessage.filter(!_.isEmpty).map(": " + _).getOrElse("")
       deprecationWarning(pos, origin, site, s"$origin${origin.locationString} is deprecated$since$message", version)
     }
 

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1285,7 +1285,7 @@ abstract class RefChecks extends Transform {
       if (sym.isDeprecated &&
           // synthetic calls to deprecated case class constructor
           !(sym.isConstructor && sym.owner.isCaseClass && currentOwner.isSynthetic) &&
-          !currentOwner.ownersIterator.exists(s => s.isDeprecated || s.companionClass.isDeprecated))
+          !currentOwner.ownersIterator.exists(_.isDeprecated))
         runReporting.deprecationWarning(pos, sym, currentOwner)
 
       // Similar to deprecation: check if the symbol is marked with @migration

--- a/src/library/scala/io/Position.scala
+++ b/src/library/scala/io/Position.scala
@@ -13,6 +13,8 @@
 package scala
 package io
 
+import annotation.nowarn
+
 /** The object Position provides convenience methods to encode
  *  line and column number in one single integer.  The encoded line
  *  (column) numbers range from 0 to `LINE_MASK` (`COLUMN_MASK`),
@@ -71,13 +73,12 @@ private[scala] abstract class Position {
   def toString(pos: Int): String = line(pos) + ":" + column(pos)
 }
 
+@nowarn
 private[scala] object Position extends Position {
   def checkInput(line: Int, column: Int): Unit = {
     if (line < 0)
-      throw new IllegalArgumentException(line + " < 0")
-    if ((line == 0) && (column != 0))
-      throw new IllegalArgumentException(line + "," + column + " not allowed")
-    if (column < 0)
-      throw new IllegalArgumentException(line + "," + column + " not allowed")
+      throw new IllegalArgumentException(s"$line < 0")
+    if (line == 0 && column != 0 || column < 0)
+      throw new IllegalArgumentException(s"$line,$column not allowed")
   }
 }

--- a/src/library/scala/languageFeature.scala
+++ b/src/library/scala/languageFeature.scala
@@ -35,6 +35,7 @@ object languageFeature {
   @deprecated("scala.language.higherKinds no longer needs to be imported explicitly", "2.13.1")
   @meta.languageFeature("higher-kinded type", enableRequired = false)
   sealed trait higherKinds
+  @deprecated("scala.language.higherKinds no longer needs to be imported explicitly", "2.13.1")
   object higherKinds extends higherKinds
 
   @meta.languageFeature("#, which cannot be expressed by wildcards,", enableRequired = false)

--- a/test/files/neg/t2799.check
+++ b/test/files/neg/t2799.check
@@ -10,6 +10,12 @@ t2799.scala:8: warning: trait T is deprecated: other mother
 t2799.scala:9: warning: method int2float in object Int is deprecated (since 2.13.1): Implicit conversion from Int to Float is dangerous because it loses precision. Write `.toFloat` instead.
   def g() = implicitly[Int => Float]
                       ^
+t2799.scala:16: warning: trait T is deprecated: other mother
+object T extends T[String] {
+                 ^
+t2799.scala:17: warning: class Bob is deprecated: hi mom
+  def t = Bob() // warn
+          ^
 error: No warnings can be incurred under -Werror.
-4 warnings
+6 warnings
 1 error

--- a/test/files/neg/t2799.scala
+++ b/test/files/neg/t2799.scala
@@ -8,3 +8,15 @@ class C[A: T] {
   def f = (t: T[A]) => null.asInstanceOf[T[A]]
   def g() = implicitly[Int => Float]
 }
+
+@deprecated("hi mom", "")
+case class Bob ()
+
+// No exclusion for companion of deprecated T
+object T extends T[String] {
+  def t = Bob() // warn
+}
+
+class Client {
+  def test = T.t // if no warn at t, then this code appears deprecation-free
+}

--- a/test/files/neg/t7783.check
+++ b/test/files/neg/t7783.check
@@ -1,16 +1,16 @@
-t7783.scala:3: warning: type D in object O is deprecated:
+t7783.scala:3: warning: type D in object O is deprecated
 object O { class C; @deprecated("", "") type D = C; def foo: Seq[D] = Nil }
                                                              ^
-t7783.scala:13: warning: type D in object O is deprecated:
+t7783.scala:13: warning: type D in object O is deprecated
   type T = O.D
              ^
-t7783.scala:14: warning: type D in object O is deprecated:
+t7783.scala:14: warning: type D in object O is deprecated
   locally(null: O.D)
                   ^
-t7783.scala:15: warning: type D in object O is deprecated:
+t7783.scala:15: warning: type D in object O is deprecated
   val x: O.D = null
            ^
-t7783.scala:16: warning: type D in object O is deprecated:
+t7783.scala:16: warning: type D in object O is deprecated
   locally(null.asInstanceOf[O.D])
                               ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/wconfSource1.check
+++ b/test/files/neg/wconfSource1.check
@@ -1,4 +1,4 @@
-wconfSource1.scala:9: error: method dep in class C is deprecated:
+wconfSource1.scala:9: error: method dep in class C is deprecated
   def t = dep
           ^
 wconfSource1.scala:10: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses

--- a/test/files/neg/wconfSource2.check
+++ b/test/files/neg/wconfSource2.check
@@ -6,7 +6,7 @@ See the Scaladoc for value scala.language.reflectiveCalls for a discussion
 why the feature should be explicitly enabled.
   def v(a: { def f: Int }) = a.f
                                ^
-wconfSource2.scala:5: error: method dep in class C is deprecated:
+wconfSource2.scala:5: error: method dep in class C is deprecated
   def t = dep
           ^
 wconfSource2.scala:6: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses

--- a/test/files/pos/t2799.scala
+++ b/test/files/pos/t2799.scala
@@ -1,11 +1,4 @@
-
 // scalac: -Xlint -Werror
 
-@deprecated("hi mom", "") case class Bob ()
-
-@deprecated("other mother", "")
-trait T
-
-object T extends T {
-  def t = Bob()
-}
+@deprecated("hi mom", "")
+case class Bob ()


### PR DESCRIPTION
~Update spec for accommodation at https://github.com/scala/scala/pull/10071~

Instead of granting companions immunity from deprecation, make them explicitly choose whether to propagate the deprecation or explicitly `nowarn`.

Avoid trailing colon if message is empty. (Parity with fix in dotty.)
