### PR TITLE
silence warning on JDK 20

### DIFF
--- a/test/junit/scala/util/UsingTest.scala
+++ b/test/junit/scala/util/UsingTest.scala
@@ -745,6 +745,7 @@ class UsingTest {
   }
 }
 
+@deprecated("ThreadDeath is deprecated on JDK 20", "")
 object UsingTest {
   final class ClosingVMError(message: String) extends VirtualMachineError(message)
   final class UsingVMError(message: String) extends VirtualMachineError(message)


### PR DESCRIPTION
as uncovered by recent merge of #10311

once merged, should fix the JDK 20 failure seen at https://github.com/scala/scala/actions/runs/4566043533/jobs/8058001307