### PR TITLE
Warn about change to parenless lambda parens under -Xsource:3

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -777,8 +777,15 @@ self =>
 
     /** Convert tree to formal parameter list. */
     def convertToParams(tree: Tree): List[ValDef] = tree match {
-      case Parens(ts) => ts map convertToParam
-      case _          => List(convertToParam(tree))
+      case Parens(ts) => ts.map(convertToParam)
+      case Typed(Ident(_), _) =>
+        val msg = "parentheses are required around the parameter of a lambda"
+        val wrn = sm"""|$msg
+                       |Use '-Wconf:msg=lambda-parens:s' to silence this warning."""
+        if (currentRun.isScala3)
+          deprecationWarning(tree.pos.point, wrn, "2.13.11")
+        List(convertToParam(tree))
+      case _ => List(convertToParam(tree))
     }
 
     /** Convert tree to formal parameter. */

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1374,17 +1374,17 @@ trait Contexts { self: Analyzer =>
           val parent = currentClass.parentSymbols.find(_.isNonBottomSubClass(inherited1.owner)).getOrElse(NoSymbol)
           val inherit = if (parent.exists && parent != inherited1.owner) s", inherited through parent $parent" else ""
           val message =
-            s"""it is both defined in the enclosing ${outer1.owner} and inherited in the enclosing $classDesc as $inherited1 (defined in ${inherited1.ownsString}$inherit)
-               |In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
-               |Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.${outer1.name}`.""".stripMargin
+            sm"""|it is both defined in the enclosing ${outer1.owner} and inherited in the enclosing $classDesc as $inherited1 (defined in ${inherited1.ownsString}$inherit)
+                 |In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
+                 |Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.${outer1.name}`."""
           if (currentRun.isScala3)
             Some(LookupAmbiguous(message))
           else {
             // passing the message to `typedIdent` as attachment, we don't have the position here to report the warning
             inherited.updateAttachment(LookupAmbiguityWarning(
-              s"""reference to ${outer1.name} is ambiguous;
-                 |$message
-                 |Or use `-Wconf:msg=legacy-binding:s` to silence this warning.""".stripMargin))
+              sm"""|reference to ${outer1.name} is ambiguous;
+                   |$message
+                   |Or use `-Wconf:msg=legacy-binding:s` to silence this warning."""))
             None
           }
         }

--- a/test/files/neg/parens-for-params.check
+++ b/test/files/neg/parens-for-params.check
@@ -1,0 +1,7 @@
+parens-for-params.scala:5: warning: parentheses are required around the parameter of a lambda
+Use '-Wconf:msg=lambda-parens:s' to silence this warning.
+    x: Int => x * 2
+     ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/parens-for-params.scala
+++ b/test/files/neg/parens-for-params.scala
@@ -1,0 +1,8 @@
+// scalac: -Werror -Xlint -Xsource:3
+
+class C {
+  def f = {
+    x: Int => x * 2
+  }
+  def g = (x: Int) => x * 2
+}

--- a/test/files/pos/parens-for-params-silent.scala
+++ b/test/files/pos/parens-for-params-silent.scala
@@ -1,0 +1,8 @@
+// scalac: -Werror -Wconf:msg=lambda-parens:s -Xsource:3
+
+class C {
+  def f = {
+    x: Int => x * 2
+  }
+  def g = (x: Int) => x * 2
+}


### PR DESCRIPTION
The syntax `xs.map { x: Int => x + 1 }` is disallowed in Scala 3.

Parenless params are deprecated under `-Xsource:3`, and will error if `-Wsource` is added.

Without `-Xsource:3`, `-Wsource` will warn.

The message is, "parentheses are required around the parameter of a lambda".