### PR TITLE
Regression test for no value discard warning

### DIFF
--- a/test/files/neg/value-discard.scala
+++ b/test/files/neg/value-discard.scala
@@ -18,4 +18,10 @@ final class UnusedTest {
     "": Unit                   // nowarn
     s.subtractOne("")          // nowarn
   }
+
+  def f(implicit x: Int): Boolean = x % 2 == 1
+
+  implicit def i: Int = 42
+
+  def u: Unit = f: Unit       // nowarn
 }


### PR DESCRIPTION
Closes scala/bug#12011

There is a test using `Future` in `neg/nonunit-statement.scala` but it is obscure. Grep for "funky applies".
