### PR TITLE
Re-enable new ambiguity warning under 2.13

### DIFF
--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -153,7 +153,7 @@ trait StdAttachments {
   /** For `val i = 42`, marks field as inferred so accessor (getter) can warn if implicit. */
   case object FieldTypeInferred extends PlainAttachment
 
-  case class LookupAmbiguityWarning(msg: String) extends PlainAttachment
+  case class LookupAmbiguityWarning(msg: String, fix: String) extends PlainAttachment
 
   /** Java sealed classes may be qualified with a permits clause specifying allowed subclasses. */
   case class PermittedSubclasses(permits: List[Tree]) extends PlainAttachment

--- a/test/files/neg/t11921-alias.check
+++ b/test/files/neg/t11921-alias.check
@@ -1,31 +1,29 @@
-t11921-alias.scala:18: warning: reference to TT is ambiguous;
+t11921-alias.scala:18: error: reference to TT is ambiguous;
 it is both defined in the enclosing object O and inherited in the enclosing class D as type TT (defined in class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.TT`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
       def n(x: TT) = x // ambiguous
                ^
-t11921-alias.scala:38: warning: reference to c is ambiguous;
+t11921-alias.scala:38: error: reference to c is ambiguous;
 it is both defined in the enclosing class B and inherited in the enclosing anonymous class as value c (defined in class A)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.c`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
       def n = c // ambiguous
               ^
-t11921-alias.scala:57: warning: reference to name is ambiguous;
+t11921-alias.scala:57: error: reference to name is ambiguous;
 it is both defined in the enclosing method m and inherited in the enclosing anonymous class as value name (defined in class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.name`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
       println(name)
               ^
-t11921-alias.scala:67: warning: reference to name is ambiguous;
+t11921-alias.scala:67: error: reference to name is ambiguous;
 it is both defined in the enclosing method m and inherited in the enclosing anonymous class as value name (defined in class A, inherited through parent class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.name`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
       println(name)
               ^
-error: No warnings can be incurred under -Werror.
-4 warnings
-1 error
+4 errors

--- a/test/files/neg/t11921.check
+++ b/test/files/neg/t11921.check
@@ -3,12 +3,11 @@ t11921.scala:6: error: type mismatch;
  required: B => B
       def iterator = coll.iterator.map(f)    // coll is ambiguous
                                        ^
-t11921.scala:6: warning: reference to coll is ambiguous;
+t11921.scala:6: error: reference to coll is ambiguous;
 it is both defined in the enclosing method lazyMap and inherited in the enclosing anonymous class as method coll (defined in trait Iterable)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.coll`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
       def iterator = coll.iterator.map(f)    // coll is ambiguous
                      ^
-1 warning
-1 error
+2 errors

--- a/test/files/neg/t11921b.check
+++ b/test/files/neg/t11921b.check
@@ -1,61 +1,60 @@
 t11921b.scala:135: error: could not find implicit value for parameter i: Int
     def u = t // doesn't compile in Scala 2 (maybe there's a ticket for that)
             ^
-t11921b.scala:11: warning: reference to x is ambiguous;
+t11921b.scala:11: error: reference to x is ambiguous;
 it is both defined in the enclosing object Test and inherited in the enclosing class D as value x (defined in class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.x`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
       println(x)  // error
               ^
-t11921b.scala:15: warning: reference to x is ambiguous;
+t11921b.scala:15: error: reference to x is ambiguous;
 it is both defined in the enclosing object Test and inherited in the enclosing anonymous class as value x (defined in class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.x`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
         println(x)  // error
                 ^
-t11921b.scala:26: warning: reference to y is ambiguous;
+t11921b.scala:26: error: reference to y is ambiguous;
 it is both defined in the enclosing method c and inherited in the enclosing anonymous class as value y (defined in class D)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.y`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
       println(y)  // error
               ^
-t11921b.scala:38: warning: reference to y is ambiguous;
+t11921b.scala:38: error: reference to y is ambiguous;
 it is both defined in the enclosing method c and inherited in the enclosing class E as value y (defined in class D)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
-Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.y`.
+Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `E.this.y`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
         println(y)  // error
                 ^
-t11921b.scala:65: warning: reference to global is ambiguous;
+t11921b.scala:65: error: reference to global is ambiguous;
 it is both defined in the enclosing package <empty> and inherited in the enclosing object D as value global (defined in class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.global`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
   println(global)    // error
           ^
-t11921b.scala:75: warning: reference to x is ambiguous;
+t11921b.scala:75: error: reference to x is ambiguous;
 it is both defined in the enclosing object Uhu and inherited in the enclosing class C as value x (defined in class A, inherited through parent class B)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
-Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.x`.
+Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `C.this.x`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
         def t = x // ambiguous, message mentions parent B
                 ^
-t11921b.scala:89: warning: reference to a is ambiguous;
+t11921b.scala:89: error: reference to a is ambiguous;
 it is both defined in the enclosing class C and inherited in the enclosing trait J as method a (defined in trait I)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.a`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
       val t = a // error
               ^
-t11921b.scala:136: warning: reference to lo is ambiguous;
+t11921b.scala:136: error: reference to lo is ambiguous;
 it is both defined in the enclosing object test10 and inherited in the enclosing class C as value lo (defined in class P)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.lo`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
     def v = t(lo) // error
               ^
-8 warnings
-1 error
+9 errors

--- a/test/files/neg/t12816.check
+++ b/test/files/neg/t12816.check
@@ -2,19 +2,18 @@ t12816.scala:8: error: package object inheritance is deprecated (https://github.
 drop the `extends` clause or use a regular object instead
 package object p extends U {
                  ^
-t12816.scala:29: warning: reference to c is ambiguous;
+t12816.scala:29: error: reference to c is ambiguous;
 it is both defined in the enclosing package p and inherited in the enclosing trait RR as method c (defined in trait T)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.c`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
     def m3 = c // warn
              ^
-t12816.scala:33: warning: reference to Z is ambiguous;
+t12816.scala:33: error: reference to Z is ambiguous;
 it is both defined in the enclosing package p and inherited in the enclosing trait RR as trait Z (defined in trait T)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.Z`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
     def n3: Z // warn
             ^
-2 warnings
-1 error
+3 errors

--- a/test/files/neg/t12816b.check
+++ b/test/files/neg/t12816b.check
@@ -2,19 +2,18 @@ A.scala:5: error: package object inheritance is deprecated (https://github.com/s
 drop the `extends` clause or use a regular object instead
 package object p extends U {
                  ^
-B.scala:19: warning: reference to c is ambiguous;
+B.scala:19: error: reference to c is ambiguous;
 it is both defined in the enclosing package p and inherited in the enclosing trait RR as method c (defined in trait T)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.c`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
     def m3 = c // warn
              ^
-B.scala:23: warning: reference to Z is ambiguous;
+B.scala:23: error: reference to Z is ambiguous;
 it is both defined in the enclosing package p and inherited in the enclosing trait RR as trait Z (defined in trait T)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.Z`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
     def n3: Z // warn
             ^
-2 warnings
-1 error
+3 errors

--- a/test/files/neg/using-source3.check
+++ b/test/files/neg/using-source3.check
@@ -1,10 +1,8 @@
-using-source3.scala:14: warning: reference to f is ambiguous;
+using-source3.scala:14: error: reference to f is ambiguous;
 it is both defined in the enclosing class D and inherited in the enclosing class E as method f (defined in class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.f`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
     def g = f
             ^
-error: No warnings can be incurred under -Werror.
-1 warning
 1 error

--- a/test/files/neg/using-source3b.check
+++ b/test/files/neg/using-source3b.check
@@ -1,10 +1,8 @@
-using-source3b.scala:13: warning: reference to f is ambiguous;
+using-source3b.scala:13: error: reference to f is ambiguous;
 it is both defined in the enclosing class D and inherited in the enclosing class E as method f (defined in class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.f`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
     def g = f
             ^
-error: No warnings can be incurred under -Werror.
-1 warning
 1 error

--- a/test/junit/scala/tools/nsc/reporters/AbstractCodeActionTest.scala
+++ b/test/junit/scala/tools/nsc/reporters/AbstractCodeActionTest.scala
@@ -76,6 +76,21 @@ abstract class AbstractCodeActionTest extends BytecodeTesting {
       """.stripMargin,
     )
 
+  @Test def outerReference(): Unit = {
+    assertCodeSuggestion(
+      """trait T { def f = 1 }
+        |object O1 { def f = 2; class C extends T { def t = f } }
+        |object O2 { def f = 2; class C extends T { object I { def t = f } } }
+        |object O3 { def f = 2; object C extends T { object I { def t = f } } }
+        |""".stripMargin,
+      """trait T { def f = 1 }
+        |object O1 { def f = 2; class C extends T { def t = this.f } }
+        |object O2 { def f = 2; class C extends T { object I { def t = C.this.f } } }
+        |object O3 { def f = 2; object C extends T { object I { def t = C.this.f } } }
+        |""".stripMargin
+    )
+  }
+
   def assertCodeSuggestion(original: String, expected: String): Unit = {
     val run = compiler.newRun()
     run.compileSources(compiler.global.newSourceFile(original) :: Nil)


### PR DESCRIPTION
Include a quick fix.

follow-up for https://github.com/scala/scala/pull/10339