### PR TITLE
Support Java 17 `sealed` in Java sources

### DIFF
--- a/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
@@ -19,6 +19,7 @@ package javac
 import symtab.Flags
 import JavaTokens._
 import scala.annotation._
+import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.language.implicitConversions
 import scala.reflect.internal.util.{ListOfNil, Position}
@@ -45,6 +46,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
 
   abstract class JavaParser extends ParserCommon {
     val in: JavaScanner
+    def unit: CompilationUnit
 
     def freshName(prefix : String): Name
     protected implicit def i2p(offset : Int) : Position
@@ -494,7 +496,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
             in.nextToken()
           case _ =>
             val unsealed = 0L   // no flag for UNSEALED
-            def consume(added: FlagSet): false = { in.nextToken(); /*flags |= added;*/ false }
+            def consume(added: FlagSet): false = { in.nextToken(); flags |= added; false }
             def lookingAhead(s: String): Boolean = {
               import scala.reflect.internal.Chars._
               var i = 0
@@ -838,6 +840,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
       else Nil
 
     def classDecl(mods: Modifiers): List[Tree] = {
+      if (mods.hasFlag(SEALED)) patmat.javaClassesByUnit(unit.source) = mutable.Set.empty
       accept(CLASS)
       val pos = in.currentPos
       val name = identForType()
@@ -904,6 +907,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
     }
 
     def interfaceDecl(mods: Modifiers): List[Tree] = {
+      if (mods.hasFlag(SEALED)) patmat.javaClassesByUnit(unit.source) = mutable.Set.empty
       accept(INTERFACE)
       val pos = in.currentPos
       val name = identForType()

--- a/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
@@ -13,9 +13,10 @@
 package scala.tools.nsc.transform.patmat
 
 import scala.annotation.tailrec
+import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.reflect.internal.{Mode, Types}
-import scala.reflect.internal.util.Statistics
+import scala.reflect.internal.util.{SourceFile, Statistics}
 import scala.tools.nsc.Global
 import scala.tools.nsc.ast
 import scala.tools.nsc.transform.{Transform, TypingTransformers}
@@ -57,6 +58,9 @@ trait PatternMatching extends Transform
   import global._
 
   val phaseName: String = "patmat"
+
+  /** Symbols to force for determining children of sealed Java classes. */
+  val javaClassesByUnit = perRunCaches.newMap[SourceFile, mutable.Set[Symbol]]()
 
   def newTransformer(unit: CompilationUnit): AstTransformer = new MatchTransformer(unit)
 

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -795,6 +795,8 @@ trait Namers extends MethodSynthesis {
       tree.symbol = enterClassSymbol(tree)
       tree.symbol setInfo completerOf(tree)
 
+      if (tree.symbol.isJava) patmat.javaClassesByUnit.get(tree.symbol.pos.source).foreach(_.addOne(tree.symbol))
+
       if (mods.isCase) {
         val m = ensureCompanionObject(tree, caseModuleDef)
         m.moduleClass.updateAttachment(new ClassForCaseCompanionAttachment(tree))

--- a/test/files/neg/t12159d.check
+++ b/test/files/neg/t12159d.check
@@ -1,0 +1,7 @@
+t.scala:7: warning: match may not be exhaustive.
+It would fail on the following input: W()
+    x match {
+    ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/t12159d/X.java
+++ b/test/files/neg/t12159d/X.java
@@ -1,0 +1,14 @@
+// javaVersion: 17+
+package p;
+
+sealed abstract public class X {
+}
+
+final class W extends X {
+}
+
+final class Y extends X {
+}
+
+final class Z extends X {
+}

--- a/test/files/neg/t12159d/t.scala
+++ b/test/files/neg/t12159d/t.scala
@@ -1,0 +1,12 @@
+// javaVersion: 17+
+// scalac: -Werror
+package p
+
+class C {
+  def f(x: X) =
+    x match {
+      case y: Y => y.toString
+      case z: Z => z.toString
+    }
+}
+

--- a/test/files/neg/t12159e.check
+++ b/test/files/neg/t12159e.check
@@ -1,0 +1,11 @@
+t.scala:7: warning: match may not be exhaustive.
+It would fail on the following input: W()
+    x match {
+    ^
+t.scala:12: warning: match may not be exhaustive.
+It would fail on the following inputs: Z(), Z2()
+    x match {
+    ^
+error: No warnings can be incurred under -Werror.
+2 warnings
+1 error

--- a/test/files/neg/t12159e/X.java
+++ b/test/files/neg/t12159e/X.java
@@ -1,0 +1,20 @@
+// javaVersion: 17+
+package p;
+
+sealed abstract public class X {
+}
+
+final class W extends X {
+}
+
+final class Y extends X {
+}
+
+sealed class Z extends X permits Z1, Z2 {
+}
+
+final class Z1 extends Z {
+}
+
+final class Z2 extends Z {
+}

--- a/test/files/neg/t12159e/t.scala
+++ b/test/files/neg/t12159e/t.scala
@@ -1,0 +1,18 @@
+// javaVersion: 17+
+// scalac: -Werror
+package p
+
+class C {
+  def f(x: X) =
+    x match {
+      case y: Y => y.toString
+      case z: Z => z.toString
+    }
+  def g(x: X) =
+    x match {
+      case w: W => w.toString
+      case y: Y => y.toString
+      case z: Z1 => z.toString
+    }
+}
+

--- a/test/files/neg/t12159f.check
+++ b/test/files/neg/t12159f.check
@@ -1,0 +1,11 @@
+t.scala:7: warning: match may not be exhaustive.
+It would fail on the following input: W()
+    x match {
+    ^
+t.scala:12: warning: match may not be exhaustive.
+It would fail on the following inputs: Z(), Z2()
+    x match {
+    ^
+error: No warnings can be incurred under -Werror.
+2 warnings
+1 error

--- a/test/files/neg/t12159f/X.java
+++ b/test/files/neg/t12159f/X.java
@@ -1,0 +1,14 @@
+// javaVersion: 17+
+package p;
+
+sealed abstract public class X {
+}
+
+final class W extends X {
+}
+
+final class Y extends X {
+}
+
+sealed class Z extends X permits Z1, Z2 {
+}

--- a/test/files/neg/t12159f/Z.java
+++ b/test/files/neg/t12159f/Z.java
@@ -1,0 +1,8 @@
+// javaVersion: 17+
+package p;
+
+final class Z1 extends Z {
+}
+
+final class Z2 extends Z {
+}

--- a/test/files/neg/t12159f/t.scala
+++ b/test/files/neg/t12159f/t.scala
@@ -1,0 +1,18 @@
+// javaVersion: 17+
+// scalac: -Werror
+package p
+
+class C {
+  def f(x: X) =
+    x match {
+      case y: Y => y.toString
+      case z: Z => z.toString
+    }
+  def g(x: X) =
+    x match {
+      case w: W => w.toString
+      case y: Y => y.toString
+      case z: Z1 => z.toString
+    }
+}
+

--- a/test/files/neg/t12159g.check
+++ b/test/files/neg/t12159g.check
@@ -1,0 +1,7 @@
+t.scala:4: warning: match may not be exhaustive.
+It would fail on the following inputs: Oz(), Z()
+  def n(a: X) = a match { case _: Y => 42 }
+                ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/t12159g/X.java
+++ b/test/files/neg/t12159g/X.java
@@ -1,0 +1,12 @@
+
+package p;
+public sealed interface X {
+  public default int x() { return 27; }
+}
+final class Y implements X { }
+final class O {
+  final static class Z implements X { }
+  final static class Inner {
+    final static class Oz implements X { }
+  }
+}

--- a/test/files/neg/t12159g/t.scala
+++ b/test/files/neg/t12159g/t.scala
@@ -1,0 +1,5 @@
+// scalac: -Werror -Xlint
+package p
+class T {
+  def n(a: X) = a match { case _: Y => 42 }
+}


### PR DESCRIPTION
Support `sealed` in Java sources. The related PR supports separate compilation, where `PermittedSubclasses` attribute specifies sealedness; there seems to be no ticket for that, alas. This PR is Java interop gravy.

Fixes https://github.com/scala/bug/issues/12171
Fixes https://github.com/scala/bug/issues/12159
