### PR TITLE
Warn about `@elidable` under -Xsource:3

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4000,6 +4000,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         reportAnnotationError(DoesNotExtendAnnotation(typedFun, annTypeSym))
         return finish(ErroneousAnnotation)
       }
+      if (currentRun.isScala3 && (/*annTypeSym.eq(SpecializedClass) ||*/ annTypeSym.eq(ElidableMethodClass)))
+        context.deprecationWarning(ann.pos, annTypeSym, s"@${annTypeSym.fullNameString} is ignored in Scala 3", "2.13.12")
 
       /* Calling constfold right here is necessary because some trees (negated
        * floats and literals in particular) are not yet folded.

--- a/test/files/neg/deprecated-annots.check
+++ b/test/files/neg/deprecated-annots.check
@@ -1,0 +1,6 @@
+deprecated-annots.scala:9: warning: @scala.annotation.elidable is ignored in Scala 3
+  @annotation.elidable(42)
+   ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/deprecated-annots.scala
+++ b/test/files/neg/deprecated-annots.scala
@@ -1,0 +1,11 @@
+
+// scalac: -Werror -Xlint -Xsource:3
+
+class C[@specialized A]
+
+class D {
+  def f[@specialized A](a: A): A = a
+
+  @annotation.elidable(42)
+  def g() = println("hello, world")
+}


### PR DESCRIPTION
Follow-up to https://github.com/scala/scala/pull/10408
~Addresses https://github.com/scala/docs.scala-lang/issues/2288~