### PR TITLE
Runner scripts -usebootcp and require javaBootClassPath

### DIFF
--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -21,7 +21,6 @@ import scala.tools.reflect.WrappedProperties.AccessControl
 import scala.tools.nsc.{CloseableRegistry, Settings}
 import scala.tools.nsc.classpath._
 import scala.tools.nsc.util.ClassPath
-import scala.util.Properties.isJavaAtLeast
 import PartialFunction.condOpt
 
 // Loosely based on the draft specification at:
@@ -258,10 +257,9 @@ final class PathResolver(settings: Settings, closeableRegistry: CloseableRegistr
 
     // Assemble the elements!
     def basis = List[Iterable[ClassPath]](
-      if (!settings.javabootclasspath.isSetByUser && isJavaAtLeast(9))
-        jrt                                         // 0. The Java 9+ classpath (backed by the ct.sym or jrt:/ virtual system, if available)
-      else
-        classesInPath(javaBootClassPath),           // 1. The Java bootstrap class path.
+      jrt                                           // 0. The Java 9+ classpath (backed by the ct.sym or jrt:/ virtual system, if available)
+        .filter(_ => !settings.javabootclasspath.isSetByUser), // respect explicit `-javabootclasspath rt.jar`
+      classesInPath(javaBootClassPath),             // 1. The Java bootstrap class path.
       contentsOfDirsInPath(javaExtDirs),            // 2. The Java extension class path.
       classesInExpandedPath(javaUserClassPath),     // 3. The Java application class path.
       classesInPath(scalaBootClassPath),            // 4. The Scala boot class path.


### PR DESCRIPTION
Follow-up to https://github.com/scala/scala/pull/10336 which too eagerly ignores `javaBootClassPath`, which is where the scala scripts put the library (via `-Dscala.boot.class.path`). That means the script needs `-nobootcp`.

It's only necessary to turn off `jrt` when user has set the `-javabootclasspath` explicitly.

The comment in `PathResolver`:
```
    // TODO It must be time for someone to figure out what all these things
    // are intended to do.  This is disabled here because it was causing all
    // the scala jars to end up on the classpath twice: one on the boot
    // classpath as set up by the runner (or regular classpath under -nobootcp)
    // and then again here.
```
Probably `-bootclasspath` was intended for "Scala platform" but is possibly generally ignored by clients? Scala 3 has the same compiler options (except `-nobootcp`) but I haven't looked at how they are used.

The other factor is `-Dscala.usejavacp`. All of these mechanisms were tagged for removal a decade ago, but it's never the right time, although springtime calls for spring cleaning.