### PR TITLE
[nomerge] fix (?) REPL test that intermittently fails on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,15 +46,18 @@
 **/.cache
 /.idea
 /.settings
+metals.sbt
 
 # Standard symbolic link to build/quick/bin
 /qbin
 
 # sbt's target directories
-/target/
-/project/target/
-/project/project/target/
-/project/project/project/target/
+target/
 /build-sbt/
 local.sbt
 jitwatch.out
+
+# metals
+.metals/
+.bloop/
+.bsp/

--- a/test/files/run/repl-paste-parse.check
+++ b/test/files/run/repl-paste-parse.check
@@ -1,4 +1,5 @@
-Type in expressions for evaluation. Or try :help.
+
+scala> 
 
 scala> repl-paste-parse.script:1: error: illegal start of simple pattern
 val case = 9

--- a/test/files/run/repl-paste-parse.scala
+++ b/test/files/run/repl-paste-parse.scala
@@ -1,27 +1,19 @@
-
-import java.io.{ BufferedReader, StringReader, StringWriter, PrintWriter }
-
-import scala.tools.partest.DirectTest
-import scala.tools.nsc.interpreter.ILoop
+import scala.tools.partest.ReplTest
+import scala.tools.nsc.Settings
 import scala.tools.nsc.GenericRunnerSettings
+import scala.tools.nsc.settings.MutableSettings
 
-object Test extends DirectTest {
-  override def extraSettings = s"-usejavacp -i $scriptPath"
+object Test extends ReplTest {
   def scriptPath = testPath.changeExtension("script")
-  override def newSettings(args: List[String]) = {
-    val ss = new GenericRunnerSettings(Console.println)
-    ss.processArguments(args, true)
-    ss
+  override def transformSettings(s: Settings) = s match {
+    case m: MutableSettings =>
+      val t = new GenericRunnerSettings(s.errorFn)
+      m copyInto t
+      t processArgumentString s"-usejavacp -i $scriptPath"
+      t
+    case _ => s
   }
+
   def code = ""
-  def show() = {
-    val r = new BufferedReader(new StringReader(""))
-    val w = new StringWriter
-    val p = new PrintWriter(w, true)
-    new ILoop(r, p).process(settings)
-    w.toString.linesIterator foreach { s =>
-      if (!s.startsWith("Welcome to Scala")) println(s)
-    }
-  }
 }
 


### PR DESCRIPTION
the test was rewritten on the 2.13.x branch and (although I'm not positive) I don't remember seeing it fail there, so this backports the 2.13 version; fingers crossed that will put an end to the intermittent failures

references scala/scala-dev#831
