### PR TITLE
Avoid directly inheriting Iterator

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -41,6 +41,19 @@ object MimaFilters extends AutoPlugin {
 
     // PR 10406
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.JavaUniverse#PerRunReporting.deprecationWarning"),
+
+    // extend AbstractIterator
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.MapKeyIterator"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.MapKeyValueTupleHashIterator"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.MapKeyValueTupleIterator"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.MapKeyValueTupleReverseIterator"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.MapNodeRemoveAllSetNodeIterator"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.MapNodeRemoveAllSetNodeIterator.next"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.MapValueIterator"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.NewVectorIterator"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.SetHashIterator"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.SetIterator"),
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.SetReverseIterator"),
   )
 
   override val buildSettings = Seq(

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/AliasingAnalyzer.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/AliasingAnalyzer.scala
@@ -15,6 +15,7 @@ package backend.jvm
 package analysis
 
 import scala.annotation.switch
+import scala.collection.AbstractIterator
 import scala.collection.mutable
 import scala.tools.asm.Opcodes
 import scala.tools.asm.tree._
@@ -423,7 +424,7 @@ class BasicAliasingAnalyzer(methodNode: MethodNode, classInternalName: InternalN
 /**
  * An iterator over Int (required to prevent boxing the result of next).
  */
-abstract class IntIterator extends Iterator[Int] {
+abstract class IntIterator extends AbstractIterator[Int] {
   def hasNext: Boolean
   def next(): Int
 }

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/BoxUnbox.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/BoxUnbox.scala
@@ -15,6 +15,7 @@ package backend.jvm
 package opt
 
 import scala.annotation.tailrec
+import scala.collection.AbstractIterator
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import scala.tools.asm.Opcodes._
@@ -551,7 +552,7 @@ abstract class BoxUnbox {
    * For a set of box creation operations and a corresponding set of box consumer operations,
    * this iterator returns all copy operations (load, store, dup) that are in between.
    */
-  class CopyOpsIterator(initialCreations: Set[BoxCreation], finalCons: Set[BoxConsumer], prodCons: ProdConsAnalyzer) extends Iterator[AbstractInsnNode] {
+  class CopyOpsIterator(initialCreations: Set[BoxCreation], finalCons: Set[BoxConsumer], prodCons: ProdConsAnalyzer) extends AbstractIterator[AbstractInsnNode] {
     private val queue = mutable.Queue.empty[AbstractInsnNode] ++= initialCreations.iterator.flatMap(_.boxConsumers(prodCons, ultimate = false))
 
     // a single copy operation can consume multiple producers: val a = if (b) box(1) else box(2).

--- a/src/compiler/scala/tools/nsc/util/JavaCharArrayReader.scala
+++ b/src/compiler/scala/tools/nsc/util/JavaCharArrayReader.scala
@@ -14,12 +14,13 @@ package scala
 package tools.nsc
 package util
 
+import scala.collection.AbstractIterator
 import scala.collection.immutable.ArraySeq
 import scala.reflect.internal.Chars._
 import scala.util.chaining._
 
 class JavaCharArrayReader(buf: ArraySeq.ofChar, start: Int, /* startline: int, startcol: int, */
-                      decodeUni: Boolean, error: String => Unit) extends Iterator[Char] with Cloneable {
+                      decodeUni: Boolean, error: String => Unit) extends AbstractIterator[Char] with Cloneable {
 
   def this(buf: ArraySeq.ofChar, decodeUni: Boolean, error: String => Unit) =
     this(buf, 0, /* 1, 1, */ decodeUni, error)

--- a/src/interactive/scala/tools/nsc/interactive/Pickler.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Pickler.scala
@@ -14,6 +14,7 @@ package scala.tools.nsc.interactive
 
 import Lexer._
 import java.io.Writer
+import scala.collection.AbstractIterator
 
 /** An abstract class for writing and reading Scala objects to and
  *  from a legible representation. The representation follows the following grammar:
@@ -277,7 +278,7 @@ object Pickler {
         p.pickle(wr, x)
       }
     }
-    def unpickle(rd: Lexer): Unpickled[Iterator[T]] = UnpickleSuccess(new Iterator[T] {
+    def unpickle(rd: Lexer): Unpickled[Iterator[T]] = UnpickleSuccess(new AbstractIterator[T] {
       var first = true
       def hasNext = {
         val t = rd.token

--- a/src/library/scala/collection/convert/JavaCollectionWrappers.scala
+++ b/src/library/scala/collection/convert/JavaCollectionWrappers.scala
@@ -42,7 +42,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
   }
 
   @SerialVersionUID(3L)
-  class JIteratorWrapper[A](val underlying: ju.Iterator[A]) extends AbstractIterator[A] with Iterator[A] with Serializable {
+  class JIteratorWrapper[A](val underlying: ju.Iterator[A]) extends AbstractIterator[A] with Serializable {
     def hasNext = underlying.hasNext
     def next() = underlying.next
     override def equals(other: Any): Boolean = other match {
@@ -53,7 +53,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
   }
 
   @SerialVersionUID(3L)
-  class JEnumerationWrapper[A](val underlying: ju.Enumeration[A]) extends AbstractIterator[A] with Iterator[A] with Serializable {
+  class JEnumerationWrapper[A](val underlying: ju.Enumeration[A]) extends AbstractIterator[A] with Serializable {
     def hasNext = underlying.hasMoreElements
     def next() = underlying.nextElement
     override def equals(other: Any): Boolean = other match {

--- a/src/library/scala/collection/immutable/ChampCommon.scala
+++ b/src/library/scala/collection/immutable/ChampCommon.scala
@@ -12,7 +12,7 @@
 
 package scala.collection.immutable
 
-
+import scala.collection.AbstractIterator
 import java.lang.Integer.bitCount
 import java.lang.Math.ceil
 import java.lang.System.arraycopy
@@ -104,7 +104,7 @@ private[collection] abstract class Node[T <: Node[T]] {
   *
   * @tparam T the trie node type we are iterating over
   */
-private[immutable] abstract class ChampBaseIterator[T <: Node[T]] {
+private[immutable] abstract class ChampBaseIterator[A, T <: Node[T]] extends AbstractIterator[A] {
 
   import Node.MaxDepth
 
@@ -192,7 +192,7 @@ private[immutable] abstract class ChampBaseIterator[T <: Node[T]] {
   *
   * @tparam T the trie node type we are iterating over
   */
-private[immutable] abstract class ChampBaseReverseIterator[T <: Node[T]] {
+private[immutable] abstract class ChampBaseReverseIterator[A, T <: Node[T]] extends AbstractIterator[A] {
 
   import Node.MaxDepth
 

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -1883,11 +1883,10 @@ private final class HashCollisionSetNode[A](val originalHash: Int, val hash: Int
 }
 
 private final class SetIterator[A](rootNode: SetNode[A])
-  extends ChampBaseIterator[SetNode[A]](rootNode) with Iterator[A] {
+  extends ChampBaseIterator[A, SetNode[A]](rootNode) {
 
   def next() = {
-    if (!hasNext)
-      throw new NoSuchElementException
+    if (!hasNext) Iterator.empty.next()
 
     val payload = currentValueNode.getPayload(currentValueCursor)
     currentValueCursor += 1
@@ -1898,11 +1897,10 @@ private final class SetIterator[A](rootNode: SetNode[A])
 }
 
 private final class SetReverseIterator[A](rootNode: SetNode[A])
-  extends ChampBaseReverseIterator[SetNode[A]](rootNode) with Iterator[A] {
+  extends ChampBaseReverseIterator[A, SetNode[A]](rootNode) {
 
   def next(): A = {
-    if (!hasNext)
-      throw new NoSuchElementException
+    if (!hasNext) Iterator.empty.next()
 
     val payload = currentValueNode.getPayload(currentValueCursor)
     currentValueCursor -= 1
@@ -1913,13 +1911,12 @@ private final class SetReverseIterator[A](rootNode: SetNode[A])
 }
 
 private final class SetHashIterator[A](rootNode: SetNode[A])
-  extends ChampBaseIterator[SetNode[A]](rootNode) with Iterator[AnyRef] {
+  extends ChampBaseIterator[AnyRef, SetNode[A]](rootNode) {
   private[this] var hash = 0
   override def hashCode(): Int = hash
 
   def next(): AnyRef = {
-    if (!hasNext)
-      throw new NoSuchElementException
+    if (!hasNext) Iterator.empty.next()
 
     hash = currentValueNode.getHash(currentValueCursor)
     currentValueCursor += 1
@@ -2088,7 +2085,7 @@ private[collection] final class HashSetBuilder[A] extends ReusableBuilder[A, Has
     ensureUnaliased()
     xs match {
       case hm: HashSet[A] =>
-        new ChampBaseIterator[SetNode[A]](hm.rootNode) {
+        new ChampBaseIterator[A, SetNode[A]](hm.rootNode) {
           while(hasNext) {
             val originalHash = currentValueNode.getHash(currentValueCursor)
             update(
@@ -2100,6 +2097,7 @@ private[collection] final class HashSetBuilder[A] extends ReusableBuilder[A, Has
             )
             currentValueCursor += 1
           }
+          override def next() = Iterator.empty.next()
         }
       case other =>
         val it = other.iterator

--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -2229,7 +2229,7 @@ private object VectorStatics {
 }
 
 
-private final class NewVectorIterator[A](v: Vector[A], private[this] var totalLength: Int, private[this] val sliceCount: Int) extends Iterator[A] with java.lang.Cloneable {
+private final class NewVectorIterator[A](v: Vector[A], private[this] var totalLength: Int, private[this] val sliceCount: Int) extends AbstractIterator[A] with java.lang.Cloneable {
 
   private[this] var a1: Arr1 = v.prefix1
   private[this] var a2: Arr2 = _

--- a/src/library/scala/util/matching/Regex.scala
+++ b/src/library/scala/util/matching/Regex.scala
@@ -803,7 +803,7 @@ object Regex {
    *  @see [[java.util.regex.Matcher]]
    */
   class MatchIterator(val source: CharSequence, val regex: Regex, private[Regex] val _groupNames: Seq[String])
-  extends AbstractIterator[String] with Iterator[String] with MatchData { self =>
+  extends AbstractIterator[String] with MatchData { self =>
 
     @deprecated("groupNames does not include inline group names, and should not be used anymore", "2.13.7")
     val groupNames: Seq[String] = _groupNames

--- a/src/reflect/scala/reflect/internal/Scopes.scala
+++ b/src/reflect/scala/reflect/internal/Scopes.scala
@@ -64,7 +64,7 @@ trait Scopes extends api.Scopes { self: SymbolTable =>
   }
 
   /** A default Scope iterator, that retrieves elements in the order given by ScopeEntry. */
-  private[Scopes] class ScopeIterator(owner: Scope) extends Iterator[Symbol] {
+  private[Scopes] class ScopeIterator(owner: Scope) extends AbstractIterator[Symbol] {
     private[this] var elem: ScopeEntry = owner.elems
 
     def hasNext: Boolean = (elem ne null) && (elem.owner == this.owner)

--- a/src/reflect/scala/reflect/internal/util/Collections.scala
+++ b/src/reflect/scala/reflect/internal/util/Collections.scala
@@ -14,6 +14,7 @@ package scala
 package reflect.internal.util
 
 import scala.reflect.ClassTag
+import scala.collection.AbstractIterator
 import scala.collection.{immutable, mutable}
 import scala.annotation.tailrec
 import mutable.ListBuffer
@@ -314,7 +315,7 @@ trait Collections {
   }
 
   final def mapFilter2[A, B, C](itA: Iterator[A], itB: Iterator[B])(f: (A, B) => Option[C]): Iterator[C] =
-    new Iterator[C] {
+    new AbstractIterator[C] {
       private[this] var head: Option[C] = None
       private[this] def advanceHead(): Unit =
         while (head.isEmpty && itA.hasNext && itB.hasNext) {


### PR DESCRIPTION
I noticed the jars are smaller, ~but not sure if the MiMA exclusion is dubious~.

Can't `deprecatedInheritance` because the lint is for concrete classes.