### PR TITLE
Remove unnecessary wildcards in covariant positions

### DIFF
--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -978,7 +978,7 @@ trait EvidenceIterableFactoryDefaults[+A, +CC[x] <: IterableOps[x, CC, CC[x]], E
 trait SortedSetFactoryDefaults[+A,
     +CC[X] <: SortedSet[X] with SortedSetOps[X, CC, CC[X]],
     +WithFilterCC[x] <: IterableOps[x, WithFilterCC, WithFilterCC[x]] with Set[x]] extends SortedSetOps[A @uncheckedVariance, CC, CC[A @uncheckedVariance]] {
-  self: IterableOps[A, WithFilterCC, _] =>
+  self: IterableOps[A, WithFilterCC, Any] =>
 
   override protected def fromSpecific(coll: IterableOnce[A @uncheckedVariance]): CC[A @uncheckedVariance]    = sortedIterableFactory.from(coll)(ordering)
   override protected def newSpecificBuilder: mutable.Builder[A @uncheckedVariance, CC[A @uncheckedVariance]] = sortedIterableFactory.newBuilder[A](ordering)
@@ -1032,7 +1032,7 @@ trait SortedMapFactoryDefaults[K, +V,
     +CC[x, y] <:  Map[x, y] with SortedMapOps[x, y, CC, CC[x, y]] with UnsortedCC[x, y],
     +WithFilterCC[x] <: IterableOps[x, WithFilterCC, WithFilterCC[x]] with Iterable[x],
     +UnsortedCC[x, y] <: Map[x, y]] extends SortedMapOps[K, V, CC, CC[K, V @uncheckedVariance]] with MapOps[K, V, UnsortedCC, CC[K, V @uncheckedVariance]] {
-  self: IterableOps[(K, V), WithFilterCC, _] =>
+  self: IterableOps[(K, V), WithFilterCC, Any] =>
 
   override def empty: CC[K, V @uncheckedVariance] = sortedMapFactory.empty(ordering)
   override protected def fromSpecific(coll: IterableOnce[(K, V @uncheckedVariance)]): CC[K, V @uncheckedVariance] = sortedMapFactory.from(coll)(ordering)

--- a/src/library/scala/collection/generic/DefaultSerializationProxy.scala
+++ b/src/library/scala/collection/generic/DefaultSerializationProxy.scala
@@ -74,7 +74,7 @@ private[collection] case object SerializeEnd
   * it directly without using this trait if you need a non-standard factory or if you want to use a different
   * serialization scheme.
   */
-trait DefaultSerializable extends Serializable { this: scala.collection.Iterable[_] =>
+trait DefaultSerializable extends Serializable { this: scala.collection.Iterable[Any] =>
   protected[this] def writeReplace(): AnyRef = {
     val f: Factory[Any, Any] = this match {
       case it: scala.collection.SortedMap[_, _] => it.sortedMapFactory.sortedMapFactory[Any, Any](it.ordering.asInstanceOf[Ordering[Any]]).asInstanceOf[Factory[Any, Any]]


### PR DESCRIPTION
Use explicit types instead of wildcards in covariant positions of self types. The aim is to avoid these types as they introduce extra type members when unpickled by TASTy Query/MiMa and possibly in Dotty. This change does not seem to be strictly necessary but is a simple way to avoid potential issues in the pickles Scala 3 pickles for the standard library.

These where identified by TASTy MiMa filters in Dotty:
* [TastyMiMaFilters.scala#L23-L24](https://github.com/lampepfl/dotty/blob/588a0b1e2928967273f8b1e96cd97006fd64e6b8/project/TastyMiMaFilters.scala#L23-L24)
* [TastyMiMaFilters.scala#L48](https://github.com/lampepfl/dotty/blob/588a0b1e2928967273f8b1e96cd97006fd64e6b8/project/TastyMiMaFilters.scala#L48)