### PR TITLE
Print verbose symbol output with syntax trees

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1476,13 +1476,14 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
       val global: Global.this.type = Global.this
       lazy val trackers = currentRun.units.toList map (x => SymbolTracker(x))
       def snapshot() = {
-        inform("\n[[symbol layout at end of " + phase + "]]")
+        println(s"\n[[symbol layout at end of $phase]]")
         exitingPhase(phase) {
           trackers foreach { t =>
             t.snapshot()
-            inform(t.show("Heading from " + phase.prev.name + " to " + phase.name))
+            println(t.show(s"Heading from ${phase.prev.name} to ${phase.name}"))
           }
         }
+        println()
       }
     }
 


### PR DESCRIPTION
The difference is that when running `partest`, symbol output is currently captured by the log, unlike output of `-Vprint`.

No tests rely on comparing symbol output via check file.

By printing, `partest` behaves like normal compilation where debug output is printed together.

Or maybe the right fix is that printlns should be converted to inform?

Is there a difference between a diagnostic about my code and a diagnostic about how the compiler transforms my code?