### PR TITLE
[backport] Fixes to backport of new precedence warning

### DIFF
--- a/test/files/pos/t11921b.scala
+++ b/test/files/pos/t11921b.scala
@@ -8,11 +8,11 @@ object test1 {
   object Test {
     val x = 1
     class D extends C {
-      println(x)  // error
+      println(x)
     }
     def f() =
       new C {
-        println(x)  // error
+        println(x)
       }
   }
 }
@@ -23,7 +23,7 @@ object test2 {
       val y = 2
     }
     new D {
-      println(y)  // error
+      println(y)
     }
   }
 }
@@ -35,7 +35,7 @@ object test3 {
     }
     class E extends D {
       class F {
-        println(y)  // error
+        println(y)
       }
     }
   }
@@ -50,8 +50,8 @@ object test4 {
     val x = 1
     class D extends C {
       def x(y: Int) = 3
-      val y: Int = this.x // OK
-      val z: Int = x      // OK
+      val y: Int = this.x
+      val z: Int = x
     }
   }
 }
@@ -62,5 +62,25 @@ class C {
   val global = 42
 }
 object D extends C {
-  println(global)    // error
+  println(global)
+}
+
+object test5 {
+  trait T {
+    val s: String
+  }
+
+  trait U {
+    this: T =>
+    val s: String
+    def t = s
+  }
+
+
+  class AA {
+    def f = 1
+    class B extends AA {
+      def g = f
+    }
+  }
 }


### PR DESCRIPTION
This is a follow-up for #10297 that fixes false positive ambiguity warnings.