### PR TITLE
[nomerge] Improve performance of String multiplication

### DIFF
--- a/src/library/scala/collection/immutable/StringLike.scala
+++ b/src/library/scala/collection/immutable/StringLike.scala
@@ -18,6 +18,7 @@ import mutable.Builder
 import scala.util.matching.Regex
 import scala.math.ScalaNumber
 import scala.reflect.ClassTag
+import java.lang.{StringBuilder => JStringBuilder}
 
 /** A companion object for the `StringLike` containing some constants.
  *  @since 2.8
@@ -69,10 +70,15 @@ self =>
 
   /** Return the current string concatenated `n` times.
    */
-  def * (n: Int): String = {
-    val buf = new StringBuilder
-    for (i <- 0 until n) buf append toString
-    buf.toString
+  def *(n: Int): String = {
+    val s0 = toString
+    var ci = 0 max n
+    val sb = new JStringBuilder(s0.length * ci)
+    while (ci > 0) {
+      sb.append(s0)
+      ci -= 1
+    }
+    sb.toString
   }
 
   override def compare(other: String) = toString compareTo other

--- a/test/junit/scala/collection/immutable/StringLikeTest.scala
+++ b/test/junit/scala/collection/immutable/StringLikeTest.scala
@@ -75,4 +75,12 @@ class StringLikeTest {
     AssertUtil.assertThrows[java.lang.NullPointerException](sNull.toDouble)
     AssertUtil.assertThrows[java.lang.NullPointerException](sNull.toFloat)
   }
+
+  @Test
+  def `the times they are achangin`(): Unit = {
+    assertEquals("xx", "x"*2)
+    assertEquals("x", "x"*1)
+    assertEquals("", "x"*0)
+    assertEquals("", "x" * -1)
+  }
 }


### PR DESCRIPTION
Improve performance of `"x" * n` on 2.12.

Fixes scala/bug#11547