### PR TITLE
Un-delay opening package objects when early-completing a (different) package object symbol

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
@@ -80,6 +80,7 @@ trait Analyzer extends AnyRef
       def apply(unit: CompilationUnit): Unit = {
         openPackageObjectsTraverser(unit.body)
         deferredOpen.foreach(openPackageModule(_))
+        deferredOpen.clear()
       }
     }
   }

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1934,7 +1934,15 @@ trait Contexts { self: Analyzer =>
           // because typechecking .java sources doesn't need it.
           sym
         }
-        else qual.tpe.nonLocalMember(nom)
+        else {
+          val tp = qual.tpe
+          val sym = tp.typeSymbol
+          // opening package objects is delayed (scala/scala#9661), but that can lead to missing symbols for
+          // package object types that are forced early through Definitions; see scala/bug#12740 / scala/scala#10333
+          if (phase.id < currentRun.typerPhase.id && sym.hasPackageFlag && analyzer.packageObjects.deferredOpen.remove(sym))
+            openPackageModule(sym)
+          tp.nonLocalMember(nom)
+        }
       while ((selectors ne Nil) && result == NoSymbol) {
         if (current.introduces(name))
           result = maybeNonLocalMember(current.name asTypeOf name)

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1661,14 +1661,13 @@ trait Definitions extends api.StandardDefinitions {
     }
 
     // documented in JavaUniverse.init
-    def init(): Unit = {
-      if (isInitialized) return
+    def init(): Unit = if (!isInitialized) {
       ObjectClass.initialize
       ScalaPackageClass.initialize
       symbolsNotPresentInBytecode
       NoSymbol
       isInitialized = true
-    } //init
+    }
 
     class UniverseDependentTypes(universe: Tree) {
       lazy val nameType         = universeMemberType(tpnme.Name)

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -389,15 +389,13 @@ abstract class SymbolTable extends macros.Universe
 
   /** if there's a `package` member object in `pkgClass`, enter its members into it. */
   def openPackageModule(pkgClass: Symbol, force: Boolean = false): Unit = {
-
-    val pkgModule = pkgClass.packageObject
+    val pkgModule  = pkgClass.packageObject
     def fromSource = pkgModule.rawInfo match {
       case ltp: SymLoader => ltp.fromSource
       case _ => false
     }
-    if (pkgModule.isModule && !fromSource) {
+    if (pkgModule.isModule && !fromSource)
       openPackageModule(pkgModule, pkgClass)
-    }
   }
 
   object perRunCaches {

--- a/src/reflect/scala/reflect/runtime/SymbolLoaders.scala
+++ b/src/reflect/scala/reflect/runtime/SymbolLoaders.scala
@@ -75,7 +75,7 @@ private[reflect] trait SymbolLoaders { self: SymbolTable =>
     override def complete(sym: Symbol): Unit = {
       assert(sym.isPackageClass, "Must be package")
       // Time travel to a phase before refchecks avoids an initialization issue. `openPackageModule`
-      // creates a module symbol and invokes invokes `companionModule` while the `infos` field is
+      // creates a module symbol and invokes `companionModule` while the `infos` field is
       // still null. This calls `isModuleNotMethod`, which forces the `info` if run after refchecks.
       slowButSafeEnteringPhaseNotLaterThan(picklerPhase) {
         sym setInfo new ClassInfoType(List(), new PackageScope(sym), sym)

--- a/test/files/pos/t12740.scala
+++ b/test/files/pos/t12740.scala
@@ -1,0 +1,17 @@
+class C(x: NoSuchElementException)
+
+// available in java.lang
+package object K extends Cloneable
+
+package object XX extends Serializable
+package object XY extends NoSuchElementException
+
+object XZ extends NoSuchElementException
+
+package object Y {
+  type NSE = java.util.NoSuchElementException
+}
+package Z {
+  import Y._
+  class C extends NSE
+}

--- a/test/files/pos/t12740b/Y_1.scala
+++ b/test/files/pos/t12740b/Y_1.scala
@@ -1,0 +1,4 @@
+
+package object Y {
+  type NSE = java.util.NoSuchElementException
+}

--- a/test/files/pos/t12740b/Z_2.scala
+++ b/test/files/pos/t12740b/Z_2.scala
@@ -1,0 +1,6 @@
+//> using options -Yimports:java.lang,scala,scala.Predef,Y
+
+package Z {
+  //import Y._
+  class C extends NSE
+}


### PR DESCRIPTION
Fixes scala/bug#12740
