### PR TITLE
Define equality between converter wrappers

### DIFF
--- a/src/library/scala/collection/convert/JavaCollectionWrappers.scala
+++ b/src/library/scala/collection/convert/JavaCollectionWrappers.scala
@@ -34,18 +34,33 @@ private[collection] object JavaCollectionWrappers extends Serializable {
     def hasMoreElements = underlying.hasNext
     def nextElement() = underlying.next()
     override def remove() = throw new UnsupportedOperationException
+    override def equals(other: Any): Boolean = other match {
+      case that: IteratorWrapper[_] => this.underlying == that.underlying
+      case _ => false
+    }
+    override def hashCode: Int = underlying.hashCode()
   }
 
   @SerialVersionUID(3L)
   class JIteratorWrapper[A](val underlying: ju.Iterator[A]) extends AbstractIterator[A] with Iterator[A] with Serializable {
     def hasNext = underlying.hasNext
     def next() = underlying.next
+    override def equals(other: Any): Boolean = other match {
+      case that: JIteratorWrapper[_] => this.underlying == that.underlying
+      case _ => false
+    }
+    override def hashCode: Int = underlying.hashCode()
   }
 
   @SerialVersionUID(3L)
   class JEnumerationWrapper[A](val underlying: ju.Enumeration[A]) extends AbstractIterator[A] with Iterator[A] with Serializable {
     def hasNext = underlying.hasMoreElements
     def next() = underlying.nextElement
+    override def equals(other: Any): Boolean = other match {
+      case that: JEnumerationWrapper[_] => this.underlying == that.underlying
+      case _ => false
+    }
+    override def hashCode: Int = underlying.hashCode()
   }
 
   trait IterableWrapperTrait[A] extends ju.AbstractCollection[A] {
@@ -57,13 +72,11 @@ private[collection] object JavaCollectionWrappers extends Serializable {
 
   @SerialVersionUID(3L)
   class IterableWrapper[A](val underlying: Iterable[A]) extends ju.AbstractCollection[A] with IterableWrapperTrait[A] with Serializable {
-    import scala.runtime.Statics._
-    override def equals(other: Any): Boolean =
-      other match {
-        case other: IterableWrapper[_] => underlying.equals(other.underlying)
-        case _ => false
-      }
-    override def hashCode = finalizeHash(mix(mix(0xcafebabe, "IterableWrapper".hashCode), anyHash(underlying)), 1)
+    override def equals(other: Any): Boolean = other match {
+      case that: IterableWrapper[_] => this.underlying == that.underlying
+      case _ => false
+    }
+    override def hashCode: Int = underlying.hashCode()
   }
 
   @SerialVersionUID(3L)
@@ -74,6 +87,11 @@ private[collection] object JavaCollectionWrappers extends Serializable {
     def iterator = underlying.iterator.asScala
     override def iterableFactory = mutable.ArrayBuffer
     override def isEmpty: Boolean = !underlying.iterator().hasNext
+    override def equals(other: Any): Boolean = other match {
+      case that: JIterableWrapper[_] => this.underlying == that.underlying
+      case _ => false
+    }
+    override def hashCode: Int = underlying.hashCode()
   }
 
   @SerialVersionUID(3L)
@@ -86,6 +104,11 @@ private[collection] object JavaCollectionWrappers extends Serializable {
     override def knownSize: Int = if (underlying.isEmpty) 0 else super.knownSize
     override def isEmpty = underlying.isEmpty
     override def iterableFactory = mutable.ArrayBuffer
+    override def equals(other: Any): Boolean = other match {
+      case that: JCollectionWrapper[_] => this.underlying == that.underlying
+      case _ => false
+    }
+    override def hashCode: Int = underlying.hashCode()
   }
 
   @SerialVersionUID(3L)
@@ -254,7 +277,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
             def getKey = k
             def getValue = v
             def setValue(v1 : V) = self.put(k, v1)
-            
+
             // It's important that this implementation conform to the contract
             // specified in the javadocs of java.util.Map.Entry.hashCode
             //

--- a/src/library/scala/collection/convert/JavaCollectionWrappers.scala
+++ b/src/library/scala/collection/convert/JavaCollectionWrappers.scala
@@ -552,6 +552,13 @@ private[collection] object JavaCollectionWrappers extends Serializable {
     } catch {
       case ex: ClassCastException => null.asInstanceOf[V]
     }
+
+    override def equals(other: Any): Boolean = other match {
+      case that: DictionaryWrapper[_, _] => this.underlying == that.underlying
+      case _ => false
+    }
+
+    override def hashCode: Int = underlying.hashCode()
   }
 
   @SerialVersionUID(3L)

--- a/test/junit/scala/collection/convert/CollectionConvertersTest.scala
+++ b/test/junit/scala/collection/convert/CollectionConvertersTest.scala
@@ -14,14 +14,9 @@ package scala.collection.convert
 
 import java.util.{
   Dictionary,
-  Collections,
-  Collection => JCollection,
   HashMap    => JMap,
   Hashtable  => JTable,
   Properties => JProperties,
-}
-import java.lang.{
-  Iterable => JIterable
 }
 import java.util.concurrent.{
   ConcurrentHashMap => JCMap,
@@ -30,8 +25,6 @@ import java.util.concurrent.{
 import org.junit.Assert.{assertEquals, assertNull, assertTrue}
 import org.junit.Test
 
-import scala.collection.mutable
-import scala.collection.concurrent
 import scala.jdk.CollectionConverters._
 import scala.tools.testkit.AssertUtil.assertThrows
 
@@ -83,75 +76,5 @@ class CollectionConvertersTest {
     val sut = new JCMap[String, String].asScala
     assertTrue(sut.isInstanceOf[JavaCollectionWrappers.JConcurrentMapWrapper[_, _]])
     assertThrows[NullPointerException](sut.put("any", null))
-  }
-
-  @Test def `All wrapper respect equals`(): Unit = {
-    val thisJList = Collections.emptyList[String]()
-    val thatJList = Collections.emptyList[String]()
-    assertEquals(thisJList.asScala, thatJList.asScala)
-
-    val thisJIterator = thisJList.iterator()
-    val thatJIterator = thatJList.iterator()
-    assertEquals(thisJIterator.asScala, thatJIterator.asScala)
-
-    val thisJEnumeration = Collections.emptyEnumeration[String]()
-    val thatJEnumeration = Collections.emptyEnumeration[String]()
-    assertEquals(thisJEnumeration.asScala, thatJEnumeration.asScala)
-
-    val thisJIterable = thisJList.asInstanceOf[JIterable[String]]
-    val thatJIterable = thatJList.asInstanceOf[JIterable[String]]
-    assertEquals(thisJIterable.asScala, thatJIterable.asScala)
-
-    val thisJCollection = thisJList.asInstanceOf[JCollection[String]]
-    val thatJCollection = thatJList.asInstanceOf[JCollection[String]]
-    assertEquals(thisJCollection.asScala, thatJCollection.asScala)
-
-    val thisJSet = Collections.emptySet[String]()
-    val thatJSet = Collections.emptySet[String]()
-    assertEquals(thisJSet.asScala, thatJSet.asScala)
-
-    val thisJMap = Collections.emptyMap[String, String]()
-    val thatJMap = Collections.emptyMap[String, String]()
-    assertEquals(thisJMap.asScala, thatJMap.asScala)
-
-    val thisJCMap = new JCMap[String, String]()
-    val thatJCMap = new JCMap[String, String]()
-    assertEquals(thisJCMap.asScala, thatJCMap.asScala)
-
-    val thisIterator = Iterator.empty[String]
-    val thatIterator = Iterator.empty[String]
-    assertEquals(thisIterator.asJava, thatIterator.asJava)
-
-    val thisIterable = Iterable.empty[String]
-    val thatIterable = Iterable.empty[String]
-    assertEquals(thisIterable.asJava, thatIterable.asJava)
-
-    val thisBuffer = mutable.Buffer.empty[String]
-    val thatBuffer = mutable.Buffer.empty[String]
-    assertEquals(thisBuffer.asJava, thatBuffer.asJava)
-
-    val thisSeq = mutable.Seq.empty[String]
-    val thatSeq = mutable.Seq.empty[String]
-    assertEquals(thisSeq.asJava, thatSeq.asJava)
-
-    val thisMutableSet = mutable.Set.empty[String]
-    val thatMutableSet = mutable.Set.empty[String]
-    assertEquals(thisMutableSet.asJava, thatMutableSet.asJava)
-
-    val thisSet = Set.empty[String]
-    val thatSet = Set.empty[String]
-    assertEquals(thisSet.asJava, thatSet.asJava)
-
-    val thisMutableMap = mutable.Map.empty[String, String]
-    val thatMutableMap = mutable.Map.empty[String, String]
-    assertEquals(thisMutableMap.asJava, thatMutableMap.asJava)
-
-    val thisMap = Map.empty[String, String]
-    val thatMap = Map.empty[String, String]
-    assertEquals(thisMap.asJava, thatMap.asJava)
-
-    val thisConcurrentMap = concurrent.TrieMap.empty[String, String]
-    val thatConcurrentMap = concurrent.TrieMap.empty[String, String]
-    assertEquals(thisConcurrentMap.asJava, thatConcurrentMap.asJava)
   }
 }

--- a/test/junit/scala/collection/convert/CollectionConvertersTest.scala
+++ b/test/junit/scala/collection/convert/CollectionConvertersTest.scala
@@ -14,9 +14,14 @@ package scala.collection.convert
 
 import java.util.{
   Dictionary,
+  Collections,
+  Collection => JCollection,
   HashMap    => JMap,
   Hashtable  => JTable,
   Properties => JProperties,
+}
+import java.lang.{
+  Iterable => JIterable
 }
 import java.util.concurrent.{
   ConcurrentHashMap => JCMap,
@@ -25,6 +30,8 @@ import java.util.concurrent.{
 import org.junit.Assert.{assertEquals, assertNull, assertTrue}
 import org.junit.Test
 
+import scala.collection.mutable
+import scala.collection.concurrent
 import scala.jdk.CollectionConverters._
 import scala.tools.testkit.AssertUtil.assertThrows
 
@@ -76,5 +83,75 @@ class CollectionConvertersTest {
     val sut = new JCMap[String, String].asScala
     assertTrue(sut.isInstanceOf[JavaCollectionWrappers.JConcurrentMapWrapper[_, _]])
     assertThrows[NullPointerException](sut.put("any", null))
+  }
+
+  @Test def `All wrapper respect equals`(): Unit = {
+    val thisJList = Collections.emptyList[String]()
+    val thatJList = Collections.emptyList[String]()
+    assertEquals(thisJList.asScala, thatJList.asScala)
+
+    val thisJIterator = thisJList.iterator()
+    val thatJIterator = thatJList.iterator()
+    assertEquals(thisJIterator.asScala, thatJIterator.asScala)
+
+    val thisJEnumeration = Collections.emptyEnumeration[String]()
+    val thatJEnumeration = Collections.emptyEnumeration[String]()
+    assertEquals(thisJEnumeration.asScala, thatJEnumeration.asScala)
+
+    val thisJIterable = thisJList.asInstanceOf[JIterable[String]]
+    val thatJIterable = thatJList.asInstanceOf[JIterable[String]]
+    assertEquals(thisJIterable.asScala, thatJIterable.asScala)
+
+    val thisJCollection = thisJList.asInstanceOf[JCollection[String]]
+    val thatJCollection = thatJList.asInstanceOf[JCollection[String]]
+    assertEquals(thisJCollection.asScala, thatJCollection.asScala)
+
+    val thisJSet = Collections.emptySet[String]()
+    val thatJSet = Collections.emptySet[String]()
+    assertEquals(thisJSet.asScala, thatJSet.asScala)
+
+    val thisJMap = Collections.emptyMap[String, String]()
+    val thatJMap = Collections.emptyMap[String, String]()
+    assertEquals(thisJMap.asScala, thatJMap.asScala)
+
+    val thisJCMap = new JCMap[String, String]()
+    val thatJCMap = new JCMap[String, String]()
+    assertEquals(thisJCMap.asScala, thatJCMap.asScala)
+
+    val thisIterator = Iterator.empty[String]
+    val thatIterator = Iterator.empty[String]
+    assertEquals(thisIterator.asJava, thatIterator.asJava)
+
+    val thisIterable = Iterable.empty[String]
+    val thatIterable = Iterable.empty[String]
+    assertEquals(thisIterable.asJava, thatIterable.asJava)
+
+    val thisBuffer = mutable.Buffer.empty[String]
+    val thatBuffer = mutable.Buffer.empty[String]
+    assertEquals(thisBuffer.asJava, thatBuffer.asJava)
+
+    val thisSeq = mutable.Seq.empty[String]
+    val thatSeq = mutable.Seq.empty[String]
+    assertEquals(thisSeq.asJava, thatSeq.asJava)
+
+    val thisMutableSet = mutable.Set.empty[String]
+    val thatMutableSet = mutable.Set.empty[String]
+    assertEquals(thisMutableSet.asJava, thatMutableSet.asJava)
+
+    val thisSet = Set.empty[String]
+    val thatSet = Set.empty[String]
+    assertEquals(thisSet.asJava, thatSet.asJava)
+
+    val thisMutableMap = mutable.Map.empty[String, String]
+    val thatMutableMap = mutable.Map.empty[String, String]
+    assertEquals(thisMutableMap.asJava, thatMutableMap.asJava)
+
+    val thisMap = Map.empty[String, String]
+    val thatMap = Map.empty[String, String]
+    assertEquals(thisMap.asJava, thatMap.asJava)
+
+    val thisConcurrentMap = concurrent.TrieMap.empty[String, String]
+    val thatConcurrentMap = concurrent.TrieMap.empty[String, String]
+    assertEquals(thisConcurrentMap.asJava, thatConcurrentMap.asJava)
   }
 }

--- a/test/junit/scala/collection/convert/EqualsTest.scala
+++ b/test/junit/scala/collection/convert/EqualsTest.scala
@@ -135,9 +135,11 @@ class EqualsTest {
 
     val iterator = Iterator.empty[String]
     assertEquals(iterator.asJava, iterator.asJava)
+    assertEquals(iterator.asJavaEnumeration, iterator.asJavaEnumeration)
 
     val iterable = Iterable.empty[String]
     assertEquals(iterable.asJava, iterable.asJava)
+    assertEquals(iterable.asJavaCollection, iterable.asJavaCollection)
 
     val buffer = mutable.Buffer.empty[String]
     assertEquals(buffer.asJava, buffer.asJava)
@@ -153,6 +155,7 @@ class EqualsTest {
 
     val mutableMap = mutable.Map.empty[String, String]
     assertEquals(mutableMap.asJava, mutableMap.asJava)
+    assertEquals(mutableMap.asJavaDictionary, mutableMap.asJavaDictionary)
 
     val map = Map.empty[String, String]
     assertEquals(map.asJava, map.asJava)


### PR DESCRIPTION
When converter destination collection does not have equality defined, we should override equals/hashcode. 2 wrappers with same underlying collection should be equal.

Follow-up for https://github.com/scala/bug/issues/12683