### PR TITLE
Bump JLine and JNA versions

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -9,5 +9,5 @@ starr.version=2.13.10
 scala-asm.version=9.4.0-scala-1
 
 # jna.version must be updated together with jline-terminal-jna
-jline.version=3.21.0
+jline.version=3.22.0
 jna.version=5.9.0

--- a/versions.properties
+++ b/versions.properties
@@ -10,4 +10,4 @@ scala-asm.version=9.4.0-scala-1
 
 # jna.version must be updated together with jline-terminal-jna
 jline.version=3.22.0
-jna.version=5.9.0
+jna.version=5.13.0


### PR DESCRIPTION
seems like a good idea to get this into 2.13.11
- JLine 3.22.0 (was 3.21.0)
- JNA 5.13.0 (was 5.9.0)

JLine release notes: https://github.com/jline/jline3/releases/tag/jline-parent-3.22.0