### PR TITLE
Restore signature of ChangeOwnerTraverser.change

### DIFF
--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -1624,7 +1624,7 @@ trait Trees extends api.Trees {
     protected val changedSymbols = mutable.Set.empty[Symbol]
     protected val treeTypes = mutable.Set.empty[Type]
 
-    def change(sym: Symbol) = {
+    def change(sym: Symbol): Unit = {
       if (sym != NoSymbol && sym.owner == oldowner) {
         sym.owner = newowner
         changedSymbols += sym


### PR DESCRIPTION
The result type changed from Unit to Any in #10389.

This broke the scalatest assert macro, which uses API from scala.reflect.internal. It shouldn't, binary compatibility is not checked in the internal package. Hopefully this commit fixes it anyway.