### PR TITLE
Add `-quickfix` compiler option to apply quickfixes to source files

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -251,11 +251,11 @@ self =>
     val syntaxErrors = new ListBuffer[(Int, String, List[CodeAction])]
     def showSyntaxErrors() =
       for ((offset, msg, actions) <- syntaxErrors)
-        reporter.error(o2p(offset), msg, actions)
+        runReporting.error(o2p(offset), msg, actions)
 
     override def syntaxError(offset: Offset, msg: String, actions: List[CodeAction]): Unit = {
       if (smartParsing) syntaxErrors += ((offset, msg, actions))
-      else reporter.error(o2p(offset), msg, actions)
+      else runReporting.error(o2p(offset), msg, actions)
     }
 
     override def incompleteInputError(msg: String, actions: List[CodeAction]): Unit = {

--- a/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
@@ -51,6 +51,21 @@ trait StandardScalaSettings { _: MutableSettings =>
   val nowarn =         BooleanSetting ("-nowarn", "Generate no warnings.") withAbbreviation "--no-warnings" withPostSetHook { s => if (s.value) maxwarns.value = 0 }
   val optimise:        BooleanSetting // depends on post hook which mutates other settings
   val print =          BooleanSetting ("-print", "Print program with Scala-specific features removed.") withAbbreviation "--print"
+  val quickfix =       MultiStringSetting(
+    "-quickfix",
+    "filters",
+    "Apply quick fixes provided by the compiler for warnings and errors to source files",
+    helpText = Some(
+      """Apply quick fixes provided by the compiler for warnings and errors to source files.
+        |Syntax: -quickfix:<filter>,...,<filter>
+        |
+        |<filter> syntax is the same as for configurable warnings, see `-Wconf:help`. Examples:
+        |  -quickfix:any                    apply all available quick fixes
+        |  -quickfix:msg=Auto-application   apply quick fixes where the message contains "Auto-application"
+        |
+        |Use `-Wconf:any:warning-verbose` to display applicable message filters with each warning.
+        |""".stripMargin),
+    prepend = true)
   val release =
     ChoiceSetting("-release", "release", "Compile for a version of the Java API and target class file.", AllTargetVersions, normalizeTarget(javaSpecVersion))
       .withPostSetHook { setting =>

--- a/src/reflect/scala/reflect/internal/util/CodeAction.scala
+++ b/src/reflect/scala/reflect/internal/util/CodeAction.scala
@@ -36,4 +36,6 @@ case class CodeAction(title: String, description: Option[String], edits: List[Te
  *  @groupname Common   Commonly used methods
  *  @group ReflectionAPI
  */
-case class TextEdit(position: Position, newText: String)
+case class TextEdit(position: Position, newText: String) {
+  def delta: Int = newText.length - (position.end - position.start)
+}

--- a/test/files/neg/auto-application.check
+++ b/test/files/neg/auto-application.check
@@ -7,7 +7,7 @@ auto-application.scala:5: error: Int does not take parameters
 auto-application.scala:6: error: Int does not take parameters
   ("": Object).##()
                  ^
-auto-application.scala:9: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method meth,
+auto-application.scala:9: warning: [quick fix available] Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method meth,
 or remove the empty argument list from its definition (Java-defined methods are exempt).
 In Scala 3, an unapplied method like this will be eta-expanded into a function.
   meth // warn, auto-application (of nilary methods) is deprecated

--- a/test/files/neg/for-comprehension-old.check
+++ b/test/files/neg/for-comprehension-old.check
@@ -1,25 +1,25 @@
-for-comprehension-old.scala:6: error: `val` keyword in for comprehension is unsupported: just remove `val`
+for-comprehension-old.scala:6: error: [quick fix available] `val` keyword in for comprehension is unsupported: just remove `val`
   for (val x <- 1 to 5 ; y = x) yield x+y       // fail
              ^
-for-comprehension-old.scala:7: error: `val` keyword in for comprehension is unsupported: just remove `val`
+for-comprehension-old.scala:7: error: [quick fix available] `val` keyword in for comprehension is unsupported: just remove `val`
   for (val x <- 1 to 5 ; val y = x) yield x+y   // fail
              ^
-for-comprehension-old.scala:11: error: `val` keyword in for comprehension is unsupported: just remove `val`
+for-comprehension-old.scala:11: error: [quick fix available] `val` keyword in for comprehension is unsupported: just remove `val`
   for (z <- 1 to 2 ; val x <- 1 to 5 ; y = x) yield x+y       // fail
                            ^
-for-comprehension-old.scala:12: error: `val` keyword in for comprehension is unsupported: just remove `val`
+for-comprehension-old.scala:12: error: [quick fix available] `val` keyword in for comprehension is unsupported: just remove `val`
   for (z <- 1 to 2 ; val x <- 1 to 5 ; val y = x) yield x+y   // fail
                            ^
-for-comprehension-old.scala:5: warning: `val` keyword in for comprehension is deprecated: instead, bind the value without `val`
+for-comprehension-old.scala:5: warning: [quick fix available] `val` keyword in for comprehension is deprecated: instead, bind the value without `val`
   for (x <- 1 to 5 ; val y = x) yield x+y       // fail
                            ^
-for-comprehension-old.scala:7: warning: `val` keyword in for comprehension is deprecated: instead, bind the value without `val`
+for-comprehension-old.scala:7: warning: [quick fix available] `val` keyword in for comprehension is deprecated: instead, bind the value without `val`
   for (val x <- 1 to 5 ; val y = x) yield x+y   // fail
                                ^
-for-comprehension-old.scala:10: warning: `val` keyword in for comprehension is deprecated: instead, bind the value without `val`
+for-comprehension-old.scala:10: warning: [quick fix available] `val` keyword in for comprehension is deprecated: instead, bind the value without `val`
   for (z <- 1 to 2 ; x <- 1 to 5 ; val y = x) yield x+y       // fail
                                          ^
-for-comprehension-old.scala:12: warning: `val` keyword in for comprehension is deprecated: instead, bind the value without `val`
+for-comprehension-old.scala:12: warning: [quick fix available] `val` keyword in for comprehension is deprecated: instead, bind the value without `val`
   for (z <- 1 to 2 ; val x <- 1 to 5 ; val y = x) yield x+y   // fail
                                              ^
 4 warnings

--- a/test/files/neg/for-comprehension-val.check
+++ b/test/files/neg/for-comprehension-val.check
@@ -1,31 +1,31 @@
-for-comprehension-val.scala:6: error: `val` keyword in for comprehension is unsupported: just remove `val`
+for-comprehension-val.scala:6: error: [quick fix available] `val` keyword in for comprehension is unsupported: just remove `val`
   for (val x <- 1 to 5 ; y = x) yield x+y       // fail
              ^
-for-comprehension-val.scala:7: error: `val` keyword in for comprehension is unsupported: just remove `val`
+for-comprehension-val.scala:7: error: [quick fix available] `val` keyword in for comprehension is unsupported: just remove `val`
   for (val x <- 1 to 5 ; val y = x) yield x+y   // fail
              ^
-for-comprehension-val.scala:11: error: `val` keyword in for comprehension is unsupported: just remove `val`
+for-comprehension-val.scala:11: error: [quick fix available] `val` keyword in for comprehension is unsupported: just remove `val`
   for (z <- 1 to 2 ; val x <- 1 to 5 ; y = x) yield x+y       // fail
                            ^
-for-comprehension-val.scala:12: error: `val` keyword in for comprehension is unsupported: just remove `val`
+for-comprehension-val.scala:12: error: [quick fix available] `val` keyword in for comprehension is unsupported: just remove `val`
   for (z <- 1 to 2 ; val x <- 1 to 5 ; val y = x) yield x+y   // fail
                            ^
-for-comprehension-val.scala:5: error: `val` keyword in for comprehension is unsupported: instead, bind the value without `val`
+for-comprehension-val.scala:5: error: [quick fix available] `val` keyword in for comprehension is unsupported: instead, bind the value without `val`
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   for (x <- 1 to 5 ; val y = x) yield x+y       // fail
                            ^
-for-comprehension-val.scala:7: error: `val` keyword in for comprehension is unsupported: instead, bind the value without `val`
+for-comprehension-val.scala:7: error: [quick fix available] `val` keyword in for comprehension is unsupported: instead, bind the value without `val`
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   for (val x <- 1 to 5 ; val y = x) yield x+y   // fail
                                ^
-for-comprehension-val.scala:10: error: `val` keyword in for comprehension is unsupported: instead, bind the value without `val`
+for-comprehension-val.scala:10: error: [quick fix available] `val` keyword in for comprehension is unsupported: instead, bind the value without `val`
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   for (z <- 1 to 2 ; x <- 1 to 5 ; val y = x) yield x+y       // fail
                                          ^
-for-comprehension-val.scala:12: error: `val` keyword in for comprehension is unsupported: instead, bind the value without `val`
+for-comprehension-val.scala:12: error: [quick fix available] `val` keyword in for comprehension is unsupported: instead, bind the value without `val`
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   for (z <- 1 to 2 ; val x <- 1 to 5 ; val y = x) yield x+y   // fail

--- a/test/files/neg/macro-deprecate-idents.check
+++ b/test/files/neg/macro-deprecate-idents.check
@@ -64,7 +64,7 @@ macro-deprecate-idents.scala:47: error: '{' expected but '}' found.
 macro-deprecate-idents.scala:54: error: ')' expected but '}' found.
 }
 ^
-macro-deprecate-idents.scala:57: warning: procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `<error>`'s return type
+macro-deprecate-idents.scala:57: warning: [quick fix available] procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `<error>`'s return type
   def macro = 2
                ^
 1 warning

--- a/test/files/neg/parens-for-params.check
+++ b/test/files/neg/parens-for-params.check
@@ -1,4 +1,4 @@
-parens-for-params.scala:5: error: parentheses are required around the parameter of a lambda
+parens-for-params.scala:5: error: [quick fix available] parentheses are required around the parameter of a lambda
 Use '-Wconf:msg=lambda-parens:s' to silence this warning.
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration

--- a/test/files/neg/prefix-unary-nilary-deprecation.check
+++ b/test/files/neg/prefix-unary-nilary-deprecation.check
@@ -4,7 +4,7 @@ prefix-unary-nilary-deprecation.scala:4: warning: unary prefix operator definiti
 prefix-unary-nilary-deprecation.scala:5: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_-(implicit pos: Long) = this`
   def unary_-()(implicit pos: Long) = this
       ^
-prefix-unary-nilary-deprecation.scala:12: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method unary_~,
+prefix-unary-nilary-deprecation.scala:12: warning: [quick fix available] Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method unary_~,
 or remove the empty argument list from its definition (Java-defined methods are exempt).
 In Scala 3, an unapplied method like this will be eta-expanded into a function.
   val f2 = ~f

--- a/test/files/neg/prefix-unary-nilary-removal.check
+++ b/test/files/neg/prefix-unary-nilary-removal.check
@@ -4,7 +4,7 @@ prefix-unary-nilary-removal.scala:4: warning: unary prefix operator definition w
 prefix-unary-nilary-removal.scala:5: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_-(implicit pos: Long) = this`
   def unary_-()(implicit pos: Long) = this
       ^
-prefix-unary-nilary-removal.scala:12: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method unary_~,
+prefix-unary-nilary-removal.scala:12: warning: [quick fix available] Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method unary_~,
 or remove the empty argument list from its definition (Java-defined methods are exempt).
 In Scala 3, an unapplied method like this will be eta-expanded into a function.
   val f2 = ~f

--- a/test/files/neg/procedure-deprecation.check
+++ b/test/files/neg/procedure-deprecation.check
@@ -1,13 +1,13 @@
-procedure-deprecation.scala:4: warning: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `bar`'s return type
+procedure-deprecation.scala:4: warning: [quick fix available] procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `bar`'s return type
   def bar {}
           ^
-procedure-deprecation.scala:5: warning: procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `baz`'s return type
+procedure-deprecation.scala:5: warning: [quick fix available] procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `baz`'s return type
   def baz
          ^
-procedure-deprecation.scala:6: warning: procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `boo`'s return type
+procedure-deprecation.scala:6: warning: [quick fix available] procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `boo`'s return type
   def boo(i: Int, l: Long)
                           ^
-procedure-deprecation.scala:7: warning: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `boz`'s return type
+procedure-deprecation.scala:7: warning: [quick fix available] procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `boz`'s return type
   def boz(i: Int, l: Long) {}
                            ^
 procedure-deprecation.scala:8: warning: procedure syntax is deprecated for constructors: add `=`, as in method definition

--- a/test/files/neg/procedure-removal.check
+++ b/test/files/neg/procedure-removal.check
@@ -1,13 +1,13 @@
-procedure-removal.scala:4: warning: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `bar`'s return type
+procedure-removal.scala:4: warning: [quick fix available] procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `bar`'s return type
   def bar {}
           ^
-procedure-removal.scala:5: warning: procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `baz`'s return type
+procedure-removal.scala:5: warning: [quick fix available] procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `baz`'s return type
   def baz
          ^
-procedure-removal.scala:6: warning: procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `boo`'s return type
+procedure-removal.scala:6: warning: [quick fix available] procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `boo`'s return type
   def boo(i: Int, l: Long)
                           ^
-procedure-removal.scala:7: warning: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `boz`'s return type
+procedure-removal.scala:7: warning: [quick fix available] procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `boz`'s return type
   def boz(i: Int, l: Long) {}
                            ^
 procedure-removal.scala:8: warning: procedure syntax is deprecated for constructors: add `=`, as in method definition

--- a/test/files/neg/t11921-alias.check
+++ b/test/files/neg/t11921-alias.check
@@ -1,4 +1,4 @@
-t11921-alias.scala:18: error: reference to TT is ambiguous;
+t11921-alias.scala:18: error: [quick fix available] reference to TT is ambiguous;
 it is both defined in the enclosing object O and inherited in the enclosing class D as type TT (defined in class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.TT`.
@@ -7,7 +7,7 @@ Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=t2.O.D.n.x
       def n(x: TT) = x // ambiguous
                ^
-t11921-alias.scala:38: error: reference to c is ambiguous;
+t11921-alias.scala:38: error: [quick fix available] reference to c is ambiguous;
 it is both defined in the enclosing class B and inherited in the enclosing anonymous class as value c (defined in class A)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.c`.
@@ -16,7 +16,7 @@ Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=t4.B.a
       def n = c // ambiguous
               ^
-t11921-alias.scala:57: error: reference to name is ambiguous;
+t11921-alias.scala:57: error: [quick fix available] reference to name is ambiguous;
 it is both defined in the enclosing method m and inherited in the enclosing anonymous class as value name (defined in class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.name`.
@@ -25,7 +25,7 @@ Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=t6.Test.m
       println(name)
               ^
-t11921-alias.scala:67: error: reference to name is ambiguous;
+t11921-alias.scala:67: error: [quick fix available] reference to name is ambiguous;
 it is both defined in the enclosing method m and inherited in the enclosing anonymous class as value name (defined in class A, inherited through parent class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.name`.

--- a/test/files/neg/t11921.check
+++ b/test/files/neg/t11921.check
@@ -3,7 +3,7 @@ t11921.scala:6: error: type mismatch;
  required: B => B
       def iterator = coll.iterator.map(f)    // coll is ambiguous
                                        ^
-t11921.scala:6: error: reference to coll is ambiguous;
+t11921.scala:6: error: [quick fix available] reference to coll is ambiguous;
 it is both defined in the enclosing method lazyMap and inherited in the enclosing anonymous class as method coll (defined in trait Iterable)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.coll`.

--- a/test/files/neg/t11921b.check
+++ b/test/files/neg/t11921b.check
@@ -1,7 +1,7 @@
 t11921b.scala:135: error: could not find implicit value for parameter i: Int
     def u = t // doesn't compile in Scala 2 (maybe there's a ticket for that)
             ^
-t11921b.scala:11: error: reference to x is ambiguous;
+t11921b.scala:11: error: [quick fix available] reference to x is ambiguous;
 it is both defined in the enclosing object Test and inherited in the enclosing class D as value x (defined in class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.x`.
@@ -10,7 +10,7 @@ Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test1.Test.D
       println(x)  // error
               ^
-t11921b.scala:15: error: reference to x is ambiguous;
+t11921b.scala:15: error: [quick fix available] reference to x is ambiguous;
 it is both defined in the enclosing object Test and inherited in the enclosing anonymous class as value x (defined in class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.x`.
@@ -19,7 +19,7 @@ Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test1.Test.f
         println(x)  // error
                 ^
-t11921b.scala:26: error: reference to y is ambiguous;
+t11921b.scala:26: error: [quick fix available] reference to y is ambiguous;
 it is both defined in the enclosing method c and inherited in the enclosing anonymous class as value y (defined in class D)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.y`.
@@ -28,7 +28,7 @@ Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test2.c
       println(y)  // error
               ^
-t11921b.scala:38: error: reference to y is ambiguous;
+t11921b.scala:38: error: [quick fix available] reference to y is ambiguous;
 it is both defined in the enclosing method c and inherited in the enclosing class E as value y (defined in class D)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `E.this.y`.
@@ -37,7 +37,7 @@ Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test3.c.E.F
         println(y)  // error
                 ^
-t11921b.scala:65: error: reference to global is ambiguous;
+t11921b.scala:65: error: [quick fix available] reference to global is ambiguous;
 it is both defined in the enclosing package <empty> and inherited in the enclosing object D as value global (defined in class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.global`.
@@ -46,7 +46,7 @@ Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=D
   println(global)    // error
           ^
-t11921b.scala:75: error: reference to x is ambiguous;
+t11921b.scala:75: error: [quick fix available] reference to x is ambiguous;
 it is both defined in the enclosing object Uhu and inherited in the enclosing class C as value x (defined in class A, inherited through parent class B)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `C.this.x`.
@@ -55,7 +55,7 @@ Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test5.Uhu.C.Inner.t
         def t = x // ambiguous, message mentions parent B
                 ^
-t11921b.scala:89: error: reference to a is ambiguous;
+t11921b.scala:89: error: [quick fix available] reference to a is ambiguous;
 it is both defined in the enclosing class C and inherited in the enclosing trait J as method a (defined in trait I)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.a`.
@@ -64,7 +64,7 @@ Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test6.C.J.t
       val t = a // error
               ^
-t11921b.scala:136: error: reference to lo is ambiguous;
+t11921b.scala:136: error: [quick fix available] reference to lo is ambiguous;
 it is both defined in the enclosing object test10 and inherited in the enclosing class C as value lo (defined in class P)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.lo`.

--- a/test/files/neg/t12798-migration.check
+++ b/test/files/neg/t12798-migration.check
@@ -13,13 +13,13 @@ package object tester extends Runnable {
 t12798-migration.scala:33: warning: procedure syntax is deprecated for constructors: add `=`, as in method definition
   def this(s: String) { this() }
                      ^
-t12798-migration.scala:34: warning: procedure syntax is unsupported: instead, add `: Unit =` to explicitly declare `f`'s return type
+t12798-migration.scala:34: warning: [quick fix available] procedure syntax is unsupported: instead, add `: Unit =` to explicitly declare `f`'s return type
   def f() { println() }
           ^
-t12798-migration.scala:35: warning: procedure syntax is unsupported: instead, add `: Unit` to explicitly declare `g`'s return type
+t12798-migration.scala:35: warning: [quick fix available] procedure syntax is unsupported: instead, add `: Unit` to explicitly declare `g`'s return type
   def g()
          ^
-t12798-migration.scala:39: warning: parentheses are required around the parameter of a lambda
+t12798-migration.scala:39: warning: [quick fix available] parentheses are required around the parameter of a lambda
 Use '-Wconf:msg=lambda-parens:s' to silence this warning.
   def f = List(42).map { x: Int => x + 1 }
                           ^

--- a/test/files/neg/t12798.check
+++ b/test/files/neg/t12798.check
@@ -19,17 +19,17 @@ Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def this(s: String) { this() }
                      ^
-t12798.scala:34: error: procedure syntax is unsupported: instead, add `: Unit =` to explicitly declare `f`'s return type
+t12798.scala:34: error: [quick fix available] procedure syntax is unsupported: instead, add `: Unit =` to explicitly declare `f`'s return type
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def f() { println() }
           ^
-t12798.scala:35: error: procedure syntax is unsupported: instead, add `: Unit` to explicitly declare `g`'s return type
+t12798.scala:35: error: [quick fix available] procedure syntax is unsupported: instead, add `: Unit` to explicitly declare `g`'s return type
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def g()
          ^
-t12798.scala:39: error: parentheses are required around the parameter of a lambda
+t12798.scala:39: error: [quick fix available] parentheses are required around the parameter of a lambda
 Use '-Wconf:msg=lambda-parens:s' to silence this warning.
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration

--- a/test/files/neg/t12816.check
+++ b/test/files/neg/t12816.check
@@ -4,7 +4,7 @@ Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
 package object p extends U {
                  ^
-t12816.scala:29: error: reference to c is ambiguous;
+t12816.scala:29: error: [quick fix available] reference to c is ambiguous;
 it is both defined in the enclosing package p and inherited in the enclosing trait RR as method c (defined in trait T)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.c`.
@@ -13,7 +13,7 @@ Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=p.RR.m3
     def m3 = c // warn
              ^
-t12816.scala:33: error: reference to Z is ambiguous;
+t12816.scala:33: error: [quick fix available] reference to Z is ambiguous;
 it is both defined in the enclosing package p and inherited in the enclosing trait RR as trait Z (defined in trait T)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.Z`.

--- a/test/files/neg/t12816b.check
+++ b/test/files/neg/t12816b.check
@@ -4,7 +4,7 @@ Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
 package object p extends U {
                  ^
-B.scala:19: error: reference to c is ambiguous;
+B.scala:19: error: [quick fix available] reference to c is ambiguous;
 it is both defined in the enclosing package p and inherited in the enclosing trait RR as method c (defined in trait T)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.c`.
@@ -13,7 +13,7 @@ Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=p.RR.m3
     def m3 = c // warn
              ^
-B.scala:23: error: reference to Z is ambiguous;
+B.scala:23: error: [quick fix available] reference to Z is ambiguous;
 it is both defined in the enclosing package p and inherited in the enclosing trait RR as trait Z (defined in trait T)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.Z`.

--- a/test/files/neg/t7187-deprecation.check
+++ b/test/files/neg/t7187-deprecation.check
@@ -16,12 +16,12 @@ t7187-deprecation.scala:20: error: type mismatch;
 t7187-deprecation.scala:31: error: Methods without a parameter list and by-name params can not be converted to functions as `m _`, write a function literal `() => m` instead
   val t7 = m1 _ // error: eta-expanding a nullary method
            ^
-t7187-deprecation.scala:24: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method m2,
+t7187-deprecation.scala:24: warning: [quick fix available] Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method m2,
 or remove the empty argument list from its definition (Java-defined methods are exempt).
 In Scala 3, an unapplied method like this will be eta-expanded into a function.
   val t5 = m2 // warn: apply, ()-insertion
            ^
-t7187-deprecation.scala:40: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method boom,
+t7187-deprecation.scala:40: warning: [quick fix available] Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method boom,
 or remove the empty argument list from its definition (Java-defined methods are exempt).
 In Scala 3, an unapplied method like this will be eta-expanded into a function.
   a.boom // warning: apply, ()-insertion

--- a/test/files/neg/t7187.check
+++ b/test/files/neg/t7187.check
@@ -26,7 +26,7 @@ t7187.scala:12: warning: An unapplied 0-arity method was eta-expanded (due to th
 Write foo() to invoke method foo, or change the expected type.
   val t1b: () => Any = foo   // eta-expansion, but lint warning
                        ^
-t7187.scala:13: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method foo,
+t7187.scala:13: warning: [quick fix available] Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method foo,
 or remove the empty argument list from its definition (Java-defined methods are exempt).
 In Scala 3, an unapplied method like this will be eta-expanded into a function.
   val t1c: () => Any = { val t = foo; t } // `()`-insertion because no expected type

--- a/test/files/neg/using-source3.check
+++ b/test/files/neg/using-source3.check
@@ -1,4 +1,4 @@
-using-source3.scala:14: error: reference to f is ambiguous;
+using-source3.scala:14: error: [quick fix available] reference to f is ambiguous;
 it is both defined in the enclosing class D and inherited in the enclosing class E as method f (defined in class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.f`.

--- a/test/files/neg/using-source3b.check
+++ b/test/files/neg/using-source3b.check
@@ -1,4 +1,4 @@
-using-source3b.scala:13: error: reference to f is ambiguous;
+using-source3b.scala:13: error: [quick fix available] reference to f is ambiguous;
 it is both defined in the enclosing class D and inherited in the enclosing class E as method f (defined in class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.f`.

--- a/test/files/run/infixPostfixAttachments.check
+++ b/test/files/run/infixPostfixAttachments.check
@@ -1,9 +1,9 @@
-newSource1.scala:15: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method d,
+newSource1.scala:15: warning: [quick fix available] Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method d,
 or remove the empty argument list from its definition (Java-defined methods are exempt).
 In Scala 3, an unapplied method like this will be eta-expanded into a function.
   def t6 = this d
                 ^
-newSource1.scala:16: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method d,
+newSource1.scala:16: warning: [quick fix available] Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method d,
 or remove the empty argument list from its definition (Java-defined methods are exempt).
 In Scala 3, an unapplied method like this will be eta-expanded into a function.
   def t7 = this.d

--- a/test/files/run/repl-errors.check
+++ b/test/files/run/repl-errors.check
@@ -5,7 +5,7 @@ scala> '\060'
 
 scala> def foo() { }
                  ^
-       warning: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `foo`'s return type
+       warning: [quick fix available] procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `foo`'s return type
 def foo(): Unit
 
 scala> @annotation.nowarn def sshhh() { }

--- a/test/junit/scala/tools/nsc/QuickfixTest.scala
+++ b/test/junit/scala/tools/nsc/QuickfixTest.scala
@@ -1,0 +1,84 @@
+package scala.tools.nsc
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.nio.file.Files
+import scala.reflect.internal.util.BatchSourceFile
+import scala.reflect.io.AbstractFile
+import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.ReleasablePath._
+import scala.util.Using
+
+class QuickfixTest extends BytecodeTesting {
+  def testQuickfix(a: String, b: String, args: String): Unit = if (!scala.util.Properties.isWin) {
+    Using.resource(Files.createTempFile("unitSource", "scala")) { src =>
+      Files.write(src, a.getBytes)
+      val c = BytecodeTesting.newCompiler(extraArgs = args)
+      val r = c.newRun()
+      val f = AbstractFile.getFile(src.toFile.getAbsolutePath)
+      r.compileSources(List(new BatchSourceFile(f)))
+      assertEquals(b, new String(Files.readAllBytes(src)))
+    }
+  }
+
+  def comp(args: String) = BytecodeTesting.newCompiler(extraArgs = args)
+
+  @Test def multipleRewrites(): Unit = {
+    // procedure syntax is a parser warning
+    // "val" in for-comprehension is a parser error
+    // auto-application is fixed only in 2nd compilation - parser error prevents later phase from running
+    val a =
+      """class C {
+        |  def f { println }
+        |  def g(xs: List[String]) = for (val x <- xs) yield x.trim
+        |}
+        |""".stripMargin
+    val b =
+      """class C {
+        |  def f: Unit = { println }
+        |  def g(xs: List[String]) = for (x <- xs) yield x.trim
+        |}
+        |""".stripMargin
+    val c =
+      """class C {
+        |  def f: Unit = { println() }
+        |  def g(xs: List[String]) = for (x <- xs) yield x.trim
+        |}
+        |""".stripMargin
+    testQuickfix(a, b, "-deprecation -quickfix:any")
+    testQuickfix(b, c, "-deprecation -quickfix:any")
+  }
+
+  @Test def filters(): Unit = {
+    val a =
+      """class C {
+        |  def f { println }
+        |  def g(xs: List[String]) = for (val x <- xs) yield x.trim
+        |}
+        |""".stripMargin
+    val b =
+      """class C {
+        |  def f { println }
+        |  def g(xs: List[String]) = for (x <- xs) yield x.trim
+        |}
+        |""".stripMargin
+    val c =
+      """class C {
+        |  def f { println() }
+        |  def g(xs: List[String]) = for (x <- xs) yield x.trim
+        |}
+        |""".stripMargin
+    val d =
+      """class C {
+        |  def f: Unit = { println() }
+        |  def g(xs: List[String]) = for (x <- xs) yield x.trim
+        |}
+        |""".stripMargin
+    testQuickfix(a, b, "-deprecation -quickfix:msg=comprehension")
+    testQuickfix(b, b, "-deprecation -quickfix:msg=teddy")
+    testQuickfix(b, c, "-deprecation -quickfix:msg=Auto-application")
+    testQuickfix(c, c, "-quickfix:cat=deprecation") // without -deprecation, the warning is not shown and not rewritten
+    testQuickfix(c, d, "-deprecation -quickfix:cat=deprecation")
+  }
+}


### PR DESCRIPTION
With 2.13.12 the compiler starts providing quick fixes with certain warnings and errors. Typically these are presented in IDEs, however it can also be practical to have the compiler directly patch the source files.

From `-quickfix:help`:

```
Apply quick fixes provided by the compiler for warnings and errors to source files.
Syntax: -quickfix:<filter>,...,<filter>

<filter> syntax is the same as for configurable warnings, see `-Wconf:help`. Examples:
  -quickfix:any                    apply all available quick fixes
  -quickfix:msg=Auto-application   apply quick fixes where the message contains "Auto-application"

Use `-Wconf:any:warning-verbose` to display applicable message filters with each warning.
```