### PR TITLE
Tweak inliner error message

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BackendReporting.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BackendReporting.scala
@@ -191,12 +191,14 @@ object BackendReporting {
             s"\nthat would cause an IllegalAccessError when inlined into class $callsiteClass."
 
         case IllegalAccessCheckFailed(_, _, _, _, callsiteClass, instruction, cause) =>
-          s"Failed to check if $calleeMethodSig can be safely inlined to $callsiteClass without causing an IllegalAccessError. Checking instruction ${AsmUtils.textify(instruction)} failed:\n" + cause
+          sm"""|Failed to check if $calleeMethodSig can be safely inlined to $callsiteClass without causing an IllegalAccessError.
+               |Checking failed for instruction ${AsmUtils.textify(instruction)}:
+               |$cause"""
 
         case MethodWithHandlerCalledOnNonEmptyStack(_, _, _, _, callsiteClass, callsiteName, callsiteDesc) =>
-          s"""The operand stack at the callsite in ${BackendReporting.methodSignature(callsiteClass, callsiteName, callsiteDesc)} contains more values than the
-             |arguments expected by the callee $calleeMethodSig. These values would be discarded
-             |when entering an exception handler declared in the inlined method.""".stripMargin
+          sm"""|The operand stack at the callsite in ${BackendReporting.methodSignature(callsiteClass, callsiteName, callsiteDesc)} contains more values than the
+               |arguments expected by the callee $calleeMethodSig. These values would be discarded
+               |when entering an exception handler declared in the inlined method."""
 
         case SynchronizedMethod(_, _, _, _) =>
           s"Method $calleeMethodSig cannot be inlined because it is synchronized."

--- a/test/files/run/noInlineUnknownIndy.check
+++ b/test/files/run/noInlineUnknownIndy.check
@@ -1,5 +1,6 @@
 newSource1.scala:1: warning: A_1::test()Ljava/lang/String; could not be inlined:
-Failed to check if A_1::test()Ljava/lang/String; can be safely inlined to T without causing an IllegalAccessError. Checking instruction INVOKEDYNAMIC m()LA_1$Fun; [
+Failed to check if A_1::test()Ljava/lang/String; can be safely inlined to T without causing an IllegalAccessError.
+Checking failed for instruction INVOKEDYNAMIC m()LA_1$Fun; [
       // handle kind 0x6 : INVOKESTATIC
       not/java/lang/SomeLambdaMetafactory.notAMetaFactoryMethod(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;[Ljava/lang/Object;)Ljava/lang/invoke/CallSite;
       // arguments:
@@ -7,7 +8,7 @@ Failed to check if A_1::test()Ljava/lang/String; can be safely inlined to T with
       // handle kind 0x6 : INVOKESTATIC
       A_1.lambda$test$0(Ljava/lang/String;)Ljava/lang/String;,
       (Ljava/lang/String;)Ljava/lang/String;
-    ] failed:
+    ]:
 The callee contains an InvokeDynamic instruction with an unknown bootstrap method (not a LambdaMetaFactory).
 class T { def foo = A_1.test }
                         ^

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlinerTest.scala
@@ -398,27 +398,28 @@ class InlinerTest extends BytecodeTesting {
     // A, so `flop` cannot be inlined, we cannot check if it's safe.
 
     val javaCode =
-      """public class A {
-        |  public static final int bar() { return 100; }
-        |}
-      """.stripMargin
+      sm"""|public class A {
+           |  public static final int bar() { return 100; }
+           |}
+        """
 
     val scalaCode =
-      """class B {
-        |  @inline final def flop = A.bar
-        |  def g = flop
-        |}
-      """.stripMargin
+      sm"""|class B {
+           |  @inline final def flop = A.bar
+           |  def g = flop
+           |}
+        """
 
     val warn =
-      """B::flop()I is annotated @inline but could not be inlined:
-        |Failed to check if B::flop()I can be safely inlined to B without causing an IllegalAccessError. Checking instruction INVOKESTATIC A.bar ()I failed:
-        |The method bar()I could not be found in the class A or any of its parents.
-        |Note that class A is defined in a Java source (mixed compilation), no bytecode is available.""".stripMargin
+      sm"""|B::flop()I is annotated @inline but could not be inlined:
+           |Failed to check if B::flop()I can be safely inlined to B without causing an IllegalAccessError.
+           |Checking failed for instruction INVOKESTATIC A.bar ()I:
+           |The method bar()I could not be found in the class A or any of its parents.
+           |Note that class A is defined in a Java source (mixed compilation), no bytecode is available."""
 
     var c = 0
-    val b = compileClass(scalaCode, List((javaCode, "A.java")), allowMessage = i => {c += 1; i.msg contains warn})
-    assert(c == 1, c)
+    val b = compileClass(scalaCode, List(javaCode -> "A.java"), allowMessage = i => { c += 1; i.msg.contains(warn) })
+    assertEquals(1, c)
     val ins = getInstructions(b, "g")
     val invokeFlop = Invoke(INVOKEVIRTUAL, "B", "flop", "()I", false)
     assert(ins contains invokeFlop, ins.stringLines)


### PR DESCRIPTION
Add line break, and move the word "failed" to top of message.

was:
```
Failed to check if A_1::test()Ljava/lang/String; can be safely inlined to T without causing an IllegalAccessError. Checking instruction INVOKEDYNAMIC m()LA_1$Fun; [
```
now:
```
Failed to check if A_1::test()Ljava/lang/String; can be safely inlined to T without causing an IllegalAccessError.
Checking failed for instruction INVOKEDYNAMIC m()LA_1$Fun; [
```

Extracted from https://github.com/scala/scala/pull/10404