### PR TITLE
Detect symbols inherited into package objects in ambiguity warning

### DIFF
--- a/test/files/neg/t12816.check
+++ b/test/files/neg/t12816.check
@@ -1,0 +1,20 @@
+t12816.scala:8: error: package object inheritance is deprecated (https://github.com/scala/scala-dev/issues/441);
+drop the `extends` clause or use a regular object instead
+package object p extends U {
+                 ^
+t12816.scala:29: warning: reference to c is ambiguous;
+it is both defined in the enclosing package p and inherited in the enclosing trait RR as method c (defined in trait T)
+In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
+Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.c`.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+    def m3 = c // warn
+             ^
+t12816.scala:33: warning: reference to Z is ambiguous;
+it is both defined in the enclosing package p and inherited in the enclosing trait RR as trait Z (defined in trait T)
+In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
+Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.Z`.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+    def n3: Z // warn
+            ^
+2 warnings
+1 error

--- a/test/files/neg/t12816.scala
+++ b/test/files/neg/t12816.scala
@@ -1,0 +1,35 @@
+// scalac: -Xsource:3 -Werror
+
+trait U {
+  def a: Int = 0
+  trait X
+}
+
+package object p extends U {
+  def b: Int = 0
+  trait Y
+}
+
+package p {
+  object c
+  trait Z
+  trait T {
+    def a = 1
+    def b = 1
+    def c = 1
+
+    trait X
+    trait Y
+    trait Z
+  }
+
+  trait RR extends T {
+    def m1 = a // ok
+    def m2 = b // ok
+    def m3 = c // warn
+
+    def n1: X // ok
+    def n2: Y // ok
+    def n3: Z // warn
+  }
+}

--- a/test/files/neg/t12816b.check
+++ b/test/files/neg/t12816b.check
@@ -1,0 +1,20 @@
+A.scala:5: error: package object inheritance is deprecated (https://github.com/scala/scala-dev/issues/441);
+drop the `extends` clause or use a regular object instead
+package object p extends U {
+                 ^
+B.scala:19: warning: reference to c is ambiguous;
+it is both defined in the enclosing package p and inherited in the enclosing trait RR as method c (defined in trait T)
+In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
+Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.c`.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+    def m3 = c // warn
+             ^
+B.scala:23: warning: reference to Z is ambiguous;
+it is both defined in the enclosing package p and inherited in the enclosing trait RR as trait Z (defined in trait T)
+In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
+Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.Z`.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+    def n3: Z // warn
+            ^
+2 warnings
+1 error

--- a/test/files/neg/t12816b/A.scala
+++ b/test/files/neg/t12816b/A.scala
@@ -1,0 +1,8 @@
+trait U {
+  def a: Int = 0
+  trait X
+}
+package object p extends U {
+  def b: Int = 0
+  trait Y
+}

--- a/test/files/neg/t12816b/B.scala
+++ b/test/files/neg/t12816b/B.scala
@@ -1,0 +1,25 @@
+// scalac: -Xsource:3 -Werror
+
+package p {
+  object c
+  trait Z
+  trait T {
+    def a = 1
+    def b = 1
+    def c = 1
+
+    trait X
+    trait Y
+    trait Z
+  }
+
+  trait RR extends T {
+    def m1 = a // ok
+    def m2 = b // ok
+    def m3 = c // warn
+
+    def n1: X // ok
+    def n2: Y // ok
+    def n3: Z // warn
+  }
+}


### PR DESCRIPTION
Symbols defined in package objects are not competing. The corresponding test failed to identify symbols inherited into package objects.

Fixes https://github.com/scala/bug/issues/12816

Another follow-up for https://github.com/scala/scala/pull/10220