### PR TITLE
Dealias `nextBinderTp` for type test patterns in MatchTranslation

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
@@ -93,7 +93,7 @@ trait MatchTranslation {
 
       private def bindingStep(sub: Symbol, subpattern: Tree) = step(SubstOnlyTreeMaker(sub, binder))(rebindTo(subpattern))
       private def equalityTestStep()                         = step(EqualityTestTreeMaker(binder, tree, pos))()
-      private def typeTestStep(sub: Symbol, subPt: Type)     = step(TypeTestTreeMaker(sub, binder, subPt, subPt)(pos))()
+      private def typeTestStep(sub: Symbol, subPt: Type)     = step(TypeTestTreeMaker(sub, binder, subPt, subPt.dealias)(pos))()
       private def alternativesStep(alts: List[Tree])         = step(AlternativesTreeMaker(binder, translatedAlts(alts), alts.head.pos))()
       private def translatedAlts(alts: List[Tree])           = alts map (alt => rebindTo(alt).translate())
       private def noStep()                                   = step()()

--- a/test/files/neg/t12814.check
+++ b/test/files/neg/t12814.check
@@ -1,0 +1,7 @@
+t12814.scala:32: error: cyclic aliasing or subtyping involving type T
+  val f: Function1[A, P3.T] = {
+                              ^
+t12814.scala:41: error: cyclic aliasing or subtyping involving type T
+  val f: Function1[A, P4.T] = x => x match {
+                                ^
+2 errors

--- a/test/files/neg/t12814.scala
+++ b/test/files/neg/t12814.scala
@@ -1,0 +1,44 @@
+sealed trait A
+sealed trait B extends A
+
+trait F[C] {
+  type T = C
+}
+
+object O extends F[B]
+
+// 2.13.10: passes
+// 2.13.11: cyclic in patmat
+// 2.13.12: passes
+object P1 extends F[O.T] {
+  val f: PartialFunction[A, P1.T] = {
+    case x: P1.T => x
+  }
+}
+
+// 2.13.10: cyclic in patmat
+// 2.13.11: cyclic in patmat
+// 2.13.12: passes
+object P2 extends F[O.T] {
+  val f: PartialFunction[A, P2.T] = x => x match {
+    case x: P2.T => x
+  }
+}
+
+// 2.13.10: cyclic in uncurry
+// 2.13.11: cyclic in patmat
+// 2.13.12: cyclic in uncurry
+object P3 extends F[O.T] {
+  val f: Function1[A, P3.T] = {
+    case x: P3.T => x
+  }
+}
+
+// 2.13.10: cyclic in uncurry
+// 2.13.11: cyclic in patmat
+// 2.13.12: cyclic in uncurry
+object P4 extends F[O.T] {
+  val f: Function1[A, P4.T] = x => x match {
+    case x: P4.T => x
+  }
+}


### PR DESCRIPTION
For https://github.com/scala/bug/issues/12814 - follow-up for https://github.com/scala/scala/pull/10247

Not sure if this is worth it though. The code pattern seems prone to "cyclic aliasing" errors. Maybe the underlying issue can be fixed, possibly the `checkNonCyclic` implementation is not right. In `P1` / `P2` etc, the symbol that triggers the cycle is `F.T`, which is involved twice (`O.T` and `P1.T`).