### PR TITLE
IteratorTest mustn't use spent iterator after terminal op

### DIFF
--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -667,6 +667,6 @@ private class RangeIterator(
         _hasNext = longPos >= lastElement
       }
     }
-      this
+    this
   }
 }

--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -274,18 +274,11 @@ class IteratorTest {
     assertEquals(10, Iterator.range(0, 10, 1).size)
     assertEquals(10, Iterator.range(10, 0, -1).size)
   }
-  @Test def range3(): Unit = {
-    val r1 = Iterator.range(0, 10)
-    assertTrue(r1 contains 5)
-    assertTrue(r1 contains 6)
-    assertFalse(r1 contains 4)
-    val r2a = Iterator.range(0, 10, 2)
-    assertFalse(r2a contains 5)
-    val r2b = Iterator.range(0, 10, 2)
-    assertTrue(r2b contains 6)
-    val r3 = Iterator.range(0, 10, 11)
-    assertFalse(r3 contains 5)
-    assertTrue(r3.isEmpty)
+  @Test def `range contains`: Unit = {
+    assertTrue(Iterator.range(0, 10).contains(5))
+    assertFalse(Iterator.range(0, 10, 2).contains(5))
+    assertTrue(Iterator.range(0, 10, 2).contains(6))
+    assertFalse(Iterator.range(0, 10, 11).contains(5))
   }
   @Test def rangeOverflow(): Unit = {
     val step = 100000000
@@ -346,8 +339,8 @@ class IteratorTest {
   }
   // ticket #429
   @Test def fromArray(): Unit = {
-    val a = List(1, 2, 3, 4).toArray
-    val xs0 = a.iterator.toList;
+    val a = Array(1, 2, 3, 4)
+    val xs0 = a.iterator.toList
     val xs1 = a.slice(0, 1).iterator
     val xs2 = a.slice(0, 2).iterator
     val xs3 = a.slice(0, 3).iterator

--- a/test/junit/scala/collection/immutable/RangeTest.scala
+++ b/test/junit/scala/collection/immutable/RangeTest.scala
@@ -55,19 +55,13 @@ class RangeTest {
 
   @Test
   def dropToEnd(): Unit = {
-    val test = 10 to 11
-    val it = test.iterator
-    it.drop(1)
-
-    assertEquals(11, it.next())
+    val it = 10.to(11).iterator
+    assertEquals(11, it.drop(1).next())
   }
   @Test
   def dropToEnd2(): Unit = {
-    val test = 10 until 11
-    val it = test.iterator
-    it.drop(0)
-
-    assertEquals(10, it.next())
+    val it = 10.to(11).iterator
+    assertEquals(10, it.drop(0).next())
   }
 
   @Test(expected = classOf[IllegalArgumentException])


### PR DESCRIPTION
Noticed at https://github.com/scala/scala/pull/10427#issuecomment-1586347286

This is just to ensure these tweaks make it in.

Included another one, I'll try to keep up.