### PR TITLE
Test for assignment rewrite

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4711,15 +4711,12 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             case _ => EmptyTree
           }
 
-        if (treeInfo.mayBeVarGetter(varsym)) {
-          val res = setterRewrite
-          if (!res.isEmpty) return res
-        }
+        val rewritten =
+          if (treeInfo.mayBeVarGetter(varsym)) setterRewrite
+          else EmptyTree
 
-//      if (varsym.isVariable ||
-//        // setter-rewrite has been done above, so rule out methods here, but, wait a minute, why are we assigning to non-variables after erasure?!
-//        (phase.erasedTypes && varsym.isValue && !varsym.isMethod)) {
-        if (varsym.isVariable || varsym.isValue && phase.assignsFields) {
+        if (!rewritten.isEmpty) rewritten
+        else if (varsym.isVariable || varsym.isValue && phase.assignsFields) {
           val rhs1 = typedByValueExpr(rhs, lhs1.tpe)
           treeCopy.Assign(tree, lhs1, checkDead(context, rhs1)) setType UnitTpe
         }

--- a/test/files/pos/t11158/CharSeqJava.java
+++ b/test/files/pos/t11158/CharSeqJava.java
@@ -1,0 +1,4 @@
+
+public interface CharSeqJava {
+    int length();
+}

--- a/test/files/pos/t11158/cs_1.scala
+++ b/test/files/pos/t11158/cs_1.scala
@@ -1,0 +1,13 @@
+
+// not computer science but the basis of the entire field, the character sequence
+class cs extends CharSeqJava {
+  private var n = 42
+  override def length: Int = n
+  def length_=(value: Int): Unit = n = value
+}
+
+object Resetter extends App {
+  val cs = new cs
+  cs.length = 0
+  assert(cs.length == 0)
+}

--- a/test/files/pos/t11158/sb_2.scala
+++ b/test/files/pos/t11158/sb_2.scala
@@ -1,0 +1,7 @@
+
+// sbt is an acronym for StringBuilder test
+class sbt {
+  val sb = new StringBuilder("There once was a man from Killarney / whose comments were nothing but blarney")
+
+  def reset() = sb.length = 42
+}


### PR DESCRIPTION
Fixes scala/bug#11158

Follows up https://github.com/scala/scala/pull/8558

Removes obsolete "scare" comment dating to dynamic rewriting; and "prefer if/else to return".