### PR TITLE
Partest recognizes using

### DIFF
--- a/test/files/neg/check-dead.scala
+++ b/test/files/neg/check-dead.scala
@@ -1,4 +1,4 @@
-/* scalac: -Ywarn-dead-code -Xfatal-warnings */
+// scalac: -Wdead-code -Werror
 object Other {
   def oops(msg: String = "xxx"): Nothing = throw new Exception(msg) // should not warn
 }

--- a/test/files/neg/t10701.check
+++ b/test/files/neg/t10701.check
@@ -1,4 +1,4 @@
-t10701/Test.java:6: warning: [deprecation] whatever() in Meh has been deprecated
+t10701/Test.java:4: warning: [deprecation] whatever() in Meh has been deprecated
         Meh.whatever();
            ^
 error: warnings found and -Werror specified

--- a/test/files/neg/t10701/Test.java
+++ b/test/files/neg/t10701/Test.java
@@ -1,6 +1,4 @@
-/*
- * javac: -Werror -deprecation
- */
+// javac: -Werror -deprecation
 public class Test {
     public static void main(String [] args) {
         Meh.whatever();

--- a/test/files/neg/t10806.check
+++ b/test/files/neg/t10806.check
@@ -1,10 +1,10 @@
-t10806.scala:12: warning: unreachable code
+t10806.scala:11: warning: unreachable code
       case e: IllegalArgumentException => println(e.getMessage)
                                                  ^
-t10806.scala:18: warning: unreachable code
+t10806.scala:17: warning: unreachable code
       case e: IllegalArgumentException => println(e.getMessage)
                                                  ^
-t10806.scala:23: warning: unreachable code
+t10806.scala:22: warning: unreachable code
       case e: IllegalArgumentException => println(e.getMessage)
                                                  ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t10806.scala
+++ b/test/files/neg/t10806.scala
@@ -1,5 +1,4 @@
-/* scalac: -Xfatal-warnings
- */
+// scalac: -Werror
 
 trait T {
 

--- a/test/files/neg/t3098/a.scala
+++ b/test/files/neg/t3098/a.scala
@@ -1,4 +1,4 @@
-// Traits.scala scalac: -Werror
+// scalac: -Werror
 sealed trait T
 
 trait A extends T

--- a/test/files/neg/using-source3.check
+++ b/test/files/neg/using-source3.check
@@ -1,0 +1,10 @@
+using-source3.scala:14: warning: reference to f is ambiguous;
+it is both defined in the enclosing class D and inherited in the enclosing class E as method f (defined in class C)
+In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
+Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.f`.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+    def g = f
+            ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/using-source3.scala
+++ b/test/files/neg/using-source3.scala
@@ -1,0 +1,16 @@
+
+// skalac: -Werror -Xsource:3
+
+//> using option -Werror
+//> using option -Xsource:3
+
+class C {
+  def f = 42
+}
+
+class D {
+  def f = 27
+  class E extends C {
+    def g = f
+  }
+}

--- a/test/files/neg/using-source3b.check
+++ b/test/files/neg/using-source3b.check
@@ -1,0 +1,10 @@
+using-source3b.scala:13: warning: reference to f is ambiguous;
+it is both defined in the enclosing class D and inherited in the enclosing class E as method f (defined in class C)
+In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
+Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.f`.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+    def g = f
+            ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/using-source3b.scala
+++ b/test/files/neg/using-source3b.scala
@@ -1,0 +1,15 @@
+
+// skalac: -Werror -Xsource:3
+
+//> using options -Werror, "-Wconf:cat=deprecation:e,cat=feature:s", -Xlint , -Xsource:3
+
+class C {
+  def f = 42
+}
+
+class D {
+  def f = 27
+  class E extends C {
+    def g = f
+  }
+}

--- a/test/files/pos/t6047.scala
+++ b/test/files/pos/t6047.scala
@@ -1,4 +1,4 @@
-/* scalac: -language:experimental.macros */
+import scala.language.experimental.macros
 import scala.reflect.macros.blackbox.Context
 import java.io.InputStream
 

--- a/test/files/run/reflect-java-param-names/J_1.java
+++ b/test/files/run/reflect-java-param-names/J_1.java
@@ -1,6 +1,4 @@
-/*
- * javac: -parameters
- */
+// javac: -parameters
 public class J_1<T> {
     public J_1(int i, int j) {}
     public <J extends T> void inst(int i, J j) {}

--- a/test/files/run/synchronized.scala
+++ b/test/files/run/synchronized.scala
@@ -1,8 +1,4 @@
-// scalac: -opt:inline:**
-//
-/*
- * filter: optimizer warnings;
- */
+// scalac: -opt:inline:** -Wopt:none
 import java.lang.Thread.holdsLock
 import scala.collection.mutable.StringBuilder
 

--- a/test/files/run/t10231/A_1.java
+++ b/test/files/run/t10231/A_1.java
@@ -1,6 +1,4 @@
-/*
- * javac: -parameters
- */
+// javac: -parameters
 public class A_1 {
   public class Inner {
     public int x;

--- a/test/files/run/t10450/A.java
+++ b/test/files/run/t10450/A.java
@@ -1,6 +1,4 @@
-/*
- * filter: unchecked
- */
+// filter: unchecked
 package a;
 
 class B<T extends B<T>> {

--- a/test/files/run/t10699/A_1.java
+++ b/test/files/run/t10699/A_1.java
@@ -1,6 +1,4 @@
-/*
- * javac: -parameters
- */
+// javac: -parameters
 public class A_1 {
     public <T> T identity_inst(T t, T other) { return t; }
     public static <T> T identity_static(T t, T other) { return t; }

--- a/test/files/run/t7198.scala
+++ b/test/files/run/t7198.scala
@@ -1,5 +1,5 @@
+// filter: Over the moon
 /* spew a few lines
- * filter: Over the moon
  */
 object Test extends App {
   Console println "The quick brown fox jumped"

--- a/test/files/run/t7634.scala
+++ b/test/files/run/t7634.scala
@@ -1,13 +1,11 @@
 // java: -Dneeds.forked.jvm.for.windows
+// filter out absolute path to java
+// filter: hello.Hello
 
 import java.io.File
 import scala.tools.partest.ReplTest
 import scala.util.Properties.propOrElse
 
-/**
-* filter out absolute path to java
-* filter: java
-*/
 object Test extends ReplTest {
   def java = propOrElse("javacmd", "java")
   def code = s""":sh $java -classpath $testOutput hello.Hello


### PR DESCRIPTION
Require line comment for current style pragma.

Other scala-cli style pragmas could be supported, but only option is recognized.

This simplifies posting code from reports, where dependencies are not involved.
