### PR TITLE
Fixed an issue with NumericRanges until/to Long.MinValue's length

### DIFF
--- a/src/library/scala/collection/immutable/NumericRange.scala
+++ b/src/library/scala/collection/immutable/NumericRange.scala
@@ -398,6 +398,10 @@ object NumericRange {
       def check(t: T): T =
         if (num.gt(t, limit)) throw new IllegalArgumentException("More than Int.MaxValue elements.")
         else t
+
+      def isMinValue(t: T): Boolean =
+        num.lt(t, num.zero) && num.gt(num.minus(t, num.one), t)
+
       // If the range crosses zero, it might overflow when subtracted
       val startside = num.sign(start)
       val endside = num.sign(end)
@@ -440,10 +444,12 @@ object NumericRange {
               // There is a last piece
               val enddiff = num.minus(end,waypointB)
               val endq    = check(num.quot(enddiff, step))
-              if (num.sign(endq) != num.sign(num.minus(endq, one))) {
-                // types smaller or equal to Int are already handled (including custom wrappers),
-                // in this case, we need an extra step of checking for Long.MinValue
-                // abs value of Long.MinValue would be Long.MinValue, so we'd need to add one to it, and then use the abs value of the expression
+              // Types smaller or equal to Int are already handled (including custom wrappers),
+              // in this case, we need an extra step of checking for "MinValue" of types larger than Int.
+              if (isMinValue(endq)) {
+                // Since num.quot("num.MinValue", "1 or -1") returns MinValue, check gets bypassed!
+                // If there are more than Int.MaxValue of elements in the [end+1, wayPointB] section of the range,
+                // there would definitely be more than Int.MaxValue elements in the range.
                 check(num.abs(num.plus(endq, one)))
               }
               val last    = if (endq == zero) waypointB else num.plus(waypointB, num.times(endq, step))

--- a/src/library/scala/collection/immutable/NumericRange.scala
+++ b/src/library/scala/collection/immutable/NumericRange.scala
@@ -402,7 +402,7 @@ object NumericRange {
       val startside = num.sign(start)
       val endside = num.sign(end)
       num.toInt{
-        if (num.gteq(num.times(startside, endside), zero)) {
+        if (num.gt(num.times(startside, endside), zero)) {
           // We're sure we can subtract these numbers.
           // Note that we do not use .rem because of different conventions for Long and BigInt
           val diff = num.minus(end, start)
@@ -440,6 +440,12 @@ object NumericRange {
               // There is a last piece
               val enddiff = num.minus(end,waypointB)
               val endq    = check(num.quot(enddiff, step))
+              if (num.sign(endq) != num.sign(num.minus(endq, one))) {
+                // types smaller or equal to Int are already handled (including custom wrappers),
+                // in this case, we need an extra step of checking for Long.MinValue
+                // abs value of Long.MinValue would be Long.MinValue, so we'd need to add one to it, and then use the abs value of the expression
+                check(num.abs(num.plus(endq, one)))
+              }
               val last    = if (endq == zero) waypointB else num.plus(waypointB, num.times(endq, step))
               // Now we have to tally up all the pieces
               //   1 for the initial value

--- a/test/junit/scala/collection/immutable/NumericRangeTest.scala
+++ b/test/junit/scala/collection/immutable/NumericRangeTest.scala
@@ -327,6 +327,18 @@ class NumericRangeTest {
     assertTrue(dropped.end == range.end && dropped.step == range.step && dropped.start == (amount * step) + range.start)
   }
 
+  @Test
+  def wideLongRangeLengthShouldCrash() = {
+    assertThrows[IllegalArgumentException](NumericRange(1L, Long.MinValue, -1L).length)
+    assertThrows[IllegalArgumentException](NumericRange(0L, Long.MinValue, -1L).length)
+    // make sure everything's fine when we approach 0 a bit
+    assertThrows[IllegalArgumentException](NumericRange(1L, Long.MinValue + 1, -1L).length)
+    assertThrows[IllegalArgumentException](NumericRange(0L, Long.MinValue + 1, -1L).length)
+    // make sure everything's fine after a whole cycle of Int.MaxValue
+    assertThrows[IllegalArgumentException](NumericRange(1L, Long.MinValue + Int.MaxValue, -1L).length)
+    assertThrows[IllegalArgumentException](NumericRange(0L, Long.MinValue + Int.MaxValue, -1L).length)
+  }
+
 }
 
 object NumericRangeTest {

--- a/test/scalacheck/scala/collection/immutable/NumericRangeProperties.scala
+++ b/test/scalacheck/scala/collection/immutable/NumericRangeProperties.scala
@@ -27,14 +27,11 @@ class NumericRangeProperties extends Properties("immutable.NumericRange") {
     }
   }
 
-  // This is commented intentionally, because of a bug in NumericRange.count,
-  // which makes the length unstable for property based testing:
-  // e.g., NumericRange(1L, -9223372036854775808L, -1L).length == 1
-//  property("same length when take and drop with a specific amount (Long)") = forAll { (r: NumericRange[Long], amount: Int) =>
-//    Try(r.length).isSuccess ==> {
-//      r.take(amount).length + r.drop(amount).length == r.length
-//    }
-//  }
+  property("same length when take and drop with a specific amount (Long)") = forAll { (r: NumericRange[Long], amount: Int) =>
+    Try(r.length).isSuccess ==> {
+      r.take(amount).length + r.drop(amount).length == r.length
+    }
+  }
 
   property("same length when take and drop with a specific amount (BigInt)") = forAll { (r: NumericRange[BigInt], amount: Int) =>
     Try(r.length).isSuccess ==> {


### PR DESCRIPTION
Fixes an issue with the evaluation of length on NumericRanges going onto `Long.MinValue`.

Fixes scala/bug#12716