### PR TITLE
Skip anonymous and placeholder symbols in Wconf site string

### DIFF
--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -208,12 +208,16 @@ trait Reporting extends internal.Reporting { self: ast.Positions with Compilatio
     }
 
     private def siteName(sym: Symbol) = if (sym.exists) {
+      def skipAnon(s: Symbol, res: Symbol): Symbol =
+        if (s.isRootSymbol || s == NoSymbol) res
+        else if (s.isAnonymousClass || s.isLocalDummy) skipAnon(s.effectiveOwner, s.effectiveOwner)
+        else skipAnon(s.effectiveOwner, res)
       // Similar to fullNameString, but don't jump to enclosing class. Keep full chain of symbols.
       def impl(s: Symbol): String =
         if (s.isRootSymbol || s == NoSymbol) s.nameString
         else if (s.owner.isEffectiveRoot) s.nameString
         else impl(s.effectiveOwner) + "." + s.nameString
-      impl(sym)
+      impl(skipAnon(sym, sym))
     } else ""
 
     override def deprecationWarning(pos: Position, msg: String, since: String, site: String, origin: String, actions: List[CodeAction] = Nil): Unit =

--- a/test/files/neg/t11921-alias.check
+++ b/test/files/neg/t11921-alias.check
@@ -13,7 +13,7 @@ In Scala 2, symbols inherited from a superclass shadow symbols defined in an out
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.c`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
-Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=t4.B.a.$anon.n
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=t4.B.a
       def n = c // ambiguous
               ^
 t11921-alias.scala:57: error: reference to name is ambiguous;
@@ -22,7 +22,7 @@ In Scala 2, symbols inherited from a superclass shadow symbols defined in an out
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.name`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
-Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=t6.Test.m.$anon.<local $anon>
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=t6.Test.m
       println(name)
               ^
 t11921-alias.scala:67: error: reference to name is ambiguous;
@@ -31,7 +31,7 @@ In Scala 2, symbols inherited from a superclass shadow symbols defined in an out
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.name`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
-Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=t7.Test.m.$anon.<local $anon>
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=t7.Test.m
       println(name)
               ^
 4 errors

--- a/test/files/neg/t11921.check
+++ b/test/files/neg/t11921.check
@@ -9,7 +9,7 @@ In Scala 2, symbols inherited from a superclass shadow symbols defined in an out
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.coll`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
-Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=C.lazyMap.$anon.iterator
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=C.lazyMap
       def iterator = coll.iterator.map(f)    // coll is ambiguous
                      ^
 2 errors

--- a/test/files/neg/t11921b.check
+++ b/test/files/neg/t11921b.check
@@ -7,7 +7,7 @@ In Scala 2, symbols inherited from a superclass shadow symbols defined in an out
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.x`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
-Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test1.Test.D.<local D>
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test1.Test.D
       println(x)  // error
               ^
 t11921b.scala:15: error: reference to x is ambiguous;
@@ -16,7 +16,7 @@ In Scala 2, symbols inherited from a superclass shadow symbols defined in an out
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.x`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
-Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test1.Test.f.$anon.<local $anon>
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test1.Test.f
         println(x)  // error
                 ^
 t11921b.scala:26: error: reference to y is ambiguous;
@@ -25,7 +25,7 @@ In Scala 2, symbols inherited from a superclass shadow symbols defined in an out
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.y`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
-Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test2.c.$anon.<local $anon>
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test2.c
       println(y)  // error
               ^
 t11921b.scala:38: error: reference to y is ambiguous;
@@ -34,7 +34,7 @@ In Scala 2, symbols inherited from a superclass shadow symbols defined in an out
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `E.this.y`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
-Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test3.c.E.F.<local F>
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test3.c.E.F
         println(y)  // error
                 ^
 t11921b.scala:65: error: reference to global is ambiguous;
@@ -43,7 +43,7 @@ In Scala 2, symbols inherited from a superclass shadow symbols defined in an out
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.global`.
 Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
-Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=D.<local D>
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=D
   println(global)    // error
           ^
 t11921b.scala:75: error: reference to x is ambiguous;


### PR DESCRIPTION
Noticed by @som-snytt in https://github.com/scala/scala/pull/10478#issuecomment-1646931753