### PR TITLE
Accept `implicit _`, `implicit (x: Int)` in lambdas, like Scala 3 does

### DIFF
--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -1182,8 +1182,8 @@ for  `try { try { ´b´ } catch ´e_1´ } finally ´e_2´`.
 ## Anonymous Functions
 
 ```ebnf
-Expr            ::=  (Bindings | [‘implicit’] id | ‘_’) ‘=>’ Expr
-ResultExpr      ::=  (Bindings | ([‘implicit’] id | ‘_’) ‘:’ CompoundType) ‘=>’ Block
+Expr            ::=  (Bindings | [‘implicit’] (id | ‘_’)) ‘=>’ Expr
+ResultExpr      ::=  (Bindings | [‘implicit’] (id | ‘_’) [‘:’ CompoundType]) ‘=>’ Block
 Bindings        ::=  ‘(’ Binding {‘,’ Binding} ‘)’
 Binding         ::=  (id | ‘_’) [‘:’ Type]
 ```

--- a/spec/13-syntax-summary.md
+++ b/spec/13-syntax-summary.md
@@ -144,7 +144,7 @@ grammar:
                       |  ‘:’ Annotation {Annotation}
                       |  ‘:’ ‘_’ ‘*’
 
-  Expr              ::=  (Bindings | [‘implicit’] id | ‘_’) ‘=>’ Expr
+  Expr              ::=  (Bindings | [‘implicit’] (id | ‘_’)) ‘=>’ Expr
                       |  Expr1
   Expr1             ::=  ‘if’ ‘(’ Expr ‘)’ {nl} Expr [[semi] ‘else’ Expr]
                       |  ‘while’ ‘(’ Expr ‘)’ {nl} Expr
@@ -188,7 +188,7 @@ grammar:
                       |  Expr1
                       |
   ResultExpr        ::=  Expr1
-                      |  (Bindings | ([‘implicit’] id | ‘_’) ‘:’ CompoundType) ‘=>’ Block
+                      |  (Bindings | [‘implicit’] (id | ‘_’) [‘:’ CompoundType]) ‘=>’ Block
 
   Enumerators       ::=  Generator {semi Generator}
   Generator         ::=  [‘case’] Pattern1 ‘<-’ Expr {[semi] Guard | semi Pattern1 ‘=’ Expr}

--- a/test/files/pos/t3672.scala
+++ b/test/files/pos/t3672.scala
@@ -1,4 +1,22 @@
 object Test {
-  def foo(f: Int => Int) = () ; foo { implicit x : Int => x + 1 }
-  def bar(f: Int => Int) = () ; foo { x : Int => x + 1 }
+  def foo(f: Int => Int) = ()
+  def test(): Unit = {
+    foo { x => x + 1 }
+    foo { implicit x => x + 1 }
+    foo { x: Int => x + 1 }
+    foo { implicit x: Int => x + 1 }
+    foo { _ => 42 }
+    foo { implicit _ => implicitly[Int] + 1 }   // scala 2 deficit
+    foo { _: Int => 42 }
+    foo { implicit _: Int => implicitly[Int] + 1 }    // scala 2 deficit
+
+    foo(x => x + 1)
+    foo(implicit x => x + 1)
+    foo((x: Int) => x + 1)
+    foo(implicit (x: Int) => x + 1)   // scala 3
+    foo(_ => 42)
+    foo(implicit _ => implicitly[Int] + 1)    // scala 2 deficit
+    foo((_: Int) => 42)
+    foo(implicit (_: Int) => implicitly[Int] + 1)   // scala 3
+  }
 }


### PR DESCRIPTION
Bring syntax in line with Scala 3 by enabling what you might already expect to work. The goal is to improve cross-building as noted at https://github.com/lampepfl/dotty/issues/14365.

Follow-up to https://github.com/scala/bug/issues/3672