### PR TITLE
Prevent leaking warnings between REPL lines

### DIFF
--- a/src/reflect/scala/reflect/internal/util/SourceFile.scala
+++ b/src/reflect/scala/reflect/internal/util/SourceFile.scala
@@ -140,6 +140,10 @@ class ScriptSourceFile(underlying: BatchSourceFile, content: Array[Char], overri
     else pos withSource underlying withShift start
 }
 
+/* See PerRunReporting.repSrc */
+class ReplBatchSourceFile(filename: String, content: String, val parserSource: BatchSourceFile)
+  extends BatchSourceFile(filename, content)
+
 /** a file whose contents do not change over time */
 class BatchSourceFile(val file : AbstractFile, content0: Array[Char]) extends SourceFile {
   def this(_file: AbstractFile)                 = this(_file, _file.toCharArray)
@@ -227,8 +231,8 @@ class BatchSourceFile(val file : AbstractFile, content0: Array[Char]) extends So
 
 
   override def equals(that : Any) = that match {
-    case that : BatchSourceFile => file.path == that.file.path && start == that.start
-    case _ => false
+    case that: BatchSourceFile if !file.isVirtual && !that.file.isVirtual => file.path == that.file.path && start == that.start
+    case _ => super.equals(that)
   }
-  override def hashCode = file.path.## + start.##
+  override def hashCode = if (!file.isVirtual) file.path.## + start.## else super.hashCode()
 }

--- a/src/repl/scala/tools/nsc/interpreter/PresentationCompilation.scala
+++ b/src/repl/scala/tools/nsc/interpreter/PresentationCompilation.scala
@@ -54,13 +54,14 @@ trait PresentationCompilation { self: IMain =>
       // where `bar` is the complete name of a member.
       val line1 = if (!cursorIsInKeyword()) buf else buf.patch(cursor, Cursor, 0)
 
-      val trees = pc.newUnitParser(line1).parseStats() match {
+      val parserSource = pc.newSourceFile(line1)
+      val trees = pc.newUnitParser(new pc.CompilationUnit(parserSource)).parseStats() match {
         case Nil => List(pc.EmptyTree)
         case xs => xs
       }
       val importer = global.mkImporter(pc)
       //println(s"pc: [[$line1]], <<${trees.size}>>")
-      val request = new Request(line1, trees map (t => importer.importTree(t)), generousImports = true, storeResultInVal = false)
+      val request = new Request(line1, trees map (t => importer.importTree(t)), parserSource, generousImports = true, storeResultInVal = false)
       val origUnit = request.mkUnit
       val unit = new pc.CompilationUnit(origUnit.source)
       unit.body = pc.mkImporter(global).importTree(origUnit.body)

--- a/src/repl/scala/tools/nsc/interpreter/Scripted.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Scripted.scala
@@ -48,7 +48,7 @@ class ScriptedInterpreter(initialSettings: Settings, reporter: ReplReporter, imp
   def addBackReferences(req: Request): Either[String, Request] = {
     val defines = req.definesTermNames
     if (defines.isEmpty) {
-      recordRequest(new Request(req.line, req.trees))
+      recordRequest(new Request(req.line, req.trees, req.parserSource))
       Left(s"new ${req.lineRep.readPath}")
     } else {
       val newReq = requestFromLine(

--- a/test/files/run/repl-suspended-warnings.check
+++ b/test/files/run/repl-suspended-warnings.check
@@ -1,0 +1,23 @@
+
+scala> @annotation.nowarn def f { }
+def f: Unit
+
+scala> def f { }
+             ^
+       error: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `f`'s return type [quickfixable]
+       Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=deprecation, version=2.13.0
+
+scala> @annotation.nowarn def f { }
+def f: Unit
+
+scala> class C { def match = 42 }
+                     ^
+       error: identifier expected but 'match' found.
+
+scala> class C { def `match` = 42 }
+class C
+
+scala> class C { def `match` = 42 }
+class C
+
+scala> :quit

--- a/test/files/run/repl-suspended-warnings.scala
+++ b/test/files/run/repl-suspended-warnings.scala
@@ -1,0 +1,13 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  override def extraSettings = "-Wconf:any:e"
+  def code =
+    """@annotation.nowarn def f { }
+      |def f { }
+      |@annotation.nowarn def f { }
+      |class C { def match = 42 }
+      |class C { def `match` = 42 }
+      |class C { def `match` = 42 }
+      |""".stripMargin
+}


### PR DESCRIPTION
The repl is creative in the way it uses `Run` instances. Parsing happens using the previous `Run`, the rest of compilation in the next one. Make sure warnings don't leak from one line to the next, but also make sure suspended warnings from parsing are not lost.

Fixes scala/bug#12910