### PR TITLE
Revert aggressive optimization of String lobounds

### DIFF
--- a/src/reflect/scala/reflect/internal/tpe/TypeConstraints.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeConstraints.scala
@@ -127,18 +127,12 @@ private[internal] trait TypeConstraints {
         case _            => !lobounds.contains(tp)
       }
       if (mustConsider) {
-        def justTwoStrings: Boolean = (
-          tp.typeSymbol == StringClass && tp.isInstanceOf[ConstantType] &&
-          lobounds.lengthCompare(1) == 0 && lobounds.head.typeSymbol == StringClass
-        )
         if (isNumericBound && isNumericValueType(tp)) {
           if (numlo == NoType || isNumericSubType(numlo, tp))
             numlo = tp
           else if (!isNumericSubType(tp, numlo))
             numlo = numericLoBound
         }
-        else if (justTwoStrings)
-          lobounds = tp.widen :: Nil // don't accumulate strings; we know they are not exactly the same bc mustConsider
         else lobounds ::= tp
       }
     }


### PR DESCRIPTION
As noticed in the community build, the attempt to avoid accumulating lobounds of String constants runs afoul of shapeless.

I verified that the shapeless unit tests compile, ~but~ and did ~not~ build the required dependencies. The tests were successful.

I didn't get the  right mix of versions for `singleton-ops`, just the sbt build requires 2.12 scala-js? Because I don't know how to tell these cross-versioned, cross-platformed projects that I want to test one platform at one version, I give up. `sbt-scalajs/scala_2.12/sbt_1.0/1.14.2` well, I guess I could back and publish that. I couldn't figure out the one sbt task to publish ALL the scala-js things: I had to publishLocal in the subprojects I needed. It's like you have to walk 5 yrs in Seth's shoes to test something.

Reverts an optimization added in https://github.com/scala/scala/pull/10352 (but doesn't revert the bugfix of that PR).