### PR TITLE
Fix crasher with `-Xasync`, string switch + boxed `Unit`

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/async/AnfTransform.scala
+++ b/src/compiler/scala/tools/nsc/transform/async/AnfTransform.scala
@@ -204,7 +204,10 @@ private[async] trait AnfTransform extends TransformUtils {
       if (isPatMatGeneratedJump(tree)) assignUnitType(tree)
 
       if (!needsResultVar || isUnitType(tree.tpe) || (tree.tpe =:= definitions.NothingTpe)) {
-        core(NoSymbol)
+        if (tree.tpe =:= definitions.BoxedUnitTpe) {
+          currentStats += assignUnitType(core(NoSymbol))
+          literalBoxedUnit
+        } else core(NoSymbol)
       } else {
         val varDef = defineVar(nameSource(), tree.tpe, tree.pos)
         currentStats += varDef

--- a/test/async/run/string-switch-bug.scala
+++ b/test/async/run/string-switch-bug.scala
@@ -1,0 +1,29 @@
+// scalac: -Xasync
+import scala.tools.partest.async.OptionAwait._
+import org.junit.Assert._
+
+// Scala.js compatible test suite for -Xasync that doesn't use Scala futures
+object Test {
+  def main(args: Array[String]): Unit = {
+    stringSwitchBug()
+  }
+
+  private def stringSwitchBug() = {
+    assertEquals(Some(true), optionally {
+      val x: String = ""
+      val as = List("x")
+      val it = as.iterator
+      var okay = false
+      while (it.hasNext) {
+        val x = it.next()
+        val res = (x match {
+          case "x" =>
+            okay = value(Some(1)) == 1
+            ()
+          case _ => ()
+        })
+      }
+      okay
+    })
+  }
+}


### PR DESCRIPTION
Pretty un-idiomatic code to trigger this! It was the expansion of two macros in the user's code base.

This commit updates the ANF transform to deal with BoxedUnit specifically -- we don't need to create a var to assign the result of such an expression, but we also can't just leave a Unit typed expression (the transformed Match) around.

In the test case, that caused a later phase to crash when performing switch-on-string translation.