### PR TITLE
[backport] Simplify macro exception stack handling

### DIFF
--- a/test/files/neg/macro-invalidret.check
+++ b/test/files/neg/macro-invalidret.check
@@ -18,15 +18,6 @@ Macros_Test_2.scala:7: error: macro defs must have explicitly specified return t
 Macros_Test_2.scala:15: error: exception during macro expansion:
 java.lang.NullPointerException
 	at Impls$.foo3(Impls_1.scala:8)
-#partest java20
-	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
-#partest java21+
-	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
-#partest java20+
-	at java.base/java.lang.reflect.Method.invoke(Method.java:578)
-	at scala.reflect.macros.runtime.JavaReflectionRuntimes$JavaReflectionResolvers.$anonfun$resolveJavaReflectionRuntime$6(JavaReflectionRuntimes.scala:51)
-	at scala.tools.nsc.typechecker.Macros.macroExpandWithRuntime(Macros.scala:849)
-#partest
 
   foo3
   ^


### PR DESCRIPTION
backport of @som-snytt's #10072 — the same test that originally prompted that PR has now begun failing on JDK 21, as noticed by @lrytz at https://github.com/scala/scala/commit/cce8a01034fb0a2635f7017a3d080e9ec6ac5584#r119808443

