### PR TITLE
Use BTypes in StringConcatFactory code gen

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeIdiomatic.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeIdiomatic.scala
@@ -236,9 +236,11 @@ abstract class BCodeIdiomatic {
         asm.Type.getMethodDescriptor(StringRef.toASMType, argTypes:_*),
         new asm.Handle(
           asm.Opcodes.H_INVOKESTATIC,
-          "java/lang/invoke/StringConcatFactory",
+          jliStringConcatFactoryRef.internalName,
           "makeConcatWithConstants",
-          "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/invoke/CallSite;",
+          List(jliMethodHandlesLookupRef, StringRef, jliMethodTypeRef, StringRef, ArrayBType(ObjectRef))
+            .map(_.descriptor)
+            .mkString("(", "", s")${jliCallSiteRef.descriptor}"),
           false
         ),
         (recipe +: constants):_*

--- a/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
@@ -210,6 +210,9 @@ abstract class CoreBTypesFromSymbols[G <: Global] extends CoreBTypes {
   def                     jliLambdaMetafactoryRef   : ClassBType = _jliLambdaMetafactoryRef.get
   private[this] lazy val _jliLambdaMetafactoryRef   : LazyVar[ClassBType] = runLazy(classBTypeFromSymbol(requiredClass[java.lang.invoke.LambdaMetafactory]))
 
+  def                     jliStringConcatFactoryRef : ClassBType = _jliStringConcatFactoryRef.get
+  private[this] lazy val _jliStringConcatFactoryRef : LazyVar[ClassBType] = runLazy(classBTypeFromSymbol(getRequiredClass("java.lang.invoke.StringConcatFactory")))
+
   def                     srBoxesRunTimeRef         : ClassBType = _srBoxesRunTimeRef.get
   private[this] lazy val _srBoxesRunTimeRef         : LazyVar[ClassBType] = runLazy(classBTypeFromSymbol(requiredClass[scala.runtime.BoxesRunTime]))
 


### PR DESCRIPTION
This makes sure the BType for the inner class `MethodHandles$Lookup` is initialized (by getting the information from the Symbol) when emitting the InnerClass attribute. If not, the backend attempts to read the BType from the classfile, which can fail (newer than supported classfile version). 

Fixes https://github.com/scala/bug/issues/12761

Thanks for the analysis on the ticket, @som-snytt!