### PR TITLE
Fix ListBuffer.insertAfter, used in patchInPlace

### DIFF
--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -46,7 +46,7 @@ class ListBuffer[A]
   @transient private[this] var mutationCount: Int = 0
 
   private var first: List[A] = Nil
-  private var last0: ::[A] = null
+  private var last0: ::[A] = null // last element (`last0` just because the name `last` is already taken)
   private[this] var aliased = false
   private[this] var len = 0
 
@@ -244,6 +244,7 @@ class ListBuffer[A]
       val follow = getNext(prev)
       if (prev eq null) first = fresh.first else prev.next = fresh.first
       fresh.last0.next = follow
+      if (follow.isEmpty) last0 = fresh.last0
       len += fresh.length
     }
   }

--- a/test/junit/scala/collection/mutable/ListBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ListBufferTest.scala
@@ -323,4 +323,19 @@ class ListBufferTest {
     test(ArrayBuffer[String]())
     test(ListBuffer[String]())
   }
+
+  @Test
+  def t12796(): Unit = {
+    val b = ListBuffer(1).patchInPlace(1, List(2), 1)
+    assertEquals(2, b.last)
+    assertEquals(List(1, 2), b.toList)
+  }
+
+  @Test
+  def t12796b(): Unit = {
+    val b = ListBuffer(1, 2)
+    b.insertAll(2, List(3))
+    assertEquals(3, b.last)
+    assertEquals(List(1, 2, 3), b.toList)
+  }
 }


### PR DESCRIPTION
If the new elements are added to the end, `last0` needs to be updated.

`insertAfter` is used in `patchInPlace` and `insertAll`, but the bug didn't manifest for `insertAll` because it delegates to `addAll` when adding to the end.

Fixes https://github.com/scala/bug/issues/12796