### PR TITLE
Emit migration warnings under `-Xsource:3` as fatal warnings, not errors; `-Xmigration` turns off erroring

### DIFF
--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -54,9 +54,9 @@ trait Reporting extends internal.Reporting { self: ast.Positions with Compilatio
         globalError(s"Failed to parse `-Wconf` configuration: ${settings.Wconf.value}\n${msgs.mkString("\n")}$multiHelp")
         WConf(Nil)
       case Right(conf) =>
-        if (isScala3 && !conf.filters.exists(_._1.exists { case MessageFilter.Category(WarningCategory.Migration) => true case _ => false })) {
+        if (isScala3 && !conf.filters.exists(_._1.exists { case MessageFilter.Category(WarningCategory.Scala3Migration) => true case _ => false })) {
           val migrationAction = if (isScala3Migration) Action.Warning else Action.Error
-          val migrationCategory = MessageFilter.Category(WarningCategory.Migration) :: Nil
+          val migrationCategory = MessageFilter.Category(WarningCategory.Scala3Migration) :: Nil
           WConf(conf.filters :+ (migrationCategory, migrationAction))
         }
         else conf
@@ -364,7 +364,7 @@ object Reporting {
 
     object JavaSource extends WarningCategory; add(JavaSource)
 
-    object Migration extends WarningCategory; add(Migration)
+    object Scala3Migration extends WarningCategory; add(Scala3Migration)
 
     sealed trait Other extends WarningCategory { override def summaryCategory: WarningCategory = Other }
     object Other extends Other { override def includes(o: WarningCategory): Boolean = o.isInstanceOf[Other] }; add(Other)

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -609,16 +609,16 @@ self =>
 
     // warn under -Xsource:3
     def migrationWarning(offset: Offset, msg: String, since: String): Unit =
-      if (currentRun.isScala3) warning(offset, msg, WarningCategory.Migration)
+      if (currentRun.isScala3) warning(offset, msg, WarningCategory.Scala3Migration)
 
     // warn under -Xsource:3, otherwise deprecation
     def hardMigrationWarning(offset: Offset, msg: String, since: String): Unit =
-      if (currentRun.isScala3) warning(offset, msg, WarningCategory.Migration)
+      if (currentRun.isScala3) warning(offset, msg, WarningCategory.Scala3Migration)
       else deprecationWarning(offset, msg, since)
 
     // deprecation or migration under -Xsource:3, with different messages
     def hardMigrationWarning(offset: Offset, depr: => String, migr: => String, since: String): Unit =
-      if (currentRun.isScala3) warning(offset, migr, WarningCategory.Migration)
+      if (currentRun.isScala3) warning(offset, migr, WarningCategory.Scala3Migration)
       else deprecationWarning(offset, depr, since)
 
     def expectedMsgTemplate(exp: String, fnd: String) = s"$exp expected but $fnd found."

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -32,7 +32,8 @@ import scala.tools.nsc.Reporting.WarningCategory
  *  the beginnings of a campaign against this latest incursion by Cutty
  *  McPastington and his army of very similar soldiers.
  */
-trait ParsersCommon extends ScannersCommon { self =>
+trait ParsersCommon extends ScannersCommon {
+  self =>
   val global : Global
   // the use of currentUnit in the parser should be avoided as it might
   // cause unexpected behaviour when you work with two units at the
@@ -606,6 +607,20 @@ self =>
       and
     }
 
+    // warn under -Xsource:3
+    def migrationWarning(offset: Offset, msg: String, since: String): Unit =
+      if (currentRun.isScala3) warning(offset, msg, WarningCategory.Migration)
+
+    // warn under -Xsource:3, otherwise deprecation
+    def hardMigrationWarning(offset: Offset, msg: String, since: String): Unit =
+      if (currentRun.isScala3) warning(offset, msg, WarningCategory.Migration)
+      else deprecationWarning(offset, msg, since)
+
+    // deprecation or migration under -Xsource:3, with different messages
+    def hardMigrationWarning(offset: Offset, depr: => String, migr: => String, since: String): Unit =
+      if (currentRun.isScala3) warning(offset, migr, WarningCategory.Migration)
+      else deprecationWarning(offset, depr, since)
+
     def expectedMsgTemplate(exp: String, fnd: String) = s"$exp expected but $fnd found."
     def expectedMsg(token: Token): String =
       in.token match {
@@ -782,8 +797,7 @@ self =>
         val msg = "parentheses are required around the parameter of a lambda"
         val wrn = sm"""|$msg
                        |Use '-Wconf:msg=lambda-parens:s' to silence this warning."""
-        if (currentRun.isScala3)
-          deprecationWarning(tree.pos.point, wrn, "2.13.11")
+        migrationWarning(tree.pos.point, wrn, "2.13.11")
         List(convertToParam(tree))
       case _ => List(convertToParam(tree))
     }
@@ -994,10 +1008,7 @@ self =>
     def finishBinaryOp(isExpr: Boolean, opinfo: OpInfo, rhs: Tree): Tree = {
       import opinfo._
       if (targs.nonEmpty)
-        if (currentRun.isScala3)
-          syntaxError(offset, "type application is not allowed for infix operators")
-        else
-          deprecationWarning(offset, "type application will be disallowed for infix operators", "2.13.11")
+        migrationWarning(offset, "type application is not allowed for infix operators", "2.13.11")
       val operatorPos: Position = Position.range(rhs.pos.source, offset, offset, offset + operator.length)
       val pos                   = lhs.pos.union(rhs.pos).union(operatorPos).withEnd(in.lastOffset).withPoint(offset)
 
@@ -2064,8 +2075,7 @@ self =>
         def msg(what: String, instead: String): String = s"`val` keyword in for comprehension is $what: $instead"
         if (hasEq) {
           val without = "instead, bind the value without `val`"
-          if (currentRun.isScala3) syntaxError(in.offset, msg("unsupported", without))
-          else deprecationWarning(in.offset, msg("deprecated", without), "2.10.0")
+          hardMigrationWarning(in.offset, msg("deprecated", without), msg("unsupported", without), "2.10.0")
         }
         else syntaxError(in.offset, msg("unsupported", "just remove `val`"))
       }
@@ -2616,9 +2626,9 @@ self =>
         checkQMarkDefinition()
         checkKeywordDefinition()
         val pname: TypeName =
-          if (in.token == USCORE && (isAbstractOwner || !currentRun.isScala3)) {
+          if (in.token == USCORE) {
             if (!isAbstractOwner)
-              deprecationWarning(in.offset, "Top-level wildcard is not allowed and will error under -Xsource:3", "2.13.7")
+              hardMigrationWarning(in.offset, "Top-level wildcard is not allowed", "2.13.7")
             in.nextToken()
             freshTypeName("_$$")
           }
@@ -2631,8 +2641,7 @@ self =>
           def msg(what: String) = s"""view bounds are $what; use an implicit parameter instead.
                                      |  example: instead of `def f[A <% Int](a: A)` use `def f[A](a: A)(implicit ev: A => Int)`""".stripMargin
           while (in.token == VIEWBOUND) {
-            if (currentRun.isScala3) syntaxError(in.offset, msg("unsupported"))
-            else deprecationWarning(in.offset, msg("deprecated"), "2.12.0")
+            hardMigrationWarning(in.offset, msg("deprecated"), msg("unsupported"), "2.12.0")
             contextBoundBuf += atPos(in.skipToken())(makeFunctionTypeTree(List(Ident(pname)), typ()))
           }
           while (in.token == COLON) {
@@ -2932,12 +2941,12 @@ self =>
     def funDefOrDcl(start: Int, mods: Modifiers): Tree = {
       in.nextToken()
       if (in.token == THIS) {
-        def missingEquals() = deprecationWarning(in.lastOffset, "procedure syntax is deprecated for constructors: add `=`, as in method definition", "2.13.2")
+        def missingEquals() = hardMigrationWarning(in.lastOffset, "procedure syntax is deprecated for constructors: add `=`, as in method definition", "2.13.2")
         atPos(start, in.skipToken()) {
           val vparamss = paramClauses(nme.CONSTRUCTOR, classContextBounds map (_.duplicate), ofCaseClass = false)
           newLineOptWhenFollowedBy(LBRACE)
           val rhs =
-            if (in.token == LBRACE && !currentRun.isScala3) {
+            if (in.token == LBRACE) {
               missingEquals(); atPos(in.offset) { constrBlock(vparamss) }
             }
             else {
@@ -2972,15 +2981,13 @@ self =>
         val rhs =
           if (isStatSep || in.token == RBRACE) {
             if (restype.isEmpty) {
-              if (currentRun.isScala3) syntaxError(in.lastOffset, msg("unsupported", ": Unit"))
-              else deprecationWarning(in.lastOffset, msg("deprecated", ": Unit"), "2.13.0")
+              hardMigrationWarning(in.lastOffset, msg("deprecated", ": Unit"), msg("unsupported", ": Unit"), "2.13.0")
               restype = scalaUnitConstr
             }
             newmods |= Flags.DEFERRED
             EmptyTree
           } else if (restype.isEmpty && in.token == LBRACE) {
-            if (currentRun.isScala3) syntaxError(in.offset, msg("unsupported", ": Unit ="))
-            else deprecationWarning(in.offset, msg("deprecated", ": Unit ="), "2.13.0")
+            hardMigrationWarning(in.offset, msg("deprecated", ": Unit ="), msg("unsupported", ": Unit ="), "2.13.0")
             restype = scalaUnitConstr
             blockExpr()
           } else {
@@ -2998,9 +3005,7 @@ self =>
         if (nme.isEncodedUnary(name) && vparamss.nonEmpty) {
           def instead = DefDef(newmods, name.toTermName.decodedName, tparams, vparamss.drop(1), restype, rhs)
           def unaryMsg(what: String) = s"unary prefix operator definition with empty parameter list is $what: instead, remove () to declare as `$instead`"
-          def warnNilary(): Unit =
-            if (currentRun.isScala3) syntaxError(nameOffset, unaryMsg("unsupported"))
-            else deprecationWarning(nameOffset, unaryMsg("deprecated"), "2.13.4")
+          def warnNilary() = hardMigrationWarning(nameOffset, unaryMsg("deprecated"), unaryMsg("unsupported"), "2.13.4")
           vparamss match {
             case List(List())                               => warnNilary()
             case List(List(), x :: xs) if x.mods.isImplicit => warnNilary()
@@ -3129,7 +3134,7 @@ self =>
       val nameOffset = in.offset
       val name = identForType()
       if (currentRun.isScala3 && in.token == LBRACKET && isAfterLineEnd)
-        deprecationWarning(in.offset, "type parameters should not follow newline", "2.13.7")
+        hardMigrationWarning(in.offset, "type parameters should not follow newline", "2.13.7")
       def orStart(p: Offset) = if (name == tpnme.ERROR) start else p
       val namePos = NamePos(r2p(orStart(nameOffset), orStart(nameOffset)))
       atPos(start, orStart(nameOffset)) {
@@ -3140,7 +3145,7 @@ self =>
           val tstart = (in.offset :: classContextBounds.map(_.pos.start)).min
           if (!classContextBounds.isEmpty && mods.isTrait) {
             val viewBoundsExist = if (currentRun.isScala3) "" else " nor view bounds `<% ...`"
-              syntaxError(s"traits cannot have type parameters with context bounds `: ...`$viewBoundsExist", skipIt = false)
+            syntaxError(s"traits cannot have type parameters with context bounds `: ...`$viewBoundsExist", skipIt = false)
             classContextBounds = List()
           }
           val constrAnnots = if (!mods.isTrait) constructorAnnotations() else Nil
@@ -3238,7 +3243,7 @@ self =>
           val advice =
             if (currentRun.isScala3) "use trait parameters instead."
             else "they will be replaced by trait parameters in 3.0, see the migration guide on avoiding var/val in traits."
-          deprecationWarning(braceOffset, s"early initializers are deprecated; $advice", "2.13.0")
+          hardMigrationWarning(braceOffset, s"early initializers are deprecated; $advice", "2.13.0")
           val earlyDefs: List[Tree] = body.map(ensureEarlyDef).filter(_.nonEmpty)
           in.nextToken()
           val parents = templateParents()
@@ -3259,8 +3264,7 @@ self =>
         copyValDef(vdef)(mods = mods | Flags.PRESUPER)
       case tdef @ TypeDef(mods, name, tparams, rhs) =>
         def msg(what: String): String = s"early type members are $what: move them to the regular body; the semantics are the same"
-        if (currentRun.isScala3) syntaxError(tdef.pos.point, msg("unsupported"))
-        else deprecationWarning(tdef.pos.point, msg("deprecated"), "2.11.0")
+        hardMigrationWarning(tdef.pos.point, msg("deprecated"), msg("unsupported"), "2.11.0")
         treeCopy.TypeDef(tdef, mods | Flags.PRESUPER, name, tparams, rhs)
       case docdef @ DocDef(comm, rhs) =>
         treeCopy.DocDef(docdef, comm, rhs)
@@ -3302,8 +3306,8 @@ self =>
 
       // warn now if user wrote parents for package object; `gen.mkParents` adds AnyRef to parents
       if (currentRun.isScala3 && name == nme.PACKAGEkw && !parents.isEmpty)
-        deprecationWarning(tstart, """package object inheritance is deprecated (https://github.com/scala/scala-dev/issues/441);
-                                     |drop the `extends` clause or use a regular object instead""".stripMargin, "3.0.0")
+        migrationWarning(tstart, sm"""|package object inheritance is deprecated (https://github.com/scala/scala-dev/issues/441);
+                                      |drop the `extends` clause or use a regular object instead""", "3.0.0")
 
       atPos(templateOffset) {
         // Exclude only the 9 primitives plus AnyVal.

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -967,7 +967,7 @@ trait Scanners extends ScannersCommon {
               deprecationWarning(pos, msg("deprecated"), since="2.13.2")
               strVal = processed
             }
-            else warning(pos, msg("ignored under -Xsource:3"), WarningCategory.Migration)
+            else warning(pos, msg("ignored under -Xsource:3"), WarningCategory.Scala3Migration)
           }
         } catch {
           case ue: StringContext.InvalidUnicodeEscapeException =>

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -190,7 +190,7 @@ trait ContextErrors extends splain.SplainErrors {
         s"Implicit definition ${if (currentRun.isScala3) "must" else "should"} have explicit type${
           if (!inferred.isErroneous) s" (inferred $inferred)" else ""
         }"
-      if (currentRun.isScala3) ErrorUtils.issueNormalTypeError(tree, msg)(cx)
+      if (currentRun.isScala3) cx.warning(tree.pos, msg, WarningCategory.Migration)
       else cx.warning(tree.pos, msg, WarningCategory.OtherImplicitType)
     }
     val sym = tree.symbol

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -190,7 +190,7 @@ trait ContextErrors extends splain.SplainErrors {
         s"Implicit definition ${if (currentRun.isScala3) "must" else "should"} have explicit type${
           if (!inferred.isErroneous) s" (inferred $inferred)" else ""
         }"
-      if (currentRun.isScala3) cx.warning(tree.pos, msg, WarningCategory.Migration)
+      if (currentRun.isScala3) cx.warning(tree.pos, msg, WarningCategory.Scala3Migration)
       else cx.warning(tree.pos, msg, WarningCategory.OtherImplicitType)
     }
     val sym = tree.symbol

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1154,7 +1154,7 @@ trait Namers extends MethodSynthesis {
             val pts = pt.toString
             val leg = legacy.toString
             val help = if (pts != leg) s" instead of $leg" else ""
-            runReporting.warning(tree.pos, s"under -Xsource:3, inferred $pts$help", WarningCategory.Migration, tree.symbol)
+            runReporting.warning(tree.pos, s"under -Xsource:3, inferred $pts$help", WarningCategory.Scala3Migration, tree.symbol)
           }
           pt
         }

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1148,9 +1148,17 @@ trait Namers extends MethodSynthesis {
               case _ => true
             }
           }
-        if (inferOverridden) pt
-        else dropIllegalStarTypes(widenIfNecessary(tree.symbol, rhsTpe, pt))
-             .tap(InferredImplicitError(tree, _, context))
+        val legacy = dropIllegalStarTypes(widenIfNecessary(tree.symbol, rhsTpe, pt))
+        if (inferOverridden) {
+          if (!(legacy =:= pt) && currentRun.isScala3) {
+            val pts = pt.toString
+            val leg = legacy.toString
+            val help = if (pts != leg) s" instead of $leg" else ""
+            runReporting.warning(tree.pos, s"under -Xsource:3, inferred $pts$help", WarningCategory.Migration, tree.symbol)
+          }
+          pt
+        }
+        else legacy.tap(InferredImplicitError(tree, _, context))
       }.setPos(tree.pos.focus)
       tree.tpt.tpe
     }

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -834,7 +834,7 @@ abstract class RefChecks extends Transform {
             .filter(c => c.exists && c.isClass)
           overridden foreach { sym2 =>
             def msg(what: String) = s"shadowing a nested class of a parent is $what but $clazz shadows $sym2 defined in ${sym2.owner}; rename the class to something else"
-            if (currentRun.isScala3) runReporting.warning(clazz.pos, msg("deprecated"), WarningCategory.Migration, clazz)
+            if (currentRun.isScala3) runReporting.warning(clazz.pos, msg("deprecated"), WarningCategory.Scala3Migration, clazz)
             else runReporting.deprecationWarning(clazz.pos, clazz, currentOwner, msg("deprecated"), "2.13.2")
           }
         }

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -834,7 +834,7 @@ abstract class RefChecks extends Transform {
             .filter(c => c.exists && c.isClass)
           overridden foreach { sym2 =>
             def msg(what: String) = s"shadowing a nested class of a parent is $what but $clazz shadows $sym2 defined in ${sym2.owner}; rename the class to something else"
-            if (currentRun.isScala3) reporter.error(clazz.pos, msg("unsupported"))
+            if (currentRun.isScala3) runReporting.warning(clazz.pos, msg("deprecated"), WarningCategory.Migration, clazz)
             else runReporting.deprecationWarning(clazz.pos, clazz, currentOwner, msg("deprecated"), "2.13.2")
           }
         }

--- a/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
@@ -158,7 +158,7 @@ trait Unapplies extends ast.TreeDSL {
         (caseMods | (inheritedMods.flags & PRIVATE)).copy(privateWithin = inheritedMods.privateWithin)
           .tap { mods =>
             if (currentRun.isScala3 && mods != caseMods)
-              runReporting.warning(cdef.pos, "constructor modifiers are assumed by synthetic `apply` method", WarningCategory.Migration, cdef.symbol)
+              runReporting.warning(cdef.pos, "constructor modifiers are assumed by synthetic `apply` method", WarningCategory.Scala3Migration, cdef.symbol)
           }
       else
         caseMods
@@ -282,7 +282,7 @@ trait Unapplies extends ast.TreeDSL {
           Modifiers(SYNTHETIC | (inheritedMods.flags & AccessFlags), inheritedMods.privateWithin)
             .tap { mods =>
               if (currentRun.isScala3 && mods != Modifiers(SYNTHETIC))
-                runReporting.warning(cdef.pos, "constructor modifiers are assumed by synthetic `copy` method", WarningCategory.Migration, cdef.symbol)
+                runReporting.warning(cdef.pos, "constructor modifiers are assumed by synthetic `copy` method", WarningCategory.Scala3Migration, cdef.symbol)
             }
         }
         else Modifiers(SYNTHETIC)

--- a/src/compiler/scala/tools/reflect/FastStringInterpolator.scala
+++ b/src/compiler/scala/tools/reflect/FastStringInterpolator.scala
@@ -47,7 +47,7 @@ trait FastStringInterpolator extends FormatInterpolator {
                   }
                   def msg(fate: String) = s"Unicode escapes in raw interpolations are $fate; use literal characters instead"
                   if (currentRun.isScala3) {
-                    runReporting.warning(pos, msg("ignored under -Xsource:3"), WarningCategory.Migration, c.internal.enclosingOwner)
+                    runReporting.warning(pos, msg("ignored under -Xsource:3"), WarningCategory.Scala3Migration, c.internal.enclosingOwner)
                     stringVal
                   }
                   else {

--- a/src/compiler/scala/tools/reflect/FastStringInterpolator.scala
+++ b/src/compiler/scala/tools/reflect/FastStringInterpolator.scala
@@ -10,7 +10,10 @@
  * additional information regarding copyright ownership.
  */
 
-package scala.tools.reflect
+package scala.tools
+package reflect
+
+import nsc.Reporting.WarningCategory
 
 trait FastStringInterpolator extends FormatInterpolator {
   import c.universe._
@@ -33,19 +36,29 @@ trait FastStringInterpolator extends FormatInterpolator {
         try
           parts.mapConserve {
             case lit @ Literal(Constant(stringVal: String)) =>
-              val value =
-                if (isRaw && currentRun.isScala3) stringVal
-                else if (isRaw) {
-                  val processed = StringContext.processUnicode(stringVal)
-                  if (processed != stringVal) {
+              def asRaw = {
+                val processed = StringContext.processUnicode(stringVal)
+                if (processed != stringVal) {
+                  val pos = {
                     val diffindex = processed.zip(stringVal).zipWithIndex.collectFirst {
                       case ((p, o), i) if p != o => i
                     }.getOrElse(processed.length - 1)
-
-                    runReporting.deprecationWarning(lit.pos.withShift(diffindex), "Unicode escapes in raw interpolations are deprecated. Use literal characters instead.", "2.13.2", "", "")
+                    lit.pos.withShift(diffindex)
                   }
-                  processed
+                  def msg(fate: String) = s"Unicode escapes in raw interpolations are $fate; use literal characters instead"
+                  if (currentRun.isScala3) {
+                    runReporting.warning(pos, msg("ignored under -Xsource:3"), WarningCategory.Migration, c.internal.enclosingOwner)
+                    stringVal
+                  }
+                  else {
+                    runReporting.deprecationWarning(pos, msg("deprecated"), "2.13.2", "", "")
+                    processed
+                  }
                 }
+                else stringVal
+              }
+              val value =
+                if (isRaw) asRaw
                 else StringContext.processEscapes(stringVal)
               val k = Constant(value)
               // To avoid the backlash of backslash, taken literally by Literal, escapes are processed strictly (scala/bug#11196)

--- a/test/files/neg/caseclass_private_constructor.scala
+++ b/test/files/neg/caseclass_private_constructor.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:3
+// scalac: -Xsource:3 -Xmigration -Wconf:cat=migration:s
 
 case class A private (i: Int)
 object A

--- a/test/files/neg/caseclass_private_constructor.scala
+++ b/test/files/neg/caseclass_private_constructor.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:3 -Xmigration -Wconf:cat=migration:s
+// scalac: -Xsource:3 -Wconf:cat=scala3-migration:s
 
 case class A private (i: Int)
 object A

--- a/test/files/neg/deprecate_package_object_extends.check
+++ b/test/files/neg/deprecate_package_object_extends.check
@@ -1,11 +1,9 @@
-deprecate_package_object_extends.scala:3: warning: package object inheritance is deprecated (https://github.com/scala/scala-dev/issues/441);
+deprecate_package_object_extends.scala:3: error: package object inheritance is deprecated (https://github.com/scala/scala-dev/issues/441);
 drop the `extends` clause or use a regular object instead
 package object foo extends C
                    ^
-deprecate_package_object_extends.scala:5: warning: package object inheritance is deprecated (https://github.com/scala/scala-dev/issues/441);
+deprecate_package_object_extends.scala:5: error: package object inheritance is deprecated (https://github.com/scala/scala-dev/issues/441);
 drop the `extends` clause or use a regular object instead
 package foo2 { object `package` extends C }
                                 ^
-error: No warnings can be incurred under -Werror.
-2 warnings
-1 error
+2 errors

--- a/test/files/neg/deprecate_package_object_extends.scala
+++ b/test/files/neg/deprecate_package_object_extends.scala
@@ -1,4 +1,4 @@
-// scalac: -Xfatal-warnings -deprecation -Xsource:3
+// scalac: -Werror -Xlint -Xmigration -Xsource:3
 class C
 package object foo extends C
 

--- a/test/files/neg/deprecate_package_object_extends.scala
+++ b/test/files/neg/deprecate_package_object_extends.scala
@@ -1,4 +1,4 @@
-// scalac: -Werror -Xlint -Xmigration -Xsource:3
+// scalac: -Xsource:3
 class C
 package object foo extends C
 

--- a/test/files/neg/dotless-targs-a.check
+++ b/test/files/neg/dotless-targs-a.check
@@ -1,15 +1,10 @@
-dotless-targs-a.scala:4: warning: type application will be disallowed for infix operators
+dotless-targs-a.scala:4: error: type application is not allowed for infix operators
   def fn2 = List apply[Int] 2
                  ^
-dotless-targs-a.scala:9: warning: type application will be disallowed for infix operators
+dotless-targs-a.scala:9: error: type application is not allowed for infix operators
   def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
                 ^
-dotless-targs-a.scala:9: warning: type application will be disallowed for infix operators
+dotless-targs-a.scala:9: error: type application is not allowed for infix operators
   def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
                                                     ^
-dotless-targs-a.scala:9: warning: multiarg infix syntax looks like a tuple and will be deprecated
-  def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
-                ^
-error: No warnings can be incurred under -Werror.
-4 warnings
-1 error
+3 errors

--- a/test/files/neg/dotless-targs-a.scala
+++ b/test/files/neg/dotless-targs-a.scala
@@ -1,4 +1,4 @@
-// scalac: -Werror -Xlint -Yrangepos:false -Xsource:3
+// scalac: -Xsource:3 -Yrangepos:false
 class A {
   def fn1 = List apply 1
   def fn2 = List apply[Int] 2

--- a/test/files/neg/dotless-targs-a.scala
+++ b/test/files/neg/dotless-targs-a.scala
@@ -1,4 +1,4 @@
-// scalac: -Werror -Xlint -Yrangepos:false
+// scalac: -Werror -Xlint -Yrangepos:false -Xsource:3
 class A {
   def fn1 = List apply 1
   def fn2 = List apply[Int] 2

--- a/test/files/neg/dotless-targs-ranged-a.check
+++ b/test/files/neg/dotless-targs-ranged-a.check
@@ -1,16 +1,24 @@
-dotless-targs-ranged-a.scala:4: error: type application is not allowed for infix operators
+dotless-targs-ranged-a.scala:4: warning: type application is not allowed for infix operators
   def fn2 = List apply[Int] 2
                  ^
-dotless-targs-ranged-a.scala:9: error: type application is not allowed for infix operators
+dotless-targs-ranged-a.scala:9: warning: type application is not allowed for infix operators
   def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
                 ^
-dotless-targs-ranged-a.scala:9: error: type application is not allowed for infix operators
+dotless-targs-ranged-a.scala:9: warning: type application is not allowed for infix operators
   def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
                                                     ^
-dotless-targs-ranged-a.scala:13: error: type application is not allowed for infix operators
+dotless-targs-ranged-a.scala:13: warning: type application is not allowed for infix operators
   def eval = 1 ->[Int] 2
                ^
-dotless-targs-ranged-a.scala:14: error: type application is not allowed for infix operators
+dotless-targs-ranged-a.scala:14: warning: type application is not allowed for infix operators
   def evil = new A() op  [Int,   String     ]  42
                      ^
-5 errors
+dotless-targs-ranged-a.scala:9: warning: multiarg infix syntax looks like a tuple and will be deprecated
+  def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
+                ^
+dotless-targs-ranged-a.scala:11: warning: type parameter A defined in method op shadows class A defined in package <empty>. You may want to rename your type parameter, or possibly remove it.
+  def op[A, B](i: Int): Int = 2*i
+         ^
+error: No warnings can be incurred under -Werror.
+7 warnings
+1 error

--- a/test/files/neg/dotless-targs-ranged-a.scala
+++ b/test/files/neg/dotless-targs-ranged-a.scala
@@ -1,4 +1,4 @@
-// scalac: -Xlint -Xsource:3 -Yrangepos:true
+// scalac: -Werror -Xlint -Xmigration -Xsource:3 -Yrangepos:true
 class A {
   def fn1 = List apply 1
   def fn2 = List apply[Int] 2

--- a/test/files/neg/early-type-defs.check
+++ b/test/files/neg/early-type-defs.check
@@ -1,8 +1,9 @@
-early-type-defs.scala:4: error: early type members are unsupported: move them to the regular body; the semantics are the same
-object Test extends { type A1 = Int } with Runnable { def run() = () }
-                           ^
-early-type-defs.scala:4: warning: early initializers are deprecated; use trait parameters instead.
+early-type-defs.scala:4: warning: early initializers are deprecated; they will be replaced by trait parameters in 3.0, see the migration guide on avoiding var/val in traits.
 object Test extends { type A1 = Int } with Runnable { def run() = () }
                     ^
-1 warning
+early-type-defs.scala:4: warning: early type members are deprecated: move them to the regular body; the semantics are the same
+object Test extends { type A1 = Int } with Runnable { def run() = () }
+                           ^
+error: No warnings can be incurred under -Werror.
+2 warnings
 1 error

--- a/test/files/neg/early-type-defs.scala
+++ b/test/files/neg/early-type-defs.scala
@@ -1,4 +1,4 @@
 //
-// scalac: -deprecation -Xsource:3
+// scalac: -Werror -Xlint
 //
 object Test extends { type A1 = Int } with Runnable { def run() = () }

--- a/test/files/neg/for-comprehension-val.check
+++ b/test/files/neg/for-comprehension-val.check
@@ -1,24 +1,24 @@
-for-comprehension-val.scala:5: error: `val` keyword in for comprehension is unsupported: instead, bind the value without `val`
-  for (x <- 1 to 5 ; val y = x) yield x+y       // fail
-                           ^
 for-comprehension-val.scala:6: error: `val` keyword in for comprehension is unsupported: just remove `val`
   for (val x <- 1 to 5 ; y = x) yield x+y       // fail
              ^
 for-comprehension-val.scala:7: error: `val` keyword in for comprehension is unsupported: just remove `val`
   for (val x <- 1 to 5 ; val y = x) yield x+y   // fail
              ^
-for-comprehension-val.scala:7: error: `val` keyword in for comprehension is unsupported: instead, bind the value without `val`
-  for (val x <- 1 to 5 ; val y = x) yield x+y   // fail
-                               ^
-for-comprehension-val.scala:10: error: `val` keyword in for comprehension is unsupported: instead, bind the value without `val`
-  for (z <- 1 to 2 ; x <- 1 to 5 ; val y = x) yield x+y       // fail
-                                         ^
 for-comprehension-val.scala:11: error: `val` keyword in for comprehension is unsupported: just remove `val`
   for (z <- 1 to 2 ; val x <- 1 to 5 ; y = x) yield x+y       // fail
                            ^
 for-comprehension-val.scala:12: error: `val` keyword in for comprehension is unsupported: just remove `val`
   for (z <- 1 to 2 ; val x <- 1 to 5 ; val y = x) yield x+y   // fail
                            ^
+for-comprehension-val.scala:5: error: `val` keyword in for comprehension is unsupported: instead, bind the value without `val`
+  for (x <- 1 to 5 ; val y = x) yield x+y       // fail
+                           ^
+for-comprehension-val.scala:7: error: `val` keyword in for comprehension is unsupported: instead, bind the value without `val`
+  for (val x <- 1 to 5 ; val y = x) yield x+y   // fail
+                               ^
+for-comprehension-val.scala:10: error: `val` keyword in for comprehension is unsupported: instead, bind the value without `val`
+  for (z <- 1 to 2 ; x <- 1 to 5 ; val y = x) yield x+y       // fail
+                                         ^
 for-comprehension-val.scala:12: error: `val` keyword in for comprehension is unsupported: instead, bind the value without `val`
   for (z <- 1 to 2 ; val x <- 1 to 5 ; val y = x) yield x+y   // fail
                                              ^

--- a/test/files/neg/for-comprehension-val.scala
+++ b/test/files/neg/for-comprehension-val.scala
@@ -1,4 +1,4 @@
-// scalac: -deprecation -Xsource:3
+// scalac: -Xsource:3
 //
 class A {
   for (x <- 1 to 5 ; y = x) yield x+y           // ok

--- a/test/files/neg/nested-class-shadowing-removal.check
+++ b/test/files/neg/nested-class-shadowing-removal.check
@@ -1,4 +1,4 @@
-nested-class-shadowing-removal.scala:9: error: shadowing a nested class of a parent is unsupported but class Status shadows class Status defined in trait Core; rename the class to something else
+nested-class-shadowing-removal.scala:9: error: shadowing a nested class of a parent is deprecated but class Status shadows class Status defined in trait Core; rename the class to something else
   class Status extends super.Status
         ^
 1 error

--- a/test/files/neg/nested-class-shadowing-removal.scala
+++ b/test/files/neg/nested-class-shadowing-removal.scala
@@ -1,4 +1,4 @@
-// scalac: -Werror -Xlint:deprecation -Xsource:3.0
+// scalac: -Xsource:3
 //
 
 trait Core {

--- a/test/files/neg/parens-for-params.check
+++ b/test/files/neg/parens-for-params.check
@@ -1,7 +1,5 @@
-parens-for-params.scala:5: warning: parentheses are required around the parameter of a lambda
+parens-for-params.scala:5: error: parentheses are required around the parameter of a lambda
 Use '-Wconf:msg=lambda-parens:s' to silence this warning.
     x: Int => x * 2
      ^
-error: No warnings can be incurred under -Werror.
-1 warning
 1 error

--- a/test/files/neg/parens-for-params.scala
+++ b/test/files/neg/parens-for-params.scala
@@ -1,4 +1,4 @@
-// scalac: -Werror -Xlint -Xmigration -Xsource:3
+// scalac: -Xsource:3
 
 class C {
   def f = {

--- a/test/files/neg/parens-for-params.scala
+++ b/test/files/neg/parens-for-params.scala
@@ -1,4 +1,4 @@
-// scalac: -Werror -Xlint -Xsource:3
+// scalac: -Werror -Xlint -Xmigration -Xsource:3
 
 class C {
   def f = {

--- a/test/files/neg/prefix-unary-nilary-removal.check
+++ b/test/files/neg/prefix-unary-nilary-removal.check
@@ -1,7 +1,20 @@
-prefix-unary-nilary-removal.scala:4: error: unary prefix operator definition with empty parameter list is unsupported: instead, remove () to declare as `def unary_~ : Foo = this`
+prefix-unary-nilary-removal.scala:4: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_~ : Foo = this`
   def unary_~() : Foo = this
       ^
-prefix-unary-nilary-removal.scala:5: error: unary prefix operator definition with empty parameter list is unsupported: instead, remove () to declare as `def unary_-(implicit pos: Long) = this`
+prefix-unary-nilary-removal.scala:5: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_-(implicit pos: Long) = this`
   def unary_-()(implicit pos: Long) = this
       ^
-2 errors
+prefix-unary-nilary-removal.scala:12: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method unary_~,
+or remove the empty argument list from its definition (Java-defined methods are exempt).
+In Scala 3, an unapplied method like this will be eta-expanded into a function.
+  val f2 = ~f
+           ^
+prefix-unary-nilary-removal.scala:5: warning: parameter pos in method unary_- is never used
+  def unary_-()(implicit pos: Long) = this
+                         ^
+prefix-unary-nilary-removal.scala:8: warning: parameter pos in method unary_+ is never used
+  def unary_+(implicit pos: Long) = this // ok
+                       ^
+error: No warnings can be incurred under -Werror.
+5 warnings
+1 error

--- a/test/files/neg/prefix-unary-nilary-removal.scala
+++ b/test/files/neg/prefix-unary-nilary-removal.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:3
+// scalac: -Werror -Xlint
 //
 class Foo {
   def unary_~() : Foo = this

--- a/test/files/neg/procedure-removal.check
+++ b/test/files/neg/procedure-removal.check
@@ -1,19 +1,27 @@
-procedure-removal.scala:4: error: procedure syntax is unsupported: instead, add `: Unit =` to explicitly declare `bar`'s return type
+procedure-removal.scala:4: warning: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `bar`'s return type
   def bar {}
           ^
-procedure-removal.scala:5: error: procedure syntax is unsupported: instead, add `: Unit` to explicitly declare `baz`'s return type
+procedure-removal.scala:5: warning: procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `baz`'s return type
   def baz
          ^
-procedure-removal.scala:6: error: procedure syntax is unsupported: instead, add `: Unit` to explicitly declare `boo`'s return type
+procedure-removal.scala:6: warning: procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `boo`'s return type
   def boo(i: Int, l: Long)
                           ^
-procedure-removal.scala:7: error: procedure syntax is unsupported: instead, add `: Unit =` to explicitly declare `boz`'s return type
+procedure-removal.scala:7: warning: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `boz`'s return type
   def boz(i: Int, l: Long) {}
                            ^
-procedure-removal.scala:8: error: '=' expected but '{' found.
+procedure-removal.scala:8: warning: procedure syntax is deprecated for constructors: add `=`, as in method definition
   def this(i: Int) { this() } // Don't complain here! Just slap them with an error.
-                   ^
-procedure-removal.scala:9: error: 'this' expected.
+                  ^
+procedure-removal.scala:4: warning: side-effecting nullary methods are discouraged: suggest defining as `def bar()` instead
+  def bar {}
+      ^
+procedure-removal.scala:5: warning: side-effecting nullary methods are discouraged: suggest defining as `def baz()` instead
+  def baz
+      ^
+procedure-removal.scala:9: warning: side-effecting nullary methods are discouraged: suggest defining as `def foz()` instead
   def foz: Unit               // Don't complain here!
-^
-6 errors
+      ^
+error: No warnings can be incurred under -Werror.
+8 warnings
+1 error

--- a/test/files/neg/procedure-removal.scala
+++ b/test/files/neg/procedure-removal.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:3
+// scalac: -Werror -Xlint
 //
 abstract class Foo {
   def bar {}

--- a/test/files/neg/t12798-migration.check
+++ b/test/files/neg/t12798-migration.check
@@ -1,0 +1,54 @@
+t12798-migration.scala:11: error: unknown parameter name: z
+Note that assignments in argument position are no longer allowed since Scala 2.13.
+To express the assignment expression, wrap it in brackets, e.g., `{ z = ... }`.
+    f(42, z = 27)
+            ^
+t12798-migration.scala:25: warning: unary prefix operator definition with empty parameter list is unsupported: instead, remove () to declare as `def unary_- = -42`
+  def unary_-() = -42
+      ^
+t12798-migration.scala:28: warning: package object inheritance is deprecated (https://github.com/scala/scala-dev/issues/441);
+drop the `extends` clause or use a regular object instead
+package object tester extends Runnable {
+                      ^
+t12798-migration.scala:33: warning: procedure syntax is deprecated for constructors: add `=`, as in method definition
+  def this(s: String) { this() }
+                     ^
+t12798-migration.scala:34: warning: procedure syntax is unsupported: instead, add `: Unit =` to explicitly declare `f`'s return type
+  def f() { println() }
+          ^
+t12798-migration.scala:35: warning: procedure syntax is unsupported: instead, add `: Unit` to explicitly declare `g`'s return type
+  def g()
+         ^
+t12798-migration.scala:39: warning: parentheses are required around the parameter of a lambda
+Use '-Wconf:msg=lambda-parens:s' to silence this warning.
+  def f = List(42).map { x: Int => x + 1 }
+                          ^
+t12798-migration.scala:43: warning: type application is not allowed for infix operators
+  def f = List(42) map [Int] (_ + 1)
+                   ^
+t12798-migration.scala:46: warning: Top-level wildcard is not allowed
+class `misuse of underscore`[_]
+                             ^
+t12798-migration.scala:48: warning: early initializers are deprecated; use trait parameters instead.
+class `early bird` extends { val x = "hello, world" } with Runnable { def run() = println(x) }
+                           ^
+t12798-migration.scala:17: warning: Unicode escapes in raw interpolations are ignored under -Xsource:3; use literal characters instead
+  def f = raw"\u0043 is for $entry"
+              ^
+t12798-migration.scala:18: warning: Unicode escapes in raw interpolations are ignored under -Xsource:3; use literal characters instead
+  def g = raw"""\u0043 is for Cat"""
+                ^
+t12798-migration.scala:50: warning: constructor modifiers are assumed by synthetic `copy` method
+case class `case mods propagate` private (s: String)
+           ^
+t12798-migration.scala:60: warning: under -Xsource:3, inferred Option[Int] instead of Some[Int]
+  override def f = Some(27)
+               ^
+t12798-migration.scala:50: warning: constructor modifiers are assumed by synthetic `apply` method
+case class `case mods propagate` private (s: String)
+           ^
+t12798-migration.scala:52: warning: constructor modifiers are assumed by synthetic `apply` method
+case class `copyless case mods propagate` private (s: String) {
+           ^
+15 warnings
+1 error

--- a/test/files/neg/t12798-migration.scala
+++ b/test/files/neg/t12798-migration.scala
@@ -1,0 +1,66 @@
+// scalac: -Xmigration -Xsource:3
+
+// Demonstrate migration warnings at typer for -Xsource:3
+
+class `named arg is not assignment` {
+  // unfortunately, z member is not available yet while erroring in g
+  //var z = 17
+  def f(x: Int, y: Int) = x + y
+  def g = {
+    var z = 17
+    f(42, z = 27)
+  }
+}
+
+class `interpolated unicode such as \u0043` {
+  def entry = "Cat"
+  def f = raw"\u0043 is for $entry"
+  def g = raw"""\u0043 is for Cat"""
+}
+
+// it was always specified that unary is parameterless.
+// The most correct behavior would be that you can define unary_-()
+// but you can't use it as unary prefix.
+class `unary op lacks parens` {
+  def unary_-() = -42
+}
+
+package object tester extends Runnable {
+  def run() = ()
+}
+
+abstract class `procedure syntax` {
+  def this(s: String) { this() }
+  def f() { println() }
+  def g()
+}
+
+class `lambda parens` {
+  def f = List(42).map { x: Int => x + 1 }
+}
+
+class `infix type args` {
+  def f = List(42) map [Int] (_ + 1)
+}
+
+class `misuse of underscore`[_]
+
+class `early bird` extends { val x = "hello, world" } with Runnable { def run() = println(x) }
+
+case class `case mods propagate` private (s: String)
+
+case class `copyless case mods propagate` private (s: String) {
+  def copy(x: String) = this
+}
+
+class Parent {
+  def f: Option[Int] = Some(42)
+}
+class Child extends Parent {
+  override def f = Some(27)
+}
+
+@annotation.nowarn
+class `get off my back` {
+  def f() { println("hello, world") }
+}

--- a/test/files/neg/t12798.check
+++ b/test/files/neg/t12798.check
@@ -1,0 +1,50 @@
+t12798.scala:11: error: unknown parameter name: z
+Note that assignments in argument position are no longer allowed since Scala 2.13.
+To express the assignment expression, wrap it in brackets, e.g., `{ z = ... }`.
+    f(42, z = 27)
+            ^
+t12798.scala:25: error: unary prefix operator definition with empty parameter list is unsupported: instead, remove () to declare as `def unary_- = -42`
+  def unary_-() = -42
+      ^
+t12798.scala:28: error: package object inheritance is deprecated (https://github.com/scala/scala-dev/issues/441);
+drop the `extends` clause or use a regular object instead
+package object tester extends Runnable {
+                      ^
+t12798.scala:33: error: procedure syntax is deprecated for constructors: add `=`, as in method definition
+  def this(s: String) { this() }
+                     ^
+t12798.scala:34: error: procedure syntax is unsupported: instead, add `: Unit =` to explicitly declare `f`'s return type
+  def f() { println() }
+          ^
+t12798.scala:35: error: procedure syntax is unsupported: instead, add `: Unit` to explicitly declare `g`'s return type
+  def g()
+         ^
+t12798.scala:39: error: parentheses are required around the parameter of a lambda
+Use '-Wconf:msg=lambda-parens:s' to silence this warning.
+  def f = List(42).map { x: Int => x + 1 }
+                          ^
+t12798.scala:43: error: type application is not allowed for infix operators
+  def f = List(42) map [Int] (_ + 1)
+                   ^
+t12798.scala:46: error: Top-level wildcard is not allowed
+class `misuse of underscore`[_]
+                             ^
+t12798.scala:48: error: early initializers are deprecated; use trait parameters instead.
+class `early bird` extends { val x = "hello, world" } with Runnable { def run() = println(x) }
+                           ^
+t12798.scala:17: error: Unicode escapes in raw interpolations are ignored under -Xsource:3; use literal characters instead
+  def f = raw"\u0043 is for $entry"
+              ^
+t12798.scala:18: error: Unicode escapes in raw interpolations are ignored under -Xsource:3; use literal characters instead
+  def g = raw"""\u0043 is for Cat"""
+                ^
+t12798.scala:50: error: constructor modifiers are assumed by synthetic `copy` method
+case class `case mods propagate` private (s: String)
+           ^
+t12798.scala:60: error: under -Xsource:3, inferred Option[Int] instead of Some[Int]
+  override def f = Some(27)
+               ^
+t12798.scala:52: error: constructor modifiers are assumed by synthetic `apply` method
+case class `copyless case mods propagate` private (s: String) {
+           ^
+15 errors

--- a/test/files/neg/t12798.scala
+++ b/test/files/neg/t12798.scala
@@ -1,0 +1,66 @@
+// scalac: -Xsource:3
+
+// Demonstrate migration warnings at typer for -Xsource:3
+
+class `named arg is not assignment` {
+  // unfortunately, z member is not available yet while erroring in g
+  //var z = 17
+  def f(x: Int, y: Int) = x + y
+  def g = {
+    var z = 17
+    f(42, z = 27)
+  }
+}
+
+class `interpolated unicode such as \u0043` {
+  def entry = "Cat"
+  def f = raw"\u0043 is for $entry"
+  def g = raw"""\u0043 is for Cat"""
+}
+
+// it was always specified that unary is parameterless.
+// The most correct behavior would be that you can define unary_-()
+// but you can't use it as unary prefix.
+class `unary op lacks parens` {
+  def unary_-() = -42
+}
+
+package object tester extends Runnable {
+  def run() = ()
+}
+
+abstract class `procedure syntax` {
+  def this(s: String) { this() }
+  def f() { println() }
+  def g()
+}
+
+class `lambda parens` {
+  def f = List(42).map { x: Int => x + 1 }
+}
+
+class `infix type args` {
+  def f = List(42) map [Int] (_ + 1)
+}
+
+class `misuse of underscore`[_]
+
+class `early bird` extends { val x = "hello, world" } with Runnable { def run() = println(x) }
+
+case class `case mods propagate` private (s: String)
+
+case class `copyless case mods propagate` private (s: String) {
+  def copy(x: String) = this
+}
+
+class Parent {
+  def f: Option[Int] = Some(42)
+}
+class Child extends Parent {
+  override def f = Some(27)
+}
+
+@annotation.nowarn
+class `get off my back` {
+  def f() { println("hello, world") }
+}

--- a/test/files/neg/t12798b.check
+++ b/test/files/neg/t12798b.check
@@ -1,0 +1,7 @@
+t12798b.scala:9: error: shadowing a nested class of a parent is deprecated but class P shadows class P defined in class HasP; rename the class to something else
+  class P extends super.P
+        ^
+t12798b.scala:15: error: shadowing a nested class of a parent is deprecated but class Q shadows class Q defined in class HasQ; rename the class to something else
+  class Q
+        ^
+2 errors

--- a/test/files/neg/t12798b.scala
+++ b/test/files/neg/t12798b.scala
@@ -1,4 +1,4 @@
-// scalac: -Wconf:cat=migration:e -Xmigration -Xsource:3
+// scalac: -Wconf:cat=scala3-migration:e -Xmigration -Xsource:3
 
 // Demonstrate migration warnings at refchecks for -Xsource:3
 

--- a/test/files/neg/t12798b.scala
+++ b/test/files/neg/t12798b.scala
@@ -1,0 +1,16 @@
+// scalac: -Wconf:cat=migration:e -Xmigration -Xsource:3
+
+// Demonstrate migration warnings at refchecks for -Xsource:3
+
+class HasP {
+  class P
+}
+class AnotherP extends HasP {
+  class P extends super.P
+}
+class HasQ {
+  class Q
+}
+class AnotherQ extends HasQ {
+  class Q
+}

--- a/test/files/neg/t5265b.check
+++ b/test/files/neg/t5265b.check
@@ -1,4 +1,7 @@
 t5265b.scala:7: error: Implicit definition must have explicit type (inferred T[String])
   implicit val tsMissing = new T[String] {}   // warn val in trait
                ^
-1 error
+t5265b.scala:20: error: under -Xsource:3, inferred T[String]
+  implicit val tsChild = new T[String] {}     // nowarn because inferred from overridden
+               ^
+2 errors

--- a/test/files/neg/t5265b.scala
+++ b/test/files/neg/t5265b.scala
@@ -1,4 +1,4 @@
-// scalac: -Werror -Xlint -Xsource:3
+// scalac: -Xsource:3
 trait T[A]
 
 class C[A: T]

--- a/test/files/neg/t5606.check
+++ b/test/files/neg/t5606.check
@@ -1,16 +1,19 @@
-t5606.scala:3: error: identifier expected but '_' found.
-case class CaseTest[_](someData: String)
-                    ^
 t5606.scala:5: error: using `?` as a type name requires backticks.
 case class CaseTest_?[?](someData: String)
                       ^
-t5606.scala:8: error: identifier expected but '_' found.
-case class CaseTest2[_, _](someData: String)
-                     ^
-t5606.scala:11: error: identifier expected but '_' found.
-  def f[_](x: Int) = ???
-        ^
 t5606.scala:23: error: using `?` as a type name requires backticks.
   def regress_?[F[?]]   = 2
                   ^
-5 errors
+t5606.scala:3: error: Top-level wildcard is not allowed
+case class CaseTest[_](someData: String)
+                    ^
+t5606.scala:8: error: Top-level wildcard is not allowed
+case class CaseTest2[_, _](someData: String)
+                     ^
+t5606.scala:8: error: Top-level wildcard is not allowed
+case class CaseTest2[_, _](someData: String)
+                        ^
+t5606.scala:11: error: Top-level wildcard is not allowed
+  def f[_](x: Int) = ???
+        ^
+6 errors

--- a/test/files/neg/t5606.scala
+++ b/test/files/neg/t5606.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:3
+// scalac: -Werror -Xlint -Xsource:3
 // was: _ taken as ident of type param, but poor interactions below
 case class CaseTest[_](someData: String)
 

--- a/test/files/neg/t5606.scala
+++ b/test/files/neg/t5606.scala
@@ -1,4 +1,4 @@
-// scalac: -Werror -Xlint -Xsource:3
+// scalac: -Xsource:3
 // was: _ taken as ident of type param, but poor interactions below
 case class CaseTest[_](someData: String)
 

--- a/test/files/neg/t5606b.check
+++ b/test/files/neg/t5606b.check
@@ -1,13 +1,13 @@
-t5606b.scala:4: warning: Top-level wildcard is not allowed and will error under -Xsource:3
+t5606b.scala:4: warning: Top-level wildcard is not allowed
 case class CaseTest[_](someData: String)
                     ^
-t5606b.scala:7: warning: Top-level wildcard is not allowed and will error under -Xsource:3
+t5606b.scala:7: warning: Top-level wildcard is not allowed
 case class CaseTest2[_, _](someData: String)
                      ^
-t5606b.scala:7: warning: Top-level wildcard is not allowed and will error under -Xsource:3
+t5606b.scala:7: warning: Top-level wildcard is not allowed
 case class CaseTest2[_, _](someData: String)
                         ^
-t5606b.scala:10: warning: Top-level wildcard is not allowed and will error under -Xsource:3
+t5606b.scala:10: warning: Top-level wildcard is not allowed
   def f[_](x: Int) = ???
         ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t7212.check
+++ b/test/files/neg/t7212.check
@@ -13,4 +13,14 @@ t7212.scala:21: error: type mismatch;
  required: String
   val s: String = w.f
                     ^
+t7212.scala:5: warning: under -Xsource:3, inferred Object instead of String
+class K extends T { def f = "" }
+                        ^
+t7212.scala:11: warning: under -Xsource:3, inferred Object instead of String
+class F extends T { val f = "" }
+                        ^
+t7212.scala:17: warning: under -Xsource:3, inferred Object instead of String
+trait V extends T { var f = "" }
+                        ^
+3 warnings
 3 errors

--- a/test/files/neg/t7212.scala
+++ b/test/files/neg/t7212.scala
@@ -1,5 +1,5 @@
 
-// scalac: -Xsource:3
+// scalac: -Xmigration -Xsource:3
 
 trait T { def f: Object }
 class K extends T { def f = "" }

--- a/test/files/pos/caseclass_private_constructor.scala
+++ b/test/files/pos/caseclass_private_constructor.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:3
+// scalac: -Xsource:3 -Xmigration
 
 case class A private (i: Int)
 object A {

--- a/test/files/pos/parens-for-params-silent.scala
+++ b/test/files/pos/parens-for-params-silent.scala
@@ -1,4 +1,4 @@
-// scalac: -Werror -Wconf:msg=lambda-parens:s -Xsource:3
+// scalac: -Werror -Wconf:msg=lambda-parens:s -Xsource:3 -Xmigration
 
 class C {
   def f = {

--- a/test/files/pos/parens-for-params-silent.scala
+++ b/test/files/pos/parens-for-params-silent.scala
@@ -1,4 +1,4 @@
-// scalac: -Werror -Wconf:msg=lambda-parens:s -Xsource:3 -Xmigration
+// scalac: -Werror -Wconf:msg=lambda-parens:s -Xsource:3
 
 class C {
   def f = {

--- a/test/files/pos/t11980.scala
+++ b/test/files/pos/t11980.scala
@@ -1,4 +1,4 @@
-//scalac: -Wconf:cat=migration:s -Werror -Wunused:privates -Xsource:3
+//scalac: -Wconf:cat=scala3-migration:s -Werror -Wunused:privates -Xsource:3
 //
 object Domain {
   def id(id: String): Domain = Domain(Some(id), None)

--- a/test/files/pos/t11980.scala
+++ b/test/files/pos/t11980.scala
@@ -1,4 +1,4 @@
-//scalac: -Werror -Wunused:privates -Xsource:3
+//scalac: -Wconf:cat=migration:s -Werror -Wunused:privates -Xsource:3
 //
 object Domain {
   def id(id: String): Domain = Domain(Some(id), None)

--- a/test/files/pos/t7212.scala
+++ b/test/files/pos/t7212.scala
@@ -1,5 +1,5 @@
 
-// scalac: -Xsource:3
+// scalac: -Xsource:3 -Xmigration
 
 class A {
   def f: Option[String] = Some("hello, world")

--- a/test/files/pos/t7212b/ScalaThing.scala
+++ b/test/files/pos/t7212b/ScalaThing.scala
@@ -1,5 +1,5 @@
 
-// scalac: -Xsource:3
+// scalac: -Xsource:3 -Xmigration
 
 class ScalaThing extends JavaThing {
   override def remove() = ???

--- a/test/files/run/t10751.check
+++ b/test/files/run/t10751.check
@@ -35,4 +35,3 @@
   }
 }
 
-warning: 4 deprecations (since 2.13.11); re-run with -deprecation for details

--- a/test/files/run/t1980.check
+++ b/test/files/run/t1980.check
@@ -1,4 +1,3 @@
-warning: 1 deprecation (since 2.13.11); re-run with -deprecation for details
 1. defining
 foo 1
 foo 2

--- a/test/files/run/t3220-213.check
+++ b/test/files/run/t3220-213.check
@@ -1,19 +1,19 @@
-t3220-213.scala:9: warning: Unicode escapes in triple quoted strings are deprecated, use the literal character instead
+t3220-213.scala:9: warning: Unicode escapes in triple quoted strings are deprecated; use the literal character instead
   def inTripleQuoted = """\u000A"""
                           ^
-t3220-213.scala:45: warning: Unicode escapes in triple quoted strings are deprecated, use the literal character instead
+t3220-213.scala:45: warning: Unicode escapes in triple quoted strings are deprecated; use the literal character instead
       "tab unicode escape in triple quoted string" -> """tab\u0009tab""",
                                                             ^
-t3220-213.scala:10: warning: Unicode escapes in raw interpolations are deprecated. Use literal characters instead.
+t3220-213.scala:10: warning: Unicode escapes in raw interpolations are deprecated; use literal characters instead
   def inInterpolation = raw"\u000A"
                             ^
-t3220-213.scala:11: warning: Unicode escapes in raw interpolations are deprecated. Use literal characters instead.
+t3220-213.scala:11: warning: Unicode escapes in raw interpolations are deprecated; use literal characters instead
   def inTripleQuotedInterpolation = raw"""\u000A"""
                                           ^
-t3220-213.scala:46: warning: Unicode escapes in raw interpolations are deprecated. Use literal characters instead.
+t3220-213.scala:46: warning: Unicode escapes in raw interpolations are deprecated; use literal characters instead
       "tab unicode escape in single quoted raw interpolator" -> raw"tab\u0009tab",
                                                                        ^
-t3220-213.scala:47: warning: Unicode escapes in raw interpolations are deprecated. Use literal characters instead.
+t3220-213.scala:47: warning: Unicode escapes in raw interpolations are deprecated; use literal characters instead
       "tab unicode escape in triple quoted raw interpolator" -> raw"""tab\u0009tab"""
                                                                          ^
 supported

--- a/test/files/run/t3220-214.check
+++ b/test/files/run/t3220-214.check
@@ -1,0 +1,9 @@
+t3220-214.scala:4: warning: Unicode escapes in triple quoted strings are ignored under -Xsource:3; use the literal character instead
+  def inTripleQuoted = """\u000A"""
+                          ^
+t3220-214.scala:5: warning: Unicode escapes in raw interpolations are ignored under -Xsource:3; use literal characters instead
+  def inRawInterpolation = raw"\u000A"
+                               ^
+t3220-214.scala:6: warning: Unicode escapes in raw interpolations are ignored under -Xsource:3; use literal characters instead
+  def inRawTripleQuoted = raw"""\u000A"""
+                                ^

--- a/test/files/run/t3220-214.scala
+++ b/test/files/run/t3220-214.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:3
+// scalac: -Xsource:3 -Xmigration
 
 object Literals214 {
   def inTripleQuoted = """\u000A"""


### PR DESCRIPTION
This allows toning down / silencing Scala 3 migration warnings using `-Wconf` or `@nowarn`.

Scala 3 migration warnings are emitted as "fatal warnings" under category `scala3-migration`. Without `-Xsource:3`, they continue to be reported as deprecations.

Adding `-Xmigration` makes the migration warnings non-fatal (same effect as `-Wconf:cat=scala3-migration:w`).

Add a new warning for the case when an inferred type differs between Scala 2 and 3. Example:

```scala
trait A { def f: Object }
trait B extends A { def f = "" } // under -Xsource:3, inferred Object instead of String
```

Benign syntax enabled by `-Xsource:3` does not warn, such as relaxed import syntax.

Fixes scala/bug#12798
