### PR TITLE
Scala 3.3.1-RC1 (enable TastyTest on JDK 21)

### DIFF
--- a/project/DottySupport.scala
+++ b/project/DottySupport.scala
@@ -12,7 +12,7 @@ import sbt.librarymanagement.{
   * Settings to support validation of TastyUnpickler against the release of dotty with the matching TASTy version
   */
 object TastySupport {
-  val supportedTASTyRelease = "3.3.0" // TASTy version 28.4-1
+  val supportedTASTyRelease = "3.3.1-RC1" // TASTy version 28.4-1
   val scala3Compiler = "org.scala-lang" % "scala3-compiler_3" % supportedTASTyRelease
   val scala3Library = "org.scala-lang" % "scala3-library_3" % supportedTASTyRelease
 
@@ -26,7 +26,7 @@ object TastySupport {
  *  Dotty in .travis.yml.
  */
 object DottySupport {
-  val dottyVersion = "3.3.0"
+  val dottyVersion = "3.3.1-RC1"
   val compileWithDotty: Boolean =
     Option(System.getProperty("scala.build.compileWithDotty")).exists(_.toBoolean)
   lazy val commonSettings = Seq(

--- a/test/tasty/neg/src-2/TestErasedTypes.check
+++ b/test/tasty/neg/src-2/TestErasedTypes.check
@@ -1,9 +1,3 @@
-TestErasedTypes_fail.scala:6: error: Unsupported Scala 3 erased modifier in refinement of type F; found in class tastytest.ErasedTypes.Bar.
-  def test1 = new Bar[Foo]
-                  ^
-TestErasedTypes_fail.scala:7: error: Unsupported Scala 3 erased modifier in refinement of type F; found in class tastytest.ErasedTypes.Baz.
-  def test2 = new Baz[Foo]
-                  ^
 TestErasedTypes_fail.scala:9: error: Unsupported Scala 3 erased value x; found in method foo1 in trait tastytest.ErasedTypes.Foo.
   def test3(f: Foo) = f.foo1("foo")
                         ^
@@ -13,4 +7,4 @@ TestErasedTypes_fail.scala:10: error: Unsupported Scala 3 erased value x; found 
 TestErasedTypes_fail.scala:12: error: Unsupported Scala 3 erased method theString; found in object tastytest.ErasedTypes.ErasedCompileTimeOps.
   def test5 = ErasedCompileTimeOps.theString
                                    ^
-5 errors
+3 errors

--- a/test/tasty/neg/src-2/TestSaferExceptions.check
+++ b/test/tasty/neg/src-2/TestSaferExceptions.check
@@ -1,4 +1,4 @@
-TestSaferExceptions_fail.scala:5: error: Unsupported Scala 3 erased context function type in bounds of type mayThrow: erased tastytest.SaferExceptions.CanThrowCapability[E] ?=> A; found in object tastytest.SaferExceptions.
+TestSaferExceptions_fail.scala:5: error: Unsupported Scala 3 erased value x$1; found in method apply in  tastytest.SaferExceptions.<refinement>.
   def test = SaferExceptions.safeDiv(1, 0) // error
                              ^
 1 error

--- a/test/tasty/test/scala/tools/tastytest/TastyTestJUnit.scala
+++ b/test/tasty/test/scala/tools/tastytest/TastyTestJUnit.scala
@@ -92,8 +92,6 @@ object TastyTestJUnit {
 
   @setup
   def init(): Unit = {
-    // TODO remove once Scala 3 has a fix for scala/bug#12783
-    assumeFalse(scala.util.Properties.isJavaAtLeast("21"))
     _dottyClassLoader = Dotc.initClassloader().get
   }
 


### PR DESCRIPTION
this should work on JDK 21 now that lampepfl/dotty#17536 has been merged?