### PR TITLE
`IndexedSeq#head` now throws `NoSuchElementException` (not `IndexOutOfBoundsException`)

### DIFF
--- a/src/library/scala/collection/IndexedSeq.scala
+++ b/src/library/scala/collection/IndexedSeq.scala
@@ -91,11 +91,29 @@ trait IndexedSeqOps[+A, +CC[_], +C] extends Any with SeqOps[A, CC, C] { self =>
 
   override def slice(from: Int, until: Int): C = fromSpecific(new IndexedSeqView.Slice(this, from, until))
 
-  override def head: A = apply(0)
+  override def head: A =
+    try apply(0)
+    catch {
+      case e: IndexOutOfBoundsException =>
+        val what = self match {
+          case self: IndexedSeq[_] => self.collectionClassName
+          case _ => toString
+        }
+        throw new NoSuchElementException(s"head of empty $what")
+    }
 
   override def headOption: Option[A] = if (isEmpty) None else Some(head)
 
-  override def last: A = apply(length - 1)
+  override def last: A =
+    try apply(length - 1)
+    catch {
+      case e: IndexOutOfBoundsException =>
+        val what = self match {
+          case self: IndexedSeq[_] => self.collectionClassName
+          case _ => toString
+        }
+        throw new NoSuchElementException(s"last of empty $what")
+    }
 
   // We already inherit an efficient `lastOption = if (isEmpty) None else Some(last)`
 

--- a/src/library/scala/collection/IndexedSeq.scala
+++ b/src/library/scala/collection/IndexedSeq.scala
@@ -92,28 +92,24 @@ trait IndexedSeqOps[+A, +CC[_], +C] extends Any with SeqOps[A, CC, C] { self =>
   override def slice(from: Int, until: Int): C = fromSpecific(new IndexedSeqView.Slice(this, from, until))
 
   override def head: A =
-    try apply(0)
-    catch {
-      case e: IndexOutOfBoundsException =>
-        val what = self match {
-          case self: IndexedSeq[_] => self.collectionClassName
-          case _ => toString
-        }
-        throw new NoSuchElementException(s"head of empty $what")
-    }
+    if (!isEmpty) apply(0)
+    else throw new NoSuchElementException(s"head of empty ${
+      self match {
+        case self: IndexedSeq[_] => self.collectionClassName
+        case _ => toString
+      }
+    }")
 
   override def headOption: Option[A] = if (isEmpty) None else Some(head)
 
   override def last: A =
-    try apply(length - 1)
-    catch {
-      case e: IndexOutOfBoundsException =>
-        val what = self match {
-          case self: IndexedSeq[_] => self.collectionClassName
-          case _ => toString
-        }
-        throw new NoSuchElementException(s"last of empty $what")
-    }
+    if (!isEmpty) apply(length - 1)
+    else throw new NoSuchElementException(s"last of empty ${
+      self match {
+        case self: IndexedSeq[_] => self.collectionClassName
+        case _ => toString
+      }
+    }")
 
   // We already inherit an efficient `lastOption = if (isEmpty) None else Some(last)`
 

--- a/test/junit/scala/collection/mutable/ArrayDequeTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayDequeTest.scala
@@ -6,6 +6,7 @@ import org.junit.Assert._
 
 import scala.annotation.nowarn
 import scala.collection.SeqFactory
+import scala.tools.testkit.AssertUtil.assertThrows
 
 class ArrayDequeTest {
 
@@ -116,6 +117,12 @@ class ArrayDequeTest {
     a.trimToSize()  // Shrink to 256
     assertEquals(a.capacity, 256)
   }
+
+  @Test def `head of empty throws NoSuchElement`: Unit =
+    assertThrows[NoSuchElementException](ArrayDeque.empty[Int].head, _.endsWith("head of empty ArrayDeque"))
+
+  @Test def `last of empty throws NoSuchElement`: Unit =
+    assertThrows[NoSuchElementException](ArrayDeque.empty[Int].last, _.endsWith("last of empty ArrayDeque"))
 }
 
 object ArrayDequeTest {


### PR DESCRIPTION
Fixes scala/bug#12782

Attempts to use `collectionClassName` for a helpful exception message, falls back to `toString`, which should be fine if the collection is in fact empty. (Extra parens at worst.)

~Avoids~ Relishes `isEmpty` in the happy path.