### PR TITLE
Retain constant value types when inferring result types

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1140,6 +1140,7 @@ trait Namers extends MethodSynthesis {
       tree.tpt.defineType {
         val inferOverridden = currentRun.isScala3 &&
           !pt.isWildcard && pt != NoType && !pt.isErroneous &&
+          !(tree.isInstanceOf[ValDef] && tree.symbol.isFinal && isConstantType(rhsTpe)) &&
           openMacros.isEmpty && {
             context.unit.transformed.get(tree.rhs) match {
               case Some(t) if t.hasAttachment[MacroExpansionAttachment] =>

--- a/test/files/pos/t12830.scala
+++ b/test/files/pos/t12830.scala
@@ -1,0 +1,23 @@
+// scalac: -Xsource:3
+
+class C {
+  def i: Int = 42
+}
+object D extends C {
+  override final val i = 27
+}
+object Test {
+  def f: 27 = D.i
+}
+
+/*
+t12830.scala:10: error: type mismatch;
+ found   : D.i.type (with underlying type Int)
+ required: 27
+  def f: 27 = D.i
+                ^
+t12830.scala:7: error: under -Xsource:3, inferred Int instead of Int(27)
+  override final val i = 27
+                     ^
+2 errors
+*/


### PR DESCRIPTION
Fixes scala/bug#12830
