### PR TITLE
More JDK 21 fixes

### DIFF
--- a/test/junit/scala/jdk/javaapi/StreamConvertersJavaTest.java
+++ b/test/junit/scala/jdk/javaapi/StreamConvertersJavaTest.java
@@ -29,7 +29,7 @@ public class StreamConvertersJavaTest {
     public List<Integer> li = CollectionConverters.asScala(Arrays.asList(1, 2)).toList();
     public List<Float> lf = CollectionConverters.asScala(Arrays.asList(1f, 2f)).toList();
 
-    public <K, V> Map<K, V> mkm(K k1, V v1, K k2, V v2) {
+    public static <K, V> Map<K, V> mkm(K k1, V v1, K k2, V v2) {
         java.util.Map<K, V> m = new java.util.HashMap<K, V>();
         m.put(k1, v1);
         m.put(k2, v2);

--- a/test/tasty/test/scala/tools/tastytest/TastyTestJUnit.scala
+++ b/test/tasty/test/scala/tools/tastytest/TastyTestJUnit.scala
@@ -2,6 +2,7 @@ package scala.tools.tastytest
 
 import org.junit.{Test => test, BeforeClass => setup, AfterClass => teardown}
 import org.junit.Assert._
+import org.junit.Assume._
 
 import scala.util.{Try, Failure, Properties}
 
@@ -91,6 +92,8 @@ object TastyTestJUnit {
 
   @setup
   def init(): Unit = {
+    // TODO remove once Scala 3 has a fix for scala/bug#12783
+    assumeFalse(scala.util.Properties.isJavaAtLeast("21"))
     _dottyClassLoader = Dotc.initClassloader().get
   }
 


### PR DESCRIPTION
- fix a warning on JDK 21
- for now, skip TASTy tests on JDK 21
