### PR TITLE
Add explicit result type to some non-private methods

### DIFF
--- a/src/library/scala/PartialFunction.scala
+++ b/src/library/scala/PartialFunction.scala
@@ -270,10 +270,10 @@ object PartialFunction {
       if (!fallbackOccurred(z)) z else f2.applyOrElse(x, default)
     }
 
-    override def orElse[A1 <: A, B1 >: B](that: PartialFunction[A1, B1]) =
+    override def orElse[A1 <: A, B1 >: B](that: PartialFunction[A1, B1]): OrElse[A1, B1] =
       new OrElse[A1, B1] (f1, f2 orElse that)
 
-    override def andThen[C](k: B => C) =
+    override def andThen[C](k: B => C): OrElse[A, C] =
       new OrElse[A, C] (f1 andThen k, f2 andThen k)
   }
 
@@ -368,8 +368,8 @@ object PartialFunction {
     def isDefinedAt(x: Any) = false
     def apply(x: Any) = throw new MatchError(x)
     override def orElse[A1, B1](that: PartialFunction[A1, B1]) = that
-    override def andThen[C](k: Nothing => C) = this
-    override val lift = (x: Any) => None
+    override def andThen[C](k: Nothing => C): PartialFunction[Any, Nothing] = this
+    override val lift: Any => None.type = (x: Any) => None
     override def runWith[U](action: Nothing => U) = constFalse
   }
 

--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -916,16 +916,16 @@ object Iterable extends IterableFactory.Delegate[Iterable](immutable.Iterable) {
     override def iterator = Iterator.single(a)
     override def knownSize = 1
     override def head = a
-    override def headOption = Some(a)
+    override def headOption: Some[A] = Some(a)
     override def last = a
-    override def lastOption = Some(a)
-    override def view = new View.Single(a)
+    override def lastOption: Some[A] = Some(a)
+    override def view: View.Single[A] = new View.Single(a)
     override def take(n: Int) = if (n > 0) this else Iterable.empty
     override def takeRight(n: Int) = if (n > 0) this else Iterable.empty
     override def drop(n: Int) = if (n > 0) Iterable.empty else this
     override def dropRight(n: Int) = if (n > 0) Iterable.empty else this
-    override def tail = Iterable.empty
-    override def init = Iterable.empty
+    override def tail: Iterable[Nothing] = Iterable.empty
+    override def init: Iterable[Nothing] = Iterable.empty
   }
 }
 

--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -19,7 +19,7 @@ import scala.collection.mutable.StringBuilder
 import scala.language.implicitConversions
 import scala.math.{Numeric, Ordering}
 import scala.reflect.ClassTag
-import scala.runtime.AbstractFunction2
+import scala.runtime.{AbstractFunction1, AbstractFunction2}
 
 /**
   * A template trait for collections which can be traversed either once only
@@ -1134,8 +1134,8 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
   def collectFirst[B](pf: PartialFunction[A, B]): Option[B] = {
     // Presumably the fastest way to get in and out of a partial function is for a sentinel function to return itself
     // (Tested to be lower-overhead than runWith.  Would be better yet to not need to (formally) allocate it)
-    val sentinel: scala.Function1[A, Any] = new scala.runtime.AbstractFunction1[A, Any] {
-      def apply(a: A) = this
+    val sentinel: scala.Function1[A, Any] = new AbstractFunction1[A, Any] {
+      def apply(a: A): AbstractFunction1[A, Any] = this
     }
     val it = iterator
     while (it.hasNext) {

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -972,7 +972,7 @@ object Iterator extends IterableFactory[Iterator] {
     def hasNext = false
     def next() = throw new NoSuchElementException("next on empty iterator")
     override def knownSize: Int = 0
-    override protected def sliceIterator(from: Int, until: Int) = this
+    override protected def sliceIterator(from: Int, until: Int): AbstractIterator[Nothing] = this
   }
 
   /** Creates a target $coll from an existing source collection

--- a/src/library/scala/collection/LazyZipOps.scala
+++ b/src/library/scala/collection/LazyZipOps.scala
@@ -35,7 +35,7 @@ final class LazyZip2[+El1, +El2, C1] private[collection](src: C1, coll1: Iterabl
 
   def map[B, C](f: (El1, El2) => B)(implicit bf: BuildFrom[C1, B, C]): C = {
     bf.fromSpecific(src)(new AbstractView[B] {
-      def iterator = new AbstractIterator[B] {
+      def iterator: AbstractIterator[B] = new AbstractIterator[B] {
         private[this] val elems1 = coll1.iterator
         private[this] val elems2 = coll2.iterator
         def hasNext = elems1.hasNext && elems2.hasNext
@@ -48,7 +48,7 @@ final class LazyZip2[+El1, +El2, C1] private[collection](src: C1, coll1: Iterabl
 
   def flatMap[B, C](f: (El1, El2) => Iterable[B])(implicit bf: BuildFrom[C1, B, C]): C = {
     bf.fromSpecific(src)(new AbstractView[B] {
-      def iterator = new AbstractIterator[B] {
+      def iterator: AbstractIterator[B] = new AbstractIterator[B] {
         private[this] val elems1 = coll1.iterator
         private[this] val elems2 = coll2.iterator
         private[this] var _current: Iterator[B] = Iterator.empty
@@ -67,7 +67,7 @@ final class LazyZip2[+El1, +El2, C1] private[collection](src: C1, coll1: Iterabl
 
   def filter[C](p: (El1, El2) => Boolean)(implicit bf: BuildFrom[C1, (El1, El2), C]): C = {
     bf.fromSpecific(src)(new AbstractView[(El1, El2)] {
-      def iterator = new AbstractIterator[(El1, El2)] {
+      def iterator: AbstractIterator[(El1, El2)] = new AbstractIterator[(El1, El2)] {
         private[this] val elems1 = coll1.iterator
         private[this] val elems2 = coll2.iterator
         private[this] var _current: (El1, El2) = _
@@ -113,7 +113,7 @@ final class LazyZip2[+El1, +El2, C1] private[collection](src: C1, coll1: Iterabl
   }
 
   private def toIterable: View[(El1, El2)] = new AbstractView[(El1, El2)] {
-    def iterator = new AbstractIterator[(El1, El2)] {
+    def iterator: AbstractIterator[(El1, El2)] = new AbstractIterator[(El1, El2)] {
       private[this] val elems1 = coll1.iterator
       private[this] val elems2 = coll2.iterator
       def hasNext = elems1.hasNext && elems2.hasNext
@@ -163,7 +163,7 @@ final class LazyZip3[+El1, +El2, +El3, C1] private[collection](src: C1,
 
   def map[B, C](f: (El1, El2, El3) => B)(implicit bf: BuildFrom[C1, B, C]): C = {
     bf.fromSpecific(src)(new AbstractView[B] {
-      def iterator = new AbstractIterator[B] {
+      def iterator: AbstractIterator[B] = new AbstractIterator[B] {
         private[this] val elems1 = coll1.iterator
         private[this] val elems2 = coll2.iterator
         private[this] val elems3 = coll3.iterator
@@ -177,7 +177,7 @@ final class LazyZip3[+El1, +El2, +El3, C1] private[collection](src: C1,
 
   def flatMap[B, C](f: (El1, El2, El3) => Iterable[B])(implicit bf: BuildFrom[C1, B, C]): C = {
     bf.fromSpecific(src)(new AbstractView[B] {
-      def iterator = new AbstractIterator[B] {
+      def iterator: AbstractIterator[B] = new AbstractIterator[B] {
         private[this] val elems1 = coll1.iterator
         private[this] val elems2 = coll2.iterator
         private[this] val elems3 = coll3.iterator
@@ -197,7 +197,7 @@ final class LazyZip3[+El1, +El2, +El3, C1] private[collection](src: C1,
 
   def filter[C](p: (El1, El2, El3) => Boolean)(implicit bf: BuildFrom[C1, (El1, El2, El3), C]): C = {
     bf.fromSpecific(src)(new AbstractView[(El1, El2, El3)] {
-      def iterator = new AbstractIterator[(El1, El2, El3)] {
+      def iterator: AbstractIterator[(El1, El2, El3)] = new AbstractIterator[(El1, El2, El3)] {
         private[this] val elems1 = coll1.iterator
         private[this] val elems2 = coll2.iterator
         private[this] val elems3 = coll3.iterator
@@ -249,7 +249,7 @@ final class LazyZip3[+El1, +El2, +El3, C1] private[collection](src: C1,
   }
 
   private def toIterable: View[(El1, El2, El3)] = new AbstractView[(El1, El2, El3)] {
-    def iterator = new AbstractIterator[(El1, El2, El3)] {
+    def iterator: AbstractIterator[(El1, El2, El3)] = new AbstractIterator[(El1, El2, El3)] {
       private[this] val elems1 = coll1.iterator
       private[this] val elems2 = coll2.iterator
       private[this] val elems3 = coll3.iterator
@@ -295,7 +295,7 @@ final class LazyZip4[+El1, +El2, +El3, +El4, C1] private[collection](src: C1,
 
   def map[B, C](f: (El1, El2, El3, El4) => B)(implicit bf: BuildFrom[C1, B, C]): C = {
     bf.fromSpecific(src)(new AbstractView[B] {
-      def iterator = new AbstractIterator[B] {
+      def iterator: AbstractIterator[B] = new AbstractIterator[B] {
         private[this] val elems1 = coll1.iterator
         private[this] val elems2 = coll2.iterator
         private[this] val elems3 = coll3.iterator
@@ -310,7 +310,7 @@ final class LazyZip4[+El1, +El2, +El3, +El4, C1] private[collection](src: C1,
 
   def flatMap[B, C](f: (El1, El2, El3, El4) => Iterable[B])(implicit bf: BuildFrom[C1, B, C]): C = {
     bf.fromSpecific(src)(new AbstractView[B] {
-      def iterator = new AbstractIterator[B] {
+      def iterator: AbstractIterator[B] = new AbstractIterator[B] {
         private[this] val elems1 = coll1.iterator
         private[this] val elems2 = coll2.iterator
         private[this] val elems3 = coll3.iterator
@@ -331,7 +331,7 @@ final class LazyZip4[+El1, +El2, +El3, +El4, C1] private[collection](src: C1,
 
   def filter[C](p: (El1, El2, El3, El4) => Boolean)(implicit bf: BuildFrom[C1, (El1, El2, El3, El4), C]): C = {
     bf.fromSpecific(src)(new AbstractView[(El1, El2, El3, El4)] {
-      def iterator = new AbstractIterator[(El1, El2, El3, El4)] {
+      def iterator: AbstractIterator[(El1, El2, El3, El4)] = new AbstractIterator[(El1, El2, El3, El4)] {
         private[this] val elems1 = coll1.iterator
         private[this] val elems2 = coll2.iterator
         private[this] val elems3 = coll3.iterator
@@ -387,7 +387,7 @@ final class LazyZip4[+El1, +El2, +El3, +El4, C1] private[collection](src: C1,
   }
 
   private def toIterable: View[(El1, El2, El3, El4)] = new AbstractView[(El1, El2, El3, El4)] {
-    def iterator = new AbstractIterator[(El1, El2, El3, El4)] {
+    def iterator: AbstractIterator[(El1, El2, El3, El4)] = new AbstractIterator[(El1, El2, El3, El4)] {
       private[this] val elems1 = coll1.iterator
       private[this] val elems2 = coll2.iterator
       private[this] val elems3 = coll3.iterator

--- a/src/library/scala/collection/concurrent/TrieMap.scala
+++ b/src/library/scala/collection/concurrent/TrieMap.scala
@@ -438,7 +438,7 @@ private[concurrent] object INode {
 private[concurrent] final class FailedNode[K, V](p: MainNode[K, V]) extends MainNode[K, V] {
   WRITE_PREV(p)
 
-  def string(lev: Int) = throw new UnsupportedOperationException
+  def string(lev: Int): Nothing = throw new UnsupportedOperationException
 
   def cachedSize(ct: AnyRef): Int = throw new UnsupportedOperationException
 

--- a/src/library/scala/collection/convert/JavaCollectionWrappers.scala
+++ b/src/library/scala/collection/convert/JavaCollectionWrappers.scala
@@ -66,7 +66,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
   trait IterableWrapperTrait[A] extends ju.AbstractCollection[A] {
     val underlying: Iterable[A]
     def size = underlying.size
-    override def iterator = new IteratorWrapper(underlying.iterator)
+    override def iterator: IteratorWrapper[A] = new IteratorWrapper(underlying.iterator)
     override def isEmpty = underlying.isEmpty
   }
 
@@ -178,7 +178,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
     }
     override def isEmpty = underlying.isEmpty
     def size = underlying.size
-    def iterator = new ju.Iterator[A] {
+    def iterator: ju.Iterator[A] = new ju.Iterator[A] {
       val ui = underlying.iterator
       var prev: Option[A] = None
       def hasNext = ui.hasNext
@@ -264,13 +264,13 @@ private[collection] object JavaCollectionWrappers extends Serializable {
     override def entrySet: ju.Set[ju.Map.Entry[K, V]] = new ju.AbstractSet[ju.Map.Entry[K, V]] {
       def size = self.size
 
-      def iterator = new ju.Iterator[ju.Map.Entry[K, V]] {
+      def iterator: ju.Iterator[ju.Map.Entry[K, V]] = new ju.Iterator[ju.Map.Entry[K, V]] {
         val ui = underlying.iterator
         var prev : Option[K] = None
 
         def hasNext = ui.hasNext
 
-        def next() = {
+        def next(): ju.Map.Entry[K, V] = {
           val (k, v) = ui.next()
           prev = Some(k)
           new ju.Map.Entry[K, V] {

--- a/src/library/scala/collection/immutable/ArraySeq.scala
+++ b/src/library/scala/collection/immutable/ArraySeq.scala
@@ -355,7 +355,8 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   @SerialVersionUID(3L)
   final class ofByte(val unsafeArray: Array[Byte]) extends ArraySeq[Byte] {
-    protected def elemTag = ClassTag.Byte
+    // Type erases to `ManifestFactory.ByteManifest`, but can't annotate that because it's not accessible
+    protected def elemTag: ClassTag.Byte.type = ClassTag.Byte
     def length: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Byte = unsafeArray(i)
@@ -396,7 +397,8 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   @SerialVersionUID(3L)
   final class ofShort(val unsafeArray: Array[Short]) extends ArraySeq[Short] {
-    protected def elemTag = ClassTag.Short
+    // Type erases to `ManifestFactory.ShortManifest`, but can't annotate that because it's not accessible
+    protected def elemTag: ClassTag.Short.type = ClassTag.Short
     def length: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Short = unsafeArray(i)
@@ -437,7 +439,8 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   @SerialVersionUID(3L)
   final class ofChar(val unsafeArray: Array[Char]) extends ArraySeq[Char] {
-    protected def elemTag = ClassTag.Char
+    // Type erases to `ManifestFactory.CharManifest`, but can't annotate that because it's not accessible
+    protected def elemTag: ClassTag.Char.type = ClassTag.Char
     def length: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Char = unsafeArray(i)
@@ -481,7 +484,8 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   @SerialVersionUID(3L)
   final class ofInt(val unsafeArray: Array[Int]) extends ArraySeq[Int] {
-    protected def elemTag = ClassTag.Int
+    // Type erases to `ManifestFactory.IntManifest`, but can't annotate that because it's not accessible
+    protected def elemTag: ClassTag.Int.type = ClassTag.Int
     def length: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Int = unsafeArray(i)
@@ -522,7 +526,8 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   @SerialVersionUID(3L)
   final class ofLong(val unsafeArray: Array[Long]) extends ArraySeq[Long] {
-    protected def elemTag = ClassTag.Long
+    // Type erases to `ManifestFactory.LongManifest`, but can't annotate that because it's not accessible
+    protected def elemTag: ClassTag.Long.type = ClassTag.Long
     def length: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Long = unsafeArray(i)
@@ -563,7 +568,8 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   @SerialVersionUID(3L)
   final class ofFloat(val unsafeArray: Array[Float]) extends ArraySeq[Float] {
-    protected def elemTag = ClassTag.Float
+    // Type erases to `ManifestFactory.FloatManifest`, but can't annotate that because it's not accessible
+    protected def elemTag: ClassTag.Float.type = ClassTag.Float
     def length: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Float = unsafeArray(i)
@@ -597,7 +603,8 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   @SerialVersionUID(3L)
   final class ofDouble(val unsafeArray: Array[Double]) extends ArraySeq[Double] {
-    protected def elemTag = ClassTag.Double
+    // Type erases to `ManifestFactory.DoubleManifest`, but can't annotate that because it's not accessible
+    protected def elemTag: ClassTag.Double.type = ClassTag.Double
     def length: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Double = unsafeArray(i)
@@ -631,7 +638,8 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   @SerialVersionUID(3L)
   final class ofBoolean(val unsafeArray: Array[Boolean]) extends ArraySeq[Boolean] {
-    protected def elemTag = ClassTag.Boolean
+    // Type erases to `ManifestFactory.BooleanManifest`, but can't annotate that because it's not accessible
+    protected def elemTag: ClassTag.Boolean.type = ClassTag.Boolean
     def length: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Boolean = unsafeArray(i)
@@ -669,7 +677,8 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   @SerialVersionUID(3L)
   final class ofUnit(val unsafeArray: Array[Unit]) extends ArraySeq[Unit] {
-    protected def elemTag = ClassTag.Unit
+    // Type erases to `ManifestFactory.UnitManifest`, but can't annotate that because it's not accessible
+    protected def elemTag: ClassTag.Unit.type = ClassTag.Unit
     def length: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): Unit = unsafeArray(i)

--- a/src/library/scala/collection/immutable/ArraySeq.scala
+++ b/src/library/scala/collection/immutable/ArraySeq.scala
@@ -325,7 +325,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   @SerialVersionUID(3L)
   final class ofRef[T <: AnyRef](val unsafeArray: Array[T]) extends ArraySeq[T] {
-    def elemTag = ClassTag[T](unsafeArray.getClass.getComponentType)
+    def elemTag: ClassTag[T] = ClassTag[T](unsafeArray.getClass.getComponentType)
     def length: Int = unsafeArray.length
     @throws[ArrayIndexOutOfBoundsException]
     def apply(i: Int): T = unsafeArray(i)

--- a/src/library/scala/collection/immutable/BitSet.scala
+++ b/src/library/scala/collection/immutable/BitSet.scala
@@ -41,7 +41,7 @@ sealed abstract class BitSet
   override protected def newSpecificBuilder: Builder[Int, BitSet] = bitSetFactory.newBuilder
   override def empty: BitSet = bitSetFactory.empty
 
-  def bitSetFactory = BitSet
+  def bitSetFactory: BitSet.type = BitSet
 
   protected[collection] def fromBitMaskNoCopy(elems: Array[Long]): BitSet = BitSet.fromBitMaskNoCopy(elems)
 

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -2157,7 +2157,7 @@ private final class MapKeyValueTupleHashIterator[K, V](rootNode: MapNode[K, V])
   private[this] var hash = 0
   private[this] var value: V = _
   override def hashCode(): Int = MurmurHash3.tuple2Hash(hash, value.##, MurmurHash3.productSeed)
-  def next() = {
+  def next(): MapKeyValueTupleHashIterator[K, V] = {
     if (!hasNext)
       throw new NoSuchElementException
 

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -1837,7 +1837,7 @@ private final class HashCollisionSetNode[A](val originalHash: Int, val hash: Int
   override def hashCode(): Int =
     throw new UnsupportedOperationException("Trie nodes do not support hashing.")
 
-  override def copy() = new HashCollisionSetNode[A](originalHash, hash, content)
+  override def copy(): HashCollisionSetNode[A] = new HashCollisionSetNode[A](originalHash, hash, content)
 
   override def concat(that: SetNode[A], shift: Int): SetNode[A] = that match {
     case hc: HashCollisionSetNode[A] =>

--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -864,7 +864,7 @@ private[collection] object RedBlackTree {
   }
 
   private[this] class EqualsIterator[A: Ordering, B](tree: Tree[A, B]) extends TreeIterator[A, B, Unit](tree, None) {
-    override def nextResult(tree: Tree[A, B]) = ???
+    override def nextResult(tree: Tree[A, B]): Nothing = ???
 
     def sameKeys[X](that:EqualsIterator[A,X]): Boolean = {
       var equal = true

--- a/src/library/scala/collection/mutable/AnyRefMap.scala
+++ b/src/library/scala/collection/mutable/AnyRefMap.scala
@@ -592,8 +592,8 @@ object AnyRefMap {
 
   implicit def toBuildFrom[K <: AnyRef, V](factory: AnyRefMap.type): BuildFrom[Any, (K, V), AnyRefMap[K, V]] = ToBuildFrom.asInstanceOf[BuildFrom[Any, (K, V), AnyRefMap[K, V]]]
   private[this] object ToBuildFrom extends BuildFrom[Any, (AnyRef, AnyRef), AnyRefMap[AnyRef, AnyRef]] {
-    def fromSpecific(from: Any)(it: IterableOnce[(AnyRef, AnyRef)]) = AnyRefMap.from(it)
-    def newBuilder(from: Any) = AnyRefMap.newBuilder[AnyRef, AnyRef]
+    def fromSpecific(from: Any)(it: IterableOnce[(AnyRef, AnyRef)]): AnyRefMap[AnyRef, AnyRef] = AnyRefMap.from(it)
+    def newBuilder(from: Any): ReusableBuilder[(AnyRef, AnyRef), AnyRefMap[AnyRef, AnyRef]] = AnyRefMap.newBuilder[AnyRef, AnyRef]
   }
 
   implicit def iterableFactory[K <: AnyRef, V]: Factory[(K, V), AnyRefMap[K, V]] = toFactory[K, V](this)

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -139,7 +139,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   @SerialVersionUID(3L)
   final class ofRef[T <: AnyRef](val array: Array[T]) extends ArraySeq[T] {
-    def elemTag = ClassTag[T](array.getClass.getComponentType)
+    def elemTag: ClassTag[T] = ClassTag[T](array.getClass.getComponentType)
     def length: Int = array.length
     def apply(index: Int): T = array(index)
     def update(index: Int, elem: T): Unit = { array(index) = elem }
@@ -161,7 +161,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   @SerialVersionUID(3L)
   final class ofByte(val array: Array[Byte]) extends ArraySeq[Byte] {
-    def elemTag = ClassTag.Byte
+    def elemTag: ClassTag.Byte.type = ClassTag.Byte
     def length: Int = array.length
     def apply(index: Int): Byte = array(index)
     def update(index: Int, elem: Byte): Unit = { array(index) = elem }
@@ -180,7 +180,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   @SerialVersionUID(3L)
   final class ofShort(val array: Array[Short]) extends ArraySeq[Short] {
-    def elemTag = ClassTag.Short
+    def elemTag: ClassTag.Short.type = ClassTag.Short
     def length: Int = array.length
     def apply(index: Int): Short = array(index)
     def update(index: Int, elem: Short): Unit = { array(index) = elem }
@@ -199,7 +199,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   @SerialVersionUID(3L)
   final class ofChar(val array: Array[Char]) extends ArraySeq[Char] {
-    def elemTag = ClassTag.Char
+    def elemTag: ClassTag.Char.type = ClassTag.Char
     def length: Int = array.length
     def apply(index: Int): Char = array(index)
     def update(index: Int, elem: Char): Unit = { array(index) = elem }
@@ -239,7 +239,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   @SerialVersionUID(3L)
   final class ofInt(val array: Array[Int]) extends ArraySeq[Int] {
-    def elemTag = ClassTag.Int
+    def elemTag: ClassTag.Int.type = ClassTag.Int
     def length: Int = array.length
     def apply(index: Int): Int = array(index)
     def update(index: Int, elem: Int): Unit = { array(index) = elem }
@@ -258,7 +258,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   @SerialVersionUID(3L)
   final class ofLong(val array: Array[Long]) extends ArraySeq[Long] {
-    def elemTag = ClassTag.Long
+    def elemTag: ClassTag.Long.type = ClassTag.Long
     def length: Int = array.length
     def apply(index: Int): Long = array(index)
     def update(index: Int, elem: Long): Unit = { array(index) = elem }
@@ -277,7 +277,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   @SerialVersionUID(3L)
   final class ofFloat(val array: Array[Float]) extends ArraySeq[Float] {
-    def elemTag = ClassTag.Float
+    def elemTag: ClassTag.Float.type = ClassTag.Float
     def length: Int = array.length
     def apply(index: Int): Float = array(index)
     def update(index: Int, elem: Float): Unit = { array(index) = elem }
@@ -296,7 +296,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   @SerialVersionUID(3L)
   final class ofDouble(val array: Array[Double]) extends ArraySeq[Double] {
-    def elemTag = ClassTag.Double
+    def elemTag: ClassTag.Double.type = ClassTag.Double
     def length: Int = array.length
     def apply(index: Int): Double = array(index)
     def update(index: Int, elem: Double): Unit = { array(index) = elem }
@@ -315,7 +315,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   @SerialVersionUID(3L)
   final class ofBoolean(val array: Array[Boolean]) extends ArraySeq[Boolean] {
-    def elemTag = ClassTag.Boolean
+    def elemTag: ClassTag.Boolean.type = ClassTag.Boolean
     def length: Int = array.length
     def apply(index: Int): Boolean = array(index)
     def update(index: Int, elem: Boolean): Unit = { array(index) = elem }
@@ -331,7 +331,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   @SerialVersionUID(3L)
   final class ofUnit(val array: Array[Unit]) extends ArraySeq[Unit] {
-    def elemTag = ClassTag.Unit
+    def elemTag: ClassTag.Unit.type = ClassTag.Unit
     def length: Int = array.length
     def apply(index: Int): Unit = array(index)
     def update(index: Int, elem: Unit): Unit = { array(index) = elem }

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -12,9 +12,7 @@
 
 package scala.collection
 package mutable
-
 import java.util.Arrays
-
 import scala.collection.Stepper.EfficientSplit
 import scala.collection.convert.impl._
 import scala.reflect.ClassTag
@@ -161,6 +159,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   @SerialVersionUID(3L)
   final class ofByte(val array: Array[Byte]) extends ArraySeq[Byte] {
+    // Type erases to `ManifestFactory.ByteManifest`, but can't annotate that because it's not accessible
     def elemTag: ClassTag.Byte.type = ClassTag.Byte
     def length: Int = array.length
     def apply(index: Int): Byte = array(index)
@@ -180,6 +179,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   @SerialVersionUID(3L)
   final class ofShort(val array: Array[Short]) extends ArraySeq[Short] {
+    // Type erases to `ManifestFactory.ShortManifest`, but can't annotate that because it's not accessible
     def elemTag: ClassTag.Short.type = ClassTag.Short
     def length: Int = array.length
     def apply(index: Int): Short = array(index)
@@ -199,6 +199,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   @SerialVersionUID(3L)
   final class ofChar(val array: Array[Char]) extends ArraySeq[Char] {
+    // Type erases to `ManifestFactory.CharManifest`, but can't annotate that because it's not accessible
     def elemTag: ClassTag.Char.type = ClassTag.Char
     def length: Int = array.length
     def apply(index: Int): Char = array(index)
@@ -239,6 +240,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   @SerialVersionUID(3L)
   final class ofInt(val array: Array[Int]) extends ArraySeq[Int] {
+    // Type erases to `ManifestFactory.IntManifest`, but can't annotate that because it's not accessible
     def elemTag: ClassTag.Int.type = ClassTag.Int
     def length: Int = array.length
     def apply(index: Int): Int = array(index)
@@ -258,6 +260,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   @SerialVersionUID(3L)
   final class ofLong(val array: Array[Long]) extends ArraySeq[Long] {
+    // Type erases to `ManifestFactory.LongManifest`, but can't annotate that because it's not accessible
     def elemTag: ClassTag.Long.type = ClassTag.Long
     def length: Int = array.length
     def apply(index: Int): Long = array(index)
@@ -277,6 +280,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   @SerialVersionUID(3L)
   final class ofFloat(val array: Array[Float]) extends ArraySeq[Float] {
+    // Type erases to `ManifestFactory.FloatManifest`, but can't annotate that because it's not accessible
     def elemTag: ClassTag.Float.type = ClassTag.Float
     def length: Int = array.length
     def apply(index: Int): Float = array(index)
@@ -296,6 +300,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   @SerialVersionUID(3L)
   final class ofDouble(val array: Array[Double]) extends ArraySeq[Double] {
+    // Type erases to `ManifestFactory.DoubleManifest`, but can't annotate that because it's not accessible
     def elemTag: ClassTag.Double.type = ClassTag.Double
     def length: Int = array.length
     def apply(index: Int): Double = array(index)
@@ -315,6 +320,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   @SerialVersionUID(3L)
   final class ofBoolean(val array: Array[Boolean]) extends ArraySeq[Boolean] {
+    // Type erases to `ManifestFactory.BooleanManifest`, but can't annotate that because it's not accessible
     def elemTag: ClassTag.Boolean.type = ClassTag.Boolean
     def length: Int = array.length
     def apply(index: Int): Boolean = array(index)
@@ -331,6 +337,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   @SerialVersionUID(3L)
   final class ofUnit(val array: Array[Unit]) extends ArraySeq[Unit] {
+    // Type erases to `ManifestFactory.UnitManifest`, but can't annotate that because it's not accessible
     def elemTag: ClassTag.Unit.type = ClassTag.Unit
     def length: Int = array.length
     def apply(index: Int): Unit = array(index)

--- a/src/library/scala/collection/mutable/BitSet.scala
+++ b/src/library/scala/collection/mutable/BitSet.scala
@@ -51,7 +51,7 @@ class BitSet(protected[collection] final var elems: Array[Long])
   override protected def newSpecificBuilder: Builder[Int, BitSet] = bitSetFactory.newBuilder
   override def empty: BitSet = bitSetFactory.empty
 
-  def bitSetFactory = BitSet
+  def bitSetFactory: BitSet.type = BitSet
 
   override def unsorted: Set[Int] = this
 

--- a/src/library/scala/collection/mutable/LongMap.scala
+++ b/src/library/scala/collection/mutable/LongMap.scala
@@ -665,7 +665,7 @@ object LongMap {
   implicit def toBuildFrom[V](factory: LongMap.type): BuildFrom[Any, (Long, V), LongMap[V]] = ToBuildFrom.asInstanceOf[BuildFrom[Any, (Long, V), LongMap[V]]]
   private object ToBuildFrom extends BuildFrom[Any, (Long, AnyRef), LongMap[AnyRef]] {
     def fromSpecific(from: Any)(it: IterableOnce[(Long, AnyRef)]) = LongMap.from(it)
-    def newBuilder(from: Any) = LongMap.newBuilder[AnyRef]
+    def newBuilder(from: Any): ReusableBuilder[(Long, AnyRef), LongMap[AnyRef]] = LongMap.newBuilder[AnyRef]
   }
 
   implicit def iterableFactory[V]: Factory[(Long, V), LongMap[V]] = toFactory(this)

--- a/src/library/scala/collection/mutable/UnrolledBuffer.scala
+++ b/src/library/scala/collection/mutable/UnrolledBuffer.scala
@@ -89,7 +89,7 @@ sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
   // def setLengthPolicy(nextLength: Int => Int): Unit = { myLengthPolicy = nextLength }
   private[collection] def calcNextLength(sz: Int) = sz // myLengthPolicy(sz)
 
-  def classTagCompanion = UnrolledBuffer
+  def classTagCompanion: UnrolledBuffer.type = UnrolledBuffer
 
   /** Concatenates the target unrolled buffer to this unrolled buffer.
     *

--- a/src/library/scala/reflect/Manifest.scala
+++ b/src/library/scala/reflect/Manifest.scala
@@ -368,7 +368,7 @@ object ManifestFactory {
 
   @SerialVersionUID(1L)
   final private class SingletonTypeManifest[T <: AnyRef](value: AnyRef) extends Manifest[T] {
-    lazy val runtimeClass = value.getClass
+    lazy val runtimeClass: Class[_ <: AnyRef] = value.getClass
     override lazy val toString = value.toString + ".type"
   }
 

--- a/src/library/scala/reflect/Manifest.scala
+++ b/src/library/scala/reflect/Manifest.scala
@@ -173,7 +173,7 @@ object ManifestFactory {
 
   @SerialVersionUID(1L)
   final private[reflect] class ByteManifest extends AnyValManifest[scala.Byte]("Byte") {
-    def runtimeClass = java.lang.Byte.TYPE
+    def runtimeClass: Class[java.lang.Byte] = java.lang.Byte.TYPE
     @inline override def newArray(len: Int): Array[Byte] = new Array[Byte](len)
     override def newWrappedArray(len: Int): ArraySeq[Byte] = new ArraySeq.ofByte(new Array[Byte](len))
     override def newArrayBuilder(): ArrayBuilder[Byte] = new ArrayBuilder.ofByte()
@@ -189,7 +189,7 @@ object ManifestFactory {
 
   @SerialVersionUID(1L)
   final private[reflect] class ShortManifest extends AnyValManifest[scala.Short]("Short") {
-    def runtimeClass = java.lang.Short.TYPE
+    def runtimeClass: Class[java.lang.Short] = java.lang.Short.TYPE
     @inline override def newArray(len: Int): Array[Short] = new Array[Short](len)
     override def newWrappedArray(len: Int): ArraySeq[Short] = new ArraySeq.ofShort(new Array[Short](len))
     override def newArrayBuilder(): ArrayBuilder[Short] = new ArrayBuilder.ofShort()
@@ -205,7 +205,7 @@ object ManifestFactory {
 
   @SerialVersionUID(1L)
   final private[reflect] class CharManifest extends AnyValManifest[scala.Char]("Char") {
-    def runtimeClass = java.lang.Character.TYPE
+    def runtimeClass: Class[java.lang.Character] = java.lang.Character.TYPE
     @inline override def newArray(len: Int): Array[Char] = new Array[Char](len)
     override def newWrappedArray(len: Int): ArraySeq[Char] = new ArraySeq.ofChar(new Array[Char](len))
     override def newArrayBuilder(): ArrayBuilder[Char] = new ArrayBuilder.ofChar()
@@ -221,7 +221,7 @@ object ManifestFactory {
 
   @SerialVersionUID(1L)
   final private[reflect] class IntManifest extends AnyValManifest[scala.Int]("Int") {
-    def runtimeClass = java.lang.Integer.TYPE
+    def runtimeClass: Class[java.lang.Integer] = java.lang.Integer.TYPE
     @inline override def newArray(len: Int): Array[Int] = new Array[Int](len)
     override def newWrappedArray(len: Int): ArraySeq[Int] = new ArraySeq.ofInt(new Array[Int](len))
     override def newArrayBuilder(): ArrayBuilder[Int] = new ArrayBuilder.ofInt()
@@ -237,7 +237,7 @@ object ManifestFactory {
 
   @SerialVersionUID(1L)
   final private[reflect] class LongManifest extends AnyValManifest[scala.Long]("Long") {
-    def runtimeClass = java.lang.Long.TYPE
+    def runtimeClass: Class[java.lang.Long] = java.lang.Long.TYPE
     @inline override def newArray(len: Int): Array[Long] = new Array[Long](len)
     override def newWrappedArray(len: Int): ArraySeq[Long] = new ArraySeq.ofLong(new Array[Long](len))
     override def newArrayBuilder(): ArrayBuilder[Long] = new ArrayBuilder.ofLong()
@@ -253,7 +253,7 @@ object ManifestFactory {
 
   @SerialVersionUID(1L)
   final private[reflect] class FloatManifest extends AnyValManifest[scala.Float]("Float") {
-    def runtimeClass = java.lang.Float.TYPE
+    def runtimeClass: Class[java.lang.Float] = java.lang.Float.TYPE
     @inline override def newArray(len: Int): Array[Float] = new Array[Float](len)
     override def newWrappedArray(len: Int): ArraySeq[Float] = new ArraySeq.ofFloat(new Array[Float](len))
     override def newArrayBuilder(): ArrayBuilder[Float] = new ArrayBuilder.ofFloat()
@@ -269,7 +269,7 @@ object ManifestFactory {
 
   @SerialVersionUID(1L)
   final private[reflect] class DoubleManifest extends AnyValManifest[scala.Double]("Double") {
-    def runtimeClass = java.lang.Double.TYPE
+    def runtimeClass: Class[java.lang.Double] = java.lang.Double.TYPE
     @inline override def newArray(len: Int): Array[Double] = new Array[Double](len)
     override def newWrappedArray(len: Int): ArraySeq[Double] = new ArraySeq.ofDouble(new Array[Double](len))
     override def newArrayBuilder(): ArrayBuilder[Double] = new ArrayBuilder.ofDouble()
@@ -286,7 +286,7 @@ object ManifestFactory {
 
   @SerialVersionUID(1L)
   final private[reflect] class BooleanManifest extends AnyValManifest[scala.Boolean]("Boolean") {
-    def runtimeClass = java.lang.Boolean.TYPE
+    def runtimeClass: Class[java.lang.Boolean] = java.lang.Boolean.TYPE
     @inline override def newArray(len: Int): Array[Boolean] = new Array[Boolean](len)
     override def newWrappedArray(len: Int): ArraySeq[Boolean] = new ArraySeq.ofBoolean(new Array[Boolean](len))
     override def newArrayBuilder(): ArrayBuilder[Boolean] = new ArrayBuilder.ofBoolean()
@@ -302,7 +302,7 @@ object ManifestFactory {
 
   @SerialVersionUID(1L)
   final private[reflect] class UnitManifest extends AnyValManifest[scala.Unit]("Unit") {
-    def runtimeClass = java.lang.Void.TYPE
+    def runtimeClass: Class[java.lang.Void] = java.lang.Void.TYPE
     @inline override def newArray(len: Int): Array[Unit] = new Array[Unit](len)
     override def newWrappedArray(len: Int): ArraySeq[Unit] = new ArraySeq.ofUnit(new Array[Unit](len))
     override def newArrayBuilder(): ArrayBuilder[Unit] = new ArrayBuilder.ofUnit()

--- a/src/library/scala/runtime/RichBoolean.scala
+++ b/src/library/scala/runtime/RichBoolean.scala
@@ -15,5 +15,5 @@ package runtime
 
 
 final class RichBoolean(val self: Boolean) extends AnyVal with OrderedProxy[Boolean] {
-  protected def ord = scala.math.Ordering.Boolean
+  protected def ord: scala.math.Ordering.Boolean.type = scala.math.Ordering.Boolean
 }

--- a/src/library/scala/runtime/RichByte.scala
+++ b/src/library/scala/runtime/RichByte.scala
@@ -14,8 +14,8 @@ package scala
 package runtime
 
 final class RichByte(val self: Byte) extends AnyVal with ScalaWholeNumberProxy[Byte] {
-  protected def num = scala.math.Numeric.ByteIsIntegral
-  protected def ord = scala.math.Ordering.Byte
+  protected def num: scala.math.Numeric.ByteIsIntegral.type = scala.math.Numeric.ByteIsIntegral
+  protected def ord: scala.math.Ordering.Byte.type = scala.math.Ordering.Byte
 
   override def doubleValue = self.toDouble
   override def floatValue  = self.toFloat

--- a/src/library/scala/runtime/RichChar.scala
+++ b/src/library/scala/runtime/RichChar.scala
@@ -14,8 +14,8 @@ package scala
 package runtime
 
 final class RichChar(val self: Char) extends AnyVal with IntegralProxy[Char] {
-  protected def num = scala.math.Numeric.CharIsIntegral
-  protected def ord = scala.math.Ordering.Char
+  protected def num: scala.math.Numeric.CharIsIntegral.type = scala.math.Numeric.CharIsIntegral
+  protected def ord: scala.math.Ordering.Char.type = scala.math.Ordering.Char
 
   override def doubleValue = self.toDouble
   override def floatValue  = self.toFloat

--- a/src/library/scala/runtime/RichInt.scala
+++ b/src/library/scala/runtime/RichInt.scala
@@ -18,8 +18,8 @@ import scala.collection.immutable.Range
 // Note that this does not implement IntegralProxy[Int] so that it can return
 // the Int-specific Range class from until/to.
 final class RichInt(val self: Int) extends AnyVal with ScalaNumberProxy[Int] with RangedProxy[Int] {
-  protected def num = scala.math.Numeric.IntIsIntegral
-  protected def ord = scala.math.Ordering.Int
+  protected def num: scala.math.Numeric.IntIsIntegral.type = scala.math.Numeric.IntIsIntegral
+  protected def ord: scala.math.Ordering.Int.type = scala.math.Ordering.Int
 
   override def doubleValue = self.toDouble
   override def floatValue  = self.toFloat

--- a/src/library/scala/runtime/RichLong.scala
+++ b/src/library/scala/runtime/RichLong.scala
@@ -14,8 +14,8 @@ package scala
 package runtime
 
 final class RichLong(val self: Long) extends AnyVal with IntegralProxy[Long] {
-  protected def num = scala.math.Numeric.LongIsIntegral
-  protected def ord = scala.math.Ordering.Long
+  protected def num: scala.math.Numeric.LongIsIntegral.type = scala.math.Numeric.LongIsIntegral
+  protected def ord: scala.math.Ordering.Long.type = scala.math.Ordering.Long
 
   override def doubleValue = self.toDouble
   override def floatValue  = self.toFloat

--- a/src/library/scala/runtime/RichShort.scala
+++ b/src/library/scala/runtime/RichShort.scala
@@ -14,8 +14,8 @@ package scala
 package runtime
 
 final class RichShort(val self: Short) extends AnyVal with ScalaWholeNumberProxy[Short] {
-  protected def num = scala.math.Numeric.ShortIsIntegral
-  protected def ord = scala.math.Ordering.Short
+  protected def num: scala.math.Numeric.ShortIsIntegral.type = scala.math.Numeric.ShortIsIntegral
+  protected def ord: scala.math.Ordering.Short.type = scala.math.Ordering.Short
 
   override def doubleValue = self.toDouble
   override def floatValue  = self.toFloat

--- a/src/library/scala/typeConstraints.scala
+++ b/src/library/scala/typeConstraints.scala
@@ -150,7 +150,7 @@ object <:< {
     override def substituteCo    [F[_]](ff: F[Any]) = ff
     override def substituteContra[F[_]](ff: F[Any]) = ff
     override def apply(x: Any) = x
-    override def flip = this
+    override def flip: Any =:= Any = this
     override def compose[C](r: C =>  Any) = r
     override def compose[C](r: C <:< Any) = r
     override def compose[C](r: C =:= Any) = r

--- a/src/library/scala/util/DynamicVariable.scala
+++ b/src/library/scala/util/DynamicVariable.scala
@@ -40,7 +40,7 @@ import java.lang.InheritableThreadLocal
  */
 class DynamicVariable[T](init: T) {
   private[this] val tl = new InheritableThreadLocal[T] {
-    override def initialValue = init.asInstanceOf[T with AnyRef]
+    override def initialValue: T with AnyRef = init.asInstanceOf[T with AnyRef]
   }
 
   /** Retrieve the current value */

--- a/src/library/scala/util/Properties.scala
+++ b/src/library/scala/util/Properties.scala
@@ -19,8 +19,8 @@ import scala.annotation.tailrec
 
 /** Loads `library.properties` from the jar. */
 object Properties extends PropertiesTrait {
-  protected def propCategory    = "library"
-  protected def pickJarBasedOn  = classOf[Option[_]]
+  protected def propCategory = "library"
+  protected def pickJarBasedOn: Class[Option[_]] = classOf[Option[_]]
 
   /** Scala manifest attributes.
    */


### PR DESCRIPTION
Add explicit result type to methods where Scala 2 and Scala 3 disagree with the inferred type. The aim is to have the same type in the Scala 2 pickles and the Scala 3 TASTy.

Follow up of https://github.com/scala/scala/pull/10435

These where identified in and tested in
  * https://github.com/lampepfl/dotty/pull/18032
  * https://github.com/lampepfl/dotty/pull/18029
  * https://github.com/lampepfl/dotty/pull/17975 (BitSet)