### PR TITLE
Fix tasty/TestLogarithms.scala failed in some platform

### DIFF
--- a/test/tasty/run/src-2/tastytest/TestLogarithms.scala
+++ b/test/tasty/run/src-2/tastytest/TestLogarithms.scala
@@ -4,10 +4,10 @@ import Logarithms._
 
 object TestLogarithms extends Suite("TestLogarithms") {
 
-  val Some(l1) = Logarithm.of(2)
-  val Some(l2) = Logarithm.of(3)
+  val Some(l1) = Logarithm.of(10)
+  val Some(l2) = Logarithm.of(100)
 
-  test(assert((l1 + l2).toDouble == 4.999999999999999))
-  test(assert((l1 * l2).toDouble == 6.0))
+  test(assert((l1 + l2).toDouble == 109.99999999999997))
+  test(assert((l1 * l2).toDouble == 1000.0))
 
 }

--- a/test/tasty/run/src-3/tastytest/Logarithms.scala
+++ b/test/tasty/run/src-3/tastytest/Logarithms.scala
@@ -1,5 +1,7 @@
 package tastytest
 
+import java.lang.StrictMath
+
 object Logarithms {
 
   opaque type Logarithm = Double
@@ -8,16 +10,16 @@ object Logarithms {
 
     // These are the two ways to lift to the Logarithm type
 
-    private[Logarithms] def apply(d: Double): Logarithm = math.log(d)
+    private[Logarithms] def apply(d: Double): Logarithm = StrictMath.log10(d)
 
     def of(d: Double): Option[Logarithm] =
-      if (d > 0.0) Some(math.log(d)) else None
+      if (d > 0.0) Some(StrictMath.log10(d)) else None
   }
 
   // implicit define cross compatible public APIs for opaque types
   final implicit class LogarithmOps(val logarithm: Logarithm) extends AnyVal {
-    def toDouble: Double = math.exp(logarithm)
-    def + (other: Logarithm): Logarithm = Logarithm(math.exp(logarithm) + math.exp(other))
+    def toDouble: Double = StrictMath.pow(10.0, logarithm)
+    def + (other: Logarithm): Logarithm = Logarithm(StrictMath.pow(10.0, logarithm) + StrictMath.pow(10.0, other))
     def * (other: Logarithm): Logarithm = logarithm + other
   }
 


### PR DESCRIPTION
Update the test case since it failed on arm64 platform. also to fix scala/bug#12759.