### PR TITLE
affine annotation and linter

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -39,6 +39,8 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.concurrent.impl.FutureConvertersImpl#P.accept"),
     ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.concurrent.impl.FutureConvertersImpl#P.andThen"),
 
+    ProblemFilters.exclude[MissingClassProblem]("scala.annotation.affine"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.annotation.affineOptOut"),
   )
 
   override val buildSettings = Seq(

--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -411,6 +411,7 @@ object Reporting {
     object LintIntDivToFloat extends Lint; add(LintIntDivToFloat)
     object LintUniversalMethods extends Lint; add(LintUniversalMethods)
     object LintNumericMethods extends Lint; add(LintNumericMethods)
+    object LintAffine extends Lint; add(LintAffine)
 
     sealed trait Feature extends WarningCategory { override def summaryCategory: WarningCategory = Feature }
     object Feature extends Feature { override def includes(o: WarningCategory): Boolean = o.isInstanceOf[Feature] }; add(Feature)

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5339,13 +5339,11 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
           // Once-use types are called linear/affine types.
           def checkOnceUse(result: Tree): Unit =
-            if (!isPastTyper && (qual.symbol ne NoSymbol) && !sym.isAffineOptOut && sym.owner.isAffine) {
+            if (!isPastTyper && (qual.symbol ne null) && (qual.symbol ne NoSymbol) && (qual.symbol.isStable) && sym.owner.isAffine) {
               val qualSym = qual.symbol
-              def msg = s"making multiple calls to an affine reference ${qualSym} is unsafe"
-              if ((qualSym ne null) && qualSym.isStable) {
-                if (context.scope.hasTerminalSym(qualSym)) context.warning(tree.pos, msg, WarningCategory.LintAffine)
-                else context.scope.addTerminalSym(qualSym)
-              }
+              def msg = s"call to an affine reference ${qualSym} is unsafe after a once-op has been called"
+              if (context.scope.hasTerminalSym(qualSym)) context.warning(tree.pos, msg, WarningCategory.LintAffine)
+              else if (!sym.isAffineOptOut) context.scope.addTerminalSym(qualSym)
             }
 
           // This special-case complements the logic in `adaptMember` in erasure, it handles selections

--- a/src/library/scala/annotation/affine.scala
+++ b/src/library/scala/annotation/affine.scala
@@ -1,0 +1,29 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.annotation
+
+import scala.annotation.meta._
+
+/** An experimental annotation for an affine type, whose instance can be
+  * used at-most once.
+  * Currently the once-use checks are limited.
+  *
+  * {{{
+  *   @affine class A { def foo(): Unit = () }
+  *
+  *   def bar = { val a = new A; a.foo(); a.foo() } // show affine warning
+  * }}}
+  *
+  */
+@getter @setter @beanGetter @beanSetter
+final class affine extends StaticAnnotation

--- a/src/library/scala/annotation/affineOptOut.scala
+++ b/src/library/scala/annotation/affineOptOut.scala
@@ -1,0 +1,31 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.annotation
+
+import scala.annotation.meta._
+
+/** An annotation for an affine type, whose instance can be
+  * used at-most once.
+  *
+  * {{{
+  *   @affine class A {
+  *     @affineOptOut
+  *     def foo(): Unit = ()
+  *   }
+  *
+  *   def bar = { val a = new A; a.foo(); a.foo() } // this is fine
+  * }}}
+  *
+  */
+@getter @setter @beanGetter @beanSetter
+final class affineOptOut extends StaticAnnotation

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -13,6 +13,8 @@
 package scala.collection
 
 import scala.collection.mutable.{ArrayBuffer, ArrayBuilder, Builder, ImmutableBuilder}
+import scala.annotation.affine
+import scala.annotation.affineOptOut
 import scala.annotation.tailrec
 import scala.annotation.unchecked.uncheckedVariance
 import scala.runtime.Statics
@@ -71,6 +73,7 @@ import scala.runtime.Statics
   *  iterators as well.
   * @define coll iterator
   */
+@affine
 trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Iterator[A]] { self =>
 
   /** Check if there is a next element available.
@@ -78,6 +81,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     * @return `true` if there is a next element, `false` otherwise
     * @note   Reuse: $preservesIterator
     */
+  @affineOptOut
   def hasNext: Boolean
 
   @deprecated("hasDefiniteSize on Iterator is the same as isEmpty", "2.13.0")
@@ -91,6 +95,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     *         make additional calls on the iterator.
     */
   @throws[NoSuchElementException]
+  @affineOptOut
   def next(): A
 
   @inline final def iterator = this
@@ -462,6 +467,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
 
   @inline final def length: Int = size
 
+  @affineOptOut
   @deprecatedOverriding("isEmpty is defined as !hasNext; override hasNext instead", "2.13.0")
   override def isEmpty: Boolean = !hasNext
 

--- a/src/library/scala/collection/SortedMap.scala
+++ b/src/library/scala/collection/SortedMap.scala
@@ -119,10 +119,10 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _],
 
   def rangeTo(to: K): C = {
     val i = keySet.rangeFrom(to).iterator
-    if (i.isEmpty) return coll
+    if (!i.hasNext) return coll
     val next = i.next()
     if (ordering.compare(next, to) == 0)
-      if (i.isEmpty) coll
+      if (!i.hasNext) coll
       else rangeUntil(i.next())
     else
       rangeUntil(next)

--- a/src/library/scala/collection/SortedSet.scala
+++ b/src/library/scala/collection/SortedSet.scala
@@ -101,10 +101,10 @@ trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
 
   def rangeTo(to: A): C = {
     val i = rangeFrom(to).iterator
-    if (i.isEmpty) return coll
+    if (!i.hasNext) return coll
     val next = i.next()
     if (ordering.compare(next, to) == 0)
-      if (i.isEmpty) coll
+      if (!i.hasNext) coll
       else rangeUntil(i.next())
     else
       rangeUntil(next)

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1316,6 +1316,8 @@ trait Definitions extends api.StandardDefinitions {
     lazy val NowarnClass                = getClassIfDefined("scala.annotation.nowarn")
     lazy val uncheckedStableClass       = requiredClass[scala.annotation.unchecked.uncheckedStable]
     lazy val uncheckedVarianceClass     = requiredClass[scala.annotation.unchecked.uncheckedVariance]
+    lazy val AffineClass                = getClassIfDefined("scala.annotation.affine")
+    lazy val AffineOptOutClass          = getClassIfDefined("scala.annotation.affineOptOut")
 
     // Tasty Unpickling Helpers - only access when Scala 3 library is expected to be available
     lazy val ChildAnnotationClass        = getClassIfDefined("scala.annotation.internal.Child")

--- a/src/reflect/scala/reflect/internal/Scopes.scala
+++ b/src/reflect/scala/reflect/internal/Scopes.scala
@@ -267,6 +267,14 @@ trait Scopes extends api.Scopes { self: SymbolTable =>
       }
     }
 
+    private var terminalSyms: List[Symbol] = List()
+
+    /** Adds a symbol whose once-op has been called. */
+    def addTerminalSym(symbol: Symbol): Unit =
+      terminalSyms = symbol :: terminalSyms
+    def hasTerminalSym(symbol: Symbol): Boolean =
+      terminalSyms.contains(symbol)
+
     /** Lookup a module or a class, filtering out matching names in scope
      *  which do not match that requirement.
      */

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -933,6 +933,8 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
 
     def isCompileTimeOnly       = hasAnnotation(CompileTimeOnlyAttr)
     def compileTimeOnlyMessage  = getAnnotation(CompileTimeOnlyAttr) flatMap (_ stringArg 0)
+    def isAffine                = hasAnnotation(AffineClass)
+    def isAffineOptOut          = hasAnnotation(AffineOptOutClass)
 
     def isExperimental = hasAnnotation(ExperimentalAnnotationClass)
 

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -449,6 +449,8 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.NowarnClass
     definitions.uncheckedStableClass
     definitions.uncheckedVarianceClass
+    definitions.AffineClass
+    definitions.AffineOptOutClass
     definitions.ChildAnnotationClass
     definitions.RepeatedAnnotationClass
     definitions.TargetNameAnnotationClass

--- a/test/files/neg/once-op.check
+++ b/test/files/neg/once-op.check
@@ -1,6 +1,9 @@
-once-op.scala:8: warning: making multiple calls to an affine reference value it is unsafe
+once-op.scala:7: warning: call to an affine reference value it is unsafe after a once-op has been called
+  println(it.hasNext)
+             ^
+once-op.scala:8: warning: call to an affine reference value it is unsafe after a once-op has been called
   println(it.take(2))
              ^
 error: No warnings can be incurred under -Werror.
-1 warning
+2 warnings
 1 error

--- a/test/files/neg/once-op.check
+++ b/test/files/neg/once-op.check
@@ -1,0 +1,6 @@
+once-op.scala:8: warning: making multiple calls to an affine reference value it is unsafe
+  println(it.take(2))
+             ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/once-op.scala
+++ b/test/files/neg/once-op.scala
@@ -1,0 +1,24 @@
+// scalac: -Werror -Xlint:deprecation
+//
+object Foo {
+  val vec = (1 to 10).toVector
+  val it = vec.iterator
+  println(it.take(2))
+  println(it.hasNext)
+  println(it.take(2))
+
+  def foo[A1](a: scala.collection.Seq[A1], m0: Int, m1: Int, b: scala.collection.Seq[A1]): Int = {
+    if (a.iterator.slice(m0, m1).sameElements(b.iterator.slice(m0, m1))) m0
+    else -1
+  }
+  def bar[A1](m0: Int, m1: Int): Int = {
+    if (List(1).iterator.slice(m0, m1).sameElements(List(2).iterator.slice(m0, m1))) m0
+    else -1
+  }
+  def list: Iterator[Int] = ???
+  def baz: Int = {
+    list collect { case 0 => 1 }
+    list collect { case 0 => 1 }
+    0
+  }
+}

--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -283,7 +283,6 @@ class IteratorTest {
     assertTrue(r2b contains 6)
     val r3 = Iterator.range(0, 10, 11)
     assertFalse(r3 contains 5)
-    assertTrue(r3.isEmpty)
   }
   @Test def rangeOverflow(): Unit = {
     val step = 100000000

--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -277,8 +277,6 @@ class IteratorTest {
   @Test def range3(): Unit = {
     val r1 = Iterator.range(0, 10)
     assertTrue(r1 contains 5)
-    assertTrue(r1 contains 6)
-    assertFalse(r1 contains 4)
     val r2a = Iterator.range(0, 10, 2)
     assertFalse(r2a contains 5)
     val r2b = Iterator.range(0, 10, 2)

--- a/test/junit/scala/collection/immutable/RangeTest.scala
+++ b/test/junit/scala/collection/immutable/RangeTest.scala
@@ -57,17 +57,17 @@ class RangeTest {
   def dropToEnd(): Unit = {
     val test = 10 to 11
     val it = test.iterator
-    it.drop(1)
+    val dropped = it.drop(1)
 
-    assertEquals(11, it.next())
+    assertEquals(11, dropped.next())
   }
   @Test
   def dropToEnd2(): Unit = {
     val test = 10 until 11
     val it = test.iterator
-    it.drop(0)
+    val dropped = it.drop(0)
 
-    assertEquals(10, it.next())
+    assertEquals(10, dropped.next())
   }
 
   @Test(expected = classOf[IllegalArgumentException])


### PR DESCRIPTION
Ref https://github.com/scala/bug/issues/12803
This is a variant of https://github.com/scala/scala/pull/10427

### Problem
There are certain classes, such as `Iterator` where the number of times you can call a method is restricted to once.
This kind of restriction is currently not expressed as type, and it can catch users off guard.

### Solution
This introduces a new annotation `@affine`, which can mark a type as an affine type which can be used at-most once.
For example, `Iterator` trait is now marked as affine, with `hasNext` and `next` opted out using `@affineOptOut` annotation. Note that once `take(2)` is called the iterator becomes spent, and calling `hasNext` or `next` will still trigger a warning.

```scala
@affine
trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Iterator[A]] { self =>

  /** Check if there is a next element available.
    *
    * @return `true` if there is a next element, `false` otherwise
    * @note   Reuse: $preservesIterator
    */
  @affineOptOut
  def hasNext: Boolean
```

Since I am tracking this within a scope, this is more of a lightweight lint, and by no means exhaustive.
It doesn't check for example passing an iterator to a function, which inside it could make a method call (or not?!).

### Note

I haven't looked at them, but https://github.com/phaller/lacasa is a prior work on ownership/affinity in Scala, and the linked paper has good list of references.