### PR TITLE
Implement quickfixes, aka actionable diagnostics (via `CodeAction`)

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -39,6 +39,8 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.concurrent.impl.FutureConvertersImpl#P.accept"),
     ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.concurrent.impl.FutureConvertersImpl#P.andThen"),
 
+    // PR 10406
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.JavaUniverse#PerRunReporting.deprecationWarning"),
   )
 
   override val buildSettings = Seq(

--- a/src/compiler/scala/reflect/macros/contexts/Parsers.scala
+++ b/src/compiler/scala/reflect/macros/contexts/Parsers.scala
@@ -32,7 +32,7 @@ trait Parsers {
       })
       val tree = gen.mkTreeOrBlock(parser.parseStatsOrPackages())
       sreporter.infos.foreach {
-        case Info(pos, msg, Reporter.ERROR) => throw ParseException(pos, msg)
+        case Info(pos, msg, Reporter.ERROR, _) => throw ParseException(pos, msg)
         case _ =>
       }
       tree

--- a/src/compiler/scala/tools/nsc/CompilationUnits.scala
+++ b/src/compiler/scala/tools/nsc/CompilationUnits.scala
@@ -47,6 +47,9 @@ trait CompilationUnits { global: Global =>
     def freshTermName(prefix: String = nme.FRESH_TERM_NAME_PREFIX) = global.freshTermName(prefix)
     def freshTypeName(prefix: String)                              = global.freshTypeName(prefix)
 
+    def sourceAt(pos: Position): String =
+      if (pos.start < pos.end) new String(source.content.slice(pos.start, pos.end)) else ""
+
     /** the content of the compilation unit in tree form */
     var body: Tree = EmptyTree
 

--- a/src/compiler/scala/tools/nsc/Parsing.scala
+++ b/src/compiler/scala/tools/nsc/Parsing.scala
@@ -14,6 +14,7 @@ package scala
 package tools.nsc
 
 import scala.reflect.internal.Positions
+import scala.reflect.internal.util.CodeAction
 
 /** Similar to Reporting: gather global functionality specific to parsing.
  */
@@ -35,8 +36,8 @@ trait Parsing { self : Positions with Reporting =>
     }
 
     def incompleteHandled = incompleteHandler != null
-    def incompleteInputError(pos: Position, msg: String): Unit =
+    def incompleteInputError(pos: Position, msg: String, actions: List[CodeAction] = Nil): Unit =
       if (incompleteHandled) incompleteHandler(pos, msg)
-      else reporter.error(pos, msg)
+      else reporter.error(pos, msg, actions)
   }
 }

--- a/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
@@ -22,7 +22,7 @@ import scala.annotation._
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.language.implicitConversions
-import scala.reflect.internal.util.{ListOfNil, Position}
+import scala.reflect.internal.util.{CodeAction, ListOfNil, Position}
 import scala.tools.nsc.Reporting.WarningCategory
 import scala.util.chaining._
 
@@ -38,7 +38,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
     def freshName(prefix: String): Name = freshTermName(prefix)
     def freshTermName(prefix: String): TermName = unit.freshTermName(prefix)
     def freshTypeName(prefix: String): TypeName = unit.freshTypeName(prefix)
-    def deprecationWarning(off: Int, msg: String, since: String) = runReporting.deprecationWarning(off, msg, since, site = "", origin = "")
+    def deprecationWarning(off: Int, msg: String, since: String, actions: List[CodeAction]) = runReporting.deprecationWarning(off, msg, since, site = "", origin = "", actions)
     implicit def i2p(offset : Int) : Position = Position.offset(unit.source, offset)
     def warning(pos : Int, msg : String) : Unit = runReporting.warning(pos, msg, WarningCategory.JavaSource, site = "")
     def syntaxError(pos: Int, msg: String) : Unit = reporter.error(pos, msg)

--- a/src/compiler/scala/tools/nsc/javac/JavaScanners.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaScanners.scala
@@ -1031,7 +1031,7 @@ trait JavaScanners extends ast.parser.ScannersCommon {
     def error(pos: Int, msg: String) = reporter.error(pos, msg)
     def incompleteInputError(pos: Int, msg: String) = currentRun.parsing.incompleteInputError(pos, msg)
     def warning(pos: Int, msg: String, category: WarningCategory) = runReporting.warning(pos, msg, category, site = "")
-    def deprecationWarning(pos: Int, msg: String, since: String) = runReporting.deprecationWarning(pos, msg, since, site = "", origin = "")
+    def deprecationWarning(pos: Int, msg: String, since: String, actions: List[CodeAction]) = runReporting.deprecationWarning(pos, msg, since, site = "", origin = "", actions)
     implicit def g2p(pos: Int): Position = Position.offset(unit.source, pos)
   }
 }

--- a/src/compiler/scala/tools/nsc/reporters/ConsoleReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/ConsoleReporter.scala
@@ -15,14 +15,14 @@ package tools.nsc
 package reporters
 
 import java.io.{BufferedReader, PrintWriter}
-import scala.reflect.internal.util.Position
+import scala.reflect.internal.util.{CodeAction, Position}
 
 /** This class implements a Reporter that displays messages on a text console. */
 class ConsoleReporter(val settings: Settings, val reader: BufferedReader, val writer: PrintWriter, val echoWriter: PrintWriter) extends FilteringReporter with PrintReporter {
   def this(settings: Settings) = this(settings, Console.in, new PrintWriter(Console.err, true), new PrintWriter(Console.out, true))
   def this(settings: Settings, reader: BufferedReader, writer: PrintWriter) = this(settings, reader, writer, writer)
 
-  def doReport(pos: Position, msg: String, severity: Severity): Unit = display(pos, msg, severity)
+  override def doReport(pos: Position, msg: String, severity: Severity, actions: List[CodeAction]): Unit = display(pos, msg, severity)
 
   override def finish(): Unit = {
     import reflect.internal.util.StringOps.countElementsAsString

--- a/src/compiler/scala/tools/nsc/reporters/ForwardingReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/ForwardingReporter.scala
@@ -12,7 +12,7 @@
 
 package scala.tools.nsc.reporters
 import scala.reflect.internal.settings.MutableSettings
-import scala.reflect.internal.util.Position
+import scala.reflect.internal.util.{CodeAction, Position}
 import scala.tools.nsc.Settings
 
 
@@ -20,7 +20,7 @@ import scala.tools.nsc.Settings
   * customize error reporting.
   * {{{
   *   val myReporter = new ForwardingReporter(global.reporter) {
-  *     override def doReport(pos: Position, msg: String, severity: Severity): Unit = { ... }
+  *     override def doReport(pos: Position, msg: String, severity: Severity, actions: List[Action]): Unit = { ... }
   *   }
   *   global.reporter = myReporter
   * }}}
@@ -28,7 +28,8 @@ import scala.tools.nsc.Settings
 class ForwardingReporter(delegate: FilteringReporter) extends FilteringReporter {
   def settings: Settings = delegate.settings
 
-  def doReport(pos: Position, msg: String, severity: Severity): Unit = delegate.doReport(pos, msg, severity)
+  override def doReport(pos: Position, msg: String, severity: Severity, actions: List[CodeAction]): Unit =
+    delegate.doReport(pos, msg, severity, actions)
 
   override def filter(pos: Position, msg: String, severity: Severity): Int = delegate.filter(pos, msg, severity)
 
@@ -56,7 +57,8 @@ class ForwardingReporter(delegate: FilteringReporter) extends FilteringReporter 
   * maxerrs and do position filtering.
   */
 class MakeFilteringForwardingReporter(delegate: Reporter, val settings: Settings) extends FilteringReporter {
-  def doReport(pos: Position, msg: String, severity: Severity): Unit = delegate.nonProtectedInfo0(pos, msg, severity)
+  override def doReport(pos: Position, msg: String, severity: Severity, actions: List[CodeAction]): Unit =
+    delegate.doReport(pos, msg, severity, actions)
 
   override def increment(severity: Severity): Unit = delegate.increment(severity)
 

--- a/src/compiler/scala/tools/nsc/reporters/NoReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/NoReporter.scala
@@ -12,11 +12,11 @@
 
 package scala.tools.nsc.reporters
 
-import scala.reflect.internal.util.Position
+import scala.reflect.internal.util.{CodeAction, Position}
 import scala.tools.nsc.Settings
 
 /** A reporter that ignores reports.
  */
 class NoReporter(val settings: Settings) extends FilteringReporter {
-  def doReport(pos: Position, msg: String, severity: Severity): Unit = ()
+  override def doReport(pos: Position, msg: String, severity: Severity, actions: List[CodeAction]): Unit = ()
 }

--- a/src/compiler/scala/tools/nsc/reporters/StoreReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/StoreReporter.scala
@@ -16,7 +16,7 @@ package reporters
 import scala.annotation.unchecked.uncheckedStable
 import scala.collection.mutable
 import scala.reflect.internal.Reporter.Severity
-import scala.reflect.internal.util.Position
+import scala.reflect.internal.util.{CodeAction, Position}
 
 /** This class implements a Reporter that stores its reports in the set `infos`. */
 class StoreReporter(val settings: Settings) extends FilteringReporter {
@@ -31,8 +31,10 @@ class StoreReporter(val settings: Settings) extends FilteringReporter {
 
   val infos = new mutable.LinkedHashSet[StoreReporter.Info]
 
-  def doReport(pos: Position, msg: String, severity: Severity): Unit =
-    infos += StoreReporter.Info(pos, msg, severity)
+  override def doReport(pos: Position, msg: String, severity: Severity, actions: List[CodeAction]): Unit = {
+    val info = StoreReporter.Info(pos, msg, severity, actions)
+    infos += info
+  }
 
   override def reset(): Unit = {
     super.reset()
@@ -40,7 +42,7 @@ class StoreReporter(val settings: Settings) extends FilteringReporter {
   }
 }
 object StoreReporter {
-  case class Info(pos: Position, msg: String, severity: Severity) {
-    override def toString: String = s"pos: $pos $msg $severity"
+  case class Info(pos: Position, msg: String, severity: Severity, actions: List[CodeAction]) {
+    override def toString: String = s"pos: $pos $msg $severity${if (actions.isEmpty) "" else " " + actions}"
   }
 }

--- a/src/compiler/scala/tools/reflect/package.scala
+++ b/src/compiler/scala/tools/reflect/package.scala
@@ -15,7 +15,7 @@ package scala.tools
 import scala.language.implicitConversions
 import scala.reflect.api.JavaUniverse
 import scala.reflect.internal.Reporter
-import scala.reflect.internal.util.Position
+import scala.reflect.internal.util.{CodeAction, Position}
 import scala.tools.nsc.Settings
 import scala.tools.nsc.reporters.{ConsoleReporter, FilteringReporter}
 
@@ -88,7 +88,7 @@ package object reflect {
     val NSC_WARNING  = Reporter.WARNING
     val NSC_ERROR    = Reporter.ERROR
 
-    def doReport(pos: Position, msg: String, nscSeverity: NscSeverity): Unit =
+    override def doReport(pos: Position, msg: String, nscSeverity: NscSeverity, actions: List[CodeAction]): Unit =
       frontEnd.log(pos, msg, (nscSeverity: @unchecked) match {
         case NSC_INFO => API_INFO
         case NSC_WARNING => API_WARNING

--- a/src/interactive/scala/tools/nsc/interactive/InteractiveReporter.scala
+++ b/src/interactive/scala/tools/nsc/interactive/InteractiveReporter.scala
@@ -14,10 +14,10 @@ package scala.tools.nsc
 package interactive
 
 import scala.collection.mutable.ArrayBuffer
-import scala.reflect.internal.util.Position
+import scala.reflect.internal.util.{CodeAction, Position}
 import scala.tools.nsc.reporters.FilteringReporter
 
-case class Problem(pos: Position, msg: String, severityLevel: Int)
+case class Problem(pos: Position, msg: String, severityLevel: Int, actions: List[CodeAction])
 
 abstract class InteractiveReporter extends FilteringReporter {
 
@@ -27,7 +27,7 @@ abstract class InteractiveReporter extends FilteringReporter {
 
   val otherProblems = new ArrayBuffer[Problem]
 
-  override def doReport(pos: Position, msg: String, severity: Severity): Unit = try {
+  override def doReport(pos: Position, msg: String, severity: Severity, actions: List[CodeAction]): Unit = try {
     val problems =
       if (compiler eq null) {
         otherProblems
@@ -44,7 +44,7 @@ abstract class InteractiveReporter extends FilteringReporter {
         compiler.debugLog("[no position] :" + msg)
         otherProblems
       }
-    problems += Problem(pos, msg, severity.id)
+    problems += Problem(pos, msg, severity.id, actions)
   } catch {
     case ex: UnsupportedOperationException =>
   }

--- a/src/partest/scala/tools/partest/nest/DirectCompiler.scala
+++ b/src/partest/scala/tools/partest/nest/DirectCompiler.scala
@@ -14,9 +14,8 @@ package scala.tools.partest
 package nest
 
 import java.io.{BufferedReader, FileWriter, PrintWriter}
-
 import scala.collection.mutable.ListBuffer
-import scala.reflect.internal.util.{NoPosition, Position, ScalaClassLoader}
+import scala.reflect.internal.util.{CodeAction, NoPosition, Position, ScalaClassLoader}
 import scala.reflect.io.AbstractFile
 import scala.tools.nsc.reporters.{ConsoleReporter, Reporter}
 import scala.tools.nsc.{CompilerCommand, Global, Settings}
@@ -30,7 +29,7 @@ object ExtConsoleReporter {
   }
 }
 class PlainReporter(settings: Settings, reader: BufferedReader, writer: PrintWriter, echo: PrintWriter) extends ConsoleReporter(settings, reader, writer, echo) {
-  override def doReport(pos: Position, msg: String, severity: Severity): Unit = writer.println(s"[$severity] [$pos]: $msg")
+  override def doReport(pos: Position, msg: String, severity: Severity, actions: List[CodeAction]): Unit = writer.println(s"[$severity] [$pos]: $msg")
 }
 
 class TestSettings(cp: String, error: String => Unit) extends Settings(error) {

--- a/src/reflect/scala/reflect/internal/util/CodeAction.scala
+++ b/src/reflect/scala/reflect/internal/util/CodeAction.scala
@@ -1,0 +1,39 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+package reflect
+package internal
+package util
+
+/**
+ *  <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>
+ *
+ *  CodeAction is used to communicate code edit suggestion to tooling in
+ *  a structured manner.
+ *
+ *  @see <a href=
+ *     "https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeAction">`CodeAction`</a>
+ *
+ *  @groupname Common   Commonly used methods
+ *  @group ReflectionAPI
+ */
+case class CodeAction(title: String, description: Option[String], edits: List[TextEdit])
+
+/**
+ *  <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>
+ *
+ *
+ *  @groupname Common   Commonly used methods
+ *  @group ReflectionAPI
+ */
+case class TextEdit(position: Position, newText: String)

--- a/src/reflect/scala/reflect/runtime/JavaUniverse.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverse.scala
@@ -19,7 +19,7 @@ import scala.reflect.internal.{SomePhase, TreeInfo}
 import scala.reflect.internal.{SymbolTable => InternalSymbolTable}
 import scala.reflect.runtime.{SymbolTable => RuntimeSymbolTable}
 import scala.reflect.api.{TypeCreator, Universe}
-import scala.reflect.internal.util.Statistics
+import scala.reflect.internal.util.{CodeAction, Statistics}
 
 /** An implementation of [[scala.reflect.api.Universe]] for runtime reflection using JVM classloaders.
  *
@@ -39,13 +39,15 @@ class JavaUniverse extends InternalSymbolTable with JavaUniverseForce with Refle
   // TODO: why put output under isLogging? Calls to inform are already conditional on debug/verbose/...
   import scala.reflect.internal.Reporter
   override def reporter: Reporter = new Reporter {
+    @nowarn("msg=overriding method info0")
     protected def info0(pos: Position, msg: String, severity: Severity, force: Boolean): Unit = log(msg)
   }
 
   // minimal Run to get Reporting wired
   def currentRun = new RunReporting {}
   class PerRunReporting extends PerRunReportingBase {
-    def deprecationWarning(pos: Position, msg: String, since: String, site: String, origin: String): Unit = reporter.warning(pos, msg)
+    def deprecationWarning(pos: Position, msg: String, since: String, site: String, origin: String, actions: List[CodeAction]): Unit =
+      reporter.warning(pos, msg)
   }
   protected def PerRunReporting = new PerRunReporting
 

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/Reporter.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/Reporter.scala
@@ -13,9 +13,8 @@
 package scala.tools.nsc.interpreter.shell
 
 import java.io.PrintWriter
-
 import scala.reflect.internal
-import scala.reflect.internal.util.{NoSourceFile, Position, StringOps}
+import scala.reflect.internal.util.{CodeAction, NoSourceFile, Position, StringOps}
 import scala.tools.nsc.interpreter.{Naming, ReplReporter, ReplRequest}
 import scala.tools.nsc.reporters.{FilteringReporter, Reporter}
 import scala.tools.nsc.{ConsoleWriter, NewLinePrintWriter, Settings}
@@ -150,7 +149,7 @@ class ReplReporterImpl(val config: ShellConfig, val settings: Settings = new Set
     case internal.Reporter.INFO    => RESET
   }
 
-  def doReport(pos: Position, msg: String, severity: Severity): Unit = withoutTruncating {
+  override def doReport(pos: Position, msg: String, severity: Severity, actions: List[CodeAction]): Unit = withoutTruncating {
     val prefix =
       if (colorOk) severityColor(severity) + clabel(severity) + RESET
       else clabel(severity)

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/Scripted.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/Scripted.scala
@@ -14,12 +14,10 @@ package scala.tools.nsc.interpreter.shell
 
 import java.io.{Closeable, OutputStream, PrintWriter, Reader}
 import java.util.Arrays.asList
-
 import javax.script._
-
 import scala.beans.BeanProperty
 import scala.jdk.CollectionConverters._
-import scala.reflect.internal.util.Position
+import scala.reflect.internal.util.{CodeAction, Position}
 import scala.tools.nsc.Settings
 import scala.tools.nsc.interpreter.Results.Incomplete
 import scala.tools.nsc.interpreter.{ImportContextPreamble, ScriptedInterpreter, ScriptedRepl}
@@ -317,7 +315,7 @@ private class SaveFirstErrorReporter(settings: Settings, out: PrintWriter) exten
   private var _firstError: Option[(Position, String)] = None
   def firstError = _firstError
 
-  override def doReport(pos: Position, msg: String, severity: Severity): Unit =
+  override def doReport(pos: Position, msg: String, severity: Severity, actions: List[CodeAction]): Unit =
     if (severity == ERROR && _firstError.isEmpty) _firstError = Some((pos, msg))
 
   override def reset() = { super.reset(); _firstError = None }

--- a/test/files/presentation/t12308.check
+++ b/test/files/presentation/t12308.check
@@ -1,11 +1,11 @@
 reload: Foo.scala
 askLoadedTyped 1
-Problem(RangePosition(t12308/src/Foo.scala, 67, 67, 72),A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.,1)
+Problem(RangePosition(t12308/src/Foo.scala, 67, 67, 72),A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.,1,List())
 askLoadedTyped 2
-Problem(RangePosition(t12308/src/Foo.scala, 67, 67, 72),A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.,1)
+Problem(RangePosition(t12308/src/Foo.scala, 67, 67, 72),A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.,1,List())
 reload: Foo.scala
 askLoadedTyped 3
-Problem(RangePosition(t12308/src/Foo.scala, 67, 67, 72),A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.,1)
+Problem(RangePosition(t12308/src/Foo.scala, 67, 67, 72),A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.,1,List())
 targeted 1
 
 askType at Foo.scala(2,37)
@@ -25,7 +25,7 @@ askType at Foo.scala(4,37)
 [response] askTypeAt (4,37)
 1
 ================================================================================
-Problem(RangePosition(t12308/src/Foo.scala, 67, 67, 72),A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.,1)
+Problem(RangePosition(t12308/src/Foo.scala, 67, 67, 72),A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.,1,List())
 reload: Foo.scala
 targeted 2 - doesn't handle nowarn correctly
 
@@ -46,5 +46,5 @@ askType at Foo.scala(4,37)
 [response] askTypeAt (4,37)
 1
 ================================================================================
-Problem(RangePosition(t12308/src/Foo.scala, 67, 67, 72),A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.,1)
-Problem(RangePosition(t12308/src/Foo.scala, 109, 109, 114),A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.,1)
+Problem(RangePosition(t12308/src/Foo.scala, 67, 67, 72),A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.,1,List())
+Problem(RangePosition(t12308/src/Foo.scala, 109, 109, 114),A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.,1,List())

--- a/test/junit/scala/tools/nsc/async/AnnotationDrivenAsyncTest.scala
+++ b/test/junit/scala/tools/nsc/async/AnnotationDrivenAsyncTest.scala
@@ -11,7 +11,7 @@ import org.junit.{Assert, Ignore, Test}
 import scala.annotation.{StaticAnnotation, nowarn, unused}
 import scala.collection.mutable
 import scala.concurrent.duration.Duration
-import scala.reflect.internal.util.Position
+import scala.reflect.internal.util.{CodeAction, Position}
 import scala.reflect.internal.util.ScalaClassLoader.URLClassLoader
 import scala.tools.nsc.backend.jvm.AsmUtils
 import scala.tools.nsc.plugins.{Plugin, PluginComponent}
@@ -515,9 +515,9 @@ class AnnotationDrivenAsyncTest {
     val out = createTempDir()
 
       val reporter = new StoreReporter(new Settings) {
-        override def doReport(pos: Position, msg: String, severity: Severity): Unit =
+        override def doReport(pos: Position, msg: String, severity: Severity, actions: List[CodeAction]): Unit =
           if (severity == INFO) println(msg)
-          else super.doReport(pos, msg, severity)
+          else super.doReport(pos, msg, severity, actions)
       }
       val settings = new Settings(println(_))
       settings.async.value = true

--- a/test/junit/scala/tools/nsc/reporters/AbstractCodeActionTest.scala
+++ b/test/junit/scala/tools/nsc/reporters/AbstractCodeActionTest.scala
@@ -1,0 +1,97 @@
+package scala.tools.nsc.reporters
+
+import org.junit.Test
+import org.junit.Assert._
+
+import scala.reflect.internal.util.CodeAction
+import scala.tools.testkit.BytecodeTesting
+
+abstract class AbstractCodeActionTest extends BytecodeTesting {
+  override def compilerArgs: String = "-Ystop-after:typer -Yvalidate-pos:typer -Yrangepos -deprecation -Xsource:3"
+  protected def reporter = compiler.global.reporter.asInstanceOf[StoreReporter]
+
+  @Test
+  def testProcedureSyntaxDecl(): Unit =
+    assertCodeSuggestion(
+      """trait Test {
+        |  def foo
+        |  def bar;
+        |  def pub { print() }
+        |  def club{ print() }
+        |  def saloon = { print() }
+        |}""".stripMargin,
+      """trait Test {
+        |  def foo: Unit
+        |  def bar: Unit;
+        |  def pub: Unit = { print() }
+        |  def club: Unit ={ print() }
+        |  def saloon = { print() }
+        |}""".stripMargin,
+    )
+
+  @Test
+  def testGreatParenInsert(): Unit = {
+    assertCodeSuggestion(
+      """trait Test {
+        |  def foo = {
+        |    println
+        |    Predef.println
+        |    toString + this.toString
+        |  }
+        |  def bar: Unit = Predef println()
+        |}
+      """.stripMargin,
+      """trait Test {
+        |  def foo = {
+        |    println()
+        |    Predef.println()
+        |    toString + this.toString
+        |  }
+        |  def bar: Unit = Predef println()
+        |}
+      """.stripMargin,
+    )
+  }
+
+  @Test
+  def testValInFor(): Unit =
+    assertCodeSuggestion(
+      """trait Test {
+        |  def foo: Unit = {
+        |    for {
+        |      val x <- 1 to 5
+        |      val y = x
+        |    } yield x+y
+        |  }
+        |}
+      """.stripMargin,
+      """trait Test {
+        |  def foo: Unit = {
+        |    for {
+        |      x <- 1 to 5
+        |      y = x
+        |    } yield x+y
+        |  }
+        |}
+      """.stripMargin,
+    )
+
+  def assertCodeSuggestion(original: String, expected: String): Unit = {
+    val run = compiler.newRun()
+    run.compileSources(compiler.global.newSourceFile(original) :: Nil)
+    val actions = reporter.infos.flatMap(_.actions).toList
+    val newCode = applyChanges(original, actions)
+    assertEquals(s"\n$newCode", expected, newCode)
+  }
+
+  def applyChanges(code: String, as: List[CodeAction]): String = {
+    var offset = 0
+    var res = code.toVector
+    for (change <- as.flatMap(_.edits).sortBy(_.position.start)) {
+      // not the most efficient but it's just for tests
+      res = res.take(change.position.start + offset) ++ change.newText.toVector ++ res.drop(change.position.end + offset)
+      offset = offset - (change.position.end - change.position.start) + change.newText.length
+    }
+    new String(res.toArray)
+  }
+}

--- a/test/junit/scala/tools/nsc/reporters/CodeActionTest.scala
+++ b/test/junit/scala/tools/nsc/reporters/CodeActionTest.scala
@@ -1,0 +1,9 @@
+package scala.tools.nsc.reporters
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class CodeActionTest extends AbstractCodeActionTest {
+  override def compilerArgs: String = "-Ystop-after:typer -Yvalidate-pos:typer -Yrangepos -deprecation"
+}

--- a/test/junit/scala/tools/nsc/reporters/CodeActionXsource3Test.scala
+++ b/test/junit/scala/tools/nsc/reporters/CodeActionXsource3Test.scala
@@ -1,0 +1,39 @@
+package scala.tools.nsc.reporters
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class CodeActionXsource3Test extends AbstractCodeActionTest {
+  override def compilerArgs: String = "-Ystop-after:typer -Yvalidate-pos:typer -Yrangepos -deprecation -Xsource:3"
+
+  @Test
+  def testLambdaParameterList(): Unit =
+    assertCodeSuggestion(
+      """trait Test {
+        |  def foo: Any = {
+        |    x: Int => x * 2
+        |  }
+        |  def bar: Any = {
+        |    x: Int=> x * 2
+        |  }
+        |  def tavern: Any = { x: Int =>
+        |    x * 2
+        |  }
+        |}
+      """.stripMargin,
+      """trait Test {
+        |  def foo: Any = {
+        |    (x: Int) => x * 2
+        |  }
+        |  def bar: Any = {
+        |    (x: Int)=> x * 2
+        |  }
+        |  def tavern: Any = { (x: Int) =>
+        |    x * 2
+        |  }
+        |}
+      """.stripMargin,
+    )
+}

--- a/test/junit/scala/tools/nsc/reporters/ConsoleReporterTest.scala
+++ b/test/junit/scala/tools/nsc/reporters/ConsoleReporterTest.scala
@@ -88,8 +88,8 @@ class ConsoleReporterTest {
     reporter.settings.maxwarns.value = 1
 
     // counting happens in .error/.warning, doReport doesn't count
-    testHelper(msg = "Testing display", severity = "warning: ")(reporter.doReport(_, "Testing display", reporter.WARNING))
-    testHelper(msg = "Testing display", severity = "error: ")(reporter.doReport(_, "Testing display", reporter.ERROR))
+    testHelper(msg = "Testing display", severity = "warning: ")(reporter.doReport(_, "Testing display", reporter.WARNING, Nil))
+    testHelper(msg = "Testing display", severity = "error: ")(reporter.doReport(_, "Testing display", reporter.ERROR, Nil))
 
     testHelper(msg = "Testing display")(reporter.echo(_, "Testing display"))
     testHelper(msg = "Testing display", severity = "warning: ")(reporter.warning(_, "Testing display"))
@@ -100,8 +100,8 @@ class ConsoleReporterTest {
     testHelper(msg = "")(reporter.error(_, "Test maxwarns"))
 
     // the filter happens in .error/.warning, doReport always reports
-    testHelper(posWithSource, msg = "Testing display", severity = "warning: ")(reporter.doReport(_, "Testing display", reporter.WARNING))
-    testHelper(posWithSource, msg = "Testing display", severity = "error: ")(reporter.doReport(_, "Testing display", reporter.ERROR))
+    testHelper(posWithSource, msg = "Testing display", severity = "warning: ")(reporter.doReport(_, "Testing display", reporter.WARNING, Nil))
+    testHelper(posWithSource, msg = "Testing display", severity = "error: ")(reporter.doReport(_, "Testing display", reporter.ERROR, Nil))
 
     reporter.reset()
 
@@ -178,7 +178,8 @@ class ConsoleReporterTest {
 
       new FilteringReporter {
         def settings: Settings = conf
-        def doReport(pos: Position, msg: String, severity: Severity): Unit = reporter.doReport(pos, msg, severity)
+        override def doReport(pos: Position, msg: String, severity: Severity, actions: List[CodeAction]): Unit =
+          reporter.doReport(pos, msg, severity, actions)
       }
     }
 
@@ -213,7 +214,7 @@ class ConsoleReporterTest {
   def filteredInfoTest(): Unit = {
     val reporter = new FilteringReporter {
       val settings: Settings = new Settings
-      def doReport(pos: Position, msg: String, severity: Severity): Unit = ()
+      override def doReport(pos: Position, msg: String, severity: Severity, actions: List[CodeAction]): Unit = ()
     }
     // test obsolete API, make sure it doesn't throw
     reporter.info(NoPosition, "goodbye, cruel world", force = false)
@@ -224,7 +225,8 @@ class ConsoleReporterTest {
     val reporter = createConsoleReporter("r", writerOut)
     val adapted  = new FilteringReporter {
       def settings: Settings = reporter.settings
-      def doReport(pos: Position, msg: String, severity: Severity): Unit = reporter.doReport(pos, msg, severity)
+      override def doReport(pos: Position, msg: String, severity: Severity, actions: List[CodeAction]): Unit =
+        reporter.doReport(pos, msg, severity, actions)
     }
 
     // pass one message

--- a/test/junit/scala/tools/nsc/reporters/PositionFilterTest.scala
+++ b/test/junit/scala/tools/nsc/reporters/PositionFilterTest.scala
@@ -19,7 +19,8 @@ class PositionFilterTest {
 
   def createFilter: FilteringReporter = new FilteringReporter {
     def settings: Settings = store.settings
-    def doReport(pos: Position, msg: String, severity: Severity): Unit = store.doReport(pos, msg, severity)
+    override def doReport(pos: Position, msg: String, severity: Severity, actions: List[CodeAction]): Unit =
+      store.doReport(pos, msg, severity, actions)
   }
 
   @Test

--- a/test/junit/scala/tools/nsc/reporters/WConfTest.scala
+++ b/test/junit/scala/tools/nsc/reporters/WConfTest.scala
@@ -338,7 +338,8 @@ class WConfTest extends BytecodeTesting {
       }, Array().toIndexedSeq), 0),
       msg = "",
       WarningCategory.Other,
-      site = "")
+      site = "",
+      actions = Nil)
 
     val aTest = Reporting.WConf.parseFilter("src=a/.*Test.scala", rootDir = "").getOrElse(null)
     assertTrue(aTest.matches(m("/a/FooTest.scala")))

--- a/test/junit/scala/tools/nsc/symtab/SymbolTableForUnitTesting.scala
+++ b/test/junit/scala/tools/nsc/symtab/SymbolTableForUnitTesting.scala
@@ -1,9 +1,10 @@
 package scala.tools.nsc
 package symtab
 
+import scala.annotation.nowarn
 import scala.reflect.ClassTag
 import scala.reflect.internal.{NoPhase, Phase, Reporter, SomePhase}
-import scala.reflect.internal.util.Statistics
+import scala.reflect.internal.util.{CodeAction, Statistics}
 import scala.tools.util.PathResolver
 import util.ClassPath
 import io.AbstractFile
@@ -85,13 +86,14 @@ class SymbolTableForUnitTesting extends SymbolTable {
 
   // Members declared in scala.reflect.internal.Reporting
   def reporter = new Reporter {
+    @nowarn("msg=overriding method info0")
     protected def info0(pos: Position, msg: String, severity: Severity, force: Boolean): Unit = println(msg)
   }
 
   // minimal Run to get Reporting wired
   def currentRun = new RunReporting {}
   class PerRunReporting extends PerRunReportingBase {
-    def deprecationWarning(pos: Position, msg: String, since: String, site: String, origin: String): Unit = reporter.warning(pos, msg)
+    def deprecationWarning(pos: Position, msg: String, since: String, site: String, origin: String, actions: List[CodeAction]): Unit = reporter.warning(pos, msg)
   }
   protected def PerRunReporting = new PerRunReporting
 


### PR DESCRIPTION
Ref https://contributors.scala-lang.org/t/roadmap-for-actionable-diagnostics/6172
Fixes https://github.com/scala/scala-dev/issues/844

This implements new reporter methods that take code actions as a parameter.
The purpose is to pass these along to Zinc and BSP so that the compiler can suggest code edits to the editors in a structural manner.

To show case this feature, I've added `CodeAction`s to the following deprecations:
- Deprecation of procedure syntax
- Deprecation of empty-paren method auto-application
- Deprecation of `val` in for-comprehension
- Deprecation of paren-less lambda parameter

## Note

Here's the flow of information

```
┌──────┐doReport┌────────┐
│scalac├───────►│compiler│
└──────┘        │bridge  │
                └──┬─────┘
                   │  xsbti.Problem
┌──────────┐     ┌─▼──┐
│BSP server│◄────┤Zinc│
└──┬───────┘     └────┘
   │  Diagnostic
┌──▼───────────────┐
│BSP client        │
│(Metals, IntelliJ)│
└──┬───────────────┘
   │  Diagnostic
┌──▼───────┐
│LSP Client│
└──────────┘
```

