### PR TITLE
refactor: allow -Xfatal-warnings to be turned off in metabuild

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,14 @@
-scalacOptions ++= Seq("-unchecked", "-feature", "-deprecation",
-  "-Xlint:-unused,_", "-Xfatal-warnings")
+lazy val baseOptions = Seq(
+  "-unchecked", "-feature", "-deprecation", "-Xlint:-unused,_"
+)
+
+scalacOptions ++= {
+  if (Option(System.getProperty("scala.build.compileWithDotty")).exists(_.toBoolean)) {
+    baseOptions
+  } else {
+    baseOptions :+ "-Xfatal-warnings"
+  }
+}
 
 libraryDependencies += "org.apache.commons" % "commons-lang3" % "3.12.0"
 


### PR DESCRIPTION
I'm just throwing this up here to start a discussion. In Dotty I'm am in
the process of updating to sbt 1.9.0, which deprecates
`IntegrationTest`. Normally it's not an issue as we just use:

```
set Global / fatalWarnings := false
```

To turn them off, but since `ScriptCommands` references
`IntegrationTest` and `-Xfatal-warnings` are turned on in the metabuild,
it fails here. I see there is `DottySupport.compileWithDotty`, but I
don't believe we can use that in this file, so I instead just carried
over the actual check and hacked this in. Again, creating this just to
start a discussion about how to handle this? Do you have any good ideas
about how to easily get `-Xfatal-warnings` turned off for the metabuild?
I want to avoid editing the build in dotty-staging just for this.


For context:

- https://github.com/lampepfl/dotty/pull/17561 (where I'm working on this)
- https://github.com/lampepfl/dotty/pull/17913 (updating Dotty to actually use a direct fork of scala/scala)
