### PR TITLE
Update LinkedHash{Map,Set} from factory method

### DIFF
--- a/src/library/scala/collection/mutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/mutable/LinkedHashMap.scala
@@ -478,11 +478,12 @@ object LinkedHashMap extends MapFactory[LinkedHashMap] {
 
   def empty[K, V] = new LinkedHashMap[K, V]
 
-  def from[K, V](it: collection.IterableOnce[(K, V)]) =
-    it match {
-      case lhm: LinkedHashMap[K, V] => lhm
-      case _ => Growable.from(empty[K, V], it)
-    }
+  def from[K, V](it: collection.IterableOnce[(K, V)]) = {
+    val newlhm = empty[K, V]
+    newlhm.sizeHint(it.knownSize)
+    newlhm.addAll(it)
+    newlhm
+  }
 
   def newBuilder[K, V] = new GrowableBuilder(empty[K, V])
 

--- a/src/library/scala/collection/mutable/LinkedHashSet.scala
+++ b/src/library/scala/collection/mutable/LinkedHashSet.scala
@@ -82,6 +82,11 @@ class LinkedHashSet[A]
 
   def contains(elem: A): Boolean = findEntry(elem) ne null
 
+  override def sizeHint(size: Int): Unit = {
+    val target = tableSizeFor(((size + 1).toDouble / LinkedHashSet.defaultLoadFactor).toInt)
+    if (target > table.length) growTable(target)
+  }
+
   override def add(elem: A): Boolean = {
     if (contentSize + 1 >= threshold) growTable(table.length * 2)
     val hash = computeHash(elem)
@@ -311,11 +316,12 @@ object LinkedHashSet extends IterableFactory[LinkedHashSet] {
 
   override def empty[A]: LinkedHashSet[A] = new LinkedHashSet[A]
 
-  def from[E](it: collection.IterableOnce[E]) =
-    it match {
-      case lhs: LinkedHashSet[E] => lhs
-      case _ => Growable.from(empty[E], it)
-    }
+  def from[E](it: collection.IterableOnce[E]) = {
+    val newlhs = empty[E]
+    newlhs.sizeHint(it.knownSize)
+    newlhs.addAll(it)
+    newlhs
+  }
 
   def newBuilder[A] = new GrowableBuilder(empty[A])
 

--- a/test/junit/scala/collection/mutable/LinkedHashMapTest.scala
+++ b/test/junit/scala/collection/mutable/LinkedHashMapTest.scala
@@ -169,4 +169,18 @@ class LinkedHashMapTest {
     assertEquals(hashMapCount4, mutable.LinkedHashMap(countingKey1 -> "a"))
 
   }
+
+  @Test
+  def testfromfactorymethod(): Unit = {
+    val data = List((1, 'a'), (2,'b'),(3,'c'), (4,'d'),(5,'e'),(6,'f'))
+    val lhm = new mutable.LinkedHashMap[Int, Char]
+    data.foreach(x => lhm.addOne(x))
+
+    val fromlhm1 = LinkedHashMap.from(data)
+    assertEquals(fromlhm1, lhm)
+
+    val fromlhm2 = LinkedHashMap.from(lhm)
+    assertEquals(fromlhm2, lhm)
+    assertFalse(fromlhm2 eq lhm)
+  }
 }

--- a/test/junit/scala/collection/mutable/LinkedHashSetTest.scala
+++ b/test/junit/scala/collection/mutable/LinkedHashSetTest.scala
@@ -24,4 +24,18 @@ class LinkedHashSetTest {
     lhs.clear()
     Assert.assertNull(lhs.lastItemRef)
   }
+
+  @Test
+  def testfromfactorymethod(): Unit = {
+    val data = List(1,2,3,4,5,6,7,8)
+    val lhs = new mutable.LinkedHashSet[Int]
+    data.foreach(x => lhs.addOne(x))
+
+    val fromlhs1 = LinkedHashSet.from(data)
+    Assert.assertEquals(fromlhs1, lhs)
+
+    val fromlhs2 = LinkedHashSet.from(lhs)
+    Assert.assertEquals(fromlhs2, lhs)
+    Assert.assertFalse(fromlhs2 eq lhs)
+  }
 }


### PR DESCRIPTION
A fix to scala/bug#12766. I am running some benchmark to see if it can improve performance.