### PR TITLE
onceop annotation and linter

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -39,6 +39,7 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.concurrent.impl.FutureConvertersImpl#P.accept"),
     ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.concurrent.impl.FutureConvertersImpl#P.andThen"),
 
+    ProblemFilters.exclude[MissingClassProblem]("scala.annotation.onceop*"),
   )
 
   override val buildSettings = Seq(

--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -411,6 +411,7 @@ object Reporting {
     object LintIntDivToFloat extends Lint; add(LintIntDivToFloat)
     object LintUniversalMethods extends Lint; add(LintUniversalMethods)
     object LintNumericMethods extends Lint; add(LintNumericMethods)
+    object LintOnceOp extends Lint; add(LintOnceOp)
 
     sealed trait Feature extends WarningCategory { override def summaryCategory: WarningCategory = Feature }
     object Feature extends Feature { override def includes(o: WarningCategory): Boolean = o.isInstanceOf[Feature] }; add(Feature)

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5338,11 +5338,12 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           }
 
           def checkOnceOp(result: Tree): Unit =
-            if (!isPastTyper && (qual.symbol ne NoSymbol) && sym.isOnceOp) {
+            if (!isPastTyper && (qual.symbol ne null) && (qual.symbol ne NoSymbol) && (qual.symbol.isStable)) {
               val qualSym = qual.symbol
-              val group = sym.onceopGroup.getOrElse("default")
-              def msg = s"multiple calls to a once-op is unsafe for the same instance ${qualSym} and the once-op group '$group'"
-              if ((qualSym ne null) && qualSym.isStable) {
+              def msg = s"call to an affine reference ${qualSym} is unsafe after a once-op has been called"
+              val group = sym.onceopGroup.getOrElse("all")
+              if (context.scope.hasTerminalSym(qualSym, "all")) context.warning(tree.pos, msg, WarningCategory.LintOnceOp)
+              else if (sym.isOnceOp) {
                 if (context.scope.hasTerminalSym(qualSym, group)) context.warning(tree.pos, msg, WarningCategory.LintOnceOp)
                 else context.scope.addTerminalSym(qualSym, group)
               }

--- a/src/library/scala/annotation/onceop.scala
+++ b/src/library/scala/annotation/onceop.scala
@@ -18,17 +18,17 @@ import scala.annotation.meta._
   * only once on a value:
   *
   * {{{
-  *   @onceop(group = "") def delete(): Unit = {}
-  *   @onceop(group = "") def deleteDir(): Unit = {}
+  *   @onceop(group = "all") def delete(): Unit = {}
+  *   @onceop(group = "all") def deleteDir(): Unit = {}
   *
   *   def bar = { delete(); deleteDir() } // show once-op warning
   * }}}
   *
   * Note that once-op invocations are grouped by the receiver
-  * and the once-op group of the method, which defaults to `"default"`.
+  * and the once-op group of the method, which defaults to `"all"`.
   * This means that in the above example, the call to `deleteDir()`
   * is considered to violated the once-op because both `delete`
-  * and `deleteDir` methods are on the default group.
+  * and `deleteDir` methods are on the `"all"` group.
   */
 @getter @setter @beanGetter @beanSetter
-final class onceop(group: String = "default") extends StaticAnnotation
+final class onceop(group: String = "all") extends StaticAnnotation

--- a/src/library/scala/annotation/onceop.scala
+++ b/src/library/scala/annotation/onceop.scala
@@ -1,0 +1,34 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.annotation
+
+import scala.annotation.meta._
+
+/** An annotation for once-ops, an operation that can be performed
+  * only once on a value:
+  *
+  * {{{
+  *   @onceop(group = "") def delete(): Unit = {}
+  *   @onceop(group = "") def deleteDir(): Unit = {}
+  *
+  *   def bar = { delete(); deleteDir() } // show once-op warning
+  * }}}
+  *
+  * Note that once-op invocations are grouped by the receiver
+  * and the once-op group of the method, which defaults to `"default"`.
+  * This means that in the above example, the call to `deleteDir()`
+  * is considered to violated the once-op because both `delete`
+  * and `deleteDir` methods are on the default group.
+  */
+@getter @setter @beanGetter @beanSetter
+final class onceop(group: String = "default") extends StaticAnnotation

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -475,6 +475,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
 
   @inline final def length: Int = size
 
+  @onceop
   @deprecatedOverriding("isEmpty is defined as !hasNext; override hasNext instead", "2.13.0")
   override def isEmpty: Boolean = !hasNext
 

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -13,6 +13,7 @@
 package scala.collection
 
 import scala.collection.mutable.{ArrayBuffer, ArrayBuilder, Builder, ImmutableBuilder}
+import scala.annotation.onceop
 import scala.annotation.tailrec
 import scala.annotation.unchecked.uncheckedVariance
 import scala.runtime.Statics
@@ -80,6 +81,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     */
   def hasNext: Boolean
 
+  @onceop
   @deprecated("hasDefiniteSize on Iterator is the same as isEmpty", "2.13.0")
   @`inline` override final def hasDefiniteSize = isEmpty
 
@@ -93,7 +95,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
   @throws[NoSuchElementException]
   def next(): A
 
-  @inline final def iterator = this
+  @onceop @inline final def iterator = this
 
   /** Wraps the value of `next()` in an option.
     *
@@ -109,6 +111,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     *               is equal (as determined by `==`) to `elem`, `false` otherwise.
     *  @note        Reuse: $consumesIterator
     */
+  @onceop
   def contains(elem: Any): Boolean = exists(_ == elem)    // Note--this seems faster than manual inlining!
 
   /** Creates a buffered iterator from this iterator.
@@ -117,6 +120,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     *  @return  a buffered iterator producing the same values as this iterator.
     *  @note    Reuse: $consumesAndProducesIterator
     */
+  @onceop
   def buffered: BufferedIterator[A] = new AbstractIterator[A] with BufferedIterator[A] {
     private[this] var hd: A = _
     private[this] var hdDefined: Boolean = false
@@ -291,6 +295,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
    *          all elements of this $coll followed by the minimal number of occurrences of `elem` so
    *          that the resulting collection has a length of at least `len`.
    */
+  @onceop
   def padTo[B >: A](len: Int, elem: B): Iterator[B] = new AbstractIterator[B] {
     private[this] var i = 0
 
@@ -321,6 +326,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
    *           is the same as in the original iterator.
    *  @note    Reuse: $consumesOneAndProducesTwoIterators
    */
+  @onceop
   def partition(p: A => Boolean): (Iterator[A], Iterator[A]) = {
     val (a, b) = duplicate
     (a filter p, b filterNot p)
@@ -341,6 +347,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
    *
    *  @note Reuse: $consumesAndProducesIterator
    */
+  @onceop
   def grouped[B >: A](size: Int): GroupedIterator[B] =
     new GroupedIterator[B](self, size, size)
 
@@ -377,9 +384,11 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
    *
    *  @note Reuse: $consumesAndProducesIterator
    */
+  @onceop
   def sliding[B >: A](size: Int, step: Int = 1): GroupedIterator[B] =
     new GroupedIterator[B](self, size, step)
 
+  @onceop
   def scanLeft[B](z: B)(op: (B, A) => B): Iterator[B] = new AbstractIterator[B] {
     // We use an intermediate iterator that iterates through the first element `z`
     // and then that will be modified to iterate through the collection
@@ -411,9 +420,11 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     def hasNext: Boolean = current.hasNext
   }
 
+  @onceop
   @deprecated("Call scanRight on an Iterable instead.", "2.13.0")
   def scanRight[B](z: B)(op: (A, B) => B): Iterator[B] = ArrayBuffer.from(this).scanRight(z)(op).iterator
 
+  @onceop
   def indexWhere(p: A => Boolean, from: Int = 0): Int = {
     var i = math.max(from, 0)
     val dropped = drop(from)
@@ -433,6 +444,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     *          or -1 if such an element does not exist until the end of the iterator is reached.
     *  @note   Reuse: $consumesIterator
     */
+  @onceop
   def indexOf[B >: A](elem: B): Int = indexOf(elem, 0)
 
   /** Returns the index of the first occurrence of the specified object in this iterable object
@@ -446,6 +458,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     *          reached.
     *  @note   Reuse: $consumesIterator
     */
+  @onceop
   def indexOf[B >: A](elem: B, from: Int): Int = {
     var i = 0
     while (i < from && hasNext) {
@@ -465,8 +478,10 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
   @deprecatedOverriding("isEmpty is defined as !hasNext; override hasNext instead", "2.13.0")
   override def isEmpty: Boolean = !hasNext
 
+  @onceop
   def filter(p: A => Boolean): Iterator[A] = filterImpl(p, isFlipped = false)
 
+  @onceop
   def filterNot(p: A => Boolean): Iterator[A] = filterImpl(p, isFlipped = true)
 
   private[collection] def filterImpl(p: A => Boolean, isFlipped: Boolean): Iterator[A] = new AbstractIterator[A] {
@@ -503,8 +518,10 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     *  @return  an iterator which produces those values of this iterator which satisfy the predicate `p`.
     *  @note    Reuse: $consumesAndProducesIterator
     */
+  @onceop
   def withFilter(p: A => Boolean): Iterator[A] = filter(p)
 
+  @onceop
   def collect[B](pf: PartialFunction[A, B]): Iterator[B] = new AbstractIterator[B] with (A => B) {
     // Manually buffer to avoid extra layer of wrapping with buffered
     private[this] var hd: B = _
@@ -619,15 +636,20 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     }
   }
 
+  @onceop
   def flatten[B](implicit ev: A => IterableOnce[B]): Iterator[B] =
     flatMap[B](ev)
 
+  @onceop
   def concat[B >: A](xs: => IterableOnce[B]): Iterator[B] = new Iterator.ConcatIterator[B](self).concat(xs)
 
+  @onceop
   @`inline` final def ++ [B >: A](xs: => IterableOnce[B]): Iterator[B] = concat(xs)
 
+  @onceop
   def take(n: Int): Iterator[A] = sliceIterator(0, n max 0)
 
+  @onceop
   def takeWhile(p: A => Boolean): Iterator[A] = new AbstractIterator[A] {
     private[this] var hd: A = _
     private[this] var hdDefined: Boolean = false
@@ -642,8 +664,10 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     def next() = if (hasNext) { hdDefined = false; hd } else Iterator.empty.next()
   }
 
+  @onceop
   def drop(n: Int): Iterator[A] = sliceIterator(n, -1)
 
+  @onceop
   def dropWhile(p: A => Boolean): Iterator[A] = new AbstractIterator[A] {
     // Magic value: -1 = hasn't dropped, 0 = found first, 1 = defer to parent iterator
     private[this] var status = -1
@@ -680,6 +704,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     *
     * @note    Reuse: $consumesOneAndProducesTwoIterators
     */
+  @onceop
   def span(p: A => Boolean): (Iterator[A], Iterator[A]) = {
     /*
      * Giving a name to following iterator (as opposed to trailing) because
@@ -779,6 +804,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     (leading, trailing)
   }
 
+  @onceop
   def slice(from: Int, until: Int): Iterator[A] = sliceIterator(from, until max 0)
 
   /** Creates an optionally bounded slice, unbounded if `until` is negative. */
@@ -793,6 +819,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     else new Iterator.SliceIterator(this, lo, rest)
   }
 
+  @onceop
   def zip[B](that: IterableOnce[B]): Iterator[(A, B)] = new AbstractIterator[(A, B)] {
     val thatIterator = that.iterator
     override def knownSize = self.knownSize min thatIterator.knownSize
@@ -800,6 +827,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     def next() = (self.next(), thatIterator.next())
   }
 
+  @onceop
   def zipAll[A1 >: A, B](that: IterableOnce[B], thisElem: A1, thatElem: B): Iterator[(A1, B)] = new AbstractIterator[(A1, B)] {
     val thatIterator = that.iterator
     override def knownSize = {
@@ -817,6 +845,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     }
   }
 
+  @onceop
   def zipWithIndex: Iterator[(A, Int)] = new AbstractIterator[(A, Int)] {
     var idx = 0
     override def knownSize = self.knownSize
@@ -837,6 +866,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
    *
    *    @inheritdoc
    */
+  @onceop
   def sameElements[B >: A](that: IterableOnce[B]): Boolean = {
     val those = that.iterator
     while (hasNext && those.hasNext)
@@ -860,6 +890,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     *          iterated by one iterator but not yet by the other.
     *  @note   Reuse: $consumesOneAndProducesTwoIterators
     */
+  @onceop
   def duplicate: (Iterator[A], Iterator[A]) = {
     val gap = new scala.collection.mutable.Queue[A]
     var ahead: Iterator[A] = null
@@ -904,6 +935,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     *  @param replaced   The number of values in the original iterator that are replaced by the patch.
     *  @note           Reuse: $consumesTwoAndProducesOneIterator
     */
+  @onceop
   def patch[B >: A](from: Int, patchElems: Iterator[B], replaced: Int): Iterator[B] =
     new AbstractIterator[B] {
       private[this] var origElems = self

--- a/src/library/scala/collection/SortedMap.scala
+++ b/src/library/scala/collection/SortedMap.scala
@@ -119,10 +119,10 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _],
 
   def rangeTo(to: K): C = {
     val i = keySet.rangeFrom(to).iterator
-    if (i.isEmpty) return coll
+    if (!i.hasNext) return coll
     val next = i.next()
     if (ordering.compare(next, to) == 0)
-      if (i.isEmpty) coll
+      if (!i.hasNext) coll
       else rangeUntil(i.next())
     else
       rangeUntil(next)

--- a/src/library/scala/collection/SortedSet.scala
+++ b/src/library/scala/collection/SortedSet.scala
@@ -101,10 +101,10 @@ trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
 
   def rangeTo(to: A): C = {
     val i = rangeFrom(to).iterator
-    if (i.isEmpty) return coll
+    if (!i.hasNext) return coll
     val next = i.next()
     if (ordering.compare(next, to) == 0)
-      if (i.isEmpty) coll
+      if (!i.hasNext) coll
       else rangeUntil(i.next())
     else
       rangeUntil(next)

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1316,6 +1316,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val NowarnClass                = getClassIfDefined("scala.annotation.nowarn")
     lazy val uncheckedStableClass       = requiredClass[scala.annotation.unchecked.uncheckedStable]
     lazy val uncheckedVarianceClass     = requiredClass[scala.annotation.unchecked.uncheckedVariance]
+    lazy val OnceopClass                = getClassIfDefined("scala.annotation.onceop")
 
     // Tasty Unpickling Helpers - only access when Scala 3 library is expected to be available
     lazy val ChildAnnotationClass        = getClassIfDefined("scala.annotation.internal.Child")

--- a/src/reflect/scala/reflect/internal/Scopes.scala
+++ b/src/reflect/scala/reflect/internal/Scopes.scala
@@ -267,6 +267,14 @@ trait Scopes extends api.Scopes { self: SymbolTable =>
       }
     }
 
+    private var terminalSyms: List[(Symbol, String)] = List()
+
+    /** Adds a symbol whose once-op has been called for the group. */
+    def addTerminalSym(symbol: Symbol, group: String): Unit =
+      terminalSyms = (symbol -> group) :: terminalSyms
+    def hasTerminalSym(symbol: Symbol, group: String): Boolean =
+      terminalSyms.contains(symbol -> group)
+
     /** Lookup a module or a class, filtering out matching names in scope
      *  which do not match that requirement.
      */

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -933,6 +933,8 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
 
     def isCompileTimeOnly       = hasAnnotation(CompileTimeOnlyAttr)
     def compileTimeOnlyMessage  = getAnnotation(CompileTimeOnlyAttr) flatMap (_ stringArg 0)
+    def isOnceOp                = hasAnnotation(OnceopClass)
+    def onceopGroup             = getAnnotation(OnceopClass).flatMap(_.stringArg(0))
 
     def isExperimental = hasAnnotation(ExperimentalAnnotationClass)
 

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -449,6 +449,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.NowarnClass
     definitions.uncheckedStableClass
     definitions.uncheckedVarianceClass
+    definitions.OnceopClass
     definitions.ChildAnnotationClass
     definitions.RepeatedAnnotationClass
     definitions.TargetNameAnnotationClass

--- a/test/files/neg/once-op.check
+++ b/test/files/neg/once-op.check
@@ -1,0 +1,6 @@
+once-op.scala:8: warning: multiple calls to a once-op is unsafe for the same instance value it and the once-op group 'default'
+  println(it.take(2))
+             ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/once-op.check
+++ b/test/files/neg/once-op.check
@@ -1,6 +1,9 @@
-once-op.scala:8: warning: multiple calls to a once-op is unsafe for the same instance value it and the once-op group 'default'
+once-op.scala:7: warning: call to an affine reference value it is unsafe after a once-op has been called
+  println(it.hasNext)
+             ^
+once-op.scala:8: warning: call to an affine reference value it is unsafe after a once-op has been called
   println(it.take(2))
              ^
 error: No warnings can be incurred under -Werror.
-1 warning
+2 warnings
 1 error

--- a/test/files/neg/once-op.scala
+++ b/test/files/neg/once-op.scala
@@ -1,0 +1,24 @@
+// scalac: -Werror -Xlint:deprecation
+//
+object Foo {
+  val vec = (1 to 10).toVector
+  val it = vec.iterator
+  println(it.take(2))
+  println(it.hasNext)
+  println(it.take(2))
+
+  def foo[A1](a: scala.collection.Seq[A1], m0: Int, m1: Int, b: scala.collection.Seq[A1]): Int = {
+    if (a.iterator.slice(m0, m1).sameElements(b.iterator.slice(m0, m1))) m0
+    else -1
+  }
+  def bar[A1](m0: Int, m1: Int): Int = {
+    if (List(1).iterator.slice(m0, m1).sameElements(List(2).iterator.slice(m0, m1))) m0
+    else -1
+  }
+  def list: Iterator[Int] = ???
+  def baz: Int = {
+    list collect { case 0 => 1 }
+    list collect { case 0 => 1 }
+    0
+  }
+}

--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -283,7 +283,6 @@ class IteratorTest {
     assertTrue(r2b contains 6)
     val r3 = Iterator.range(0, 10, 11)
     assertFalse(r3 contains 5)
-    assertTrue(r3.isEmpty)
   }
   @Test def rangeOverflow(): Unit = {
     val step = 100000000

--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -277,8 +277,6 @@ class IteratorTest {
   @Test def range3(): Unit = {
     val r1 = Iterator.range(0, 10)
     assertTrue(r1 contains 5)
-    assertTrue(r1 contains 6)
-    assertFalse(r1 contains 4)
     val r2a = Iterator.range(0, 10, 2)
     assertFalse(r2a contains 5)
     val r2b = Iterator.range(0, 10, 2)

--- a/test/junit/scala/collection/immutable/RangeTest.scala
+++ b/test/junit/scala/collection/immutable/RangeTest.scala
@@ -57,17 +57,17 @@ class RangeTest {
   def dropToEnd(): Unit = {
     val test = 10 to 11
     val it = test.iterator
-    it.drop(1)
+    val dropped = it.drop(1)
 
-    assertEquals(11, it.next())
+    assertEquals(11, dropped.next())
   }
   @Test
   def dropToEnd2(): Unit = {
     val test = 10 until 11
     val it = test.iterator
-    it.drop(0)
+    val dropped = it.drop(0)
 
-    assertEquals(10, it.next())
+    assertEquals(10, dropped.next())
   }
 
   @Test(expected = classOf[IllegalArgumentException])


### PR DESCRIPTION
Ref https://github.com/scala/bug/issues/12803

**Problem**
There are certain classes, such as `Iterator` where the number of times you can call a method is restricted to once. This kind of restriction is currently not expressed as type, and it can catch users off guard.

**Solution**
This introduces a new annotation called `@onceop(...)`, which can mark methods that can be called once per instance per onceop group. For example, all `Iterator` methods except for `hasNext` and `next` are marked with `@onceop("all")` such that calling `take(2)`, and then calling any other method would now result to a warning.

Since I am tracking this within a scope, this is more as a lightweight check, and by no means exhaustive.
It doesn't check for example passing an iterator to a function, which inside could make a onceop call or not.