### PR TITLE
Tweak deprecation of array conversion

### DIFF
--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -579,7 +579,7 @@ private[scala] abstract class LowPriorityImplicits extends LowPriorityImplicits2
 }
 
 private[scala] abstract class LowPriorityImplicits2 {
-  @deprecated("Implicit conversions from Array to immutable.IndexedSeq are implemented by copying; Use the more efficient non-copying ArraySeq.unsafeWrapArray or an explicit toIndexedSeq call", "2.13.0")
+  @deprecated("implicit conversions from Array to immutable.IndexedSeq are implemented by copying; use `toIndexedSeq` explicitly if you want to copy, or use the more efficient non-copying ArraySeq.unsafeWrapArray", since="2.13.0")
   implicit def copyArrayToImmutableIndexedSeq[T](xs: Array[T]): IndexedSeq[T] =
     if (xs eq null) null
     else new ArrayOps(xs).toIndexedSeq

--- a/test/files/neg/t12199.check
+++ b/test/files/neg/t12199.check
@@ -1,0 +1,6 @@
+t12199.scala:4: warning: method copyArrayToImmutableIndexedSeq in class LowPriorityImplicits2 is deprecated (since 2.13.0): implicit conversions from Array to immutable.IndexedSeq are implemented by copying; use `toIndexedSeq` explicitly if you want to copy, or use the more efficient non-copying ArraySeq.unsafeWrapArray
+  val a: IndexedSeq[Int] = Array(1, 2, 3)
+                                ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/t12199.scala
+++ b/test/files/neg/t12199.scala
@@ -1,0 +1,5 @@
+// scalac: -Werror -Xlint
+
+class C {
+  val a: IndexedSeq[Int] = Array(1, 2, 3)
+}


### PR DESCRIPTION
Fixes scala/bug#12199

Touching `Predef` is the longest compilation round trip ever.