### PR TITLE
GitHub Actions config: JDK 20 is now generally available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: [8, 11, 17, 20-ea]
+        java: [8, 11, 17, 20]
     runs-on: ${{matrix.os}}
     steps:
       - run: git config --global core.autocrlf false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: Scala Merge CI
 on:
   push:
     branches: ['2.*.x']
+  pull_request:
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
I'm testing this in PR validation first (with a commit adding `pull-request:` that I'll drop before merge) so we can be sure that the JDK 20 builds are actually available through GitHub Actions now. They are definitely available from the Temurin site.

If this succeeds, I should merge 2.12.x onto 2.13.x.