### PR TITLE
Lambdaless test is more forgiving

### DIFF
--- a/src/partest/scala/tools/partest/ReplTest.scala
+++ b/src/partest/scala/tools/partest/ReplTest.scala
@@ -89,7 +89,7 @@ trait Lambdaless extends ReplTest {
   override def normalize(s: String) = stripLambdaClassName(super.normalize(s))
 }
 object Lambdaless {
-  private val lambdaless = """\$Lambda\$\d+/(?:0x[a-f0-9]{16}|\d+)(@[a-fA-F0-9]+)?""".r
+  private val lambdaless = """\$Lambda(?:\$\d+)?/(?:0x[a-f0-9]{16}|\d+)(?:@[a-fA-F0-9]+)?""".r
   private def stripLambdaClassName(s: String): String = lambdaless.replaceAllIn(s, Regex.quoteReplacement("<function>"))
 }
 


### PR DESCRIPTION
As per https://github.com/scala/scala/pull/10394

"Ad astera per as per."