### PR TITLE
Fix partial function conversion with inner Match body

### DIFF
--- a/test/files/neg/exhausting.check
+++ b/test/files/neg/exhausting.check
@@ -22,6 +22,10 @@ exhausting.scala:58: warning: match may not be exhaustive.
 It would fail on the following inputs: (Bar1, Bar2), (Bar1, Bar3), (Bar2, Bar1), (Bar2, Bar2)
   def fail5[T](xx: (Foo[T], Foo[T])) = xx match {
                                        ^
+exhausting.scala:68: warning: match may not be exhaustive.
+It would fail on the following input: None
+      map.get(i) match {
+             ^
 error: No warnings can be incurred under -Werror.
-6 warnings
+7 warnings
 1 error

--- a/test/files/neg/exhausting.scala
+++ b/test/files/neg/exhausting.scala
@@ -60,4 +60,14 @@ object Test {
     case (Bar2, Bar3) => ()
     case (Bar3, _) => ()
   }
+
+  // fails for: None
+  def fail6 = {
+    val map = Map(5 -> 2)
+    List(1).collect (i => 
+      map.get(i) match {
+        case Some(x) => x
+      }
+    )
+  }
 }


### PR DESCRIPTION
The conversion of `x => $sel match {<cases>}` into `PartialFunction` wasn't checking if the function body is a match by an actual arg. 
That was leading to incorrect conversion if `$sel` was some other expr
```scala

val map = Map(4 -> "foo")
List(1).collect { i =>
  map.get(i) match {
    case Some(i) => i
  }
}
// was converted into icorrect PF
// `new PartialFunction { def applyOrElse(x, default) = map.get(i) match { <cases> } }`
```
The following case was noticed by missing warning for None case.