### PR TITLE
Prevent ArrayBuilder capacity overflow/infinite looping in ArrayBuilder.ensureSize(size:Int).

### DIFF
--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -283,15 +283,6 @@ object IterableOnce {
       case src: Iterable[A] => src.copyToArray[B](xs, start, len)
       case src              => src.iterator.copyToArray[B](xs, start, len)
     }
-
-  @inline private[collection] def checkArraySizeWithinVMLimit(size: Int): Unit = {
-    import scala.runtime.PStatics.VM_MaxArraySize
-    if (size > VM_MaxArraySize) {
-      throw new Exception(s"Size of array-backed collection exceeds VM array size limit of $VM_MaxArraySize.  Encountered size: $size")
-    } else if (size < 0) {
-      throw new Exception(s"Size of array-backed collection must exceed 0.  Encountered size: $size")
-    }
-  }
 }
 
 /** This implementation trait can be mixed into an `IterableOnce` to get the basic methods that are shared between

--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -287,7 +287,9 @@ object IterableOnce {
   @inline private[collection] def checkArraySizeWithinVMLimit(size: Int): Unit = {
     import scala.runtime.PStatics.VM_MaxArraySize
     if (size > VM_MaxArraySize) {
-      throw new Exception(s"Size of array-backed collection exceeds VM array size limit of ${VM_MaxArraySize}")
+      throw new Exception(s"Size of array-backed collection exceeds VM array size limit of $VM_MaxArraySize.  Encountered size: $size")
+    } else if (size < 0) {
+      throw new Exception(s"Size of array-backed collection must exceed 0.  Encountered size: $size")
     }
   }
 }

--- a/src/library/scala/collection/mutable/ArrayBuilder.scala
+++ b/src/library/scala/collection/mutable/ArrayBuilder.scala
@@ -488,21 +488,21 @@ object ArrayBuilder {
     protected def elems: Array[Unit] = throw new UnsupportedOperationException()
 
     def addOne(elem: Unit): this.type = {
-      val newSize:Int = size + 1
+      val newSize = size + 1
       ensureSize(newSize)
       size = newSize
       this
     }
 
     override def addAll(xs: IterableOnce[Unit]): this.type = {
-      val newSize:Int = size + xs.iterator.size
+      val newSize = size + xs.iterator.size
       ensureSize(newSize)
       size = newSize
       this
     }
 
     override def addAll(xs: Array[_ <: Unit], offset: Int, length: Int): this.type = {
-      val newSize: Int = size + length
+      val newSize = size + length
       ensureSize(newSize)
       size = newSize
       this
@@ -520,9 +520,8 @@ object ArrayBuilder {
       case _ => false
     }
 
-    protected[this] def resize(size: Int): Unit = ()
+    protected[this] def resize(size: Int): Unit = capacity = size
 
     override def toString = "ArrayBuilder.ofUnit"
   }
 }
-

--- a/src/library/scala/collection/mutable/ArrayBuilder.scala
+++ b/src/library/scala/collection/mutable/ArrayBuilder.scala
@@ -13,6 +13,7 @@
 package scala.collection
 package mutable
 
+import scala.collection.mutable.ArrayBuffer.resizeUp
 import scala.reflect.ClassTag
 
 /** A builder class for arrays.
@@ -34,15 +35,11 @@ sealed abstract class ArrayBuilder[T]
   override def knownSize: Int = size
 
   protected[this] final def ensureSize(size: Int): Unit = {
-    if (capacity < size || capacity == 0) {
-      var newsize = if (capacity == 0) 16 else capacity * 2
-      while (newsize < size) newsize *= 2
-      resize(newsize)
-    }
+    val newLen = resizeUp(capacity, size)
+    if (newLen > 0) resize(newLen)
   }
 
-  override final def sizeHint(size: Int): Unit =
-    if (capacity < size) resize(size)
+  override final def sizeHint(size: Int): Unit = if (capacity < size) resize(size)
 
   def clear(): Unit = size = 0
 
@@ -491,17 +488,23 @@ object ArrayBuilder {
     protected def elems: Array[Unit] = throw new UnsupportedOperationException()
 
     def addOne(elem: Unit): this.type = {
-      size += 1
+      val newSize:Int = size + 1
+      ensureSize(newSize)
+      size = newSize
       this
     }
 
     override def addAll(xs: IterableOnce[Unit]): this.type = {
-      size += xs.iterator.size
+      val newSize:Int = size + xs.iterator.size
+      ensureSize(newSize)
+      size = newSize
       this
     }
 
     override def addAll(xs: Array[_ <: Unit], offset: Int, length: Int): this.type = {
-      size += length
+      val newSize: Int = size + length
+      ensureSize(newSize)
+      size = newSize
       this
     }
 
@@ -522,3 +525,4 @@ object ArrayBuilder {
     override def toString = "ArrayBuilder.ofUnit"
   }
 }
+

--- a/src/library/scala/collection/mutable/PriorityQueue.scala
+++ b/src/library/scala/collection/mutable/PriorityQueue.scala
@@ -89,7 +89,7 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
     def p_size0_=(s: Int) = size0 = s
     def p_array = array
     def p_ensureSize(n: Int) = super.ensureSize(n)
-    def p_ensureAdditionalSize(n: Int) = super.ensureAdditionalSize(n)
+    def p_ensureAdditionalSize(n: Int) = super.ensureSize(size0 + n)
     def p_swap(a: Int, b: Int): Unit = {
       val h = array(a)
       array(a) = array(b)

--- a/src/library/scala/runtime/PStatics.scala
+++ b/src/library/scala/runtime/PStatics.scala
@@ -15,5 +15,7 @@ package scala.runtime
 // things that should be in `Statics`, but can't be yet for bincompat reasons
 // TODO 3.T: move to `Statics`
 private[scala] object PStatics {
-  final val VM_MaxArraySize:Int = 2147483639 // `Int.MaxValue - 8` traditional soft limit to maximize compatibility with diverse JVMs.
+  // `Int.MaxValue - 8` traditional soft limit to maximize compatibility with diverse JVMs
+  // See https://stackoverflow.com/a/8381338 for example
+  final val VM_MaxArraySize = 2147483639
 }

--- a/src/library/scala/runtime/PStatics.scala
+++ b/src/library/scala/runtime/PStatics.scala
@@ -15,5 +15,5 @@ package scala.runtime
 // things that should be in `Statics`, but can't be yet for bincompat reasons
 // TODO 3.T: move to `Statics`
 private[scala] object PStatics {
-  final val VM_MaxArraySize = 2147483645 // == `Int.MaxValue - 2`, hotspot limit
+  final val VM_MaxArraySize:Int = 2147483639 // `Int.MaxValue - 8` traditional soft limit to maximize compatibility with diverse JVMs.
 }

--- a/test/junit/scala/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBufferTest.scala
@@ -1,10 +1,11 @@
 package scala.collection.mutable
 
-import org.junit.Test
 import org.junit.Assert.{assertEquals, assertTrue}
+import org.junit.Test
 
 import java.lang.reflect.InvocationTargetException
 import scala.annotation.nowarn
+import scala.runtime.PStatics.VM_MaxArraySize
 import scala.tools.testkit.AssertUtil.{assertSameElements, assertThrows, fail}
 import scala.tools.testkit.ReflectUtil.{getMethodAccessible, _}
 import scala.util.chaining._
@@ -390,25 +391,26 @@ class ArrayBufferTest {
     def resizeUp(arrayLen: Int, targetLen: Int): Int = sut.invoke(ArrayBuffer, arrayLen, targetLen).asInstanceOf[Int]
 
     // check termination and correctness
-    assertTrue(7 < ArrayBuffer.DefaultInitialSize)  // condition of test
+    assertTrue(7 < ArrayBuffer.DefaultInitialSize) // condition of test
     assertEquals(ArrayBuffer.DefaultInitialSize, resizeUp(7, 10))
-    assertEquals(Int.MaxValue - 8, resizeUp(Int.MaxValue / 2, Int.MaxValue / 2 + 1))  // was: ok
-    assertEquals(Int.MaxValue - 8, resizeUp(Int.MaxValue / 2, Int.MaxValue / 2 + 2))  // was: ok
-    assertEquals(-1, resizeUp(Int.MaxValue / 2 + 1, Int.MaxValue / 2 + 1))  // was: wrong
-    assertEquals(Int.MaxValue - 8, resizeUp(Int.MaxValue / 2 + 1, Int.MaxValue / 2 + 2))  // was: hang
-    assertEquals(Int.MaxValue - 8, resizeUp(Int.MaxValue / 2, Int.MaxValue - 8))
+    assertEquals(VM_MaxArraySize, resizeUp(Int.MaxValue / 2, Int.MaxValue / 2 + 1)) // `MaxValue / 2` cannot be doubled
+    assertEquals(VM_MaxArraySize / 2 * 2, resizeUp(VM_MaxArraySize / 2, VM_MaxArraySize / 2 + 1)) // `VM_MaxArraySize / 2` can be doubled
+    assertEquals(VM_MaxArraySize, resizeUp(Int.MaxValue / 2, Int.MaxValue / 2 + 2))
+    assertEquals(-1, resizeUp(Int.MaxValue / 2 + 1, Int.MaxValue / 2 + 1)) // no resize needed
+    assertEquals(VM_MaxArraySize, resizeUp(Int.MaxValue / 2 + 1, Int.MaxValue / 2 + 2))
+    assertEquals(VM_MaxArraySize, resizeUp(Int.MaxValue / 2, VM_MaxArraySize))
+    assertEquals(123456*2+33, resizeUp(123456, 123456*2+33)) // use targetLen if it's larger than double the current
 
     // check limits
     def rethrow(op: => Any): Unit =
       try op catch { case e: InvocationTargetException => throw e.getCause }
     def checkExceedsMaxInt(targetLen: Int): Unit = {
       assertThrows[Exception](rethrow(resizeUp(0, targetLen)),
-                              _ == s"Size of array-backed collection must exceed 0.  Encountered size: $targetLen")
+                              _ == s"Overflow while resizing array of array-backed collection. Requested length: $targetLen; current length: 0; increase: $targetLen")
     }
-    import scala.runtime.PStatics
     def checkExceedsVMArrayLimit(targetLen: Int): Unit =
       assertThrows[Exception](rethrow(resizeUp(0, targetLen)),
-                              _ == s"Size of array-backed collection exceeds VM array size limit of ${PStatics.VM_MaxArraySize}.  Encountered size: $targetLen")
+                              _ == s"Array of array-backed collection exceeds VM length limit of $VM_MaxArraySize. Requested length: $targetLen; current length: 0")
 
     checkExceedsMaxInt(Int.MaxValue + 1)
     checkExceedsVMArrayLimit(Int.MaxValue)

--- a/test/junit/scala/collection/mutable/ArrayBuilderTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBuilderTest.scala
@@ -1,40 +1,35 @@
 package scala.collection.mutable
 
-import org.junit.Test
 import org.junit.Assert.assertEquals
+import org.junit.Test
+
+import scala.runtime.PStatics.VM_MaxArraySize
 import scala.tools.testkit.AssertUtil.assertThrows
 
-import scala.runtime.PStatics
 class ArrayBuilderTest {
-
-  /* Test for scala/bug#12617 */
-
-  val MaxArraySize: Int = PStatics.VM_MaxArraySize
-
   @Test
-  def testCapacityGrowthLimit: Unit = {
-
+  def t12617: Unit = {
     val ab: ArrayBuilder[Unit] = ArrayBuilder.make[Unit]
 
-    var i: Int = 0
-    while (i < MaxArraySize) {
-      ab.addOne(())
-      i += 1
-    }
+    // ArrayBuilder.ofUnit.addAll doesn't iterate if the iterator has a `knownSize`
+    ab.addAll(new Iterator[Unit] {
+      override def knownSize: Int = VM_MaxArraySize
+      def hasNext: Boolean = true
+      def next(): Unit = ()
+    })
 
     // reached maximum size without entering an infinite loop?
-    assertEquals(ab.length, MaxArraySize)
+    assertEquals(ab.length, VM_MaxArraySize)
 
     // expect an exception when trying to grow larger than maximum size by addOne
-    assertThrows[Exception](ab.addOne(()))
+    assertThrows[Exception](ab.addOne(()), _.endsWith("Requested length: 2147483640; current length: 2147483639"))
 
-    val arr:Array[Unit] = Array[Unit]((), (), (), (), (), (), (), (), (), (), (), ())
+    val arr = Array[Unit]((), (), (), (), (), (), (), (), (), (), (), ())
 
     // expect an exception when trying to grow larger than maximum size by addAll(iterator)
-    assertThrows[Exception](ab.addAll(arr.iterator))
+    assertThrows[Exception](ab.addAll(arr.iterator), _.endsWith("Requested length: -2147483645; current length: 2147483639; increase: 12"))
 
     // expect an exception when trying to grow larger than maximum size by addAll(array)
     assertThrows[Exception](ab.addAll(arr))
-
   }
 }

--- a/test/junit/scala/collection/mutable/ArrayBuilderTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBuilderTest.scala
@@ -1,0 +1,40 @@
+package scala.collection.mutable
+
+import org.junit.Test
+import org.junit.Assert.assertEquals
+import scala.tools.testkit.AssertUtil.assertThrows
+
+import scala.runtime.PStatics
+class ArrayBuilderTest {
+
+  /* Test for scala/bug#12617 */
+
+  val MaxArraySize: Int = PStatics.VM_MaxArraySize
+
+  @Test
+  def testCapacityGrowthLimit: Unit = {
+
+    val ab: ArrayBuilder[Unit] = ArrayBuilder.make[Unit]
+
+    var i: Int = 0
+    while (i < MaxArraySize) {
+      ab.addOne(())
+      i += 1
+    }
+
+    // reached maximum size without entering an infinite loop?
+    assertEquals(ab.length, MaxArraySize)
+
+    // expect an exception when trying to grow larger than maximum size by addOne
+    assertThrows[Exception](ab.addOne(()))
+
+    val arr:Array[Unit] = Array[Unit]((), (), (), (), (), (), (), (), (), (), (), ())
+
+    // expect an exception when trying to grow larger than maximum size by addAll(iterator)
+    assertThrows[Exception](ab.addAll(arr.iterator))
+
+    // expect an exception when trying to grow larger than maximum size by addAll(array)
+    assertThrows[Exception](ab.addAll(arr))
+
+  }
+}


### PR DESCRIPTION
Added:
  - capacity limit to ArrayBuilder
  - guards against exceeding capacity
  - guard against capacity overflow which triggers an infinite loop in ArrayBuilder.ensureSize
  - capacity limit guards to ArrayBuilder.ofUnit
  - Unit test to exercise and test the behavior of ArrayBuilder.ensureSize as it approaches the capacity limits.

Fixes https://github.com/scala/bug/issues/12617