### PR TITLE
Invalidate type caches in ChangeOwnerTraverser

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -1305,7 +1305,7 @@ trait Infer extends Checkable {
           }
         }
         tvars foreach instantiateTypeVar
-        invalidateTreeTpeCaches(tree0, tvars.map(_.origin.typeSymbol))
+        invalidateTreeTpeCaches(tree0, tvars.map(_.origin.typeSymbol).toSet)
       }
       /* If the scrutinee has free type parameters but the pattern does not,
        * we have to flip the arguments so the expected type is treated as more

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -179,7 +179,7 @@ trait Namers extends MethodSynthesis {
       val newFlags = (sym.flags & LOCKED) | flags
       // !!! needed for: pos/t5954d; the uniques type cache will happily serve up the same TypeRef
       // over this mutated symbol, and we witness a stale cache for `parents`.
-      invalidateCaches(sym.rawInfo, sym :: sym.moduleClass :: Nil)
+      invalidateCaches(sym.rawInfo, Set(sym, sym.moduleClass))
       sym reset NoType setFlag newFlags setPos pos
       sym.moduleClass andAlso (updatePosFlags(_, pos, moduleClassFlags(flags)))
 

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -1870,7 +1870,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       info match {
         case ci @ ClassInfoType(_, _, _) =>
           setInfo(ci.copy(parents = ci.parents :+ SerializableTpe))
-          invalidateCaches(ci.typeSymbol.typeOfThis, ci.typeSymbol :: Nil)
+          invalidateCaches(ci.typeSymbol.typeOfThis, Set(ci.typeSymbol))
         case i =>
           abort("Only ClassInfoTypes can be made serializable: "+ i)
       }

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -1620,13 +1620,29 @@ trait Trees extends api.Trees {
   }
 
   class ChangeOwnerTraverser(val oldowner: Symbol, val newowner: Symbol) extends InternalTraverser {
-    final def change(sym: Symbol) = {
+    protected val changedSymbols = mutable.Set.empty[Symbol]
+    protected val treeTypes = mutable.Set.empty[Type]
+
+    def change(sym: Symbol) = {
       if (sym != NoSymbol && sym.owner == oldowner) {
         sym.owner = newowner
-        if (sym.isModule) sym.moduleClass.owner = newowner
+        changedSymbols += sym
+        if (sym.isModule) {
+          sym.moduleClass.owner = newowner
+          changedSymbols += sym.moduleClass
+        }
       }
     }
+
+    override def apply[T <: Tree](tree: T): T = {
+      traverse(tree)
+      if (changedSymbols.nonEmpty)
+        new InvalidateTypeCaches(changedSymbols).invalidate(treeTypes)
+      tree
+    }
+
     override def traverse(tree: Tree): Unit = {
+      if (tree.tpe != null) treeTypes += tree.tpe
       tree match {
         case _: Return =>
           if (tree.symbol == oldowner) {
@@ -1758,7 +1774,10 @@ trait Trees extends api.Trees {
    */
   class TreeSymSubstituter(from: List[Symbol], to: List[Symbol]) extends InternalTransformer {
     val symSubst = SubstSymMap(from, to)
-    private[this] var mutatedSymbols: List[Symbol] = Nil
+
+    protected val changedSymbols = mutable.Set.empty[Symbol]
+    protected val treeTypes = mutable.Set.empty[Type]
+
     override def transform(tree: Tree): Tree = {
       @tailrec
       def subst(from: List[Symbol], to: List[Symbol]): Unit = {
@@ -1767,6 +1786,7 @@ trait Trees extends api.Trees {
           else subst(from.tail, to.tail)
       }
       tree modifyType symSubst
+      if (tree.tpe != null) treeTypes += tree.tpe
 
       if (tree.hasSymbolField) {
         subst(from, to)
@@ -1779,7 +1799,7 @@ trait Trees extends api.Trees {
                   |TreeSymSubstituter: updated info of symbol ${sym}
                   |  Old: ${showRaw(sym.info, printTypes = true, printIds = true)}
                   |  New: ${showRaw(newInfo, printTypes = true, printIds = true)}""")
-                mutatedSymbols ::= sym
+                changedSymbols += sym
                 sym updateInfo newInfo
               }
             }
@@ -1804,7 +1824,8 @@ trait Trees extends api.Trees {
     }
     def apply[T <: Tree](tree: T): T = {
       val tree1 = transform(tree)
-      invalidateTreeTpeCaches(tree1, mutatedSymbols)
+      if (changedSymbols.nonEmpty)
+        new InvalidateTypeCaches(changedSymbols).invalidate(treeTypes)
       tree1.asInstanceOf[T]
     }
     override def toString() = "TreeSymSubstituter/" + substituterString("Symbol", "Symbol", from, to)


### PR DESCRIPTION
This PR adds invalidation of caches in `Type`s affected by `ChangeOwnerTraverser`, similar to the existing invalidation in `TreeSymSubstituter`. The issue showed up in a compiler plugin:

```scala
trait M

class C[TC] {
  type A = TC with M
  def a(arg: Option[A]) = 0
}

object C {
  def b[Tb](arg: Option[Tb with M]) = {
    val r = new C[Tb]
    r.a(arg)
  }
}
```

`r.a` has param type `AliasRef(pre = SingleType(r), C.A)`, the (cached) normalized type is `Tb with M` where `Tb` is the type param of `b`.

The plugin moves b's body to a new method `def b$synth[Tbs](arg: Option[Tbs with M]) = body` and calls `changeOwner`. The `AliasRef(pre = SingleType(r), C.A)` remains valid, but it's cached `normalized` needs to be cleared. The correct new normalized type will be `Tbs with M` where `Tbs` is now the type param of `b$shynth`.

This PR improves the existing type cache invalidation used in `TreeSymSubstituter`:
  - invalidate a type if one of its components (e.g., the prefix) was invalidated
  - avoid a separate tree traversal to collect types
  - remember seen types in the invalidation type traversal