### PR TITLE
Add explicit result type to some non-private methods

### DIFF
--- a/src/library/scala/collection/View.scala
+++ b/src/library/scala/collection/View.scala
@@ -164,7 +164,7 @@ object View extends IterableFactory[View] {
 
   @SerialVersionUID(3L)
   class LeftPartitionMapped[A, A1, A2](underlying: SomeIterableOps[A], f: A => Either[A1, A2]) extends AbstractView[A1] {
-    def iterator = new AbstractIterator[A1] {
+    def iterator: AbstractIterator[A1] = new AbstractIterator[A1] {
       private[this] val self = underlying.iterator
       private[this] var hd: A1 = _
       private[this] var hdDefined: Boolean = false
@@ -189,7 +189,7 @@ object View extends IterableFactory[View] {
 
   @SerialVersionUID(3L)
   class RightPartitionMapped[A, A1, A2](underlying: SomeIterableOps[A], f: A => Either[A1, A2]) extends AbstractView[A2] {
-      def iterator = new AbstractIterator[A2] {
+      def iterator: AbstractIterator[A2] = new AbstractIterator[A2] {
         private[this] val self = underlying.iterator
         private[this] var hd: A2 = _
         private[this] var hdDefined: Boolean = false

--- a/src/library/scala/collection/convert/JavaCollectionWrappers.scala
+++ b/src/library/scala/collection/convert/JavaCollectionWrappers.scala
@@ -33,7 +33,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
     def next() = underlying.next()
     def hasMoreElements = underlying.hasNext
     def nextElement() = underlying.next()
-    override def remove() = throw new UnsupportedOperationException
+    override def remove(): Nothing = throw new UnsupportedOperationException
     override def equals(other: Any): Boolean = other match {
       case that: IteratorWrapper[_] => this.underlying == that.underlying
       case _ => false
@@ -85,7 +85,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
       with StrictOptimizedIterableOps[A, Iterable, Iterable[A]]
       with Serializable {
     def iterator = underlying.iterator.asScala
-    override def iterableFactory = mutable.ArrayBuffer
+    override def iterableFactory: mutable.ArrayBuffer.type = mutable.ArrayBuffer
     override def isEmpty: Boolean = !underlying.iterator().hasNext
     override def equals(other: Any): Boolean = other match {
       case that: JIterableWrapper[_] => this.underlying == that.underlying
@@ -103,7 +103,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
     override def size = underlying.size
     override def knownSize: Int = if (underlying.isEmpty) 0 else super.knownSize
     override def isEmpty = underlying.isEmpty
-    override def iterableFactory = mutable.ArrayBuffer
+    override def iterableFactory: mutable.ArrayBuffer.type = mutable.ArrayBuffer
     override def equals(other: Any): Boolean = other match {
       case that: JCollectionWrapper[_] => this.underlying == that.underlying
       case _ => false
@@ -165,7 +165,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
       this
     }
     def remove(from: Int, n: Int): Unit = underlying.subList(from, from+n).clear()
-    override def iterableFactory = mutable.ArrayBuffer
+    override def iterableFactory: mutable.ArrayBuffer.type = mutable.ArrayBuffer
     override def subtractOne(elem: A): this.type = { underlying.remove(elem.asInstanceOf[AnyRef]); this }
   }
 
@@ -448,7 +448,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
 
     override def isEmpty: Boolean = underlying.isEmpty
     override def knownSize: Int = if (underlying.isEmpty) 0 else super.knownSize
-    override def empty = new JMapWrapper(new ju.HashMap[K, V])
+    override def empty: JMapWrapper[K, V] = new JMapWrapper(new ju.HashMap[K, V])
   }
 
   @SerialVersionUID(3L)
@@ -495,7 +495,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
 
     override def isEmpty: Boolean = underlying.isEmpty
     override def knownSize: Int = if (underlying.isEmpty) 0 else super.knownSize
-    override def empty = new JConcurrentMapWrapper(new juc.ConcurrentHashMap[K, V])
+    override def empty: JConcurrentMapWrapper[K, V] = new JConcurrentMapWrapper(new juc.ConcurrentHashMap[K, V])
 
     def putIfAbsent(k: K, v: V): Option[V] = Option(underlying.putIfAbsent(k, v))
 
@@ -581,7 +581,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
 
     override def clear() = iterator.foreach(entry => underlying.remove(entry._1))
 
-    override def mapFactory = mutable.HashMap
+    override def mapFactory: mutable.HashMap.type = mutable.HashMap
   }
 
   @SerialVersionUID(3L)
@@ -626,7 +626,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
 
     override def clear() = underlying.clear()
 
-    override def empty = new JPropertiesWrapper(new ju.Properties)
+    override def empty: JPropertiesWrapper = new JPropertiesWrapper(new ju.Properties)
 
     def getProperty(key: String) = underlying.getProperty(key)
 
@@ -636,7 +636,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
     def setProperty(key: String, value: String) =
       underlying.setProperty(key, value)
 
-    override def mapFactory = mutable.HashMap
+    override def mapFactory: mutable.HashMap.type = mutable.HashMap
   }
 
   /** Thrown when certain Map operations attempt to put a null value. */

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -48,7 +48,7 @@ final class TreeSet[A] private[immutable] (private[immutable] val tree: RB.Tree[
 
   def this()(implicit ordering: Ordering[A]) = this(null)(ordering)
 
-  override def sortedIterableFactory = TreeSet
+  override def sortedIterableFactory: TreeSet.type = TreeSet
 
   private[this] def newSetOrSelf(t: RB.Tree[A, Any]) = if(t eq tree) this else new TreeSet[A](t)
 

--- a/src/library/scala/collection/mutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/mutable/LinkedHashMap.scala
@@ -485,7 +485,7 @@ object LinkedHashMap extends MapFactory[LinkedHashMap] {
     newlhm
   }
 
-  def newBuilder[K, V] = new GrowableBuilder(empty[K, V])
+  def newBuilder[K, V]: GrowableBuilder[(K, V), LinkedHashMap[K, V]] = new GrowableBuilder(empty[K, V])
 
   /** Class for the linked hash map entry, used internally.
     */

--- a/src/library/scala/collection/mutable/LinkedHashSet.scala
+++ b/src/library/scala/collection/mutable/LinkedHashSet.scala
@@ -323,7 +323,7 @@ object LinkedHashSet extends IterableFactory[LinkedHashSet] {
     newlhs
   }
 
-  def newBuilder[A] = new GrowableBuilder(empty[A])
+  def newBuilder[A]: GrowableBuilder[A, LinkedHashSet[A]] = new GrowableBuilder(empty[A])
 
   /** Class for the linked hash set entry, used internally.
    */

--- a/src/library/scala/collection/mutable/TreeMap.scala
+++ b/src/library/scala/collection/mutable/TreeMap.scala
@@ -38,7 +38,7 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
     with SortedMapFactoryDefaults[K, V, TreeMap, Iterable, Map]
     with DefaultSerializable {
 
-  override def sortedMapFactory = TreeMap
+  override def sortedMapFactory: TreeMap.type = TreeMap
 
   /**
     * Creates an empty `TreeMap`.

--- a/src/library/scala/concurrent/duration/Duration.scala
+++ b/src/library/scala/concurrent/duration/Duration.scala
@@ -708,7 +708,7 @@ final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duratio
    */
   def mul(factor: Long): FiniteDuration  = this * factor
 
-  def unary_- = Duration(-length, unit)
+  def unary_- : FiniteDuration = Duration(-length, unit)
 
   final def isFinite = true
 

--- a/src/library/scala/math/BigDecimal.scala
+++ b/src/library/scala/math/BigDecimal.scala
@@ -466,7 +466,7 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
 
   def isWhole = scale <= 0 || bigDecimal.stripTrailingZeros.scale <= 0
 
-  def underlying = bigDecimal
+  def underlying: java.math.BigDecimal = bigDecimal
 
 
   /** Compares this BigDecimal with the specified BigDecimal for equality.

--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -76,7 +76,7 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
   /** Returns whether a comparison between `x` and `y` is defined, and if so
     * the result of `compare(x, y)`.
     */
-  def tryCompare(x: T, y: T) = Some(compare(x, y))
+  def tryCompare(x: T, y: T): Some[Int] = Some(compare(x, y))
 
  /** Returns an integer whose sign communicates how x compares to y.
    *

--- a/src/library/scala/sys/process/ProcessBuilderImpl.scala
+++ b/src/library/scala/sys/process/ProcessBuilderImpl.scala
@@ -100,8 +100,8 @@ private[process] trait ProcessBuilderImpl {
   }
 
   private[scala] abstract class AbstractBuilder extends ProcessBuilder with Sink with Source {
-    protected def toSource = this
-    protected def toSink = this
+    protected def toSource: AbstractBuilder = this
+    protected def toSink: AbstractBuilder = this
 
     private[this] val defaultStreamCapacity = 4096
 
@@ -209,11 +209,11 @@ private[process] trait ProcessBuilderImpl {
   }
 
   private[process] class URLImpl(url: URL) extends URLBuilder with Source {
-    protected def toSource = new URLInput(url)
+    protected def toSource: URLInput = new URLInput(url)
   }
   private[process] class FileImpl(base: File) extends FileBuilder with Sink with Source {
-    protected def toSource = new FileInput(base)
-    protected def toSink   = new FileOutput(base, false)
+    protected def toSource: FileInput = new FileInput(base)
+    protected def toSink: FileOutput = new FileOutput(base, false)
 
     def #<<(f: File): ProcessBuilder           = #<<(new FileInput(f))
     def #<<(u: URL): ProcessBuilder            = #<<(new URLInput(u))
@@ -248,27 +248,27 @@ private[process] trait ProcessBuilderImpl {
     toError: Boolean
   ) extends SequentialBuilder(first, second, if (toError) "#|!" else "#|") {
 
-    override def createProcess(io: ProcessIO) = new PipedProcesses(first, second, io, toError)
+    override def createProcess(io: ProcessIO): PipedProcesses = new PipedProcesses(first, second, io, toError)
   }
 
   private[process] class AndBuilder(
     first: ProcessBuilder,
     second: ProcessBuilder
   ) extends SequentialBuilder(first, second, "#&&") {
-    override def createProcess(io: ProcessIO) = new AndProcess(first, second, io)
+    override def createProcess(io: ProcessIO): AndProcess = new AndProcess(first, second, io)
   }
 
   private[process] class OrBuilder(
     first: ProcessBuilder,
     second: ProcessBuilder
   ) extends SequentialBuilder(first, second, "#||") {
-    override def createProcess(io: ProcessIO) = new OrProcess(first, second, io)
+    override def createProcess(io: ProcessIO): OrProcess = new OrProcess(first, second, io)
   }
 
   private[process] class SequenceBuilder(
     first: ProcessBuilder,
     second: ProcessBuilder
   ) extends SequentialBuilder(first, second, "###") {
-    override def createProcess(io: ProcessIO) = new ProcessSequence(first, second, io)
+    override def createProcess(io: ProcessIO): ProcessSequence = new ProcessSequence(first, second, io)
   }
 }


### PR DESCRIPTION
Add explicit result type to methods where Scala 2 and Scala 3 disagree with the inferred type. The aim is to have the same type in the Scala 2 pickles and the Scala 3 TASTy.

These where identified in https://github.com/lampepfl/dotty/pull/17975