### PR TITLE
[backport] Warn when `equals` compares non-references

### DIFF
--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -340,6 +340,7 @@ object Reporting {
     object OtherMigration extends Other; add(OtherMigration)
     object OtherMatchAnalysis extends WarningCategory; add(OtherMatchAnalysis)
     object OtherDebug extends WarningCategory; add(OtherDebug)
+    object OtherNonCooperativeEquals extends Other; add(OtherNonCooperativeEquals)
 
     sealed trait WFlag extends WarningCategory { override def summaryCategory: WarningCategory = WFlag }
     object WFlag extends WFlag { override def includes(o: WarningCategory): Boolean = o.isInstanceOf[WFlag] }; add(WFlag)

--- a/test/files/neg/checksensible-equals.check
+++ b/test/files/neg/checksensible-equals.check
@@ -1,0 +1,18 @@
+checksensible-equals.scala:4: warning: comparing values of types Long and Int using `equals` unsafely bypasses cooperative equality; use `==` instead
+  1L equals 1
+     ^
+checksensible-equals.scala:11: warning: comparing values of types Any and Int using `equals` unsafely bypasses cooperative equality; use `==` instead
+  (1L: Any) equals 1
+            ^
+checksensible-equals.scala:12: warning: comparing values of types AnyVal and Int using `equals` unsafely bypasses cooperative equality; use `==` instead
+  (1L: AnyVal) equals 1
+               ^
+checksensible-equals.scala:13: warning: comparing values of types AnyVal and AnyVal using `equals` unsafely bypasses cooperative equality; use `==` instead
+  (1L: AnyVal) equals (1: AnyVal)
+               ^
+checksensible-equals.scala:16: warning: comparing values of types A and Int using `equals` unsafely bypasses cooperative equality; use `==` instead
+  def foo[A](a: A) = a.equals(1)
+                             ^
+error: No warnings can be incurred under -Xfatal-warnings.
+5 warnings found
+one error found

--- a/test/files/neg/checksensible-equals.scala
+++ b/test/files/neg/checksensible-equals.scala
@@ -1,0 +1,19 @@
+// scalac: -Xsource:2.13 -Werror
+
+class AnyEqualsTest {
+  1L equals 1
+  // ok, because it's between the same numeric types
+  1 equals 1
+  // ok
+  1L equals "string"
+  // ok
+  1L.equals(())
+  (1L: Any) equals 1
+  (1L: AnyVal) equals 1
+  (1L: AnyVal) equals (1: AnyVal)
+  // ok
+  "string" equals 1
+  def foo[A](a: A) = a.equals(1)
+  // ok
+  def bar[A <: AnyRef](a: A) = a.equals(1)
+}


### PR DESCRIPTION
Backport of https://github.com/scala/scala/pull/8120 under `-Xsource:2.13`