### PR TITLE
2.13: not for merge: sbt 1.9.0 (was 1.8.3)

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.3
+sbt.version=1.9.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 scalacOptions ++= Seq("-unchecked", "-feature", "-deprecation",
-  "-Xlint:-unused,_", "-Xfatal-warnings")
+  "-Xlint:-unused,_")
 
 libraryDependencies += "org.apache.commons" % "commons-lang3" % "3.12.0"
 


### PR DESCRIPTION
not for merge until 1.9.0 final, but let's see how CI likes it. fyi @eed3si9n 

I also opened a 2.12 PR at #10387. that one can be merged forward rather than merging this one, but I wanted to see how CI likes it in the meantime