### PR TITLE
[REVISIT NEEDS SPEC] Respect bounds in indexOfSlice [ci: last-only]

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -1496,7 +1496,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
 
   // can't use a default arg because we already have another overload with a default arg
   /** Tests whether this array starts with the given array. */
-  @`inline` def startsWith[B >: A](that: Array[B]): Boolean = startsWith(that, 0)
+  @inline def startsWith[B >: A](that: Array[B]): Boolean = xs.eq(that) || startsWith(that, 0)
 
   /** Tests whether this array contains the given array at a given index.
     *
@@ -1505,17 +1505,15 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     * @return `true` if the array `that` is contained in this array at
     *         index `offset`, otherwise `false`.
     */
-  def startsWith[B >: A](that: Array[B], offset: Int): Boolean = {
-    val safeOffset = offset.max(0)
-    val thatl = that.length
-    if(thatl > xs.length-safeOffset) thatl == 0
+  def startsWith[B >: A](that: Array[B], offset: Int): Boolean = offset >= 0 && {
+    val l = xs.length
+    val tl = that.length
+    if (offset >= l) offset == l && tl == 0
     else {
       var i = 0
-      while(i < thatl) {
-        if(xs(i+safeOffset) != that(i)) return false
+      while (i < tl && xs(i + offset) == that(i))
         i += 1
-      }
-      true
+      i == tl
     }
   }
 

--- a/test/junit/scala/collection/ArrayOpsTest.scala
+++ b/test/junit/scala/collection/ArrayOpsTest.scala
@@ -77,18 +77,35 @@ class ArrayOpsTest {
     assertArrayEquals(Array(0), zero)
   }
 
-  @Test
-  def startsWith(): Unit = {
+  @Test def startsWith: Unit = {
     val l0 = Nil
     val l1 = 1 :: Nil
     val a0 = Array[Int]()
     val a1 = Array[Int](1)
-    assertEquals(l0.startsWith(l0, 0), a0.startsWith(a0, 0))
-    assertEquals(l0.startsWith(l0, 1), a0.startsWith(a0, 1))
+    val a2 = Array[Int](1, 2)
+    assertTrue(l0.startsWith(l0, 0) && a0.startsWith(a0, 0))
+    assertFalse("empties don't start with themselves at offset 1", l0.startsWith(l0, 1) || a0.startsWith(a0, 1))
+
     assertEquals(l0.startsWith(l1, 0), a0.startsWith(a1, 0))
     assertEquals(l0.startsWith(l1, 1), a0.startsWith(a1, 1))
     assertEquals(l0.startsWith(l1, -1), a0.startsWith(a1, -1))
     assertEquals(l0.startsWith(l1, Int.MinValue), a0.startsWith(a1, Int.MinValue))
+
+    assertTrue(a1.startsWith(a1))
+    assertTrue(a2.startsWith(a1))
+  }
+
+  @Test def `startsWith implies supplied from index is in range`: Unit = {
+    val xs = (1 to 10).toArray
+    val ys = (1 to 05).toList
+    assertTrue(xs.startsWith(ys))
+    assertTrue(xs.startsWith(ys, offset = 0))
+    assertFalse(xs.startsWith(ys, offset = -10))
+    assertFalse(xs.startsWith(ys, offset = 100))
+    assertFalse(xs.startsWith(Nil, offset = 100))
+    assertTrue(xs.startsWith(Nil, offset = 9))
+    assertTrue(xs.startsWith(Nil, offset = 10))
+    assertFalse(xs.startsWith(Nil, offset = 11))
   }
 
   @Test

--- a/test/junit/scala/collection/SeqTest.scala
+++ b/test/junit/scala/collection/SeqTest.scala
@@ -40,8 +40,30 @@ class SeqTest extends AllocationTest {
     assertEquals(0, Vector(0, 1).indexOfSlice(List(0, 1)))
     assertEquals(0, Vector(0, 1).indexOfSlice(Vector(0, 1)))
     assertEquals(1, Vector(0, 1, 2, 0, 1, 2).indexOfSlice(Vector(1, 2)))
+    assertEquals(1, Vector(0, 1, 2, 0, 1, 2).indexOfSlice(List(1, 2)))
     assertEquals(4, Vector(0, 1, 2, 0, 1, 2).indexOfSlice(Vector(1, 2), from = 2))
+    assertEquals(4, Vector(0, 1, 2, 0, 1, 2).indexOfSlice(List(1, 2), from = 2))
+    assertEquals(-1, Vector(0, 1).indexOfSlice(Vector(1, 2)))
+    assertEquals(-1, Vector(0, 1).indexOfSlice(List(1, 2)))
+
+    assertEquals(0, Vector(0, 1).indexOfSlice(Vector.empty[Int]))
+    assertEquals(0, Vector(0, 1).indexOfSlice(Vector.empty[Int], from = -2))
+    assertEquals(2, Vector(0, 1).indexOfSlice(Vector.empty[Int], from = 2))
+    assertEquals(2, Vector(0, 1, 2).indexOfSlice(Vector.empty[Int], from = 2))
+    assertEquals(0, Vector(0, 1).indexOfSlice(Nil))
+    assertEquals(0, Vector(0, 1).indexOfSlice(Nil, from = -2))
+    assertEquals(2, Vector(0, 1).indexOfSlice(Nil, from = 2))
+    assertEquals(2, Vector(0, 1, 2).indexOfSlice(Nil, from = 2))
+
+    assertEquals(0, List(0, 1).indexOfSlice(List(0, 1)))
+    assertEquals(1, List(0, 1, 2, 0, 1, 2).indexOfSlice(List(1, 2)))
+    assertEquals(4, List(0, 1, 2, 0, 1, 2).indexOfSlice(List(1, 2), from = 2))
     assertEquals(-1, List(0, 1).indexOfSlice(List(1, 2)))
+
+    assertEquals(0, Seq(0, 1).indexOfSlice(Nil))
+    assertEquals(0, Seq(0, 1).indexOfSlice(Nil, from = -2))
+    assertEquals(2, Seq(0, 1).indexOfSlice(Nil, from = 2))
+    assertEquals(2, Seq(0, 1, 2).indexOfSlice(Nil, from = 2))
   }
 
   @Test
@@ -113,5 +135,25 @@ class SeqTest extends AllocationTest {
       Seq("0", "1", "2", "3", "4", "5", "6", "7", "8", "9"))
     exactAllocates(expected(20), "collection seq size 20")(
       Seq("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"))
+  }
+
+  @Test def `startsWith implies supplied from index is in range`: Unit = {
+    val xs = (1 to 10).toList
+    val ys = (1 to 05).toList
+    val zs = (1 to 10).to(Vector)
+    assertTrue(xs.startsWith(ys))
+    assertTrue(xs.startsWith(ys, offset = 0))
+    assertFalse(xs.startsWith(ys, offset = -10))
+    assertFalse(xs.startsWith(ys, offset = 100))
+    assertFalse(xs.startsWith(Nil, offset = 100))
+    assertTrue(xs.startsWith(Nil, offset = 9))
+    assertTrue(xs.startsWith(Nil, offset = 10))
+    assertFalse(xs.startsWith(Nil, offset = 11))
+
+    assertTrue(zs.startsWith(ys))
+    assertTrue(zs.startsWith(ys, offset = 0))
+    assertFalse(zs.startsWith(ys, offset = -10))
+    assertFalse(zs.startsWith(ys, offset = 100))
+    assertFalse(zs.startsWith(Nil, offset = 100))
   }
 }

--- a/test/junit/scala/collection/immutable/RangeTest.scala
+++ b/test/junit/scala/collection/immutable/RangeTest.scala
@@ -99,7 +99,7 @@ class RangeTest {
 
   @Test
   def `startsWith should not throw an exception when out of range`(): Unit = {
-    assertTrue((1 to 5).startsWith(Nil, 7))
+    assertFalse((1 to 5).startsWith(Nil, 7))
     assertFalse((1 to 5).startsWith(1 to 1, 8))
   }
 

--- a/test/scalacheck/scala/collection/IndexOfSliceTest.scala
+++ b/test/scalacheck/scala/collection/IndexOfSliceTest.scala
@@ -16,17 +16,30 @@ object IndexOfSliceTest extends Properties("indexOfSlice") {
       Arbitrary.arbitrary[collection.immutable.ArraySeq[Int]],
       Arbitrary.arbitrary[collection.mutable.ListBuffer[Int]],
       Arbitrary.arbitrary[collection.mutable.ArrayBuffer[Int]],
-      Arbitrary.arbitrary[collection.mutable.WrappedArray[Int]]
+      Arbitrary.arbitrary[collection.mutable.WrappedArray[Int]],
     )
+  val genDifferentEmpties =
+    Gen.oneOf[Seq[Int]](
+      List.empty[Int],
+      Vector.empty[Int],
+      LazyList.empty[Int],
+    )
+  val genPositive = Gen.chooseNum(1, Int.MaxValue)
 
-  property("indexOfSlice(Nil) == 0") =
-    forAll(genDifferentSeqs) { seq: Seq[Int] =>
-      seq.indexOfSlice(Nil) == 0 && seq.indexOfSlice(LazyList.empty) == 0
+  property("indexOfSlice(empty) == 0") =
+    forAll(genDifferentSeqs, genDifferentEmpties) { (seq: Seq[Int], empty: Seq[Int]) =>
+      seq.indexOfSlice(empty) == 0
     }
 
-  property("indexOfSlice(Nil, from = size + 1) == -1") =
-    forAll(genDifferentSeqs) { seq: Seq[Int] =>
-      seq.indexOfSlice(Nil, from = seq.size + 1) == -1
+  property("indexOfSlice(Nil, from = size) == size") =
+    forAll(genDifferentSeqs, genDifferentEmpties) { (seq: Seq[Int], empty: Seq[Int]) =>
+      seq.indexOfSlice(empty, from = seq.size) == seq.size
+    }
+
+  property("indexOfSlice(Nil, from = size + N) == -1") =
+    forAll(genDifferentSeqs, genDifferentEmpties, genPositive) { (seq: Seq[Int], empty: Seq[Int], excess: Int) =>
+      val from = math.min(Int.MaxValue.toLong, seq.size.toLong + excess)
+      seq.indexOfSlice(empty, from = from.toInt) == -1
     }
 
 }


### PR DESCRIPTION
Fixes scala/bug#12780
Fixes https://github.com/scala/bug/issues/12781

The non-trivial tweak is L51 of the test: `from` ~can't~ _can_ be after the last elements, ~even~ to match an empty sequence.

The "generic" slow path, with unknown size, matches ~nothing~ [Ed _empty_] once the sequence is empty.