### PR TITLE
Scaladoc tool: removed “crash course” for ambiguous links

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/base/MemberLookupBase.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/MemberLookupBase.scala
@@ -43,19 +43,9 @@ trait MemberLookupBase {
   private def explanation: String =
     if (showExplanation) {
       showExplanation = false
-      """
-      |Quick crash course on using Scaladoc links
-      |==========================================
-      |Disambiguating terms and types: Suffix terms with '$' and types with '!' in case both names are in use:
-      | - [[scala.collection.immutable.List!.apply class List's apply method]] and
-      | - [[scala.collection.immutable.List$.apply object List's apply method]]
-      |Disambiguating overloaded members: If a term is overloaded, you can indicate the first part of its signature followed by *:
-      | - [[[scala.collection.immutable.List$.fill[A](Int)(=> A):List[A]* Fill with a single parameter]]]
-      | - [[[scala.collection.immutable.List$.fill[A](Int, Int)(=> A):List[List[A]]* Fill with a two parameters]]]
-      |Notes:
-      | - you can use any number of matching square brackets to avoid interference with the signature
-      | - you can use \\. to escape dots in prefixes (don't forget to use * at the end to match the signature!)
-      | - you can use \\# to escape hashes, otherwise they will be considered as delimiters, like dots.""".stripMargin
+      """For an explanation of how to resolve ambiguous links,
+        |see "Resolving Ambiguous Links within Scaladoc Comments" in the Scaladoc for Library Authors guide
+        |(https://docs.scala-lang.org/overviews/scaladoc/for-library-authors.html)""".stripMargin
     } else ""
 
   def memberLookup(pos: Position, query: String, site: Symbol): LinkTo = {


### PR DESCRIPTION
Removed "quick crash course to ambiguous links" and pointed a link at the docs instead: this is because much of the advice in the current guide is _wrong_, and there is much more that can be said in the link. There is an associated PR https://github.com/scala/docs.scala-lang/pull/2860 here for adding the quick guide into the docs and fixing it up.

This PR will wait in draft until that one has been merged.