### PR TITLE
Respect user target always

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
@@ -73,7 +73,7 @@ trait StandardScalaSettings { _: MutableSettings =>
       // .withAbbreviation("-Xtarget")
       // .withAbbreviation("-Xunchecked-java-output-version")
       .withDeprecationMessage("Use -release instead to compile against the correct platform API.")
-  def targetValue: String = releaseValue.getOrElse(target.value)
+  def targetValue: String = target.valueSetByUser.orElse(releaseValue).getOrElse(target.value)
   val unchecked =      BooleanSetting ("-unchecked", "Enable additional warnings where generated code depends on assumptions. See also -Wconf.") withAbbreviation "--unchecked" withPostSetHook { s =>
     if (s.value) Wconf.tryToSet(List(s"cat=unchecked:w"))
     else Wconf.tryToSet(List(s"cat=unchecked:s"))

--- a/test/junit/scala/tools/nsc/settings/TargetTest.scala
+++ b/test/junit/scala/tools/nsc/settings/TargetTest.scala
@@ -19,11 +19,16 @@ import org.junit.runners.JUnit4
 
 import scala.collection.mutable.ListBuffer
 import scala.tools.nsc.settings.StandardScalaSettings._
+import scala.tools.testkit.AssertUtil.assertFails
 import scala.util.Properties.isJavaAtLeast
 import scala.util.Try
 
 @RunWith(classOf[JUnit4])
 class TargetTest {
+
+  private def lately[A](body: => A): Unit = if (isJavaAtLeast(11)) body: Unit
+
+  private def eightly[A](body: => A): Unit = if (!isJavaAtLeast(9)) body: Unit
 
   @Test def testSettingTargetSetting(): Unit = {
     def goodVersion(v: String): Boolean = Try(isJavaAtLeast(v)).getOrElse(false)
@@ -64,5 +69,36 @@ class TargetTest {
     checkFail("-target:jvm-7")    // no longer
     checkFail("-target:jvm-3000") // not in our lifetime
     checkFail("-target:msil")     // really?
+  }
+  @Test def `respect user target`: Unit = lately {
+    val settings = new Settings(err => fail(s"Error output: $err"))
+    val (ok, _) = settings.processArgumentString("--release:11 --target:8")
+    assertTrue(ok)
+    assertEquals("8", settings.target.value)
+    assertEquals("11", settings.release.value)
+    assertEquals("8", settings.targetValue)
+    assertEquals(Some("11"), settings.releaseValue)
+  }
+  @Test def `target is release if specified`: Unit = lately {
+    val settings = new Settings(err => fail(s"Error output: $err"))
+    val (ok, _) = settings.processArgumentString("--release:11")
+    assertTrue(ok)
+    assertEquals("8", settings.target.value)        // default
+    assertEquals(None, settings.target.valueSetByUser)
+    assertEquals("11", settings.release.value)
+    assertEquals("11", settings.targetValue)        // because --release:11
+    assertEquals(Some("11"), settings.releaseValue)
+  }
+  @Test def `disrespect user target`: Unit = lately {
+    val settings = new Settings(err => fail(s"Error output: $err"))
+    assertFails(_.contains("-release cannot be less than -target")) {
+      settings.processArgumentString("--release:8 --target:11")
+    }
+  }
+  @Test def `cannot bump release on jdk 8`: Unit = eightly {
+    val settings = new Settings(err => fail(s"Error output: $err"))
+    assertFails(_.contains("'9' is not a valid choice for '-release'")) {
+      settings.processArgumentString("--release:9")
+    }
   }
 }


### PR DESCRIPTION
Reverts the commit https://github.com/scala/scala/pull/9982/commits/cc600585c35fdc42a3234500c486f4fa14e12fca in which I seem to have changed my mind whether to respect explicit `--target` in the presence of explicit `--release`.

The possibly dubious use case is to work around https://github.com/scala/bug/issues/12761.

Note that if you're going to ignore my compiler option, you should at least tell me so. The deprecation is ambiguous.
```
warning: -target is deprecated: Use -release instead to compile against the correct platform API.
```