### PR TITLE
Do not defer typing empty refinement

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Checkable.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Checkable.scala
@@ -370,8 +370,10 @@ trait Checkable {
               def isSealedOrFinal(sym: Symbol) = sym.isSealed || sym.isFinal
               val Xsym = X.typeSymbol
               val Psym = P.typeSymbol
-              if (isSealedOrFinal(Xsym) && isSealedOrFinal(Psym) && (currentRun.compiles(Xsym) || currentRun.compiles(Psym)))
+              if (isSealedOrFinal(Xsym) && isSealedOrFinal(Psym) && (currentRun.compiles(Xsym) || currentRun.compiles(Psym))) {
+                debuglog(s"deferred recheckFruitless($X, $P)")
                 context.unit.addPostTyperCheck(() => recheckFruitless())
+              }
             }
         }
       }


### PR DESCRIPTION
Avoid trivial work if refinement is empty.

Cherry-pick from https://github.com/scala/scala/pull/10302