### PR TITLE
Fix test directive syntax so test passes on Windows

### DIFF
--- a/test/files/run/t9915/C_1.java
+++ b/test/files/run/t9915/C_1.java
@@ -1,6 +1,4 @@
-/*
- * javac: -encoding UTF-8
- */
+// javac: -encoding UTF-8
 public class C_1 {
     public static final String NULLED = "X\000ABC";
     public static final String SUPPED = "𐒈𐒝𐒑𐒛𐒐𐒘𐒕𐒖";


### PR DESCRIPTION
this little missing piece of #10405 was causing CI failures on Windows on JDK 8, 11, and 17 (but not 20+, since the default encoding changed)
