### PR TITLE
Lint for integral divisions that are widened to a float

### DIFF
--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -381,6 +381,7 @@ object Reporting {
     object LintEtaZero extends Lint; add(LintEtaZero)
     object LintEtaSam extends Lint; add(LintEtaSam)
     object LintDeprecation extends Lint; add(LintDeprecation)
+    object LintIntDivToFloat extends Lint; add(LintIntDivToFloat)
     object LintBynameImplicit extends Lint; add(LintBynameImplicit)
     object LintRecurseWithDefault extends Lint; add(LintRecurseWithDefault)
     object LintUnitSpecialization extends Lint; add(LintUnitSpecialization)

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -183,6 +183,7 @@ trait Warnings {
     val Constant               = LintWarning("constant",                  "Evaluation of a constant arithmetic expression results in an error.")
     val Unused                 = LintWarning("unused",                    "Enable -Ywarn-unused:imports,privates,locals,implicits,nowarn.")
     val Deprecation            = LintWarning("deprecation",               "Enable -deprecation and also check @deprecated annotations.")
+    val IntDivToFloat          = LintWarning("int-div-to-float",          "Warn when an integer division is converted (widened) to floating point: `(someInt / 2): Double`.")
 
     def allLintWarnings = values.toSeq.asInstanceOf[Seq[LintWarning]]
   }
@@ -207,6 +208,7 @@ trait Warnings {
   def warnConstant               = lint contains Constant
   def lintUnused                 = lint contains Unused
   def lintDeprecation            = lint contains Deprecation
+  def lintIntDivToFloat          = lint contains IntDivToFloat
 
   // Lint warnings that are currently -Y, but deprecated in that usage
   @deprecated("Use warnAdaptedArgs", since="2.11.2")

--- a/src/library/scala/math/BigInt.scala
+++ b/src/library/scala/math/BigInt.scala
@@ -172,6 +172,7 @@ final class BigInt(val bigInteger: BigInteger)
     (shifted.signum != 0) && !(shifted equals BigInt.minusOne)
   }
 
+  @deprecated("isWhole on an integer type is always true", "2.12.15")
   def isWhole() = true
   def underlying = bigInteger
 

--- a/src/library/scala/runtime/RichInt.scala
+++ b/src/library/scala/runtime/RichInt.scala
@@ -31,6 +31,7 @@ final class RichInt(val self: Int) extends AnyVal with ScalaNumberProxy[Int] wit
   /** Returns `'''true'''` if this number has no decimal component.
     * Always `'''true'''` for `RichInt`.
     */
+  @deprecated("isWhole on an integer type is always true", "2.12.15")
   def isWhole() = true
 
   override def isValidInt   = true

--- a/src/library/scala/runtime/ScalaNumberProxy.scala
+++ b/src/library/scala/runtime/ScalaNumberProxy.scala
@@ -45,6 +45,7 @@ trait ScalaNumberProxy[T] extends Any with ScalaNumericAnyConversions with Typed
   def signum          = num.signum(self)
 }
 trait ScalaWholeNumberProxy[T] extends Any with ScalaNumberProxy[T] {
+  @deprecated("isWhole on an integer type is always true", "2.12.15")
   def isWhole() = true
 }
 trait IntegralProxy[T] extends Any with ScalaWholeNumberProxy[T] with RangedProxy[T] {

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -180,6 +180,13 @@ trait Definitions extends api.StandardDefinitions {
     }
     def ScalaPrimitiveValueClasses: List[ClassSymbol] = ScalaValueClasses
 
+    lazy val ScalaIntegralValueClasses: Set[Symbol] = Set(
+      CharClass,
+      ByteClass,
+      ShortClass,
+      IntClass,
+      LongClass)
+
     def underlyingOfValueClass(clazz: Symbol): Type =
       clazz.derivedValueClassUnbox.tpe.resultType
 

--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -845,10 +845,10 @@ abstract class TreeInfo {
   object Applied {
     def apply(tree: Tree): Applied = new Applied(tree)
 
-    def unapply(applied: Applied): Option[(Tree, List[Tree], List[List[Tree]])] =
+    def unapply(applied: Applied): Some[(Tree, List[Tree], List[List[Tree]])] =
       Some((applied.core, applied.targs, applied.argss))
 
-    def unapply(tree: Tree): Option[(Tree, List[Tree], List[List[Tree]])] =
+    def unapply(tree: Tree): Some[(Tree, List[Tree], List[List[Tree]])] =
       unapply(dissectApplied(tree))
   }
 

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -498,6 +498,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.ScalaValueClasses
     definitions.ScalaValueClassesSet
     definitions.ScalaNumericValueClassesSet
+    definitions.ScalaIntegralValueClasses
 
     uncurry.VarargsSymbolAttachment
     uncurry.DesugaredParameterType

--- a/test/files/neg/lint-int-div-to-float.check
+++ b/test/files/neg/lint-int-div-to-float.check
@@ -1,0 +1,18 @@
+lint-int-div-to-float.scala:6: warning: integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`.
+  def w1: Double = f / 2
+                     ^
+lint-int-div-to-float.scala:7: warning: integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`.
+  def w2: Double = (f / 2) * 3
+                      ^
+lint-int-div-to-float.scala:8: warning: integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`.
+  def w3: Double = -(f / 2)
+                       ^
+lint-int-div-to-float.scala:9: warning: integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`.
+  def w4: Double = (new C).f / (new C).f * 3
+                             ^
+lint-int-div-to-float.scala:10: warning: integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`.
+  def w5: Double = f - f.abs / 2
+                             ^
+error: No warnings can be incurred under -Xfatal-warnings.
+5 warnings found
+one error found

--- a/test/files/neg/lint-int-div-to-float.scala
+++ b/test/files/neg/lint-int-div-to-float.scala
@@ -1,0 +1,18 @@
+// scalac: -Xlint -Xfatal-warnings
+
+class C {
+  def f = 1
+
+  def w1: Double = f / 2
+  def w2: Double = (f / 2) * 3
+  def w3: Double = -(f / 2)
+  def w4: Double = (new C).f / (new C).f * 3
+  def w5: Double = f - f.abs / 2
+
+  def o1: Double = (f / 2).toDouble
+  def o2: Double = f.toDouble / 2
+  def o3: Double = f / 2.toDouble
+  def o4: Double = f / 2d
+  def o5: Double = (new C).f.toDouble / (new C).f * 3
+  def o6: Long = f / 2 + 3 // only warn if widening to a floating point, not when widening int to long
+}

--- a/test/files/run/is-valid-num.scala
+++ b/test/files/run/is-valid-num.scala
@@ -1,5 +1,5 @@
 /*
- * filter: inliner warnings; re-run with
+ * filter: re-run with -deprecation
  */
 object Test {
   def x = BigInt("10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")


### PR DESCRIPTION
Add a lint warning for integer divisions that are implicitly converted to floats (`someInt / 2: Double`). Such expressions are probably a mistake, or otherwise very likely to be misunderstood by reviewers / readers.

The same argument could be made for other integer operations as they can overflow. `Int.MaxValue * 2: Double` is different from `Int.MaxValue.toDouble * 2`. But division is much more likely to be a bug because the result is different also without an overflow.

The existing `-Ywarn-numeric-widen` flag (`-Wnumeric-widen` on 2.13) warns about all widening conversions, which is probably too restrictive for some users.

While working on this, I noticed a couple of extension methods on integrals that are nonsensical: `ceil`, `floor`, `isNaN`, `isNegInfinity`, `isPosInfinity`, `isInfinite`, `isInfinity`, `isFinite`. We could add a warning for those in RefChecks, for example. `someInt.isNaN` compiles to `Predef.float2Float(someInt.toFloat).isNaN`, the widening conversion `toFloat` is inserted during implicit search.