### PR TITLE
docs: add in a note about elidable not being supported in Scala 3

### DIFF
--- a/src/library/scala/annotation/elidable.scala
+++ b/src/library/scala/annotation/elidable.scala
@@ -75,6 +75,29 @@ package scala.annotation
  *     (O: C).f() // elided if compiled with `-Xelide-below 1`
  *   }
  * }}}
+ *
+ * Note for Scala 3 users:
+ * If you're using Scala 3, the annotation exists since Scala 3 uses the Scala 2
+ * standard library, but it's unsupported by the Scala 3 compiler. Instead, to
+ * achieve the same result you'd want to utilize the `inline if` feature to
+ * introduce behavior that makes a method de facto elided at compile-time.
+ * {{{
+ *    type LogLevel = Int
+ *    
+ *    object LogLevel:
+ *      inline val Info = 0
+ *      inline val Warn = 1
+ *      inline val Debug = 2
+ *    
+ *    inline val appLogLevel = LogLevel.Warn
+ *    
+ *    inline def log(msg: String, inline level: LogLevel): Unit = 
+ *      inline if (level <= appLogLevel) then println(msg)
+ *    
+ *    log("Warn log", LogLevel.Warn)
+ *    
+ *    log("Debug log", LogLevel. Debug)
+ * }}}
  */
 final class elidable(final val level: Int) extends scala.annotation.ConstantAnnotation
 


### PR DESCRIPTION
This is a follow-up of the comment in
https://github.com/lampepfl/dotty/issues/15766#issuecomment-1492846839
to try and make it clear to Scala 3 users that while this API exists and
is visible in Scala 3, it's not supported by the actual compiler.
Therefore it's recommended to instead use the `inline if` alternative.
This just adds a note to the Scaladoc to that effect.

refs: https://github.com/lampepfl/dotty/issues/15766
