### PR TITLE
`javabootclasspath` supersedes `jrt`

### DIFF
--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -16,12 +16,13 @@ package util
 
 import java.net.URL
 
+import scala.reflect.io.{Directory, File, Path}
 import scala.tools.reflect.WrappedProperties.AccessControl
 import scala.tools.nsc.{CloseableRegistry, Settings}
-import scala.tools.nsc.util.ClassPath
-import scala.reflect.io.{Directory, File, Path}
-import PartialFunction.condOpt
 import scala.tools.nsc.classpath._
+import scala.tools.nsc.util.ClassPath
+import scala.util.Properties.isJavaAtLeast
+import PartialFunction.condOpt
 
 // Loosely based on the draft specification at:
 // https://wiki.scala-lang.org/display/SIW/Classpath
@@ -211,22 +212,21 @@ final class PathResolver(settings: Settings, closeableRegistry: CloseableRegistr
 
   private val classPathFactory = new ClassPathFactory(settings, closeableRegistry)
 
-  import PathResolver.{ AsLines, Defaults, ppcp }
+  import PathResolver.{AsLines, Defaults, ppcp}
 
-  private def cmdLineOrElse(name: String, alt: String) = {
-    (commandLineFor(name) match {
-      case Some("") => None
-      case x        => x
-    }) getOrElse alt
-  }
+  private def cmdLineOrElse(name: String, alt: String) =
+    commandLineFor(name) match {
+      case Some("") | None => alt
+      case Some(x)         => x
+    }
 
   private def commandLineFor(s: String): Option[String] = condOpt(s) {
-    case "javabootclasspath"  => settings.javabootclasspath.value
-    case "javaextdirs"        => settings.javaextdirs.value
-    case "bootclasspath"      => settings.bootclasspath.value
-    case "extdirs"            => settings.extdirs.value
-    case "classpath" | "cp"   => settings.classpath.value
-    case "sourcepath"         => settings.sourcepath.value
+    case "javabootclasspath" => settings.javabootclasspath.value
+    case "javaextdirs"       => settings.javaextdirs.value
+    case "bootclasspath"     => settings.bootclasspath.value
+    case "extdirs"           => settings.extdirs.value
+    case "classpath" | "cp"  => settings.classpath.value
+    case "sourcepath"        => settings.sourcepath.value
   }
 
   /** Calculated values based on any given command line options, falling back on
@@ -258,8 +258,10 @@ final class PathResolver(settings: Settings, closeableRegistry: CloseableRegistr
 
     // Assemble the elements!
     def basis = List[Iterable[ClassPath]](
-      jrt,                                          // 0. The Java 9+ classpath (backed by the ct.sym or jrt:/ virtual system, if available)
-      classesInPath(javaBootClassPath),             // 1. The Java bootstrap class path.
+      if (!settings.javabootclasspath.isSetByUser && isJavaAtLeast(9))
+        jrt                                         // 0. The Java 9+ classpath (backed by the ct.sym or jrt:/ virtual system, if available)
+      else
+        classesInPath(javaBootClassPath),           // 1. The Java bootstrap class path.
       contentsOfDirsInPath(javaExtDirs),            // 2. The Java extension class path.
       classesInExpandedPath(javaUserClassPath),     // 3. The Java application class path.
       classesInPath(scalaBootClassPath),            // 4. The Scala boot class path.


### PR DESCRIPTION
To compile against a JDK 8 `rt.jar`, use `-javabootclasspath rt.jar -nobootcp`.

That disables the `jrt` class path for the ambient JDK, and puts the Scala libraries on the user class path.

(Alternatively, `-usebootcp` but list the libraries explicitly on `-javabootclasspath`.)

Fixes scala/bug#12257