### PR TITLE
Move nullary override check to refchecks

### DIFF
--- a/test/files/neg/nullary-override-3b.check
+++ b/test/files/neg/nullary-override-3b.check
@@ -1,7 +1,9 @@
 nullary-override-3b.scala:6: error: method without a parameter list overrides a method with a single empty one
+def x(): Int (defined in class P)
 class Q extends P { override def x: Int = 4 }
                                  ^
 nullary-override-3b.scala:11: error: method without a parameter list overrides a method with a single empty one
+def x(): String (defined in trait T2)
 class Mix12a extends T1 with T2 { override def x   = "12a" }
                                                ^
 2 errors

--- a/test/files/neg/nullary-override.check
+++ b/test/files/neg/nullary-override.check
@@ -1,12 +1,12 @@
+nullary-override.scala:4: warning: method with a single empty parameter list overrides method without any parameter list
+class B extends A { override def x(): Int = 4 }
+                                 ^
 nullary-override.scala:15: warning: method without a parameter list overrides a method with a single empty one
 class Q extends P { override def x: Int = 4 }
                                  ^
 nullary-override.scala:36: warning: method without a parameter list overrides a method with a single empty one
 class Mix12a extends T1 with T2 { override def x   = "12a" }
                                                ^
-nullary-override.scala:4: warning: method with a single empty parameter list overrides method without any parameter list
-class B extends A { override def x(): Int = 4 }
-                                 ^
 nullary-override.scala:37: warning: method with a single empty parameter list overrides method without any parameter list
 class Mix12b extends T1 with T2 { override def x() = "12b" }
                                                ^

--- a/test/files/neg/t5429.check
+++ b/test/files/neg/t5429.check
@@ -1,9 +1,3 @@
-t5429.scala:68: warning: method without a parameter list overrides a method with a single empty one
-  def emptyArg = 10   // fail
-      ^
-t5429.scala:75: warning: method without a parameter list overrides a method with a single empty one
-  override def emptyArg = 10  // override
-               ^
 t5429.scala:20: error: `override` modifier required to override concrete member:
 val value: Int (defined in class A)
   object value      // fail
@@ -121,6 +115,9 @@ t5429.scala:73: error: stable, immutable value required to override:
 lazy val lazyvalue: Any (defined in class A0)
   override def lazyvalue = 2  // fail
                ^
+t5429.scala:75: warning: method without a parameter list overrides a method with a single empty one
+  override def emptyArg = 10  // override
+               ^
 t5429.scala:76: error: method oneArg overrides nothing.
 Note: the super classes of class E0 contain the following, non final members named oneArg:
 def oneArg(x: String): Any
@@ -151,5 +148,5 @@ Note: the super classes of class F0 contain the following, non final members nam
 def oneArg(x: String): Any
   override lazy val oneArg = 15    // fail
                     ^
-2 warnings
+1 warning
 34 errors


### PR DESCRIPTION
The warning
```
method with a single empty parameter list overrides method without any parameter list
```
is now listed together with its converse,
```
method without a parameter list overrides a method with a single empty one
```
so that the format and ordering of messages has changed, although the message text is the same.

Cherry-pick from https://github.com/scala/scala/pull/10302