### PR TITLE
Add quickfixes to some warnings and errors

### DIFF
--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -352,6 +352,9 @@ trait Reporting extends internal.Reporting { self: ast.Positions with Compilatio
     def warning(pos: Position, msg: String, category: WarningCategory, site: Symbol, origin: String): Unit =
       issueIfNotSuppressed(Message.Origin(pos, msg, category, siteName(site), origin, actions = Nil))
 
+    def codeAction(title: String, pos: Position, newText: String, desc: String, expected: Option[(String, CompilationUnit)] = None) =
+      CodeAction(title, pos, newText, desc, expected.forall(e => e._1 == e._2.sourceAt(pos)))
+
     // Remember CodeActions that match `-quickfix` and report the error through the reporter
     def error(pos: Position, msg: String, actions: List[CodeAction]): Unit = {
       val quickfixed = {

--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -169,7 +169,7 @@ trait Reporting extends internal.Reporting { self: ast.Positions with Compilatio
 
       val quickfixed = {
         if (!skipRewriteAction(action) && registerTextEdit(warning)) s"[rewritten by -quickfix] ${warning.msg}"
-        else if (warning.actions.exists(_.edits.nonEmpty) && !settings.quickFixSilent) s"${warning.msg} [quick fix available]"
+        else if (warning.actions.exists(_.edits.nonEmpty) && !settings.quickFixSilent) s"${warning.msg} [quickfixable]"
         else warning.msg
       }
 
@@ -361,7 +361,7 @@ trait Reporting extends internal.Reporting { self: ast.Positions with Compilatio
     def error(pos: Position, msg: String, actions: List[CodeAction]): Unit = {
       val quickfixed = {
         if (registerErrorTextEdit(pos, msg, actions)) s"[rewritten by -quickfix] $msg"
-        else if (actions.exists(_.edits.nonEmpty) && !settings.quickFixSilent) s"$msg [quick fix available]"
+        else if (actions.exists(_.edits.nonEmpty) && !settings.quickFixSilent) s"$msg [quickfixable]"
         else msg
       }
       reporter.error(pos, quickfixed, actions)

--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -69,6 +69,8 @@ trait Reporting extends internal.Reporting { self: ast.Positions with Compilatio
       if (settings.quickfix.isSetByUser && settings.quickfix.value.isEmpty) {
         globalError(s"Missing message filter for `-quickfix`; see `-quickfix:help` or use `-quickfix:any` to apply all available quick fixes.")
         Nil
+      } else if (settings.quickFixSilent) {
+        Nil
       } else {
         val parsed = settings.quickfix.value.map(WConf.parseFilter(_, rootDirPrefix))
         val msgs = parsed.collect { case Left(msg) => msg }
@@ -167,7 +169,7 @@ trait Reporting extends internal.Reporting { self: ast.Positions with Compilatio
 
       val quickfixed = {
         if (!skipRewriteAction(action) && registerTextEdit(warning)) s"[rewritten by -quickfix] ${warning.msg}"
-        else if (warning.actions.exists(_.edits.nonEmpty)) s"[quick fix available] ${warning.msg}"
+        else if (warning.actions.exists(_.edits.nonEmpty) && !settings.quickFixSilent) s"${warning.msg} [quick fix available]"
         else warning.msg
       }
 
@@ -359,7 +361,7 @@ trait Reporting extends internal.Reporting { self: ast.Positions with Compilatio
     def error(pos: Position, msg: String, actions: List[CodeAction]): Unit = {
       val quickfixed = {
         if (registerErrorTextEdit(pos, msg, actions)) s"[rewritten by -quickfix] $msg"
-        else if (actions.exists(_.edits.nonEmpty)) s"[quick fix available] $msg"
+        else if (actions.exists(_.edits.nonEmpty) && !settings.quickFixSilent) s"$msg [quick fix available]"
         else msg
       }
       reporter.error(pos, quickfixed, actions)

--- a/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
@@ -64,8 +64,11 @@ trait StandardScalaSettings { _: MutableSettings =>
         |  -quickfix:msg=Auto-application   apply quick fixes where the message contains "Auto-application"
         |
         |Use `-Wconf:any:warning-verbose` to display applicable message filters with each warning.
+        |
+        |Use `-quickfix:silent` to omit the `[quick fix available]` tag in compiler messages.
         |""".stripMargin),
     prepend = true)
+  def quickFixSilent: Boolean = quickfix.value == List("silent")
   val release =
     ChoiceSetting("-release", "release", "Compile for a version of the Java API and target class file.", AllTargetVersions, normalizeTarget(javaSpecVersion))
       .withPostSetHook { setting =>

--- a/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
@@ -65,7 +65,7 @@ trait StandardScalaSettings { _: MutableSettings =>
         |
         |Use `-Wconf:any:warning-verbose` to display applicable message filters with each warning.
         |
-        |Use `-quickfix:silent` to omit the `[quick fix available]` tag in compiler messages.
+        |Use `-quickfix:silent` to omit the `[quickfixable]` tag in compiler messages.
         |""".stripMargin),
     prepend = true)
   def quickFixSilent: Boolean = quickfix.value == List("silent")

--- a/src/compiler/scala/tools/nsc/typechecker/Adaptations.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Adaptations.scala
@@ -98,9 +98,13 @@ trait Adaptations {
         if (settings.lintArgDiscard && discardedArgs) context.warning(t.pos, adaptWarningMessage(
           s"adapted the argument list to expected Unit type: arguments will be discarded"),
           WarningCategory.LintAdaptedArgs)
-        else if (settings.warnAdaptedArgs && !isInfix) context.warning(t.pos, adaptWarningMessage(
-          s"adapted the argument list to the expected ${args.size}-tuple: add additional parens instead"),
-          WarningCategory.LintAdaptedArgs)
+        else if (settings.warnAdaptedArgs && !isInfix) {
+          val msg = adaptWarningMessage(
+            s"adapted the argument list to the expected ${args.size}-tuple: add additional parens instead")
+          val pos = wrappingPos(args)
+          context.warning(t.pos, msg, WarningCategory.LintAdaptedArgs,
+            runReporting.codeAction("add wrapping parentheses", pos, s"(${currentUnit.sourceAt(pos)})", msg))
+        }
         true // keep adaptation
       }
       if (args.nonEmpty)

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1851,7 +1851,7 @@ trait Contexts { self: Analyzer =>
 
   private[typechecker] class ImmediateReporter(_errorBuffer: mutable.LinkedHashSet[AbsTypeError] = null, _warningBuffer: mutable.LinkedHashSet[ContextWarning] = null) extends ContextReporter(_errorBuffer, _warningBuffer) {
     override def makeBuffering: ContextReporter = new BufferingReporter(errorBuffer, warningBuffer)
-    def error(pos: Position, msg: String, actions: List[CodeAction]): Unit = reporter.error(pos, msg, actions)
+    def error(pos: Position, msg: String, actions: List[CodeAction]): Unit = runReporting.error(pos, msg, actions)
  }
 
   private[typechecker] class BufferingReporter(_errorBuffer: mutable.LinkedHashSet[AbsTypeError] = null, _warningBuffer: mutable.LinkedHashSet[ContextWarning] = null) extends ContextReporter(_errorBuffer, _warningBuffer) {

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1155,7 +1155,12 @@ trait Namers extends MethodSynthesis {
             val pts = pt.toString
             val leg = legacy.toString
             val help = if (pts != leg) s" instead of $leg" else ""
-            runReporting.warning(tree.pos, s"under -Xsource:3, inferred $pts$help", WarningCategory.Scala3Migration, tree.symbol)
+            val msg = s"under -Xsource:3, inferred $pts$help"
+            val namePos = tree.pos.focus.withEnd(tree.pos.point + tree.symbol.decodedName.length)
+            val action =
+              if (currentUnit.sourceAt(namePos) == tree.symbol.decodedName) runReporting.codeAction("add explicit type", namePos.focusEnd, s": $leg", msg)
+              else Nil
+            runReporting.warning(tree.pos, msg, WarningCategory.Scala3Migration, tree.symbol, action)
           }
           pt
         }

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -320,7 +320,7 @@ abstract class RefChecks extends Transform {
           infoStringWithLocation(other) + (if (msg.isEmpty) "" else s"\n$indent") + msg + addendum
         }
         def emitOverrideError(fullmsg: String, actions: List[CodeAction] = Nil): Unit = {
-          if (memberClass == clazz) reporter.error(member.pos, fullmsg, actions)
+          if (memberClass == clazz) runReporting.error(member.pos, fullmsg, actions)
           else mixinOverrideErrors += MixinOverrideError(member, fullmsg)
         }
 

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -15,6 +15,7 @@ package typechecker
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
+import scala.reflect.internal.util.CodeAction
 import scala.tools.nsc.Reporting.WarningCategory
 import scala.tools.nsc.settings.ScalaVersion
 import scala.tools.nsc.settings.NoScalaVersion
@@ -103,8 +104,8 @@ abstract class RefChecks extends Transform {
       !seen
     }
 
-    private def refchecksWarning(pos: Position, msg: String, cat: WarningCategory): Unit =
-      runReporting.warning(pos, msg, cat, currentOwner)
+    private def refchecksWarning(pos: Position, msg: String, cat: WarningCategory, actions: List[CodeAction] = Nil): Unit =
+      runReporting.warning(pos, msg, cat, currentOwner, actions)
 
     // only one overloaded alternative is allowed to define default arguments
     private def checkOverloadedRestrictions(clazz: Symbol, defaultClass: Symbol): Unit = {
@@ -318,13 +319,13 @@ abstract class RefChecks extends Transform {
 
           infoStringWithLocation(other) + (if (msg.isEmpty) "" else s"\n$indent") + msg + addendum
         }
-        def emitOverrideError(fullmsg: String): Unit = {
-          if (memberClass == clazz) reporter.error(member.pos, fullmsg)
+        def emitOverrideError(fullmsg: String, actions: List[CodeAction] = Nil): Unit = {
+          if (memberClass == clazz) reporter.error(member.pos, fullmsg, actions)
           else mixinOverrideErrors += MixinOverrideError(member, fullmsg)
         }
 
-        def overrideErrorWithMemberInfo(msg: String): Unit =
-          if (noErrorType) emitOverrideError(msg + "\n" + overriddenWithAddendum(if (member.owner == clazz) "" else s"with ${infoString(member)}"))
+        def overrideErrorWithMemberInfo(msg: String, actions: List[CodeAction] = Nil): Unit =
+          if (noErrorType) emitOverrideError(msg + "\n" + overriddenWithAddendum(if (member.owner == clazz) "" else s"with ${infoString(member)}"), actions)
 
         def overrideError(msg: String): Unit =
           if (noErrorType) emitOverrideError(msg)
@@ -445,22 +446,33 @@ abstract class RefChecks extends Transform {
               def javaDetermined(sym: Symbol) = sym.isJavaDefined || isUniversalMember(sym)
               if (member.hasAttachment[NullaryOverrideAdapted.type]) {
                 def exempt() = member.overrides.exists(sym => sym.isJavaDefined || isUniversalMember(sym))
-                val msg = "method without a parameter list overrides a method with a single empty one"
-                if (!exempt())
+                if (!exempt()) {
+                  val msg = "method without a parameter list overrides a method with a single empty one"
+                  val namePos = member.pos.focus.withEnd(member.pos.point + member.decodedName.length)
+                  val action =
+                    if (currentUnit.sourceAt(namePos) == member.decodedName)
+                      runReporting.codeAction("add empty parameter list", namePos.focusEnd, "()", msg)
+                    else Nil
                   if (currentRun.isScala3)
-                    overrideErrorWithMemberInfo(msg)
+                    overrideErrorWithMemberInfo(msg, action)
                   else
-                    refchecksWarning(member.pos, msg, WarningCategory.OtherNullaryOverride)
+                    refchecksWarning(member.pos, msg, WarningCategory.OtherNullaryOverride, action)
+                }
               }
               else if (other.paramss.isEmpty && !member.paramss.isEmpty &&
                 !javaDetermined(member) && !member.overrides.exists(javaDetermined) &&
                 !member.hasAnnotation(BeanPropertyAttr) && !member.hasAnnotation(BooleanBeanPropertyAttr)
               ) {
                 val msg = "method with a single empty parameter list overrides method without any parameter list"
+                val namePos = member.pos.focus.withEnd(member.pos.point + member.decodedName.length)
+                val action =
+                  if (currentUnit.sourceAt(namePos) == member.decodedName)
+                    runReporting.codeAction("remove empty parameter list", namePos.focusEnd.withEnd(namePos.end + 2), "", msg, expected = Some(("()", currentUnit)))
+                  else Nil
                 if (currentRun.isScala3)
-                  overrideErrorWithMemberInfo(msg)
+                  overrideErrorWithMemberInfo(msg, action)
                 else
-                  refchecksWarning(member.pos, msg, WarningCategory.OtherNullaryOverride)
+                  refchecksWarning(member.pos, msg, WarningCategory.OtherNullaryOverride, action)
               }
             }
           }
@@ -1741,8 +1753,15 @@ abstract class RefChecks extends Transform {
           || sym.allOverriddenSymbols.exists(over => !(over.tpe.resultType =:= sym.tpe.resultType))
           || sym.isArtifact
         )
-        if (!isOk)
-          refchecksWarning(sym.pos, s"side-effecting nullary methods are discouraged: suggest defining as `def ${sym.name.decode}()` instead", WarningCategory.LintNullaryUnit)
+        if (!isOk) {
+          val msg = s"side-effecting nullary methods are discouraged: suggest defining as `def ${sym.name.decode}()` instead"
+          val namePos = sym.pos.focus.withEnd(sym.pos.point + sym.decodedName.length)
+          val action =
+            if (currentUnit.sourceAt(namePos) == sym.decodedName)
+              runReporting.codeAction("add empty parameter list", namePos.focusEnd, "()", msg)
+            else Nil
+          refchecksWarning(sym.pos, msg, WarningCategory.LintNullaryUnit, action)
+        }
       case _ => ()
     }
 

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -15,16 +15,10 @@ package tools.nsc
 package typechecker
 
 import scala.annotation.{tailrec, unused}
-import scala.collection.mutable, mutable.ListBuffer
+import scala.collection.mutable
+import mutable.ListBuffer
 import scala.reflect.internal.{Chars, TypesStats}
-import scala.reflect.internal.util.{
-  CodeAction,
-  FreshNameCreator,
-  ListOfNil,
-  Statistics,
-  StringContextStripMarginOps,
-  TextEdit,
-}
+import scala.reflect.internal.util.{CodeAction, FreshNameCreator, ListOfNil, Statistics, StringContextStripMarginOps}
 import scala.tools.nsc.Reporting.{MessageFilter, Suppression, WConf, WarningCategory}
 import scala.util.chaining._
 import symtab.Flags._
@@ -971,15 +965,12 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         // This means an accessor that overrides a Java-defined method gets a MethodType instead of a NullaryMethodType, which breaks lots of assumptions about accessors)
         def checkCanAutoApply(): Boolean = {
           if (!isPastTyper && !matchNullaryLoosely) {
-            val description =
+            val msg =
               s"""Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method ${meth.decodedName},
                  |or remove the empty argument list from its definition (Java-defined methods are exempt).
                  |In Scala 3, an unapplied method like this will be eta-expanded into a function.""".stripMargin
-            val actions = if (tree.pos.isRange)
-                List(CodeAction("auto-application of empty-paren methods", Some(description),
-                  List(TextEdit(tree.pos.focusEnd, "()"))))
-              else Nil
-            context.deprecationWarning(tree.pos, NoSymbol, description, "2.13.3", actions)
+            val action = runReporting.codeAction("add `()`", tree.pos.focusEnd, "()", msg)
+            context.deprecationWarning(tree.pos, NoSymbol, msg, "2.13.3", action)
           }
           true
         }
@@ -1142,15 +1133,20 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               def longWidened = tpSym == LongClass && targetIsWide
               intWidened || longWidened
             }
-            if (isInharmonic)
+            if (isInharmonic) {
               // not `context.deprecationWarning` because they are not buffered in silent mode
-              context.warning(tree.pos, s"Widening conversion from ${tpSym.name} to ${ptSym.name} is deprecated because it loses precision. Write `.to${ptSym.name}` instead.", WarningCategory.Deprecation)
-            else {
+              val msg = s"Widening conversion from ${tpSym.name} to ${ptSym.name} is deprecated because it loses precision. Write `.to${ptSym.name}` instead."
+              val orig = currentUnit.sourceAt(tree.pos)
+              context.warning(tree.pos, msg, WarningCategory.Deprecation,
+                runReporting.codeAction("add conversion", tree.pos, s"${CodeAction.maybeWrapInParens(orig)}.to${ptSym.name}", msg))
+            } else {
               object warnIntDiv extends Traverser {
                 def isInt(t: Tree) = ScalaIntegralValueClasses(t.tpe.typeSymbol)
                 override def traverse(tree: Tree): Unit = tree match {
                   case Apply(Select(q, nme.DIV), _) if isInt(q) =>
-                    context.warning(tree.pos, s"integral division is implicitly converted (widened) to floating point. Add an explicit `.to${ptSym.name}`.", WarningCategory.LintIntDivToFloat)
+                    val msg = s"integral division is implicitly converted (widened) to floating point. Add an explicit `.to${ptSym.name}`."
+                    context.warning(tree.pos, msg, WarningCategory.LintIntDivToFloat,
+                      runReporting.codeAction("add conversion", tree.pos, s"(${currentUnit.sourceAt(tree.pos)}).to${ptSym.name}", msg))
                   case Apply(Select(a1, _), List(a2)) if isInt(tree) && isInt(a1) && isInt(a2) => traverse(a1); traverse(a2)
                   case Select(q, _) if isInt(tree) && isInt(q) => traverse(q)
                   case _ =>
@@ -4968,10 +4964,17 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
           val result = typed(Function(Nil, methodValue) setSymbol funSym setPos pos, mode, pt)
 
+          val action = {
+            val etaPos = pos.withEnd(pos.end + 2)
+            if (currentUnit.sourceAt(etaPos).endsWith(" _"))
+              runReporting.codeAction("replace by function literal", etaPos, s"() => ${currentUnit.sourceAt(pos)}", UnderscoreNullaryEtaWarnMsg)
+            else Nil
+          }
+
           if (currentRun.isScala3) {
-            UnderscoreNullaryEtaError(methodValue)
+            UnderscoreNullaryEtaError(methodValue, action)
           } else {
-            context.deprecationWarning(pos, NoSymbol, UnderscoreNullaryEtaWarnMsg, "2.13.2")
+            context.deprecationWarning(pos, NoSymbol, UnderscoreNullaryEtaWarnMsg, "2.13.2", action)
             result
           }
 
@@ -5570,7 +5573,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           case LookupSucceeded(qual, sym)   =>
             sym.getAndRemoveAttachment[LookupAmbiguityWarning].foreach(w => {
               val cat = if (currentRun.isScala3) WarningCategory.Scala3Migration else WarningCategory.Other
-              val fix = List(CodeAction("ambiguous reference", Some(w.msg), List(TextEdit(tree.pos.focusStart, w.fix))))
+              val fix = runReporting.codeAction("make reference explicit", tree.pos.focusStart, w.fix, w.msg)
               runReporting.warning(tree.pos, w.msg, cat, context.owner, fix)
             })
             (// this -> Foo.this

--- a/src/reflect/scala/reflect/internal/util/CodeAction.scala
+++ b/src/reflect/scala/reflect/internal/util/CodeAction.scala
@@ -29,6 +29,16 @@ package util
  */
 case class CodeAction(title: String, description: Option[String], edits: List[TextEdit])
 
+object CodeAction {
+  def apply(title: String, pos: Position, newText: String, desc: String, check: => Boolean = true): List[CodeAction] =
+    if (check) List(CodeAction(title, Some(desc), List(TextEdit(pos, newText))))
+    else Nil
+
+  private lazy val parens = raw"\(.*\)".r
+  def maybeWrapInParens(s: String) = if (s.contains(" ") && !parens.matches(s)) s"($s)" else s
+  def wrapInParens(s: String) = if (!parens.matches(s)) s"($s)" else s
+}
+
 /**
  *  <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>
  *

--- a/test/files/jvm/interpreter.check
+++ b/test/files/jvm/interpreter.check
@@ -88,7 +88,7 @@ class Bar
 
 scala> implicit def foo2bar(foo: Foo) = Bar(foo.n)
                     ^
-       warning: [quick fix available] Implicit definition should have explicit type (inferred Bar)
+       warning: Implicit definition should have explicit type (inferred Bar) [quick fix available]
 warning: 1 feature warning; for details, enable `:setting -feature` or `:replay -feature`
 def foo2bar(foo: Foo): Bar
 

--- a/test/files/jvm/interpreter.check
+++ b/test/files/jvm/interpreter.check
@@ -88,7 +88,7 @@ class Bar
 
 scala> implicit def foo2bar(foo: Foo) = Bar(foo.n)
                     ^
-       warning: Implicit definition should have explicit type (inferred Bar) [quick fix available]
+       warning: Implicit definition should have explicit type (inferred Bar) [quickfixable]
 warning: 1 feature warning; for details, enable `:setting -feature` or `:replay -feature`
 def foo2bar(foo: Foo): Bar
 

--- a/test/files/jvm/interpreter.check
+++ b/test/files/jvm/interpreter.check
@@ -88,7 +88,7 @@ class Bar
 
 scala> implicit def foo2bar(foo: Foo) = Bar(foo.n)
                     ^
-       warning: Implicit definition should have explicit type (inferred Bar)
+       warning: [quick fix available] Implicit definition should have explicit type (inferred Bar)
 warning: 1 feature warning; for details, enable `:setting -feature` or `:replay -feature`
 def foo2bar(foo: Foo): Bar
 

--- a/test/files/neg/auto-application.check
+++ b/test/files/neg/auto-application.check
@@ -9,7 +9,7 @@ auto-application.scala:6: error: Int does not take parameters
                  ^
 auto-application.scala:9: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method meth,
 or remove the empty argument list from its definition (Java-defined methods are exempt).
-In Scala 3, an unapplied method like this will be eta-expanded into a function. [quick fix available]
+In Scala 3, an unapplied method like this will be eta-expanded into a function. [quickfixable]
   meth // warn, auto-application (of nilary methods) is deprecated
   ^
 1 warning

--- a/test/files/neg/auto-application.check
+++ b/test/files/neg/auto-application.check
@@ -7,9 +7,9 @@ auto-application.scala:5: error: Int does not take parameters
 auto-application.scala:6: error: Int does not take parameters
   ("": Object).##()
                  ^
-auto-application.scala:9: warning: [quick fix available] Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method meth,
+auto-application.scala:9: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method meth,
 or remove the empty argument list from its definition (Java-defined methods are exempt).
-In Scala 3, an unapplied method like this will be eta-expanded into a function.
+In Scala 3, an unapplied method like this will be eta-expanded into a function. [quick fix available]
   meth // warn, auto-application (of nilary methods) is deprecated
   ^
 1 warning

--- a/test/files/neg/checksensible.check
+++ b/test/files/neg/checksensible.check
@@ -1,4 +1,4 @@
-checksensible.scala:54: warning: symbol literal is deprecated; use Symbol("sym") instead
+checksensible.scala:54: warning: [quick fix available] symbol literal is deprecated; use Symbol("sym") instead
   (1 != 'sym)
         ^
 checksensible.scala:15: warning: comparing a fresh object using `eq` will always yield false

--- a/test/files/neg/checksensible.check
+++ b/test/files/neg/checksensible.check
@@ -1,4 +1,4 @@
-checksensible.scala:54: warning: [quick fix available] symbol literal is deprecated; use Symbol("sym") instead
+checksensible.scala:54: warning: symbol literal is deprecated; use Symbol("sym") instead [quick fix available]
   (1 != 'sym)
         ^
 checksensible.scala:15: warning: comparing a fresh object using `eq` will always yield false

--- a/test/files/neg/checksensible.check
+++ b/test/files/neg/checksensible.check
@@ -1,4 +1,4 @@
-checksensible.scala:54: warning: symbol literal is deprecated; use Symbol("sym") instead [quick fix available]
+checksensible.scala:54: warning: symbol literal is deprecated; use Symbol("sym") instead [quickfixable]
   (1 != 'sym)
         ^
 checksensible.scala:15: warning: comparing a fresh object using `eq` will always yield false

--- a/test/files/neg/deprecated_widening.check
+++ b/test/files/neg/deprecated_widening.check
@@ -1,55 +1,55 @@
-deprecated_widening.scala:5: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:5: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
     val i_f: Float = i  // deprecated
                      ^
-deprecated_widening.scala:7: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:7: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
     val l_f: Float = l  // deprecated
                      ^
-deprecated_widening.scala:8: warning: [quick fix available] Widening conversion from Long to Double is deprecated because it loses precision. Write `.toDouble` instead.
+deprecated_widening.scala:8: warning: Widening conversion from Long to Double is deprecated because it loses precision. Write `.toDouble` instead. [quick fix available]
     val l_d: Double = l // deprecated
                       ^
-deprecated_widening.scala:23: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:23: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
   val truncatedPosFloat:Float = 16777217L  // deprecated
                                 ^
-deprecated_widening.scala:26: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:26: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
   val truncatedNegFloat: Float = - 16777217L // deprecated
                                  ^
-deprecated_widening.scala:30: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:30: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
   val truncatedPosFloatI:Float = 16777217  // deprecated
                                  ^
-deprecated_widening.scala:33: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:33: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
   val truncatedNegFloatI: Float = - 16777217 // deprecated
                                   ^
-deprecated_widening.scala:37: warning: [quick fix available] Widening conversion from Long to Double is deprecated because it loses precision. Write `.toDouble` instead.
+deprecated_widening.scala:37: warning: Widening conversion from Long to Double is deprecated because it loses precision. Write `.toDouble` instead. [quick fix available]
   val truncatedPosDouble:Double = 18014398509481985L // deprecated
                                   ^
-deprecated_widening.scala:40: warning: [quick fix available] Widening conversion from Long to Double is deprecated because it loses precision. Write `.toDouble` instead.
+deprecated_widening.scala:40: warning: Widening conversion from Long to Double is deprecated because it loses precision. Write `.toDouble` instead. [quick fix available]
   val truncatedNegDouble: Double = - 18014398509481985L // deprecated
                                    ^
-deprecated_widening.scala:47: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:47: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
   def literals  = Set[Float](0x7fffffc0, 0x7ffffffd, 0x7ffffffe, 0x7fffffff)
                              ^
-deprecated_widening.scala:47: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:47: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
   def literals  = Set[Float](0x7fffffc0, 0x7ffffffd, 0x7ffffffe, 0x7fffffff)
                                          ^
-deprecated_widening.scala:47: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:47: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
   def literals  = Set[Float](0x7fffffc0, 0x7ffffffd, 0x7ffffffe, 0x7fffffff)
                                                      ^
-deprecated_widening.scala:48: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:48: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
   def longingly = Set[Float](0x7fffffc0L, 0x7ffffffdL, 0x7ffffffeL, 0x7fffffffL)
                              ^
-deprecated_widening.scala:48: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:48: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
   def longingly = Set[Float](0x7fffffc0L, 0x7ffffffdL, 0x7ffffffeL, 0x7fffffffL)
                                           ^
-deprecated_widening.scala:48: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:48: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
   def longingly = Set[Float](0x7fffffc0L, 0x7ffffffdL, 0x7ffffffeL, 0x7fffffffL)
                                                        ^
-deprecated_widening.scala:48: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:48: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
   def longingly = Set[Float](0x7fffffc0L, 0x7ffffffdL, 0x7ffffffeL, 0x7fffffffL)
                                                                     ^
-deprecated_widening.scala:50: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:50: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
   def `pick one` = Set[Float](0x1000003, 0x1000004, 0x1000005)
                               ^
-deprecated_widening.scala:50: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:50: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
   def `pick one` = Set[Float](0x1000003, 0x1000004, 0x1000005)
                                                     ^
 deprecated_widening.scala:12: warning: method int2float in object Int is deprecated (since 2.13.1): Implicit conversion from Int to Float is dangerous because it loses precision. Write `.toFloat` instead.

--- a/test/files/neg/deprecated_widening.check
+++ b/test/files/neg/deprecated_widening.check
@@ -1,55 +1,55 @@
-deprecated_widening.scala:5: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:5: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
     val i_f: Float = i  // deprecated
                      ^
-deprecated_widening.scala:7: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:7: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
     val l_f: Float = l  // deprecated
                      ^
-deprecated_widening.scala:8: warning: Widening conversion from Long to Double is deprecated because it loses precision. Write `.toDouble` instead.
+deprecated_widening.scala:8: warning: [quick fix available] Widening conversion from Long to Double is deprecated because it loses precision. Write `.toDouble` instead.
     val l_d: Double = l // deprecated
                       ^
-deprecated_widening.scala:23: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:23: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
   val truncatedPosFloat:Float = 16777217L  // deprecated
                                 ^
-deprecated_widening.scala:26: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:26: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
   val truncatedNegFloat: Float = - 16777217L // deprecated
                                  ^
-deprecated_widening.scala:30: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:30: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
   val truncatedPosFloatI:Float = 16777217  // deprecated
                                  ^
-deprecated_widening.scala:33: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:33: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
   val truncatedNegFloatI: Float = - 16777217 // deprecated
                                   ^
-deprecated_widening.scala:37: warning: Widening conversion from Long to Double is deprecated because it loses precision. Write `.toDouble` instead.
+deprecated_widening.scala:37: warning: [quick fix available] Widening conversion from Long to Double is deprecated because it loses precision. Write `.toDouble` instead.
   val truncatedPosDouble:Double = 18014398509481985L // deprecated
                                   ^
-deprecated_widening.scala:40: warning: Widening conversion from Long to Double is deprecated because it loses precision. Write `.toDouble` instead.
+deprecated_widening.scala:40: warning: [quick fix available] Widening conversion from Long to Double is deprecated because it loses precision. Write `.toDouble` instead.
   val truncatedNegDouble: Double = - 18014398509481985L // deprecated
                                    ^
-deprecated_widening.scala:47: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:47: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
   def literals  = Set[Float](0x7fffffc0, 0x7ffffffd, 0x7ffffffe, 0x7fffffff)
                              ^
-deprecated_widening.scala:47: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:47: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
   def literals  = Set[Float](0x7fffffc0, 0x7ffffffd, 0x7ffffffe, 0x7fffffff)
                                          ^
-deprecated_widening.scala:47: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:47: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
   def literals  = Set[Float](0x7fffffc0, 0x7ffffffd, 0x7ffffffe, 0x7fffffff)
                                                      ^
-deprecated_widening.scala:48: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:48: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
   def longingly = Set[Float](0x7fffffc0L, 0x7ffffffdL, 0x7ffffffeL, 0x7fffffffL)
                              ^
-deprecated_widening.scala:48: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:48: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
   def longingly = Set[Float](0x7fffffc0L, 0x7ffffffdL, 0x7ffffffeL, 0x7fffffffL)
                                           ^
-deprecated_widening.scala:48: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:48: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
   def longingly = Set[Float](0x7fffffc0L, 0x7ffffffdL, 0x7ffffffeL, 0x7fffffffL)
                                                        ^
-deprecated_widening.scala:48: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:48: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
   def longingly = Set[Float](0x7fffffc0L, 0x7ffffffdL, 0x7ffffffeL, 0x7fffffffL)
                                                                     ^
-deprecated_widening.scala:50: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:50: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
   def `pick one` = Set[Float](0x1000003, 0x1000004, 0x1000005)
                               ^
-deprecated_widening.scala:50: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+deprecated_widening.scala:50: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
   def `pick one` = Set[Float](0x1000003, 0x1000004, 0x1000005)
                                                     ^
 deprecated_widening.scala:12: warning: method int2float in object Int is deprecated (since 2.13.1): Implicit conversion from Int to Float is dangerous because it loses precision. Write `.toFloat` instead.

--- a/test/files/neg/deprecated_widening.check
+++ b/test/files/neg/deprecated_widening.check
@@ -1,55 +1,55 @@
-deprecated_widening.scala:5: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+deprecated_widening.scala:5: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
     val i_f: Float = i  // deprecated
                      ^
-deprecated_widening.scala:7: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+deprecated_widening.scala:7: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
     val l_f: Float = l  // deprecated
                      ^
-deprecated_widening.scala:8: warning: Widening conversion from Long to Double is deprecated because it loses precision. Write `.toDouble` instead. [quick fix available]
+deprecated_widening.scala:8: warning: Widening conversion from Long to Double is deprecated because it loses precision. Write `.toDouble` instead. [quickfixable]
     val l_d: Double = l // deprecated
                       ^
-deprecated_widening.scala:23: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+deprecated_widening.scala:23: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
   val truncatedPosFloat:Float = 16777217L  // deprecated
                                 ^
-deprecated_widening.scala:26: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+deprecated_widening.scala:26: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
   val truncatedNegFloat: Float = - 16777217L // deprecated
                                  ^
-deprecated_widening.scala:30: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+deprecated_widening.scala:30: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
   val truncatedPosFloatI:Float = 16777217  // deprecated
                                  ^
-deprecated_widening.scala:33: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+deprecated_widening.scala:33: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
   val truncatedNegFloatI: Float = - 16777217 // deprecated
                                   ^
-deprecated_widening.scala:37: warning: Widening conversion from Long to Double is deprecated because it loses precision. Write `.toDouble` instead. [quick fix available]
+deprecated_widening.scala:37: warning: Widening conversion from Long to Double is deprecated because it loses precision. Write `.toDouble` instead. [quickfixable]
   val truncatedPosDouble:Double = 18014398509481985L // deprecated
                                   ^
-deprecated_widening.scala:40: warning: Widening conversion from Long to Double is deprecated because it loses precision. Write `.toDouble` instead. [quick fix available]
+deprecated_widening.scala:40: warning: Widening conversion from Long to Double is deprecated because it loses precision. Write `.toDouble` instead. [quickfixable]
   val truncatedNegDouble: Double = - 18014398509481985L // deprecated
                                    ^
-deprecated_widening.scala:47: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+deprecated_widening.scala:47: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
   def literals  = Set[Float](0x7fffffc0, 0x7ffffffd, 0x7ffffffe, 0x7fffffff)
                              ^
-deprecated_widening.scala:47: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+deprecated_widening.scala:47: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
   def literals  = Set[Float](0x7fffffc0, 0x7ffffffd, 0x7ffffffe, 0x7fffffff)
                                          ^
-deprecated_widening.scala:47: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+deprecated_widening.scala:47: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
   def literals  = Set[Float](0x7fffffc0, 0x7ffffffd, 0x7ffffffe, 0x7fffffff)
                                                      ^
-deprecated_widening.scala:48: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+deprecated_widening.scala:48: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
   def longingly = Set[Float](0x7fffffc0L, 0x7ffffffdL, 0x7ffffffeL, 0x7fffffffL)
                              ^
-deprecated_widening.scala:48: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+deprecated_widening.scala:48: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
   def longingly = Set[Float](0x7fffffc0L, 0x7ffffffdL, 0x7ffffffeL, 0x7fffffffL)
                                           ^
-deprecated_widening.scala:48: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+deprecated_widening.scala:48: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
   def longingly = Set[Float](0x7fffffc0L, 0x7ffffffdL, 0x7ffffffeL, 0x7fffffffL)
                                                        ^
-deprecated_widening.scala:48: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+deprecated_widening.scala:48: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
   def longingly = Set[Float](0x7fffffc0L, 0x7ffffffdL, 0x7ffffffeL, 0x7fffffffL)
                                                                     ^
-deprecated_widening.scala:50: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+deprecated_widening.scala:50: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
   def `pick one` = Set[Float](0x1000003, 0x1000004, 0x1000005)
                               ^
-deprecated_widening.scala:50: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+deprecated_widening.scala:50: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
   def `pick one` = Set[Float](0x1000003, 0x1000004, 0x1000005)
                                                     ^
 deprecated_widening.scala:12: warning: method int2float in object Int is deprecated (since 2.13.1): Implicit conversion from Int to Float is dangerous because it loses precision. Write `.toFloat` instead.

--- a/test/files/neg/dotless-targs-a.check
+++ b/test/files/neg/dotless-targs-a.check
@@ -1,14 +1,14 @@
-dotless-targs-a.scala:4: error: type application is not allowed for infix operators
+dotless-targs-a.scala:4: error: [quick fix available] type application is not allowed for infix operators
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def fn2 = List apply[Int] 2
                  ^
-dotless-targs-a.scala:9: error: type application is not allowed for infix operators
+dotless-targs-a.scala:9: error: [quick fix available] type application is not allowed for infix operators
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
                 ^
-dotless-targs-a.scala:9: error: type application is not allowed for infix operators
+dotless-targs-a.scala:9: error: [quick fix available] type application is not allowed for infix operators
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)

--- a/test/files/neg/dotless-targs-a.check
+++ b/test/files/neg/dotless-targs-a.check
@@ -1,14 +1,14 @@
-dotless-targs-a.scala:4: error: type application is not allowed for infix operators [quick fix available]
+dotless-targs-a.scala:4: error: type application is not allowed for infix operators [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def fn2 = List apply[Int] 2
                  ^
-dotless-targs-a.scala:9: error: type application is not allowed for infix operators [quick fix available]
+dotless-targs-a.scala:9: error: type application is not allowed for infix operators [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
                 ^
-dotless-targs-a.scala:9: error: type application is not allowed for infix operators [quick fix available]
+dotless-targs-a.scala:9: error: type application is not allowed for infix operators [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)

--- a/test/files/neg/dotless-targs-a.check
+++ b/test/files/neg/dotless-targs-a.check
@@ -1,14 +1,14 @@
-dotless-targs-a.scala:4: error: [quick fix available] type application is not allowed for infix operators
+dotless-targs-a.scala:4: error: type application is not allowed for infix operators [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def fn2 = List apply[Int] 2
                  ^
-dotless-targs-a.scala:9: error: [quick fix available] type application is not allowed for infix operators
+dotless-targs-a.scala:9: error: type application is not allowed for infix operators [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
                 ^
-dotless-targs-a.scala:9: error: [quick fix available] type application is not allowed for infix operators
+dotless-targs-a.scala:9: error: type application is not allowed for infix operators [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)

--- a/test/files/neg/dotless-targs-b.check
+++ b/test/files/neg/dotless-targs-b.check
@@ -1,14 +1,14 @@
-dotless-targs-b.scala:4: error: type application is not allowed for infix operators [quick fix available]
+dotless-targs-b.scala:4: error: type application is not allowed for infix operators [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def fn2 = List apply[Int] 2
                  ^
-dotless-targs-b.scala:9: error: type application is not allowed for infix operators [quick fix available]
+dotless-targs-b.scala:9: error: type application is not allowed for infix operators [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
                 ^
-dotless-targs-b.scala:9: error: type application is not allowed for infix operators [quick fix available]
+dotless-targs-b.scala:9: error: type application is not allowed for infix operators [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)

--- a/test/files/neg/dotless-targs-b.check
+++ b/test/files/neg/dotless-targs-b.check
@@ -1,14 +1,14 @@
-dotless-targs-b.scala:4: error: type application is not allowed for infix operators
+dotless-targs-b.scala:4: error: [quick fix available] type application is not allowed for infix operators
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def fn2 = List apply[Int] 2
                  ^
-dotless-targs-b.scala:9: error: type application is not allowed for infix operators
+dotless-targs-b.scala:9: error: [quick fix available] type application is not allowed for infix operators
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
                 ^
-dotless-targs-b.scala:9: error: type application is not allowed for infix operators
+dotless-targs-b.scala:9: error: [quick fix available] type application is not allowed for infix operators
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)

--- a/test/files/neg/dotless-targs-b.check
+++ b/test/files/neg/dotless-targs-b.check
@@ -1,14 +1,14 @@
-dotless-targs-b.scala:4: error: [quick fix available] type application is not allowed for infix operators
+dotless-targs-b.scala:4: error: type application is not allowed for infix operators [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def fn2 = List apply[Int] 2
                  ^
-dotless-targs-b.scala:9: error: [quick fix available] type application is not allowed for infix operators
+dotless-targs-b.scala:9: error: type application is not allowed for infix operators [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
                 ^
-dotless-targs-b.scala:9: error: [quick fix available] type application is not allowed for infix operators
+dotless-targs-b.scala:9: error: type application is not allowed for infix operators [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)

--- a/test/files/neg/dotless-targs-ranged-a.check
+++ b/test/files/neg/dotless-targs-ranged-a.check
@@ -1,16 +1,16 @@
-dotless-targs-ranged-a.scala:4: warning: [quick fix available] type application is not allowed for infix operators
+dotless-targs-ranged-a.scala:4: warning: type application is not allowed for infix operators [quick fix available]
   def fn2 = List apply[Int] 2
                  ^
-dotless-targs-ranged-a.scala:9: warning: [quick fix available] type application is not allowed for infix operators
+dotless-targs-ranged-a.scala:9: warning: type application is not allowed for infix operators [quick fix available]
   def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
                 ^
-dotless-targs-ranged-a.scala:9: warning: [quick fix available] type application is not allowed for infix operators
+dotless-targs-ranged-a.scala:9: warning: type application is not allowed for infix operators [quick fix available]
   def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
                                                     ^
-dotless-targs-ranged-a.scala:13: warning: [quick fix available] type application is not allowed for infix operators
+dotless-targs-ranged-a.scala:13: warning: type application is not allowed for infix operators [quick fix available]
   def eval = 1 ->[Int] 2
                ^
-dotless-targs-ranged-a.scala:14: warning: [quick fix available] type application is not allowed for infix operators
+dotless-targs-ranged-a.scala:14: warning: type application is not allowed for infix operators [quick fix available]
   def evil = new A() op  [Int,   String     ]  42
                      ^
 dotless-targs-ranged-a.scala:9: warning: multiarg infix syntax looks like a tuple and will be deprecated

--- a/test/files/neg/dotless-targs-ranged-a.check
+++ b/test/files/neg/dotless-targs-ranged-a.check
@@ -1,16 +1,16 @@
-dotless-targs-ranged-a.scala:4: warning: type application is not allowed for infix operators
+dotless-targs-ranged-a.scala:4: warning: [quick fix available] type application is not allowed for infix operators
   def fn2 = List apply[Int] 2
                  ^
-dotless-targs-ranged-a.scala:9: warning: type application is not allowed for infix operators
+dotless-targs-ranged-a.scala:9: warning: [quick fix available] type application is not allowed for infix operators
   def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
                 ^
-dotless-targs-ranged-a.scala:9: warning: type application is not allowed for infix operators
+dotless-targs-ranged-a.scala:9: warning: [quick fix available] type application is not allowed for infix operators
   def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
                                                     ^
-dotless-targs-ranged-a.scala:13: warning: type application is not allowed for infix operators
+dotless-targs-ranged-a.scala:13: warning: [quick fix available] type application is not allowed for infix operators
   def eval = 1 ->[Int] 2
                ^
-dotless-targs-ranged-a.scala:14: warning: type application is not allowed for infix operators
+dotless-targs-ranged-a.scala:14: warning: [quick fix available] type application is not allowed for infix operators
   def evil = new A() op  [Int,   String     ]  42
                      ^
 dotless-targs-ranged-a.scala:9: warning: multiarg infix syntax looks like a tuple and will be deprecated

--- a/test/files/neg/dotless-targs-ranged-a.check
+++ b/test/files/neg/dotless-targs-ranged-a.check
@@ -1,16 +1,16 @@
-dotless-targs-ranged-a.scala:4: warning: type application is not allowed for infix operators [quick fix available]
+dotless-targs-ranged-a.scala:4: warning: type application is not allowed for infix operators [quickfixable]
   def fn2 = List apply[Int] 2
                  ^
-dotless-targs-ranged-a.scala:9: warning: type application is not allowed for infix operators [quick fix available]
+dotless-targs-ranged-a.scala:9: warning: type application is not allowed for infix operators [quickfixable]
   def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
                 ^
-dotless-targs-ranged-a.scala:9: warning: type application is not allowed for infix operators [quick fix available]
+dotless-targs-ranged-a.scala:9: warning: type application is not allowed for infix operators [quickfixable]
   def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
                                                     ^
-dotless-targs-ranged-a.scala:13: warning: type application is not allowed for infix operators [quick fix available]
+dotless-targs-ranged-a.scala:13: warning: type application is not allowed for infix operators [quickfixable]
   def eval = 1 ->[Int] 2
                ^
-dotless-targs-ranged-a.scala:14: warning: type application is not allowed for infix operators [quick fix available]
+dotless-targs-ranged-a.scala:14: warning: type application is not allowed for infix operators [quickfixable]
   def evil = new A() op  [Int,   String     ]  42
                      ^
 dotless-targs-ranged-a.scala:9: warning: multiarg infix syntax looks like a tuple and will be deprecated

--- a/test/files/neg/for-comprehension-old.check
+++ b/test/files/neg/for-comprehension-old.check
@@ -1,25 +1,25 @@
-for-comprehension-old.scala:6: error: [quick fix available] `val` keyword in for comprehension is unsupported: just remove `val`
+for-comprehension-old.scala:6: error: `val` keyword in for comprehension is unsupported: just remove `val` [quick fix available]
   for (val x <- 1 to 5 ; y = x) yield x+y       // fail
              ^
-for-comprehension-old.scala:7: error: [quick fix available] `val` keyword in for comprehension is unsupported: just remove `val`
+for-comprehension-old.scala:7: error: `val` keyword in for comprehension is unsupported: just remove `val` [quick fix available]
   for (val x <- 1 to 5 ; val y = x) yield x+y   // fail
              ^
-for-comprehension-old.scala:11: error: [quick fix available] `val` keyword in for comprehension is unsupported: just remove `val`
+for-comprehension-old.scala:11: error: `val` keyword in for comprehension is unsupported: just remove `val` [quick fix available]
   for (z <- 1 to 2 ; val x <- 1 to 5 ; y = x) yield x+y       // fail
                            ^
-for-comprehension-old.scala:12: error: [quick fix available] `val` keyword in for comprehension is unsupported: just remove `val`
+for-comprehension-old.scala:12: error: `val` keyword in for comprehension is unsupported: just remove `val` [quick fix available]
   for (z <- 1 to 2 ; val x <- 1 to 5 ; val y = x) yield x+y   // fail
                            ^
-for-comprehension-old.scala:5: warning: [quick fix available] `val` keyword in for comprehension is deprecated: instead, bind the value without `val`
+for-comprehension-old.scala:5: warning: `val` keyword in for comprehension is deprecated: instead, bind the value without `val` [quick fix available]
   for (x <- 1 to 5 ; val y = x) yield x+y       // fail
                            ^
-for-comprehension-old.scala:7: warning: [quick fix available] `val` keyword in for comprehension is deprecated: instead, bind the value without `val`
+for-comprehension-old.scala:7: warning: `val` keyword in for comprehension is deprecated: instead, bind the value without `val` [quick fix available]
   for (val x <- 1 to 5 ; val y = x) yield x+y   // fail
                                ^
-for-comprehension-old.scala:10: warning: [quick fix available] `val` keyword in for comprehension is deprecated: instead, bind the value without `val`
+for-comprehension-old.scala:10: warning: `val` keyword in for comprehension is deprecated: instead, bind the value without `val` [quick fix available]
   for (z <- 1 to 2 ; x <- 1 to 5 ; val y = x) yield x+y       // fail
                                          ^
-for-comprehension-old.scala:12: warning: [quick fix available] `val` keyword in for comprehension is deprecated: instead, bind the value without `val`
+for-comprehension-old.scala:12: warning: `val` keyword in for comprehension is deprecated: instead, bind the value without `val` [quick fix available]
   for (z <- 1 to 2 ; val x <- 1 to 5 ; val y = x) yield x+y   // fail
                                              ^
 4 warnings

--- a/test/files/neg/for-comprehension-old.check
+++ b/test/files/neg/for-comprehension-old.check
@@ -1,25 +1,25 @@
-for-comprehension-old.scala:6: error: `val` keyword in for comprehension is unsupported: just remove `val` [quick fix available]
+for-comprehension-old.scala:6: error: `val` keyword in for comprehension is unsupported: just remove `val` [quickfixable]
   for (val x <- 1 to 5 ; y = x) yield x+y       // fail
              ^
-for-comprehension-old.scala:7: error: `val` keyword in for comprehension is unsupported: just remove `val` [quick fix available]
+for-comprehension-old.scala:7: error: `val` keyword in for comprehension is unsupported: just remove `val` [quickfixable]
   for (val x <- 1 to 5 ; val y = x) yield x+y   // fail
              ^
-for-comprehension-old.scala:11: error: `val` keyword in for comprehension is unsupported: just remove `val` [quick fix available]
+for-comprehension-old.scala:11: error: `val` keyword in for comprehension is unsupported: just remove `val` [quickfixable]
   for (z <- 1 to 2 ; val x <- 1 to 5 ; y = x) yield x+y       // fail
                            ^
-for-comprehension-old.scala:12: error: `val` keyword in for comprehension is unsupported: just remove `val` [quick fix available]
+for-comprehension-old.scala:12: error: `val` keyword in for comprehension is unsupported: just remove `val` [quickfixable]
   for (z <- 1 to 2 ; val x <- 1 to 5 ; val y = x) yield x+y   // fail
                            ^
-for-comprehension-old.scala:5: warning: `val` keyword in for comprehension is deprecated: instead, bind the value without `val` [quick fix available]
+for-comprehension-old.scala:5: warning: `val` keyword in for comprehension is deprecated: instead, bind the value without `val` [quickfixable]
   for (x <- 1 to 5 ; val y = x) yield x+y       // fail
                            ^
-for-comprehension-old.scala:7: warning: `val` keyword in for comprehension is deprecated: instead, bind the value without `val` [quick fix available]
+for-comprehension-old.scala:7: warning: `val` keyword in for comprehension is deprecated: instead, bind the value without `val` [quickfixable]
   for (val x <- 1 to 5 ; val y = x) yield x+y   // fail
                                ^
-for-comprehension-old.scala:10: warning: `val` keyword in for comprehension is deprecated: instead, bind the value without `val` [quick fix available]
+for-comprehension-old.scala:10: warning: `val` keyword in for comprehension is deprecated: instead, bind the value without `val` [quickfixable]
   for (z <- 1 to 2 ; x <- 1 to 5 ; val y = x) yield x+y       // fail
                                          ^
-for-comprehension-old.scala:12: warning: `val` keyword in for comprehension is deprecated: instead, bind the value without `val` [quick fix available]
+for-comprehension-old.scala:12: warning: `val` keyword in for comprehension is deprecated: instead, bind the value without `val` [quickfixable]
   for (z <- 1 to 2 ; val x <- 1 to 5 ; val y = x) yield x+y   // fail
                                              ^
 4 warnings

--- a/test/files/neg/for-comprehension-val.check
+++ b/test/files/neg/for-comprehension-val.check
@@ -1,31 +1,31 @@
-for-comprehension-val.scala:6: error: `val` keyword in for comprehension is unsupported: just remove `val` [quick fix available]
+for-comprehension-val.scala:6: error: `val` keyword in for comprehension is unsupported: just remove `val` [quickfixable]
   for (val x <- 1 to 5 ; y = x) yield x+y       // fail
              ^
-for-comprehension-val.scala:7: error: `val` keyword in for comprehension is unsupported: just remove `val` [quick fix available]
+for-comprehension-val.scala:7: error: `val` keyword in for comprehension is unsupported: just remove `val` [quickfixable]
   for (val x <- 1 to 5 ; val y = x) yield x+y   // fail
              ^
-for-comprehension-val.scala:11: error: `val` keyword in for comprehension is unsupported: just remove `val` [quick fix available]
+for-comprehension-val.scala:11: error: `val` keyword in for comprehension is unsupported: just remove `val` [quickfixable]
   for (z <- 1 to 2 ; val x <- 1 to 5 ; y = x) yield x+y       // fail
                            ^
-for-comprehension-val.scala:12: error: `val` keyword in for comprehension is unsupported: just remove `val` [quick fix available]
+for-comprehension-val.scala:12: error: `val` keyword in for comprehension is unsupported: just remove `val` [quickfixable]
   for (z <- 1 to 2 ; val x <- 1 to 5 ; val y = x) yield x+y   // fail
                            ^
-for-comprehension-val.scala:5: error: `val` keyword in for comprehension is unsupported: instead, bind the value without `val` [quick fix available]
+for-comprehension-val.scala:5: error: `val` keyword in for comprehension is unsupported: instead, bind the value without `val` [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   for (x <- 1 to 5 ; val y = x) yield x+y       // fail
                            ^
-for-comprehension-val.scala:7: error: `val` keyword in for comprehension is unsupported: instead, bind the value without `val` [quick fix available]
+for-comprehension-val.scala:7: error: `val` keyword in for comprehension is unsupported: instead, bind the value without `val` [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   for (val x <- 1 to 5 ; val y = x) yield x+y   // fail
                                ^
-for-comprehension-val.scala:10: error: `val` keyword in for comprehension is unsupported: instead, bind the value without `val` [quick fix available]
+for-comprehension-val.scala:10: error: `val` keyword in for comprehension is unsupported: instead, bind the value without `val` [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   for (z <- 1 to 2 ; x <- 1 to 5 ; val y = x) yield x+y       // fail
                                          ^
-for-comprehension-val.scala:12: error: `val` keyword in for comprehension is unsupported: instead, bind the value without `val` [quick fix available]
+for-comprehension-val.scala:12: error: `val` keyword in for comprehension is unsupported: instead, bind the value without `val` [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   for (z <- 1 to 2 ; val x <- 1 to 5 ; val y = x) yield x+y   // fail

--- a/test/files/neg/for-comprehension-val.check
+++ b/test/files/neg/for-comprehension-val.check
@@ -1,31 +1,31 @@
-for-comprehension-val.scala:6: error: [quick fix available] `val` keyword in for comprehension is unsupported: just remove `val`
+for-comprehension-val.scala:6: error: `val` keyword in for comprehension is unsupported: just remove `val` [quick fix available]
   for (val x <- 1 to 5 ; y = x) yield x+y       // fail
              ^
-for-comprehension-val.scala:7: error: [quick fix available] `val` keyword in for comprehension is unsupported: just remove `val`
+for-comprehension-val.scala:7: error: `val` keyword in for comprehension is unsupported: just remove `val` [quick fix available]
   for (val x <- 1 to 5 ; val y = x) yield x+y   // fail
              ^
-for-comprehension-val.scala:11: error: [quick fix available] `val` keyword in for comprehension is unsupported: just remove `val`
+for-comprehension-val.scala:11: error: `val` keyword in for comprehension is unsupported: just remove `val` [quick fix available]
   for (z <- 1 to 2 ; val x <- 1 to 5 ; y = x) yield x+y       // fail
                            ^
-for-comprehension-val.scala:12: error: [quick fix available] `val` keyword in for comprehension is unsupported: just remove `val`
+for-comprehension-val.scala:12: error: `val` keyword in for comprehension is unsupported: just remove `val` [quick fix available]
   for (z <- 1 to 2 ; val x <- 1 to 5 ; val y = x) yield x+y   // fail
                            ^
-for-comprehension-val.scala:5: error: [quick fix available] `val` keyword in for comprehension is unsupported: instead, bind the value without `val`
+for-comprehension-val.scala:5: error: `val` keyword in for comprehension is unsupported: instead, bind the value without `val` [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   for (x <- 1 to 5 ; val y = x) yield x+y       // fail
                            ^
-for-comprehension-val.scala:7: error: [quick fix available] `val` keyword in for comprehension is unsupported: instead, bind the value without `val`
+for-comprehension-val.scala:7: error: `val` keyword in for comprehension is unsupported: instead, bind the value without `val` [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   for (val x <- 1 to 5 ; val y = x) yield x+y   // fail
                                ^
-for-comprehension-val.scala:10: error: [quick fix available] `val` keyword in for comprehension is unsupported: instead, bind the value without `val`
+for-comprehension-val.scala:10: error: `val` keyword in for comprehension is unsupported: instead, bind the value without `val` [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   for (z <- 1 to 2 ; x <- 1 to 5 ; val y = x) yield x+y       // fail
                                          ^
-for-comprehension-val.scala:12: error: [quick fix available] `val` keyword in for comprehension is unsupported: instead, bind the value without `val`
+for-comprehension-val.scala:12: error: `val` keyword in for comprehension is unsupported: instead, bind the value without `val` [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   for (z <- 1 to 2 ; val x <- 1 to 5 ; val y = x) yield x+y   // fail

--- a/test/files/neg/implicits.check
+++ b/test/files/neg/implicits.check
@@ -16,10 +16,10 @@ implicits.scala:47: error: type mismatch;
 implicits.scala:59: error: could not find implicit value for parameter x: Nothing
   foo {
       ^
-implicits.scala:34: warning: Implicit definition should have explicit type (inferred T)
+implicits.scala:34: warning: [quick fix available] Implicit definition should have explicit type (inferred T)
   implicit def select[T](t: HSome[T,_]) = t.head
                ^
-implicits.scala:35: warning: Implicit definition should have explicit type (inferred L)
+implicits.scala:35: warning: [quick fix available] Implicit definition should have explicit type (inferred L)
   implicit def selectTail[L](t: HSome[_,L]) = t.tail
                ^
 2 warnings

--- a/test/files/neg/implicits.check
+++ b/test/files/neg/implicits.check
@@ -16,10 +16,10 @@ implicits.scala:47: error: type mismatch;
 implicits.scala:59: error: could not find implicit value for parameter x: Nothing
   foo {
       ^
-implicits.scala:34: warning: Implicit definition should have explicit type (inferred T) [quick fix available]
+implicits.scala:34: warning: Implicit definition should have explicit type (inferred T) [quickfixable]
   implicit def select[T](t: HSome[T,_]) = t.head
                ^
-implicits.scala:35: warning: Implicit definition should have explicit type (inferred L) [quick fix available]
+implicits.scala:35: warning: Implicit definition should have explicit type (inferred L) [quickfixable]
   implicit def selectTail[L](t: HSome[_,L]) = t.tail
                ^
 2 warnings

--- a/test/files/neg/implicits.check
+++ b/test/files/neg/implicits.check
@@ -16,10 +16,10 @@ implicits.scala:47: error: type mismatch;
 implicits.scala:59: error: could not find implicit value for parameter x: Nothing
   foo {
       ^
-implicits.scala:34: warning: [quick fix available] Implicit definition should have explicit type (inferred T)
+implicits.scala:34: warning: Implicit definition should have explicit type (inferred T) [quick fix available]
   implicit def select[T](t: HSome[T,_]) = t.head
                ^
-implicits.scala:35: warning: [quick fix available] Implicit definition should have explicit type (inferred L)
+implicits.scala:35: warning: Implicit definition should have explicit type (inferred L) [quick fix available]
   implicit def selectTail[L](t: HSome[_,L]) = t.tail
                ^
 2 warnings

--- a/test/files/neg/lint-int-div-to-float.check
+++ b/test/files/neg/lint-int-div-to-float.check
@@ -1,16 +1,16 @@
-lint-int-div-to-float.scala:6: warning: integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`. [quick fix available]
+lint-int-div-to-float.scala:6: warning: integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`. [quickfixable]
   def w1: Double = f / 2
                      ^
-lint-int-div-to-float.scala:7: warning: integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`. [quick fix available]
+lint-int-div-to-float.scala:7: warning: integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`. [quickfixable]
   def w2: Double = (f / 2) * 3
                       ^
-lint-int-div-to-float.scala:8: warning: integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`. [quick fix available]
+lint-int-div-to-float.scala:8: warning: integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`. [quickfixable]
   def w3: Double = -(f / 2)
                        ^
-lint-int-div-to-float.scala:9: warning: integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`. [quick fix available]
+lint-int-div-to-float.scala:9: warning: integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`. [quickfixable]
   def w4: Double = (new C).f / (new C).f * 3
                              ^
-lint-int-div-to-float.scala:10: warning: integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`. [quick fix available]
+lint-int-div-to-float.scala:10: warning: integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`. [quickfixable]
   def w5: Double = f - f.abs / 2
                              ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/lint-int-div-to-float.check
+++ b/test/files/neg/lint-int-div-to-float.check
@@ -1,16 +1,16 @@
-lint-int-div-to-float.scala:6: warning: [quick fix available] integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`.
+lint-int-div-to-float.scala:6: warning: integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`. [quick fix available]
   def w1: Double = f / 2
                      ^
-lint-int-div-to-float.scala:7: warning: [quick fix available] integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`.
+lint-int-div-to-float.scala:7: warning: integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`. [quick fix available]
   def w2: Double = (f / 2) * 3
                       ^
-lint-int-div-to-float.scala:8: warning: [quick fix available] integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`.
+lint-int-div-to-float.scala:8: warning: integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`. [quick fix available]
   def w3: Double = -(f / 2)
                        ^
-lint-int-div-to-float.scala:9: warning: [quick fix available] integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`.
+lint-int-div-to-float.scala:9: warning: integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`. [quick fix available]
   def w4: Double = (new C).f / (new C).f * 3
                              ^
-lint-int-div-to-float.scala:10: warning: [quick fix available] integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`.
+lint-int-div-to-float.scala:10: warning: integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`. [quick fix available]
   def w5: Double = f - f.abs / 2
                              ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/lint-int-div-to-float.check
+++ b/test/files/neg/lint-int-div-to-float.check
@@ -1,16 +1,16 @@
-lint-int-div-to-float.scala:6: warning: integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`.
+lint-int-div-to-float.scala:6: warning: [quick fix available] integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`.
   def w1: Double = f / 2
                      ^
-lint-int-div-to-float.scala:7: warning: integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`.
+lint-int-div-to-float.scala:7: warning: [quick fix available] integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`.
   def w2: Double = (f / 2) * 3
                       ^
-lint-int-div-to-float.scala:8: warning: integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`.
+lint-int-div-to-float.scala:8: warning: [quick fix available] integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`.
   def w3: Double = -(f / 2)
                        ^
-lint-int-div-to-float.scala:9: warning: integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`.
+lint-int-div-to-float.scala:9: warning: [quick fix available] integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`.
   def w4: Double = (new C).f / (new C).f * 3
                              ^
-lint-int-div-to-float.scala:10: warning: integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`.
+lint-int-div-to-float.scala:10: warning: [quick fix available] integral division is implicitly converted (widened) to floating point. Add an explicit `.toDouble`.
   def w5: Double = f - f.abs / 2
                              ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/literals.check
+++ b/test/files/neg/literals.check
@@ -49,10 +49,10 @@ literals.scala:26: warning: Decimal integer literals should not have a leading z
 literals.scala:28: warning: Decimal integer literals should not have a leading zero. (Octal syntax is obsolete.)
   def zeroOfNine: Int    = 09            // line 28: no leading zero
                            ^
-literals.scala:50: warning: Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead
+literals.scala:50: warning: [quick fix available] Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead
   def bad = 1l
              ^
-literals.scala:52: warning: Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead
+literals.scala:52: warning: [quick fix available] Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead
   def worse = 123l
                  ^
 8 warnings

--- a/test/files/neg/literals.check
+++ b/test/files/neg/literals.check
@@ -49,10 +49,10 @@ literals.scala:26: warning: Decimal integer literals should not have a leading z
 literals.scala:28: warning: Decimal integer literals should not have a leading zero. (Octal syntax is obsolete.)
   def zeroOfNine: Int    = 09            // line 28: no leading zero
                            ^
-literals.scala:50: warning: Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead [quick fix available]
+literals.scala:50: warning: Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead [quickfixable]
   def bad = 1l
              ^
-literals.scala:52: warning: Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead [quick fix available]
+literals.scala:52: warning: Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead [quickfixable]
   def worse = 123l
                  ^
 8 warnings

--- a/test/files/neg/literals.check
+++ b/test/files/neg/literals.check
@@ -49,10 +49,10 @@ literals.scala:26: warning: Decimal integer literals should not have a leading z
 literals.scala:28: warning: Decimal integer literals should not have a leading zero. (Octal syntax is obsolete.)
   def zeroOfNine: Int    = 09            // line 28: no leading zero
                            ^
-literals.scala:50: warning: [quick fix available] Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead
+literals.scala:50: warning: Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead [quick fix available]
   def bad = 1l
              ^
-literals.scala:52: warning: [quick fix available] Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead
+literals.scala:52: warning: Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead [quick fix available]
   def worse = 123l
                  ^
 8 warnings

--- a/test/files/neg/macro-deprecate-idents.check
+++ b/test/files/neg/macro-deprecate-idents.check
@@ -64,7 +64,7 @@ macro-deprecate-idents.scala:47: error: '{' expected but '}' found.
 macro-deprecate-idents.scala:54: error: ')' expected but '}' found.
 }
 ^
-macro-deprecate-idents.scala:57: warning: [quick fix available] procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `<error>`'s return type
+macro-deprecate-idents.scala:57: warning: procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `<error>`'s return type [quick fix available]
   def macro = 2
                ^
 1 warning

--- a/test/files/neg/macro-deprecate-idents.check
+++ b/test/files/neg/macro-deprecate-idents.check
@@ -64,7 +64,7 @@ macro-deprecate-idents.scala:47: error: '{' expected but '}' found.
 macro-deprecate-idents.scala:54: error: ')' expected but '}' found.
 }
 ^
-macro-deprecate-idents.scala:57: warning: procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `<error>`'s return type [quick fix available]
+macro-deprecate-idents.scala:57: warning: procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `<error>`'s return type [quickfixable]
   def macro = 2
                ^
 1 warning

--- a/test/files/neg/names-defaults-neg.check
+++ b/test/files/neg/names-defaults-neg.check
@@ -127,10 +127,10 @@ names-defaults-neg.scala:147: error: parameter 'a' is already specified at param
 names-defaults-neg.scala:148: error: missing parameter type for expanded function ((<x$4: error>) => b = x$4)
   val taf4: (Int, String) => Unit = testAnnFun(_, b = _)
                                                       ^
-names-defaults-neg.scala:103: warning: symbol literal is deprecated; use Symbol("foo") instead
+names-defaults-neg.scala:103: warning: [quick fix available] symbol literal is deprecated; use Symbol("foo") instead
   def deprNam6(@deprecatedName('foo) deprNam6Arg: String) = 0
                                ^
-names-defaults-neg.scala:105: warning: symbol literal is deprecated; use Symbol("bar") instead
+names-defaults-neg.scala:105: warning: [quick fix available] symbol literal is deprecated; use Symbol("bar") instead
   def deprNam7(@deprecatedName('bar, "2.12.0") deprNam7Arg: String) = 0
                                ^
 names-defaults-neg.scala:95: warning: the parameter name y is deprecated: use b instead

--- a/test/files/neg/names-defaults-neg.check
+++ b/test/files/neg/names-defaults-neg.check
@@ -127,10 +127,10 @@ names-defaults-neg.scala:147: error: parameter 'a' is already specified at param
 names-defaults-neg.scala:148: error: missing parameter type for expanded function ((<x$4: error>) => b = x$4)
   val taf4: (Int, String) => Unit = testAnnFun(_, b = _)
                                                       ^
-names-defaults-neg.scala:103: warning: symbol literal is deprecated; use Symbol("foo") instead [quick fix available]
+names-defaults-neg.scala:103: warning: symbol literal is deprecated; use Symbol("foo") instead [quickfixable]
   def deprNam6(@deprecatedName('foo) deprNam6Arg: String) = 0
                                ^
-names-defaults-neg.scala:105: warning: symbol literal is deprecated; use Symbol("bar") instead [quick fix available]
+names-defaults-neg.scala:105: warning: symbol literal is deprecated; use Symbol("bar") instead [quickfixable]
   def deprNam7(@deprecatedName('bar, "2.12.0") deprNam7Arg: String) = 0
                                ^
 names-defaults-neg.scala:95: warning: the parameter name y is deprecated: use b instead

--- a/test/files/neg/names-defaults-neg.check
+++ b/test/files/neg/names-defaults-neg.check
@@ -127,10 +127,10 @@ names-defaults-neg.scala:147: error: parameter 'a' is already specified at param
 names-defaults-neg.scala:148: error: missing parameter type for expanded function ((<x$4: error>) => b = x$4)
   val taf4: (Int, String) => Unit = testAnnFun(_, b = _)
                                                       ^
-names-defaults-neg.scala:103: warning: [quick fix available] symbol literal is deprecated; use Symbol("foo") instead
+names-defaults-neg.scala:103: warning: symbol literal is deprecated; use Symbol("foo") instead [quick fix available]
   def deprNam6(@deprecatedName('foo) deprNam6Arg: String) = 0
                                ^
-names-defaults-neg.scala:105: warning: [quick fix available] symbol literal is deprecated; use Symbol("bar") instead
+names-defaults-neg.scala:105: warning: symbol literal is deprecated; use Symbol("bar") instead [quick fix available]
   def deprNam7(@deprecatedName('bar, "2.12.0") deprNam7Arg: String) = 0
                                ^
 names-defaults-neg.scala:95: warning: the parameter name y is deprecated: use b instead

--- a/test/files/neg/nullary-override-3a.check
+++ b/test/files/neg/nullary-override-3a.check
@@ -1,13 +1,13 @@
 nullary-override-3a.scala:4: error: method with a single empty parameter list overrides method without any parameter list
-def x: Int (defined in class A)
+def x: Int (defined in class A) [quick fix available]
 class B extends A { override def x(): Int = 4 }
                                  ^
 nullary-override-3a.scala:16: error: method with a single empty parameter list overrides method without any parameter list
-def x: String (defined in trait T1)
+def x: String (defined in trait T1) [quick fix available]
 class Mix12b extends T1 with T2 { override def x() = "12b" }
                                                ^
 nullary-override-3a.scala:19: error: method with a single empty parameter list overrides method without any parameter list
-def x: String (defined in trait T1)
+def x: String (defined in trait T1) [quick fix available]
 class Mix21b extends T2 with T1 { override def x() = "21b" }
                                                ^
 3 errors

--- a/test/files/neg/nullary-override-3a.check
+++ b/test/files/neg/nullary-override-3a.check
@@ -1,13 +1,13 @@
 nullary-override-3a.scala:4: error: method with a single empty parameter list overrides method without any parameter list
-def x: Int (defined in class A) [quick fix available]
+def x: Int (defined in class A) [quickfixable]
 class B extends A { override def x(): Int = 4 }
                                  ^
 nullary-override-3a.scala:16: error: method with a single empty parameter list overrides method without any parameter list
-def x: String (defined in trait T1) [quick fix available]
+def x: String (defined in trait T1) [quickfixable]
 class Mix12b extends T1 with T2 { override def x() = "12b" }
                                                ^
 nullary-override-3a.scala:19: error: method with a single empty parameter list overrides method without any parameter list
-def x: String (defined in trait T1) [quick fix available]
+def x: String (defined in trait T1) [quickfixable]
 class Mix21b extends T2 with T1 { override def x() = "21b" }
                                                ^
 3 errors

--- a/test/files/neg/nullary-override-3b.check
+++ b/test/files/neg/nullary-override-3b.check
@@ -1,9 +1,9 @@
 nullary-override-3b.scala:6: error: method without a parameter list overrides a method with a single empty one
-def x(): Int (defined in class P)
+def x(): Int (defined in class P) [quick fix available]
 class Q extends P { override def x: Int = 4 }
                                  ^
 nullary-override-3b.scala:11: error: method without a parameter list overrides a method with a single empty one
-def x(): String (defined in trait T2)
+def x(): String (defined in trait T2) [quick fix available]
 class Mix12a extends T1 with T2 { override def x   = "12a" }
                                                ^
 2 errors

--- a/test/files/neg/nullary-override-3b.check
+++ b/test/files/neg/nullary-override-3b.check
@@ -1,9 +1,9 @@
 nullary-override-3b.scala:6: error: method without a parameter list overrides a method with a single empty one
-def x(): Int (defined in class P) [quick fix available]
+def x(): Int (defined in class P) [quickfixable]
 class Q extends P { override def x: Int = 4 }
                                  ^
 nullary-override-3b.scala:11: error: method without a parameter list overrides a method with a single empty one
-def x(): String (defined in trait T2) [quick fix available]
+def x(): String (defined in trait T2) [quickfixable]
 class Mix12a extends T1 with T2 { override def x   = "12a" }
                                                ^
 2 errors

--- a/test/files/neg/nullary-override.check
+++ b/test/files/neg/nullary-override.check
@@ -1,16 +1,16 @@
-nullary-override.scala:4: warning: method with a single empty parameter list overrides method without any parameter list [quick fix available]
+nullary-override.scala:4: warning: method with a single empty parameter list overrides method without any parameter list [quickfixable]
 class B extends A { override def x(): Int = 4 }
                                  ^
-nullary-override.scala:15: warning: method without a parameter list overrides a method with a single empty one [quick fix available]
+nullary-override.scala:15: warning: method without a parameter list overrides a method with a single empty one [quickfixable]
 class Q extends P { override def x: Int = 4 }
                                  ^
-nullary-override.scala:36: warning: method without a parameter list overrides a method with a single empty one [quick fix available]
+nullary-override.scala:36: warning: method without a parameter list overrides a method with a single empty one [quickfixable]
 class Mix12a extends T1 with T2 { override def x   = "12a" }
                                                ^
-nullary-override.scala:37: warning: method with a single empty parameter list overrides method without any parameter list [quick fix available]
+nullary-override.scala:37: warning: method with a single empty parameter list overrides method without any parameter list [quickfixable]
 class Mix12b extends T1 with T2 { override def x() = "12b" }
                                                ^
-nullary-override.scala:40: warning: method with a single empty parameter list overrides method without any parameter list [quick fix available]
+nullary-override.scala:40: warning: method with a single empty parameter list overrides method without any parameter list [quickfixable]
 class Mix21b extends T2 with T1 { override def x() = "21b" }
                                                ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/nullary-override.check
+++ b/test/files/neg/nullary-override.check
@@ -1,16 +1,16 @@
-nullary-override.scala:4: warning: method with a single empty parameter list overrides method without any parameter list
+nullary-override.scala:4: warning: [quick fix available] method with a single empty parameter list overrides method without any parameter list
 class B extends A { override def x(): Int = 4 }
                                  ^
-nullary-override.scala:15: warning: method without a parameter list overrides a method with a single empty one
+nullary-override.scala:15: warning: [quick fix available] method without a parameter list overrides a method with a single empty one
 class Q extends P { override def x: Int = 4 }
                                  ^
-nullary-override.scala:36: warning: method without a parameter list overrides a method with a single empty one
+nullary-override.scala:36: warning: [quick fix available] method without a parameter list overrides a method with a single empty one
 class Mix12a extends T1 with T2 { override def x   = "12a" }
                                                ^
-nullary-override.scala:37: warning: method with a single empty parameter list overrides method without any parameter list
+nullary-override.scala:37: warning: [quick fix available] method with a single empty parameter list overrides method without any parameter list
 class Mix12b extends T1 with T2 { override def x() = "12b" }
                                                ^
-nullary-override.scala:40: warning: method with a single empty parameter list overrides method without any parameter list
+nullary-override.scala:40: warning: [quick fix available] method with a single empty parameter list overrides method without any parameter list
 class Mix21b extends T2 with T1 { override def x() = "21b" }
                                                ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/nullary-override.check
+++ b/test/files/neg/nullary-override.check
@@ -1,16 +1,16 @@
-nullary-override.scala:4: warning: [quick fix available] method with a single empty parameter list overrides method without any parameter list
+nullary-override.scala:4: warning: method with a single empty parameter list overrides method without any parameter list [quick fix available]
 class B extends A { override def x(): Int = 4 }
                                  ^
-nullary-override.scala:15: warning: [quick fix available] method without a parameter list overrides a method with a single empty one
+nullary-override.scala:15: warning: method without a parameter list overrides a method with a single empty one [quick fix available]
 class Q extends P { override def x: Int = 4 }
                                  ^
-nullary-override.scala:36: warning: [quick fix available] method without a parameter list overrides a method with a single empty one
+nullary-override.scala:36: warning: method without a parameter list overrides a method with a single empty one [quick fix available]
 class Mix12a extends T1 with T2 { override def x   = "12a" }
                                                ^
-nullary-override.scala:37: warning: [quick fix available] method with a single empty parameter list overrides method without any parameter list
+nullary-override.scala:37: warning: method with a single empty parameter list overrides method without any parameter list [quick fix available]
 class Mix12b extends T1 with T2 { override def x() = "12b" }
                                                ^
-nullary-override.scala:40: warning: [quick fix available] method with a single empty parameter list overrides method without any parameter list
+nullary-override.scala:40: warning: method with a single empty parameter list overrides method without any parameter list [quick fix available]
 class Mix21b extends T2 with T1 { override def x() = "21b" }
                                                ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/override-final-implicit.check
+++ b/test/files/neg/override-final-implicit.check
@@ -1,4 +1,4 @@
-override-final-implicit.scala:6: warning: [quick fix available] Implicit definition should have explicit type (inferred Test.this.FooExtender)
+override-final-implicit.scala:6: warning: Implicit definition should have explicit type (inferred Test.this.FooExtender) [quick fix available]
   override implicit def FooExtender(foo: String) = super.FooExtender(foo)
                         ^
 override-final-implicit.scala:6: error: cannot override final member:

--- a/test/files/neg/override-final-implicit.check
+++ b/test/files/neg/override-final-implicit.check
@@ -1,4 +1,4 @@
-override-final-implicit.scala:6: warning: Implicit definition should have explicit type (inferred Test.this.FooExtender) [quick fix available]
+override-final-implicit.scala:6: warning: Implicit definition should have explicit type (inferred Test.this.FooExtender) [quickfixable]
   override implicit def FooExtender(foo: String) = super.FooExtender(foo)
                         ^
 override-final-implicit.scala:6: error: cannot override final member:

--- a/test/files/neg/override-final-implicit.check
+++ b/test/files/neg/override-final-implicit.check
@@ -1,4 +1,4 @@
-override-final-implicit.scala:6: warning: Implicit definition should have explicit type (inferred Test.this.FooExtender)
+override-final-implicit.scala:6: warning: [quick fix available] Implicit definition should have explicit type (inferred Test.this.FooExtender)
   override implicit def FooExtender(foo: String) = super.FooExtender(foo)
                         ^
 override-final-implicit.scala:6: error: cannot override final member:

--- a/test/files/neg/parens-for-params.check
+++ b/test/files/neg/parens-for-params.check
@@ -1,5 +1,5 @@
 parens-for-params.scala:5: error: parentheses are required around the parameter of a lambda
-Use '-Wconf:msg=lambda-parens:s' to silence this warning. [quick fix available]
+Use '-Wconf:msg=lambda-parens:s' to silence this warning. [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
     x: Int => x * 2

--- a/test/files/neg/parens-for-params.check
+++ b/test/files/neg/parens-for-params.check
@@ -1,5 +1,5 @@
-parens-for-params.scala:5: error: [quick fix available] parentheses are required around the parameter of a lambda
-Use '-Wconf:msg=lambda-parens:s' to silence this warning.
+parens-for-params.scala:5: error: parentheses are required around the parameter of a lambda
+Use '-Wconf:msg=lambda-parens:s' to silence this warning. [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
     x: Int => x * 2

--- a/test/files/neg/prefix-unary-nilary-deprecation.check
+++ b/test/files/neg/prefix-unary-nilary-deprecation.check
@@ -1,12 +1,12 @@
-prefix-unary-nilary-deprecation.scala:4: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_~ : Foo = this` [quick fix available]
+prefix-unary-nilary-deprecation.scala:4: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_~ : Foo = this` [quickfixable]
   def unary_~() : Foo = this
       ^
-prefix-unary-nilary-deprecation.scala:5: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_-(implicit pos: Long) = this` [quick fix available]
+prefix-unary-nilary-deprecation.scala:5: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_-(implicit pos: Long) = this` [quickfixable]
   def unary_-()(implicit pos: Long) = this
       ^
 prefix-unary-nilary-deprecation.scala:12: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method unary_~,
 or remove the empty argument list from its definition (Java-defined methods are exempt).
-In Scala 3, an unapplied method like this will be eta-expanded into a function. [quick fix available]
+In Scala 3, an unapplied method like this will be eta-expanded into a function. [quickfixable]
   val f2 = ~f
            ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/prefix-unary-nilary-deprecation.check
+++ b/test/files/neg/prefix-unary-nilary-deprecation.check
@@ -1,12 +1,12 @@
-prefix-unary-nilary-deprecation.scala:4: warning: [quick fix available] unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_~ : Foo = this`
+prefix-unary-nilary-deprecation.scala:4: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_~ : Foo = this` [quick fix available]
   def unary_~() : Foo = this
       ^
-prefix-unary-nilary-deprecation.scala:5: warning: [quick fix available] unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_-(implicit pos: Long) = this`
+prefix-unary-nilary-deprecation.scala:5: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_-(implicit pos: Long) = this` [quick fix available]
   def unary_-()(implicit pos: Long) = this
       ^
-prefix-unary-nilary-deprecation.scala:12: warning: [quick fix available] Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method unary_~,
+prefix-unary-nilary-deprecation.scala:12: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method unary_~,
 or remove the empty argument list from its definition (Java-defined methods are exempt).
-In Scala 3, an unapplied method like this will be eta-expanded into a function.
+In Scala 3, an unapplied method like this will be eta-expanded into a function. [quick fix available]
   val f2 = ~f
            ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/prefix-unary-nilary-deprecation.check
+++ b/test/files/neg/prefix-unary-nilary-deprecation.check
@@ -1,7 +1,7 @@
-prefix-unary-nilary-deprecation.scala:4: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_~ : Foo = this`
+prefix-unary-nilary-deprecation.scala:4: warning: [quick fix available] unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_~ : Foo = this`
   def unary_~() : Foo = this
       ^
-prefix-unary-nilary-deprecation.scala:5: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_-(implicit pos: Long) = this`
+prefix-unary-nilary-deprecation.scala:5: warning: [quick fix available] unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_-(implicit pos: Long) = this`
   def unary_-()(implicit pos: Long) = this
       ^
 prefix-unary-nilary-deprecation.scala:12: warning: [quick fix available] Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method unary_~,

--- a/test/files/neg/prefix-unary-nilary-removal.check
+++ b/test/files/neg/prefix-unary-nilary-removal.check
@@ -1,7 +1,7 @@
-prefix-unary-nilary-removal.scala:4: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_~ : Foo = this`
+prefix-unary-nilary-removal.scala:4: warning: [quick fix available] unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_~ : Foo = this`
   def unary_~() : Foo = this
       ^
-prefix-unary-nilary-removal.scala:5: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_-(implicit pos: Long) = this`
+prefix-unary-nilary-removal.scala:5: warning: [quick fix available] unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_-(implicit pos: Long) = this`
   def unary_-()(implicit pos: Long) = this
       ^
 prefix-unary-nilary-removal.scala:12: warning: [quick fix available] Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method unary_~,

--- a/test/files/neg/prefix-unary-nilary-removal.check
+++ b/test/files/neg/prefix-unary-nilary-removal.check
@@ -1,12 +1,12 @@
-prefix-unary-nilary-removal.scala:4: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_~ : Foo = this` [quick fix available]
+prefix-unary-nilary-removal.scala:4: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_~ : Foo = this` [quickfixable]
   def unary_~() : Foo = this
       ^
-prefix-unary-nilary-removal.scala:5: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_-(implicit pos: Long) = this` [quick fix available]
+prefix-unary-nilary-removal.scala:5: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_-(implicit pos: Long) = this` [quickfixable]
   def unary_-()(implicit pos: Long) = this
       ^
 prefix-unary-nilary-removal.scala:12: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method unary_~,
 or remove the empty argument list from its definition (Java-defined methods are exempt).
-In Scala 3, an unapplied method like this will be eta-expanded into a function. [quick fix available]
+In Scala 3, an unapplied method like this will be eta-expanded into a function. [quickfixable]
   val f2 = ~f
            ^
 prefix-unary-nilary-removal.scala:5: warning: parameter pos in method unary_- is never used

--- a/test/files/neg/prefix-unary-nilary-removal.check
+++ b/test/files/neg/prefix-unary-nilary-removal.check
@@ -1,12 +1,12 @@
-prefix-unary-nilary-removal.scala:4: warning: [quick fix available] unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_~ : Foo = this`
+prefix-unary-nilary-removal.scala:4: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_~ : Foo = this` [quick fix available]
   def unary_~() : Foo = this
       ^
-prefix-unary-nilary-removal.scala:5: warning: [quick fix available] unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_-(implicit pos: Long) = this`
+prefix-unary-nilary-removal.scala:5: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_-(implicit pos: Long) = this` [quick fix available]
   def unary_-()(implicit pos: Long) = this
       ^
-prefix-unary-nilary-removal.scala:12: warning: [quick fix available] Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method unary_~,
+prefix-unary-nilary-removal.scala:12: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method unary_~,
 or remove the empty argument list from its definition (Java-defined methods are exempt).
-In Scala 3, an unapplied method like this will be eta-expanded into a function.
+In Scala 3, an unapplied method like this will be eta-expanded into a function. [quick fix available]
   val f2 = ~f
            ^
 prefix-unary-nilary-removal.scala:5: warning: parameter pos in method unary_- is never used

--- a/test/files/neg/private-implicit-class.check
+++ b/test/files/neg/private-implicit-class.check
@@ -1,7 +1,7 @@
 private-implicit-class.scala:6: error: method BarExtender in class ImplicitsPrivate cannot be accessed as a member of ImplicitsPrivate from class TestPrivate
   override implicit def BarExtender(bar: Int) = super.BarExtender(bar) // error
                                                       ^
-private-implicit-class.scala:6: warning: Implicit definition should have explicit type [quick fix available]
+private-implicit-class.scala:6: warning: Implicit definition should have explicit type [quickfixable]
   override implicit def BarExtender(bar: Int) = super.BarExtender(bar) // error
                         ^
 1 warning

--- a/test/files/neg/private-implicit-class.check
+++ b/test/files/neg/private-implicit-class.check
@@ -1,7 +1,7 @@
 private-implicit-class.scala:6: error: method BarExtender in class ImplicitsPrivate cannot be accessed as a member of ImplicitsPrivate from class TestPrivate
   override implicit def BarExtender(bar: Int) = super.BarExtender(bar) // error
                                                       ^
-private-implicit-class.scala:6: warning: [quick fix available] Implicit definition should have explicit type
+private-implicit-class.scala:6: warning: Implicit definition should have explicit type [quick fix available]
   override implicit def BarExtender(bar: Int) = super.BarExtender(bar) // error
                         ^
 1 warning

--- a/test/files/neg/private-implicit-class.check
+++ b/test/files/neg/private-implicit-class.check
@@ -1,7 +1,7 @@
 private-implicit-class.scala:6: error: method BarExtender in class ImplicitsPrivate cannot be accessed as a member of ImplicitsPrivate from class TestPrivate
   override implicit def BarExtender(bar: Int) = super.BarExtender(bar) // error
                                                       ^
-private-implicit-class.scala:6: warning: Implicit definition should have explicit type
+private-implicit-class.scala:6: warning: [quick fix available] Implicit definition should have explicit type
   override implicit def BarExtender(bar: Int) = super.BarExtender(bar) // error
                         ^
 1 warning

--- a/test/files/neg/procedure-deprecation.check
+++ b/test/files/neg/procedure-deprecation.check
@@ -1,16 +1,16 @@
-procedure-deprecation.scala:4: warning: [quick fix available] procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `bar`'s return type
+procedure-deprecation.scala:4: warning: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `bar`'s return type [quick fix available]
   def bar {}
           ^
-procedure-deprecation.scala:5: warning: [quick fix available] procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `baz`'s return type
+procedure-deprecation.scala:5: warning: procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `baz`'s return type [quick fix available]
   def baz
          ^
-procedure-deprecation.scala:6: warning: [quick fix available] procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `boo`'s return type
+procedure-deprecation.scala:6: warning: procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `boo`'s return type [quick fix available]
   def boo(i: Int, l: Long)
                           ^
-procedure-deprecation.scala:7: warning: [quick fix available] procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `boz`'s return type
+procedure-deprecation.scala:7: warning: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `boz`'s return type [quick fix available]
   def boz(i: Int, l: Long) {}
                            ^
-procedure-deprecation.scala:8: warning: [quick fix available] procedure syntax is deprecated for constructors: add `=`, as in method definition
+procedure-deprecation.scala:8: warning: procedure syntax is deprecated for constructors: add `=`, as in method definition [quick fix available]
   def this(i: Int) { this() } // Don't complain here! or maybe do complain
                   ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/procedure-deprecation.check
+++ b/test/files/neg/procedure-deprecation.check
@@ -1,16 +1,16 @@
-procedure-deprecation.scala:4: warning: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `bar`'s return type [quick fix available]
+procedure-deprecation.scala:4: warning: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `bar`'s return type [quickfixable]
   def bar {}
           ^
-procedure-deprecation.scala:5: warning: procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `baz`'s return type [quick fix available]
+procedure-deprecation.scala:5: warning: procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `baz`'s return type [quickfixable]
   def baz
          ^
-procedure-deprecation.scala:6: warning: procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `boo`'s return type [quick fix available]
+procedure-deprecation.scala:6: warning: procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `boo`'s return type [quickfixable]
   def boo(i: Int, l: Long)
                           ^
-procedure-deprecation.scala:7: warning: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `boz`'s return type [quick fix available]
+procedure-deprecation.scala:7: warning: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `boz`'s return type [quickfixable]
   def boz(i: Int, l: Long) {}
                            ^
-procedure-deprecation.scala:8: warning: procedure syntax is deprecated for constructors: add `=`, as in method definition [quick fix available]
+procedure-deprecation.scala:8: warning: procedure syntax is deprecated for constructors: add `=`, as in method definition [quickfixable]
   def this(i: Int) { this() } // Don't complain here! or maybe do complain
                   ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/procedure-deprecation.check
+++ b/test/files/neg/procedure-deprecation.check
@@ -10,7 +10,7 @@ procedure-deprecation.scala:6: warning: [quick fix available] procedure syntax i
 procedure-deprecation.scala:7: warning: [quick fix available] procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `boz`'s return type
   def boz(i: Int, l: Long) {}
                            ^
-procedure-deprecation.scala:8: warning: procedure syntax is deprecated for constructors: add `=`, as in method definition
+procedure-deprecation.scala:8: warning: [quick fix available] procedure syntax is deprecated for constructors: add `=`, as in method definition
   def this(i: Int) { this() } // Don't complain here! or maybe do complain
                   ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/procedure-removal.check
+++ b/test/files/neg/procedure-removal.check
@@ -1,25 +1,25 @@
-procedure-removal.scala:4: warning: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `bar`'s return type [quick fix available]
+procedure-removal.scala:4: warning: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `bar`'s return type [quickfixable]
   def bar {}
           ^
-procedure-removal.scala:5: warning: procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `baz`'s return type [quick fix available]
+procedure-removal.scala:5: warning: procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `baz`'s return type [quickfixable]
   def baz
          ^
-procedure-removal.scala:6: warning: procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `boo`'s return type [quick fix available]
+procedure-removal.scala:6: warning: procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `boo`'s return type [quickfixable]
   def boo(i: Int, l: Long)
                           ^
-procedure-removal.scala:7: warning: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `boz`'s return type [quick fix available]
+procedure-removal.scala:7: warning: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `boz`'s return type [quickfixable]
   def boz(i: Int, l: Long) {}
                            ^
-procedure-removal.scala:8: warning: procedure syntax is deprecated for constructors: add `=`, as in method definition [quick fix available]
+procedure-removal.scala:8: warning: procedure syntax is deprecated for constructors: add `=`, as in method definition [quickfixable]
   def this(i: Int) { this() } // Don't complain here! Just slap them with an error.
                   ^
-procedure-removal.scala:4: warning: side-effecting nullary methods are discouraged: suggest defining as `def bar()` instead [quick fix available]
+procedure-removal.scala:4: warning: side-effecting nullary methods are discouraged: suggest defining as `def bar()` instead [quickfixable]
   def bar {}
       ^
-procedure-removal.scala:5: warning: side-effecting nullary methods are discouraged: suggest defining as `def baz()` instead [quick fix available]
+procedure-removal.scala:5: warning: side-effecting nullary methods are discouraged: suggest defining as `def baz()` instead [quickfixable]
   def baz
       ^
-procedure-removal.scala:9: warning: side-effecting nullary methods are discouraged: suggest defining as `def foz()` instead [quick fix available]
+procedure-removal.scala:9: warning: side-effecting nullary methods are discouraged: suggest defining as `def foz()` instead [quickfixable]
   def foz: Unit               // Don't complain here!
       ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/procedure-removal.check
+++ b/test/files/neg/procedure-removal.check
@@ -10,16 +10,16 @@ procedure-removal.scala:6: warning: [quick fix available] procedure syntax is de
 procedure-removal.scala:7: warning: [quick fix available] procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `boz`'s return type
   def boz(i: Int, l: Long) {}
                            ^
-procedure-removal.scala:8: warning: procedure syntax is deprecated for constructors: add `=`, as in method definition
+procedure-removal.scala:8: warning: [quick fix available] procedure syntax is deprecated for constructors: add `=`, as in method definition
   def this(i: Int) { this() } // Don't complain here! Just slap them with an error.
                   ^
-procedure-removal.scala:4: warning: side-effecting nullary methods are discouraged: suggest defining as `def bar()` instead
+procedure-removal.scala:4: warning: [quick fix available] side-effecting nullary methods are discouraged: suggest defining as `def bar()` instead
   def bar {}
       ^
-procedure-removal.scala:5: warning: side-effecting nullary methods are discouraged: suggest defining as `def baz()` instead
+procedure-removal.scala:5: warning: [quick fix available] side-effecting nullary methods are discouraged: suggest defining as `def baz()` instead
   def baz
       ^
-procedure-removal.scala:9: warning: side-effecting nullary methods are discouraged: suggest defining as `def foz()` instead
+procedure-removal.scala:9: warning: [quick fix available] side-effecting nullary methods are discouraged: suggest defining as `def foz()` instead
   def foz: Unit               // Don't complain here!
       ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/procedure-removal.check
+++ b/test/files/neg/procedure-removal.check
@@ -1,25 +1,25 @@
-procedure-removal.scala:4: warning: [quick fix available] procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `bar`'s return type
+procedure-removal.scala:4: warning: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `bar`'s return type [quick fix available]
   def bar {}
           ^
-procedure-removal.scala:5: warning: [quick fix available] procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `baz`'s return type
+procedure-removal.scala:5: warning: procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `baz`'s return type [quick fix available]
   def baz
          ^
-procedure-removal.scala:6: warning: [quick fix available] procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `boo`'s return type
+procedure-removal.scala:6: warning: procedure syntax is deprecated: instead, add `: Unit` to explicitly declare `boo`'s return type [quick fix available]
   def boo(i: Int, l: Long)
                           ^
-procedure-removal.scala:7: warning: [quick fix available] procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `boz`'s return type
+procedure-removal.scala:7: warning: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `boz`'s return type [quick fix available]
   def boz(i: Int, l: Long) {}
                            ^
-procedure-removal.scala:8: warning: [quick fix available] procedure syntax is deprecated for constructors: add `=`, as in method definition
+procedure-removal.scala:8: warning: procedure syntax is deprecated for constructors: add `=`, as in method definition [quick fix available]
   def this(i: Int) { this() } // Don't complain here! Just slap them with an error.
                   ^
-procedure-removal.scala:4: warning: [quick fix available] side-effecting nullary methods are discouraged: suggest defining as `def bar()` instead
+procedure-removal.scala:4: warning: side-effecting nullary methods are discouraged: suggest defining as `def bar()` instead [quick fix available]
   def bar {}
       ^
-procedure-removal.scala:5: warning: [quick fix available] side-effecting nullary methods are discouraged: suggest defining as `def baz()` instead
+procedure-removal.scala:5: warning: side-effecting nullary methods are discouraged: suggest defining as `def baz()` instead [quick fix available]
   def baz
       ^
-procedure-removal.scala:9: warning: [quick fix available] side-effecting nullary methods are discouraged: suggest defining as `def foz()` instead
+procedure-removal.scala:9: warning: side-effecting nullary methods are discouraged: suggest defining as `def foz()` instead [quick fix available]
   def foz: Unit               // Don't complain here!
       ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/qmark-deprecated.check
+++ b/test/files/neg/qmark-deprecated.check
@@ -1,25 +1,25 @@
-qmark-deprecated.scala:4: error: [quick fix available] using `?` as a type name requires backticks.
+qmark-deprecated.scala:4: error: using `?` as a type name requires backticks. [quick fix available]
 class Foo[?] // error
           ^
-qmark-deprecated.scala:6: error: [quick fix available] using `?` as a type name requires backticks.
+qmark-deprecated.scala:6: error: using `?` as a type name requires backticks. [quick fix available]
 class Bar[M[?] <: List[?]] // error on the definition
             ^
-qmark-deprecated.scala:10: error: [quick fix available] using `?` as a type name requires backticks.
+qmark-deprecated.scala:10: error: using `?` as a type name requires backticks. [quick fix available]
   class ? { val x = 1 } // error
         ^
-qmark-deprecated.scala:16: error: [quick fix available] using `?` as a type name requires backticks.
+qmark-deprecated.scala:16: error: using `?` as a type name requires backticks. [quick fix available]
   trait ? // error
         ^
-qmark-deprecated.scala:22: error: [quick fix available] using `?` as a type name requires backticks.
+qmark-deprecated.scala:22: error: using `?` as a type name requires backticks. [quick fix available]
   type ? = Int // error
        ^
-qmark-deprecated.scala:33: error: [quick fix available] using `?` as a type name requires backticks.
+qmark-deprecated.scala:33: error: using `?` as a type name requires backticks. [quick fix available]
   def bar1[?] = {} // error
            ^
-qmark-deprecated.scala:35: error: [quick fix available] using `?` as a type name requires backticks.
+qmark-deprecated.scala:35: error: using `?` as a type name requires backticks. [quick fix available]
   def bar3[M[?]] = {} // error
              ^
-qmark-deprecated.scala:38: error: [quick fix available] using `?` as a type name requires backticks.
+qmark-deprecated.scala:38: error: using `?` as a type name requires backticks. [quick fix available]
   type A[?] = Int // error
          ^
 8 errors

--- a/test/files/neg/qmark-deprecated.check
+++ b/test/files/neg/qmark-deprecated.check
@@ -1,25 +1,25 @@
-qmark-deprecated.scala:4: error: using `?` as a type name requires backticks. [quick fix available]
+qmark-deprecated.scala:4: error: using `?` as a type name requires backticks. [quickfixable]
 class Foo[?] // error
           ^
-qmark-deprecated.scala:6: error: using `?` as a type name requires backticks. [quick fix available]
+qmark-deprecated.scala:6: error: using `?` as a type name requires backticks. [quickfixable]
 class Bar[M[?] <: List[?]] // error on the definition
             ^
-qmark-deprecated.scala:10: error: using `?` as a type name requires backticks. [quick fix available]
+qmark-deprecated.scala:10: error: using `?` as a type name requires backticks. [quickfixable]
   class ? { val x = 1 } // error
         ^
-qmark-deprecated.scala:16: error: using `?` as a type name requires backticks. [quick fix available]
+qmark-deprecated.scala:16: error: using `?` as a type name requires backticks. [quickfixable]
   trait ? // error
         ^
-qmark-deprecated.scala:22: error: using `?` as a type name requires backticks. [quick fix available]
+qmark-deprecated.scala:22: error: using `?` as a type name requires backticks. [quickfixable]
   type ? = Int // error
        ^
-qmark-deprecated.scala:33: error: using `?` as a type name requires backticks. [quick fix available]
+qmark-deprecated.scala:33: error: using `?` as a type name requires backticks. [quickfixable]
   def bar1[?] = {} // error
            ^
-qmark-deprecated.scala:35: error: using `?` as a type name requires backticks. [quick fix available]
+qmark-deprecated.scala:35: error: using `?` as a type name requires backticks. [quickfixable]
   def bar3[M[?]] = {} // error
              ^
-qmark-deprecated.scala:38: error: using `?` as a type name requires backticks. [quick fix available]
+qmark-deprecated.scala:38: error: using `?` as a type name requires backticks. [quickfixable]
   type A[?] = Int // error
          ^
 8 errors

--- a/test/files/neg/qmark-deprecated.check
+++ b/test/files/neg/qmark-deprecated.check
@@ -1,25 +1,25 @@
-qmark-deprecated.scala:4: error: using `?` as a type name requires backticks.
+qmark-deprecated.scala:4: error: [quick fix available] using `?` as a type name requires backticks.
 class Foo[?] // error
           ^
-qmark-deprecated.scala:6: error: using `?` as a type name requires backticks.
+qmark-deprecated.scala:6: error: [quick fix available] using `?` as a type name requires backticks.
 class Bar[M[?] <: List[?]] // error on the definition
             ^
-qmark-deprecated.scala:10: error: using `?` as a type name requires backticks.
+qmark-deprecated.scala:10: error: [quick fix available] using `?` as a type name requires backticks.
   class ? { val x = 1 } // error
         ^
-qmark-deprecated.scala:16: error: using `?` as a type name requires backticks.
+qmark-deprecated.scala:16: error: [quick fix available] using `?` as a type name requires backticks.
   trait ? // error
         ^
-qmark-deprecated.scala:22: error: using `?` as a type name requires backticks.
+qmark-deprecated.scala:22: error: [quick fix available] using `?` as a type name requires backticks.
   type ? = Int // error
        ^
-qmark-deprecated.scala:33: error: using `?` as a type name requires backticks.
+qmark-deprecated.scala:33: error: [quick fix available] using `?` as a type name requires backticks.
   def bar1[?] = {} // error
            ^
-qmark-deprecated.scala:35: error: using `?` as a type name requires backticks.
+qmark-deprecated.scala:35: error: [quick fix available] using `?` as a type name requires backticks.
   def bar3[M[?]] = {} // error
              ^
-qmark-deprecated.scala:38: error: using `?` as a type name requires backticks.
+qmark-deprecated.scala:38: error: [quick fix available] using `?` as a type name requires backticks.
   type A[?] = Int // error
          ^
 8 errors

--- a/test/files/neg/quickfix-silent.check
+++ b/test/files/neg/quickfix-silent.check
@@ -1,0 +1,11 @@
+quickfix-silent.scala:4: warning: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `f`'s return type
+  def f { println }
+        ^
+quickfix-silent.scala:4: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method println,
+or remove the empty argument list from its definition (Java-defined methods are exempt).
+In Scala 3, an unapplied method like this will be eta-expanded into a function.
+  def f { println }
+          ^
+error: No warnings can be incurred under -Werror.
+2 warnings
+1 error

--- a/test/files/neg/quickfix-silent.scala
+++ b/test/files/neg/quickfix-silent.scala
@@ -1,0 +1,5 @@
+// scalac: -deprecation -Werror -quickfix:silent
+
+class C {
+  def f { println }
+}

--- a/test/files/neg/scala3-keywords.check
+++ b/test/files/neg/scala3-keywords.check
@@ -1,19 +1,19 @@
-scala3-keywords.scala:15: warning: Wrap `enum` in backticks to use it as an identifier, it will become a keyword in Scala 3.
+scala3-keywords.scala:15: warning: [quick fix available] Wrap `enum` in backticks to use it as an identifier, it will become a keyword in Scala 3.
   val enum: Int = 1 // error
       ^
-scala3-keywords.scala:16: warning: Wrap `export` in backticks to use it as an identifier, it will become a keyword in Scala 3.
+scala3-keywords.scala:16: warning: [quick fix available] Wrap `export` in backticks to use it as an identifier, it will become a keyword in Scala 3.
   val export: Int = 1 // error
       ^
-scala3-keywords.scala:17: warning: Wrap `given` in backticks to use it as an identifier, it will become a keyword in Scala 3.
+scala3-keywords.scala:17: warning: [quick fix available] Wrap `given` in backticks to use it as an identifier, it will become a keyword in Scala 3.
   val given: Int = 1 // error
       ^
-scala3-keywords.scala:18: warning: Wrap `given` in backticks to use it as an identifier, it will become a keyword in Scala 3.
+scala3-keywords.scala:18: warning: [quick fix available] Wrap `given` in backticks to use it as an identifier, it will become a keyword in Scala 3.
   def foo(given: Int) = {} // error
           ^
-scala3-keywords.scala:19: warning: Wrap `export` in backticks to use it as an identifier, it will become a keyword in Scala 3.
+scala3-keywords.scala:19: warning: [quick fix available] Wrap `export` in backticks to use it as an identifier, it will become a keyword in Scala 3.
   def bla[export <: Int] = {} // error
           ^
-scala3-keywords.scala:21: warning: Wrap `enum` in backticks to use it as an identifier, it will become a keyword in Scala 3.
+scala3-keywords.scala:21: warning: [quick fix available] Wrap `enum` in backticks to use it as an identifier, it will become a keyword in Scala 3.
 class enum // error
       ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/scala3-keywords.check
+++ b/test/files/neg/scala3-keywords.check
@@ -1,19 +1,19 @@
-scala3-keywords.scala:15: warning: [quick fix available] Wrap `enum` in backticks to use it as an identifier, it will become a keyword in Scala 3.
+scala3-keywords.scala:15: warning: Wrap `enum` in backticks to use it as an identifier, it will become a keyword in Scala 3. [quick fix available]
   val enum: Int = 1 // error
       ^
-scala3-keywords.scala:16: warning: [quick fix available] Wrap `export` in backticks to use it as an identifier, it will become a keyword in Scala 3.
+scala3-keywords.scala:16: warning: Wrap `export` in backticks to use it as an identifier, it will become a keyword in Scala 3. [quick fix available]
   val export: Int = 1 // error
       ^
-scala3-keywords.scala:17: warning: [quick fix available] Wrap `given` in backticks to use it as an identifier, it will become a keyword in Scala 3.
+scala3-keywords.scala:17: warning: Wrap `given` in backticks to use it as an identifier, it will become a keyword in Scala 3. [quick fix available]
   val given: Int = 1 // error
       ^
-scala3-keywords.scala:18: warning: [quick fix available] Wrap `given` in backticks to use it as an identifier, it will become a keyword in Scala 3.
+scala3-keywords.scala:18: warning: Wrap `given` in backticks to use it as an identifier, it will become a keyword in Scala 3. [quick fix available]
   def foo(given: Int) = {} // error
           ^
-scala3-keywords.scala:19: warning: [quick fix available] Wrap `export` in backticks to use it as an identifier, it will become a keyword in Scala 3.
+scala3-keywords.scala:19: warning: Wrap `export` in backticks to use it as an identifier, it will become a keyword in Scala 3. [quick fix available]
   def bla[export <: Int] = {} // error
           ^
-scala3-keywords.scala:21: warning: [quick fix available] Wrap `enum` in backticks to use it as an identifier, it will become a keyword in Scala 3.
+scala3-keywords.scala:21: warning: Wrap `enum` in backticks to use it as an identifier, it will become a keyword in Scala 3. [quick fix available]
 class enum // error
       ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/scala3-keywords.check
+++ b/test/files/neg/scala3-keywords.check
@@ -1,19 +1,19 @@
-scala3-keywords.scala:15: warning: Wrap `enum` in backticks to use it as an identifier, it will become a keyword in Scala 3. [quick fix available]
+scala3-keywords.scala:15: warning: Wrap `enum` in backticks to use it as an identifier, it will become a keyword in Scala 3. [quickfixable]
   val enum: Int = 1 // error
       ^
-scala3-keywords.scala:16: warning: Wrap `export` in backticks to use it as an identifier, it will become a keyword in Scala 3. [quick fix available]
+scala3-keywords.scala:16: warning: Wrap `export` in backticks to use it as an identifier, it will become a keyword in Scala 3. [quickfixable]
   val export: Int = 1 // error
       ^
-scala3-keywords.scala:17: warning: Wrap `given` in backticks to use it as an identifier, it will become a keyword in Scala 3. [quick fix available]
+scala3-keywords.scala:17: warning: Wrap `given` in backticks to use it as an identifier, it will become a keyword in Scala 3. [quickfixable]
   val given: Int = 1 // error
       ^
-scala3-keywords.scala:18: warning: Wrap `given` in backticks to use it as an identifier, it will become a keyword in Scala 3. [quick fix available]
+scala3-keywords.scala:18: warning: Wrap `given` in backticks to use it as an identifier, it will become a keyword in Scala 3. [quickfixable]
   def foo(given: Int) = {} // error
           ^
-scala3-keywords.scala:19: warning: Wrap `export` in backticks to use it as an identifier, it will become a keyword in Scala 3. [quick fix available]
+scala3-keywords.scala:19: warning: Wrap `export` in backticks to use it as an identifier, it will become a keyword in Scala 3. [quickfixable]
   def bla[export <: Int] = {} // error
           ^
-scala3-keywords.scala:21: warning: Wrap `enum` in backticks to use it as an identifier, it will become a keyword in Scala 3. [quick fix available]
+scala3-keywords.scala:21: warning: Wrap `enum` in backticks to use it as an identifier, it will become a keyword in Scala 3. [quickfixable]
 class enum // error
       ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/sip23-no-unit-type.check
+++ b/test/files/neg/sip23-no-unit-type.check
@@ -1,16 +1,16 @@
-sip23-no-unit-type.scala:6: error: Illegal literal type (), use Unit instead
+sip23-no-unit-type.scala:6: error: [quick fix available] Illegal literal type (), use Unit instead
     case _: ()      => "err"
             ^
-sip23-no-unit-type.scala:7: error: Illegal literal type (), use Unit instead
+sip23-no-unit-type.scala:7: error: [quick fix available] Illegal literal type (), use Unit instead
     case _: ().type => "err"
             ^
 sip23-no-unit-type.scala:7: error: '=>' expected but '.' found.
     case _: ().type => "err"
               ^
-sip23-no-unit-type.scala:10: error: Illegal literal type (), use Unit instead
+sip23-no-unit-type.scala:10: error: [quick fix available] Illegal literal type (), use Unit instead
   val younit: () = ()
               ^
-sip23-no-unit-type.scala:11: error: Illegal literal type (), use Unit instead
+sip23-no-unit-type.scala:11: error: [quick fix available] Illegal literal type (), use Unit instead
   val unit: ().type = ()
             ^
 sip23-no-unit-type.scala:11: error: '=' expected but '.' found.

--- a/test/files/neg/sip23-no-unit-type.check
+++ b/test/files/neg/sip23-no-unit-type.check
@@ -1,16 +1,16 @@
-sip23-no-unit-type.scala:6: error: Illegal literal type (), use Unit instead [quick fix available]
+sip23-no-unit-type.scala:6: error: Illegal literal type (), use Unit instead [quickfixable]
     case _: ()      => "err"
             ^
-sip23-no-unit-type.scala:7: error: Illegal literal type (), use Unit instead [quick fix available]
+sip23-no-unit-type.scala:7: error: Illegal literal type (), use Unit instead [quickfixable]
     case _: ().type => "err"
             ^
 sip23-no-unit-type.scala:7: error: '=>' expected but '.' found.
     case _: ().type => "err"
               ^
-sip23-no-unit-type.scala:10: error: Illegal literal type (), use Unit instead [quick fix available]
+sip23-no-unit-type.scala:10: error: Illegal literal type (), use Unit instead [quickfixable]
   val younit: () = ()
               ^
-sip23-no-unit-type.scala:11: error: Illegal literal type (), use Unit instead [quick fix available]
+sip23-no-unit-type.scala:11: error: Illegal literal type (), use Unit instead [quickfixable]
   val unit: ().type = ()
             ^
 sip23-no-unit-type.scala:11: error: '=' expected but '.' found.

--- a/test/files/neg/sip23-no-unit-type.check
+++ b/test/files/neg/sip23-no-unit-type.check
@@ -1,16 +1,16 @@
-sip23-no-unit-type.scala:6: error: [quick fix available] Illegal literal type (), use Unit instead
+sip23-no-unit-type.scala:6: error: Illegal literal type (), use Unit instead [quick fix available]
     case _: ()      => "err"
             ^
-sip23-no-unit-type.scala:7: error: [quick fix available] Illegal literal type (), use Unit instead
+sip23-no-unit-type.scala:7: error: Illegal literal type (), use Unit instead [quick fix available]
     case _: ().type => "err"
             ^
 sip23-no-unit-type.scala:7: error: '=>' expected but '.' found.
     case _: ().type => "err"
               ^
-sip23-no-unit-type.scala:10: error: [quick fix available] Illegal literal type (), use Unit instead
+sip23-no-unit-type.scala:10: error: Illegal literal type (), use Unit instead [quick fix available]
   val younit: () = ()
               ^
-sip23-no-unit-type.scala:11: error: [quick fix available] Illegal literal type (), use Unit instead
+sip23-no-unit-type.scala:11: error: Illegal literal type (), use Unit instead [quick fix available]
   val unit: ().type = ()
             ^
 sip23-no-unit-type.scala:11: error: '=' expected but '.' found.

--- a/test/files/neg/symbol-literal-deprecation.check
+++ b/test/files/neg/symbol-literal-deprecation.check
@@ -1,4 +1,4 @@
-symbol-literal-deprecation.scala:4: warning: symbol literal is deprecated; use Symbol("TestSymbol") instead
+symbol-literal-deprecation.scala:4: warning: [quick fix available] symbol literal is deprecated; use Symbol("TestSymbol") instead
   val foo = 'TestSymbol
             ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/symbol-literal-deprecation.check
+++ b/test/files/neg/symbol-literal-deprecation.check
@@ -1,4 +1,4 @@
-symbol-literal-deprecation.scala:4: warning: symbol literal is deprecated; use Symbol("TestSymbol") instead [quick fix available]
+symbol-literal-deprecation.scala:4: warning: symbol literal is deprecated; use Symbol("TestSymbol") instead [quickfixable]
   val foo = 'TestSymbol
             ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/symbol-literal-deprecation.check
+++ b/test/files/neg/symbol-literal-deprecation.check
@@ -1,4 +1,4 @@
-symbol-literal-deprecation.scala:4: warning: [quick fix available] symbol literal is deprecated; use Symbol("TestSymbol") instead
+symbol-literal-deprecation.scala:4: warning: symbol literal is deprecated; use Symbol("TestSymbol") instead [quick fix available]
   val foo = 'TestSymbol
             ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t10678.check
+++ b/test/files/neg/t10678.check
@@ -4,7 +4,7 @@ class C <: T {
 t10678.scala:11: error: ';' expected but '<:' found.
 object O <: T {
          ^
-t10678.scala:6: warning: Using `<:` for `extends` is deprecated [quick fix available]
+t10678.scala:6: warning: Using `<:` for `extends` is deprecated [quickfixable]
 trait U <: T
         ^
 1 warning

--- a/test/files/neg/t10678.check
+++ b/test/files/neg/t10678.check
@@ -4,7 +4,7 @@ class C <: T {
 t10678.scala:11: error: ';' expected but '<:' found.
 object O <: T {
          ^
-t10678.scala:6: warning: [quick fix available] Using `<:` for `extends` is deprecated
+t10678.scala:6: warning: Using `<:` for `extends` is deprecated [quick fix available]
 trait U <: T
         ^
 1 warning

--- a/test/files/neg/t10678.check
+++ b/test/files/neg/t10678.check
@@ -4,7 +4,7 @@ class C <: T {
 t10678.scala:11: error: ';' expected but '<:' found.
 object O <: T {
          ^
-t10678.scala:6: warning: Using `<:` for `extends` is deprecated
+t10678.scala:6: warning: [quick fix available] Using `<:` for `extends` is deprecated
 trait U <: T
         ^
 1 warning

--- a/test/files/neg/t11921-alias.check
+++ b/test/files/neg/t11921-alias.check
@@ -1,35 +1,35 @@
-t11921-alias.scala:18: error: [quick fix available] reference to TT is ambiguous;
+t11921-alias.scala:18: error: reference to TT is ambiguous;
 it is both defined in the enclosing object O and inherited in the enclosing class D as type TT (defined in class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.TT`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=t2.O.D.n.x
       def n(x: TT) = x // ambiguous
                ^
-t11921-alias.scala:38: error: [quick fix available] reference to c is ambiguous;
+t11921-alias.scala:38: error: reference to c is ambiguous;
 it is both defined in the enclosing class B and inherited in the enclosing anonymous class as value c (defined in class A)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.c`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=t4.B.a
       def n = c // ambiguous
               ^
-t11921-alias.scala:57: error: [quick fix available] reference to name is ambiguous;
+t11921-alias.scala:57: error: reference to name is ambiguous;
 it is both defined in the enclosing method m and inherited in the enclosing anonymous class as value name (defined in class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.name`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=t6.Test.m
       println(name)
               ^
-t11921-alias.scala:67: error: [quick fix available] reference to name is ambiguous;
+t11921-alias.scala:67: error: reference to name is ambiguous;
 it is both defined in the enclosing method m and inherited in the enclosing anonymous class as value name (defined in class A, inherited through parent class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.name`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=t7.Test.m
       println(name)

--- a/test/files/neg/t11921-alias.check
+++ b/test/files/neg/t11921-alias.check
@@ -2,7 +2,7 @@ t11921-alias.scala:18: error: reference to TT is ambiguous;
 it is both defined in the enclosing object O and inherited in the enclosing class D as type TT (defined in class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.TT`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=t2.O.D.n.x
       def n(x: TT) = x // ambiguous
@@ -11,7 +11,7 @@ t11921-alias.scala:38: error: reference to c is ambiguous;
 it is both defined in the enclosing class B and inherited in the enclosing anonymous class as value c (defined in class A)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.c`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=t4.B.a
       def n = c // ambiguous
@@ -20,7 +20,7 @@ t11921-alias.scala:57: error: reference to name is ambiguous;
 it is both defined in the enclosing method m and inherited in the enclosing anonymous class as value name (defined in class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.name`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=t6.Test.m
       println(name)
@@ -29,7 +29,7 @@ t11921-alias.scala:67: error: reference to name is ambiguous;
 it is both defined in the enclosing method m and inherited in the enclosing anonymous class as value name (defined in class A, inherited through parent class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.name`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=t7.Test.m
       println(name)

--- a/test/files/neg/t11921.check
+++ b/test/files/neg/t11921.check
@@ -7,7 +7,7 @@ t11921.scala:6: error: reference to coll is ambiguous;
 it is both defined in the enclosing method lazyMap and inherited in the enclosing anonymous class as method coll (defined in trait Iterable)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.coll`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=C.lazyMap
       def iterator = coll.iterator.map(f)    // coll is ambiguous

--- a/test/files/neg/t11921.check
+++ b/test/files/neg/t11921.check
@@ -3,11 +3,11 @@ t11921.scala:6: error: type mismatch;
  required: B => B
       def iterator = coll.iterator.map(f)    // coll is ambiguous
                                        ^
-t11921.scala:6: error: [quick fix available] reference to coll is ambiguous;
+t11921.scala:6: error: reference to coll is ambiguous;
 it is both defined in the enclosing method lazyMap and inherited in the enclosing anonymous class as method coll (defined in trait Iterable)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.coll`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=C.lazyMap
       def iterator = coll.iterator.map(f)    // coll is ambiguous

--- a/test/files/neg/t11921b.check
+++ b/test/files/neg/t11921b.check
@@ -1,74 +1,74 @@
 t11921b.scala:135: error: could not find implicit value for parameter i: Int
     def u = t // doesn't compile in Scala 2 (maybe there's a ticket for that)
             ^
-t11921b.scala:11: error: [quick fix available] reference to x is ambiguous;
+t11921b.scala:11: error: reference to x is ambiguous;
 it is both defined in the enclosing object Test and inherited in the enclosing class D as value x (defined in class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.x`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test1.Test.D
       println(x)  // error
               ^
-t11921b.scala:15: error: [quick fix available] reference to x is ambiguous;
+t11921b.scala:15: error: reference to x is ambiguous;
 it is both defined in the enclosing object Test and inherited in the enclosing anonymous class as value x (defined in class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.x`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test1.Test.f
         println(x)  // error
                 ^
-t11921b.scala:26: error: [quick fix available] reference to y is ambiguous;
+t11921b.scala:26: error: reference to y is ambiguous;
 it is both defined in the enclosing method c and inherited in the enclosing anonymous class as value y (defined in class D)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.y`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test2.c
       println(y)  // error
               ^
-t11921b.scala:38: error: [quick fix available] reference to y is ambiguous;
+t11921b.scala:38: error: reference to y is ambiguous;
 it is both defined in the enclosing method c and inherited in the enclosing class E as value y (defined in class D)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `E.this.y`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test3.c.E.F
         println(y)  // error
                 ^
-t11921b.scala:65: error: [quick fix available] reference to global is ambiguous;
+t11921b.scala:65: error: reference to global is ambiguous;
 it is both defined in the enclosing package <empty> and inherited in the enclosing object D as value global (defined in class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.global`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=D
   println(global)    // error
           ^
-t11921b.scala:75: error: [quick fix available] reference to x is ambiguous;
+t11921b.scala:75: error: reference to x is ambiguous;
 it is both defined in the enclosing object Uhu and inherited in the enclosing class C as value x (defined in class A, inherited through parent class B)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `C.this.x`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test5.Uhu.C.Inner.t
         def t = x // ambiguous, message mentions parent B
                 ^
-t11921b.scala:89: error: [quick fix available] reference to a is ambiguous;
+t11921b.scala:89: error: reference to a is ambiguous;
 it is both defined in the enclosing class C and inherited in the enclosing trait J as method a (defined in trait I)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.a`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test6.C.J.t
       val t = a // error
               ^
-t11921b.scala:136: error: [quick fix available] reference to lo is ambiguous;
+t11921b.scala:136: error: reference to lo is ambiguous;
 it is both defined in the enclosing object test10 and inherited in the enclosing class C as value lo (defined in class P)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.lo`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test10.C.v
     def v = t(lo) // error

--- a/test/files/neg/t11921b.check
+++ b/test/files/neg/t11921b.check
@@ -5,7 +5,7 @@ t11921b.scala:11: error: reference to x is ambiguous;
 it is both defined in the enclosing object Test and inherited in the enclosing class D as value x (defined in class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.x`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test1.Test.D
       println(x)  // error
@@ -14,7 +14,7 @@ t11921b.scala:15: error: reference to x is ambiguous;
 it is both defined in the enclosing object Test and inherited in the enclosing anonymous class as value x (defined in class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.x`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test1.Test.f
         println(x)  // error
@@ -23,7 +23,7 @@ t11921b.scala:26: error: reference to y is ambiguous;
 it is both defined in the enclosing method c and inherited in the enclosing anonymous class as value y (defined in class D)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.y`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test2.c
       println(y)  // error
@@ -32,7 +32,7 @@ t11921b.scala:38: error: reference to y is ambiguous;
 it is both defined in the enclosing method c and inherited in the enclosing class E as value y (defined in class D)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `E.this.y`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test3.c.E.F
         println(y)  // error
@@ -41,7 +41,7 @@ t11921b.scala:65: error: reference to global is ambiguous;
 it is both defined in the enclosing package <empty> and inherited in the enclosing object D as value global (defined in class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.global`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=D
   println(global)    // error
@@ -50,7 +50,7 @@ t11921b.scala:75: error: reference to x is ambiguous;
 it is both defined in the enclosing object Uhu and inherited in the enclosing class C as value x (defined in class A, inherited through parent class B)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `C.this.x`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test5.Uhu.C.Inner.t
         def t = x // ambiguous, message mentions parent B
@@ -59,7 +59,7 @@ t11921b.scala:89: error: reference to a is ambiguous;
 it is both defined in the enclosing class C and inherited in the enclosing trait J as method a (defined in trait I)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.a`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test6.C.J.t
       val t = a // error
@@ -68,7 +68,7 @@ t11921b.scala:136: error: reference to lo is ambiguous;
 it is both defined in the enclosing object test10 and inherited in the enclosing class C as value lo (defined in class P)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.lo`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test10.C.v
     def v = t(lo) // error

--- a/test/files/neg/t11962.check
+++ b/test/files/neg/t11962.check
@@ -1,7 +1,7 @@
-t11962.scala:3: warning: side-effecting nullary methods are discouraged: suggest defining as `def f()` instead [quick fix available]
+t11962.scala:3: warning: side-effecting nullary methods are discouraged: suggest defining as `def f()` instead [quickfixable]
   def f = println()
       ^
-t11962.scala:7: warning: side-effecting nullary methods are discouraged: suggest defining as `def f()` instead [quick fix available]
+t11962.scala:7: warning: side-effecting nullary methods are discouraged: suggest defining as `def f()` instead [quickfixable]
   override def f = super.f
                ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t11962.check
+++ b/test/files/neg/t11962.check
@@ -1,7 +1,7 @@
-t11962.scala:3: warning: side-effecting nullary methods are discouraged: suggest defining as `def f()` instead
+t11962.scala:3: warning: [quick fix available] side-effecting nullary methods are discouraged: suggest defining as `def f()` instead
   def f = println()
       ^
-t11962.scala:7: warning: side-effecting nullary methods are discouraged: suggest defining as `def f()` instead
+t11962.scala:7: warning: [quick fix available] side-effecting nullary methods are discouraged: suggest defining as `def f()` instead
   override def f = super.f
                ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t11962.check
+++ b/test/files/neg/t11962.check
@@ -1,7 +1,7 @@
-t11962.scala:3: warning: [quick fix available] side-effecting nullary methods are discouraged: suggest defining as `def f()` instead
+t11962.scala:3: warning: side-effecting nullary methods are discouraged: suggest defining as `def f()` instead [quick fix available]
   def f = println()
       ^
-t11962.scala:7: warning: [quick fix available] side-effecting nullary methods are discouraged: suggest defining as `def f()` instead
+t11962.scala:7: warning: side-effecting nullary methods are discouraged: suggest defining as `def f()` instead [quick fix available]
   override def f = super.f
                ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t12728.check
+++ b/test/files/neg/t12728.check
@@ -22,97 +22,97 @@ t12728.scala:16: warning: dubious usage of method isInstanceOf with unit value
 t12728.scala:17: warning: dubious usage of method toString with unit value
   println(u.toString)
             ^
-t12728.scala:20: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+t12728.scala:20: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
   println(i.isNaN)
           ^
 t12728.scala:20: warning: dubious usage of method isNaN with integer value
   println(i.isNaN)
             ^
-t12728.scala:21: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+t12728.scala:21: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
   println(i.isInfinity)
           ^
 t12728.scala:21: warning: dubious usage of method isInfinity with integer value
   println(i.isInfinity)
             ^
-t12728.scala:22: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+t12728.scala:22: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
   println(i.isInfinite)
           ^
 t12728.scala:22: warning: dubious usage of method isInfinite with integer value
   println(i.isInfinite)
             ^
-t12728.scala:23: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+t12728.scala:23: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
   println(i.isFinite)
           ^
 t12728.scala:23: warning: dubious usage of method isFinite with integer value
   println(i.isFinite)
             ^
-t12728.scala:24: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+t12728.scala:24: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
   println(i.isPosInfinity)
           ^
 t12728.scala:24: warning: dubious usage of method isPosInfinity with integer value
   println(i.isPosInfinity)
             ^
-t12728.scala:25: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+t12728.scala:25: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
   println(i.isNegInfinity)
           ^
 t12728.scala:25: warning: dubious usage of method isNegInfinity with integer value
   println(i.isNegInfinity)
             ^
-t12728.scala:27: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+t12728.scala:27: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
   println(i.ceil)
           ^
 t12728.scala:27: warning: dubious usage of method ceil with integer value
   println(i.ceil)
             ^
-t12728.scala:28: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+t12728.scala:28: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
   println(i.floor)
           ^
 t12728.scala:28: warning: dubious usage of method floor with integer value
   println(i.floor)
             ^
-t12728.scala:30: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+t12728.scala:30: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
   println(l.isNaN)
           ^
 t12728.scala:30: warning: dubious usage of method isNaN with integer value
   println(l.isNaN)
             ^
-t12728.scala:31: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+t12728.scala:31: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
   println(l.isInfinity)
           ^
 t12728.scala:31: warning: dubious usage of method isInfinity with integer value
   println(l.isInfinity)
             ^
-t12728.scala:32: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+t12728.scala:32: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
   println(l.isInfinite)
           ^
 t12728.scala:32: warning: dubious usage of method isInfinite with integer value
   println(l.isInfinite)
             ^
-t12728.scala:33: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+t12728.scala:33: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
   println(l.isFinite)
           ^
 t12728.scala:33: warning: dubious usage of method isFinite with integer value
   println(l.isFinite)
             ^
-t12728.scala:34: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+t12728.scala:34: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
   println(l.isPosInfinity)
           ^
 t12728.scala:34: warning: dubious usage of method isPosInfinity with integer value
   println(l.isPosInfinity)
             ^
-t12728.scala:35: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+t12728.scala:35: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
   println(l.isNegInfinity)
           ^
 t12728.scala:35: warning: dubious usage of method isNegInfinity with integer value
   println(l.isNegInfinity)
             ^
-t12728.scala:37: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+t12728.scala:37: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
   println(l.ceil)
           ^
 t12728.scala:37: warning: dubious usage of method ceil with integer value
   println(l.ceil)
             ^
-t12728.scala:38: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
+t12728.scala:38: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quickfixable]
   println(l.floor)
           ^
 t12728.scala:38: warning: dubious usage of method floor with integer value

--- a/test/files/neg/t12728.check
+++ b/test/files/neg/t12728.check
@@ -22,97 +22,97 @@ t12728.scala:16: warning: dubious usage of method isInstanceOf with unit value
 t12728.scala:17: warning: dubious usage of method toString with unit value
   println(u.toString)
             ^
-t12728.scala:20: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:20: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
   println(i.isNaN)
           ^
 t12728.scala:20: warning: dubious usage of method isNaN with integer value
   println(i.isNaN)
             ^
-t12728.scala:21: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:21: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
   println(i.isInfinity)
           ^
 t12728.scala:21: warning: dubious usage of method isInfinity with integer value
   println(i.isInfinity)
             ^
-t12728.scala:22: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:22: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
   println(i.isInfinite)
           ^
 t12728.scala:22: warning: dubious usage of method isInfinite with integer value
   println(i.isInfinite)
             ^
-t12728.scala:23: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:23: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
   println(i.isFinite)
           ^
 t12728.scala:23: warning: dubious usage of method isFinite with integer value
   println(i.isFinite)
             ^
-t12728.scala:24: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:24: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
   println(i.isPosInfinity)
           ^
 t12728.scala:24: warning: dubious usage of method isPosInfinity with integer value
   println(i.isPosInfinity)
             ^
-t12728.scala:25: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:25: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
   println(i.isNegInfinity)
           ^
 t12728.scala:25: warning: dubious usage of method isNegInfinity with integer value
   println(i.isNegInfinity)
             ^
-t12728.scala:27: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:27: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
   println(i.ceil)
           ^
 t12728.scala:27: warning: dubious usage of method ceil with integer value
   println(i.ceil)
             ^
-t12728.scala:28: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:28: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
   println(i.floor)
           ^
 t12728.scala:28: warning: dubious usage of method floor with integer value
   println(i.floor)
             ^
-t12728.scala:30: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:30: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
   println(l.isNaN)
           ^
 t12728.scala:30: warning: dubious usage of method isNaN with integer value
   println(l.isNaN)
             ^
-t12728.scala:31: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:31: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
   println(l.isInfinity)
           ^
 t12728.scala:31: warning: dubious usage of method isInfinity with integer value
   println(l.isInfinity)
             ^
-t12728.scala:32: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:32: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
   println(l.isInfinite)
           ^
 t12728.scala:32: warning: dubious usage of method isInfinite with integer value
   println(l.isInfinite)
             ^
-t12728.scala:33: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:33: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
   println(l.isFinite)
           ^
 t12728.scala:33: warning: dubious usage of method isFinite with integer value
   println(l.isFinite)
             ^
-t12728.scala:34: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:34: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
   println(l.isPosInfinity)
           ^
 t12728.scala:34: warning: dubious usage of method isPosInfinity with integer value
   println(l.isPosInfinity)
             ^
-t12728.scala:35: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:35: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
   println(l.isNegInfinity)
           ^
 t12728.scala:35: warning: dubious usage of method isNegInfinity with integer value
   println(l.isNegInfinity)
             ^
-t12728.scala:37: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:37: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
   println(l.ceil)
           ^
 t12728.scala:37: warning: dubious usage of method ceil with integer value
   println(l.ceil)
             ^
-t12728.scala:38: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:38: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
   println(l.floor)
           ^
 t12728.scala:38: warning: dubious usage of method floor with integer value

--- a/test/files/neg/t12728.check
+++ b/test/files/neg/t12728.check
@@ -22,97 +22,97 @@ t12728.scala:16: warning: dubious usage of method isInstanceOf with unit value
 t12728.scala:17: warning: dubious usage of method toString with unit value
   println(u.toString)
             ^
-t12728.scala:20: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:20: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
   println(i.isNaN)
           ^
 t12728.scala:20: warning: dubious usage of method isNaN with integer value
   println(i.isNaN)
             ^
-t12728.scala:21: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:21: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
   println(i.isInfinity)
           ^
 t12728.scala:21: warning: dubious usage of method isInfinity with integer value
   println(i.isInfinity)
             ^
-t12728.scala:22: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:22: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
   println(i.isInfinite)
           ^
 t12728.scala:22: warning: dubious usage of method isInfinite with integer value
   println(i.isInfinite)
             ^
-t12728.scala:23: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:23: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
   println(i.isFinite)
           ^
 t12728.scala:23: warning: dubious usage of method isFinite with integer value
   println(i.isFinite)
             ^
-t12728.scala:24: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:24: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
   println(i.isPosInfinity)
           ^
 t12728.scala:24: warning: dubious usage of method isPosInfinity with integer value
   println(i.isPosInfinity)
             ^
-t12728.scala:25: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:25: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
   println(i.isNegInfinity)
           ^
 t12728.scala:25: warning: dubious usage of method isNegInfinity with integer value
   println(i.isNegInfinity)
             ^
-t12728.scala:27: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:27: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
   println(i.ceil)
           ^
 t12728.scala:27: warning: dubious usage of method ceil with integer value
   println(i.ceil)
             ^
-t12728.scala:28: warning: [quick fix available] Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:28: warning: Widening conversion from Int to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
   println(i.floor)
           ^
 t12728.scala:28: warning: dubious usage of method floor with integer value
   println(i.floor)
             ^
-t12728.scala:30: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:30: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
   println(l.isNaN)
           ^
 t12728.scala:30: warning: dubious usage of method isNaN with integer value
   println(l.isNaN)
             ^
-t12728.scala:31: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:31: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
   println(l.isInfinity)
           ^
 t12728.scala:31: warning: dubious usage of method isInfinity with integer value
   println(l.isInfinity)
             ^
-t12728.scala:32: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:32: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
   println(l.isInfinite)
           ^
 t12728.scala:32: warning: dubious usage of method isInfinite with integer value
   println(l.isInfinite)
             ^
-t12728.scala:33: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:33: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
   println(l.isFinite)
           ^
 t12728.scala:33: warning: dubious usage of method isFinite with integer value
   println(l.isFinite)
             ^
-t12728.scala:34: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:34: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
   println(l.isPosInfinity)
           ^
 t12728.scala:34: warning: dubious usage of method isPosInfinity with integer value
   println(l.isPosInfinity)
             ^
-t12728.scala:35: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:35: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
   println(l.isNegInfinity)
           ^
 t12728.scala:35: warning: dubious usage of method isNegInfinity with integer value
   println(l.isNegInfinity)
             ^
-t12728.scala:37: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:37: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
   println(l.ceil)
           ^
 t12728.scala:37: warning: dubious usage of method ceil with integer value
   println(l.ceil)
             ^
-t12728.scala:38: warning: [quick fix available] Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead.
+t12728.scala:38: warning: Widening conversion from Long to Float is deprecated because it loses precision. Write `.toFloat` instead. [quick fix available]
   println(l.floor)
           ^
 t12728.scala:38: warning: dubious usage of method floor with integer value

--- a/test/files/neg/t12798-migration.check
+++ b/test/files/neg/t12798-migration.check
@@ -3,14 +3,14 @@ Note that assignments in argument position are no longer allowed since Scala 2.1
 To express the assignment expression, wrap it in brackets, e.g., `{ z = ... }`.
     f(42, z = 27)
             ^
-t12798-migration.scala:25: warning: unary prefix operator definition with empty parameter list is unsupported: instead, remove () to declare as `def unary_- = -42`
+t12798-migration.scala:25: warning: [quick fix available] unary prefix operator definition with empty parameter list is unsupported: instead, remove () to declare as `def unary_- = -42`
   def unary_-() = -42
       ^
 t12798-migration.scala:28: warning: package object inheritance is deprecated (https://github.com/scala/scala-dev/issues/441);
 drop the `extends` clause or use a regular object instead
 package object tester extends Runnable {
                       ^
-t12798-migration.scala:33: warning: procedure syntax is deprecated for constructors: add `=`, as in method definition
+t12798-migration.scala:33: warning: [quick fix available] procedure syntax is deprecated for constructors: add `=`, as in method definition
   def this(s: String) { this() }
                      ^
 t12798-migration.scala:34: warning: [quick fix available] procedure syntax is unsupported: instead, add `: Unit =` to explicitly declare `f`'s return type
@@ -23,7 +23,7 @@ t12798-migration.scala:39: warning: [quick fix available] parentheses are requir
 Use '-Wconf:msg=lambda-parens:s' to silence this warning.
   def f = List(42).map { x: Int => x + 1 }
                           ^
-t12798-migration.scala:43: warning: type application is not allowed for infix operators
+t12798-migration.scala:43: warning: [quick fix available] type application is not allowed for infix operators
   def f = List(42) map [Int] (_ + 1)
                    ^
 t12798-migration.scala:46: warning: Top-level wildcard is not allowed
@@ -41,7 +41,7 @@ t12798-migration.scala:18: warning: Unicode escapes in raw interpolations are ig
 t12798-migration.scala:50: warning: constructor modifiers are assumed by synthetic `copy` method
 case class `case mods propagate` private (s: String)
            ^
-t12798-migration.scala:60: warning: under -Xsource:3, inferred Option[Int] instead of Some[Int]
+t12798-migration.scala:60: warning: [quick fix available] under -Xsource:3, inferred Option[Int] instead of Some[Int]
   override def f = Some(27)
                ^
 t12798-migration.scala:50: warning: constructor modifiers are assumed by synthetic `apply` method

--- a/test/files/neg/t12798-migration.check
+++ b/test/files/neg/t12798-migration.check
@@ -3,27 +3,27 @@ Note that assignments in argument position are no longer allowed since Scala 2.1
 To express the assignment expression, wrap it in brackets, e.g., `{ z = ... }`.
     f(42, z = 27)
             ^
-t12798-migration.scala:25: warning: [quick fix available] unary prefix operator definition with empty parameter list is unsupported: instead, remove () to declare as `def unary_- = -42`
+t12798-migration.scala:25: warning: unary prefix operator definition with empty parameter list is unsupported: instead, remove () to declare as `def unary_- = -42` [quick fix available]
   def unary_-() = -42
       ^
 t12798-migration.scala:28: warning: package object inheritance is deprecated (https://github.com/scala/scala-dev/issues/441);
 drop the `extends` clause or use a regular object instead
 package object tester extends Runnable {
                       ^
-t12798-migration.scala:33: warning: [quick fix available] procedure syntax is deprecated for constructors: add `=`, as in method definition
+t12798-migration.scala:33: warning: procedure syntax is deprecated for constructors: add `=`, as in method definition [quick fix available]
   def this(s: String) { this() }
                      ^
-t12798-migration.scala:34: warning: [quick fix available] procedure syntax is unsupported: instead, add `: Unit =` to explicitly declare `f`'s return type
+t12798-migration.scala:34: warning: procedure syntax is unsupported: instead, add `: Unit =` to explicitly declare `f`'s return type [quick fix available]
   def f() { println() }
           ^
-t12798-migration.scala:35: warning: [quick fix available] procedure syntax is unsupported: instead, add `: Unit` to explicitly declare `g`'s return type
+t12798-migration.scala:35: warning: procedure syntax is unsupported: instead, add `: Unit` to explicitly declare `g`'s return type [quick fix available]
   def g()
          ^
-t12798-migration.scala:39: warning: [quick fix available] parentheses are required around the parameter of a lambda
-Use '-Wconf:msg=lambda-parens:s' to silence this warning.
+t12798-migration.scala:39: warning: parentheses are required around the parameter of a lambda
+Use '-Wconf:msg=lambda-parens:s' to silence this warning. [quick fix available]
   def f = List(42).map { x: Int => x + 1 }
                           ^
-t12798-migration.scala:43: warning: [quick fix available] type application is not allowed for infix operators
+t12798-migration.scala:43: warning: type application is not allowed for infix operators [quick fix available]
   def f = List(42) map [Int] (_ + 1)
                    ^
 t12798-migration.scala:46: warning: Top-level wildcard is not allowed
@@ -41,7 +41,7 @@ t12798-migration.scala:18: warning: Unicode escapes in raw interpolations are ig
 t12798-migration.scala:50: warning: constructor modifiers are assumed by synthetic `copy` method
 case class `case mods propagate` private (s: String)
            ^
-t12798-migration.scala:60: warning: [quick fix available] under -Xsource:3, inferred Option[Int] instead of Some[Int]
+t12798-migration.scala:60: warning: under -Xsource:3, inferred Option[Int] instead of Some[Int] [quick fix available]
   override def f = Some(27)
                ^
 t12798-migration.scala:50: warning: constructor modifiers are assumed by synthetic `apply` method

--- a/test/files/neg/t12798-migration.check
+++ b/test/files/neg/t12798-migration.check
@@ -3,27 +3,27 @@ Note that assignments in argument position are no longer allowed since Scala 2.1
 To express the assignment expression, wrap it in brackets, e.g., `{ z = ... }`.
     f(42, z = 27)
             ^
-t12798-migration.scala:25: warning: unary prefix operator definition with empty parameter list is unsupported: instead, remove () to declare as `def unary_- = -42` [quick fix available]
+t12798-migration.scala:25: warning: unary prefix operator definition with empty parameter list is unsupported: instead, remove () to declare as `def unary_- = -42` [quickfixable]
   def unary_-() = -42
       ^
 t12798-migration.scala:28: warning: package object inheritance is deprecated (https://github.com/scala/scala-dev/issues/441);
 drop the `extends` clause or use a regular object instead
 package object tester extends Runnable {
                       ^
-t12798-migration.scala:33: warning: procedure syntax is deprecated for constructors: add `=`, as in method definition [quick fix available]
+t12798-migration.scala:33: warning: procedure syntax is deprecated for constructors: add `=`, as in method definition [quickfixable]
   def this(s: String) { this() }
                      ^
-t12798-migration.scala:34: warning: procedure syntax is unsupported: instead, add `: Unit =` to explicitly declare `f`'s return type [quick fix available]
+t12798-migration.scala:34: warning: procedure syntax is unsupported: instead, add `: Unit =` to explicitly declare `f`'s return type [quickfixable]
   def f() { println() }
           ^
-t12798-migration.scala:35: warning: procedure syntax is unsupported: instead, add `: Unit` to explicitly declare `g`'s return type [quick fix available]
+t12798-migration.scala:35: warning: procedure syntax is unsupported: instead, add `: Unit` to explicitly declare `g`'s return type [quickfixable]
   def g()
          ^
 t12798-migration.scala:39: warning: parentheses are required around the parameter of a lambda
-Use '-Wconf:msg=lambda-parens:s' to silence this warning. [quick fix available]
+Use '-Wconf:msg=lambda-parens:s' to silence this warning. [quickfixable]
   def f = List(42).map { x: Int => x + 1 }
                           ^
-t12798-migration.scala:43: warning: type application is not allowed for infix operators [quick fix available]
+t12798-migration.scala:43: warning: type application is not allowed for infix operators [quickfixable]
   def f = List(42) map [Int] (_ + 1)
                    ^
 t12798-migration.scala:46: warning: Top-level wildcard is not allowed
@@ -41,7 +41,7 @@ t12798-migration.scala:18: warning: Unicode escapes in raw interpolations are ig
 t12798-migration.scala:50: warning: constructor modifiers are assumed by synthetic `copy` method
 case class `case mods propagate` private (s: String)
            ^
-t12798-migration.scala:60: warning: under -Xsource:3, inferred Option[Int] instead of Some[Int] [quick fix available]
+t12798-migration.scala:60: warning: under -Xsource:3, inferred Option[Int] instead of Some[Int] [quickfixable]
   override def f = Some(27)
                ^
 t12798-migration.scala:50: warning: constructor modifiers are assumed by synthetic `apply` method

--- a/test/files/neg/t12798.check
+++ b/test/files/neg/t12798.check
@@ -3,7 +3,7 @@ Note that assignments in argument position are no longer allowed since Scala 2.1
 To express the assignment expression, wrap it in brackets, e.g., `{ z = ... }`.
     f(42, z = 27)
             ^
-t12798.scala:25: error: unary prefix operator definition with empty parameter list is unsupported: instead, remove () to declare as `def unary_- = -42` [quick fix available]
+t12798.scala:25: error: unary prefix operator definition with empty parameter list is unsupported: instead, remove () to declare as `def unary_- = -42` [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def unary_-() = -42
@@ -14,28 +14,28 @@ Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
 package object tester extends Runnable {
                       ^
-t12798.scala:33: error: procedure syntax is deprecated for constructors: add `=`, as in method definition [quick fix available]
+t12798.scala:33: error: procedure syntax is deprecated for constructors: add `=`, as in method definition [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def this(s: String) { this() }
                      ^
-t12798.scala:34: error: procedure syntax is unsupported: instead, add `: Unit =` to explicitly declare `f`'s return type [quick fix available]
+t12798.scala:34: error: procedure syntax is unsupported: instead, add `: Unit =` to explicitly declare `f`'s return type [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def f() { println() }
           ^
-t12798.scala:35: error: procedure syntax is unsupported: instead, add `: Unit` to explicitly declare `g`'s return type [quick fix available]
+t12798.scala:35: error: procedure syntax is unsupported: instead, add `: Unit` to explicitly declare `g`'s return type [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def g()
          ^
 t12798.scala:39: error: parentheses are required around the parameter of a lambda
-Use '-Wconf:msg=lambda-parens:s' to silence this warning. [quick fix available]
+Use '-Wconf:msg=lambda-parens:s' to silence this warning. [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def f = List(42).map { x: Int => x + 1 }
                           ^
-t12798.scala:43: error: type application is not allowed for infix operators [quick fix available]
+t12798.scala:43: error: type application is not allowed for infix operators [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def f = List(42) map [Int] (_ + 1)
@@ -65,7 +65,7 @@ Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=case mods propagate
 case class `case mods propagate` private (s: String)
            ^
-t12798.scala:60: error: under -Xsource:3, inferred Option[Int] instead of Some[Int] [quick fix available]
+t12798.scala:60: error: under -Xsource:3, inferred Option[Int] instead of Some[Int] [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=Child.f
   override def f = Some(27)

--- a/test/files/neg/t12798.check
+++ b/test/files/neg/t12798.check
@@ -3,7 +3,7 @@ Note that assignments in argument position are no longer allowed since Scala 2.1
 To express the assignment expression, wrap it in brackets, e.g., `{ z = ... }`.
     f(42, z = 27)
             ^
-t12798.scala:25: error: [quick fix available] unary prefix operator definition with empty parameter list is unsupported: instead, remove () to declare as `def unary_- = -42`
+t12798.scala:25: error: unary prefix operator definition with empty parameter list is unsupported: instead, remove () to declare as `def unary_- = -42` [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def unary_-() = -42
@@ -14,28 +14,28 @@ Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
 package object tester extends Runnable {
                       ^
-t12798.scala:33: error: [quick fix available] procedure syntax is deprecated for constructors: add `=`, as in method definition
+t12798.scala:33: error: procedure syntax is deprecated for constructors: add `=`, as in method definition [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def this(s: String) { this() }
                      ^
-t12798.scala:34: error: [quick fix available] procedure syntax is unsupported: instead, add `: Unit =` to explicitly declare `f`'s return type
+t12798.scala:34: error: procedure syntax is unsupported: instead, add `: Unit =` to explicitly declare `f`'s return type [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def f() { println() }
           ^
-t12798.scala:35: error: [quick fix available] procedure syntax is unsupported: instead, add `: Unit` to explicitly declare `g`'s return type
+t12798.scala:35: error: procedure syntax is unsupported: instead, add `: Unit` to explicitly declare `g`'s return type [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def g()
          ^
-t12798.scala:39: error: [quick fix available] parentheses are required around the parameter of a lambda
-Use '-Wconf:msg=lambda-parens:s' to silence this warning.
+t12798.scala:39: error: parentheses are required around the parameter of a lambda
+Use '-Wconf:msg=lambda-parens:s' to silence this warning. [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def f = List(42).map { x: Int => x + 1 }
                           ^
-t12798.scala:43: error: [quick fix available] type application is not allowed for infix operators
+t12798.scala:43: error: type application is not allowed for infix operators [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def f = List(42) map [Int] (_ + 1)
@@ -65,7 +65,7 @@ Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=case mods propagate
 case class `case mods propagate` private (s: String)
            ^
-t12798.scala:60: error: [quick fix available] under -Xsource:3, inferred Option[Int] instead of Some[Int]
+t12798.scala:60: error: under -Xsource:3, inferred Option[Int] instead of Some[Int] [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=Child.f
   override def f = Some(27)

--- a/test/files/neg/t12798.check
+++ b/test/files/neg/t12798.check
@@ -3,7 +3,7 @@ Note that assignments in argument position are no longer allowed since Scala 2.1
 To express the assignment expression, wrap it in brackets, e.g., `{ z = ... }`.
     f(42, z = 27)
             ^
-t12798.scala:25: error: unary prefix operator definition with empty parameter list is unsupported: instead, remove () to declare as `def unary_- = -42`
+t12798.scala:25: error: [quick fix available] unary prefix operator definition with empty parameter list is unsupported: instead, remove () to declare as `def unary_- = -42`
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def unary_-() = -42
@@ -14,7 +14,7 @@ Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
 package object tester extends Runnable {
                       ^
-t12798.scala:33: error: procedure syntax is deprecated for constructors: add `=`, as in method definition
+t12798.scala:33: error: [quick fix available] procedure syntax is deprecated for constructors: add `=`, as in method definition
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def this(s: String) { this() }
@@ -35,7 +35,7 @@ Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def f = List(42).map { x: Int => x + 1 }
                           ^
-t12798.scala:43: error: type application is not allowed for infix operators
+t12798.scala:43: error: [quick fix available] type application is not allowed for infix operators
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def f = List(42) map [Int] (_ + 1)
@@ -65,7 +65,7 @@ Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=case mods propagate
 case class `case mods propagate` private (s: String)
            ^
-t12798.scala:60: error: under -Xsource:3, inferred Option[Int] instead of Some[Int]
+t12798.scala:60: error: [quick fix available] under -Xsource:3, inferred Option[Int] instead of Some[Int]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=Child.f
   override def f = Some(27)

--- a/test/files/neg/t12815.check
+++ b/test/files/neg/t12815.check
@@ -1,7 +1,7 @@
-t12815.scala:22: warning: method with a single empty parameter list overrides method without any parameter list
+t12815.scala:22: warning: [quick fix available] method with a single empty parameter list overrides method without any parameter list
   def e(): Int = 1 // warn
       ^
-t12815.scala:23: warning: method without a parameter list overrides a method with a single empty one
+t12815.scala:23: warning: [quick fix available] method without a parameter list overrides a method with a single empty one
   def f: Int = 1   // warn
       ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t12815.check
+++ b/test/files/neg/t12815.check
@@ -1,7 +1,7 @@
-t12815.scala:22: warning: [quick fix available] method with a single empty parameter list overrides method without any parameter list
+t12815.scala:22: warning: method with a single empty parameter list overrides method without any parameter list [quick fix available]
   def e(): Int = 1 // warn
       ^
-t12815.scala:23: warning: [quick fix available] method without a parameter list overrides a method with a single empty one
+t12815.scala:23: warning: method without a parameter list overrides a method with a single empty one [quick fix available]
   def f: Int = 1   // warn
       ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t12815.check
+++ b/test/files/neg/t12815.check
@@ -1,7 +1,7 @@
-t12815.scala:22: warning: method with a single empty parameter list overrides method without any parameter list [quick fix available]
+t12815.scala:22: warning: method with a single empty parameter list overrides method without any parameter list [quickfixable]
   def e(): Int = 1 // warn
       ^
-t12815.scala:23: warning: method without a parameter list overrides a method with a single empty one [quick fix available]
+t12815.scala:23: warning: method without a parameter list overrides a method with a single empty one [quickfixable]
   def f: Int = 1   // warn
       ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t12816.check
+++ b/test/files/neg/t12816.check
@@ -8,7 +8,7 @@ t12816.scala:29: error: reference to c is ambiguous;
 it is both defined in the enclosing package p and inherited in the enclosing trait RR as method c (defined in trait T)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.c`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=p.RR.m3
     def m3 = c // warn
@@ -17,7 +17,7 @@ t12816.scala:33: error: reference to Z is ambiguous;
 it is both defined in the enclosing package p and inherited in the enclosing trait RR as trait Z (defined in trait T)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.Z`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=p.RR.n3
     def n3: Z // warn

--- a/test/files/neg/t12816.check
+++ b/test/files/neg/t12816.check
@@ -4,20 +4,20 @@ Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
 package object p extends U {
                  ^
-t12816.scala:29: error: [quick fix available] reference to c is ambiguous;
+t12816.scala:29: error: reference to c is ambiguous;
 it is both defined in the enclosing package p and inherited in the enclosing trait RR as method c (defined in trait T)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.c`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=p.RR.m3
     def m3 = c // warn
              ^
-t12816.scala:33: error: [quick fix available] reference to Z is ambiguous;
+t12816.scala:33: error: reference to Z is ambiguous;
 it is both defined in the enclosing package p and inherited in the enclosing trait RR as trait Z (defined in trait T)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.Z`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=p.RR.n3
     def n3: Z // warn

--- a/test/files/neg/t12816b.check
+++ b/test/files/neg/t12816b.check
@@ -8,7 +8,7 @@ B.scala:19: error: reference to c is ambiguous;
 it is both defined in the enclosing package p and inherited in the enclosing trait RR as method c (defined in trait T)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.c`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=p.RR.m3
     def m3 = c // warn
@@ -17,7 +17,7 @@ B.scala:23: error: reference to Z is ambiguous;
 it is both defined in the enclosing package p and inherited in the enclosing trait RR as trait Z (defined in trait T)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.Z`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=p.RR.n3
     def n3: Z // warn

--- a/test/files/neg/t12816b.check
+++ b/test/files/neg/t12816b.check
@@ -4,20 +4,20 @@ Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
 package object p extends U {
                  ^
-B.scala:19: error: [quick fix available] reference to c is ambiguous;
+B.scala:19: error: reference to c is ambiguous;
 it is both defined in the enclosing package p and inherited in the enclosing trait RR as method c (defined in trait T)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.c`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=p.RR.m3
     def m3 = c // warn
              ^
-B.scala:23: error: [quick fix available] reference to Z is ambiguous;
+B.scala:23: error: reference to Z is ambiguous;
 it is both defined in the enclosing package p and inherited in the enclosing trait RR as trait Z (defined in trait T)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.Z`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=p.RR.n3
     def n3: Z // warn

--- a/test/files/neg/t2206.check
+++ b/test/files/neg/t2206.check
@@ -2,7 +2,7 @@ t2206.scala:10: error: value f is not a member of o.A
  Note: implicit method ax is not applicable here because it comes after the application point and it lacks an explicit result type.
   a.f()
     ^
-t2206.scala:13: warning: Implicit definition should have explicit type (inferred o.AX) [quick fix available]
+t2206.scala:13: warning: Implicit definition should have explicit type (inferred o.AX) [quickfixable]
       implicit def ax(a: A) = new AX
                    ^
 1 warning

--- a/test/files/neg/t2206.check
+++ b/test/files/neg/t2206.check
@@ -2,7 +2,7 @@ t2206.scala:10: error: value f is not a member of o.A
  Note: implicit method ax is not applicable here because it comes after the application point and it lacks an explicit result type.
   a.f()
     ^
-t2206.scala:13: warning: Implicit definition should have explicit type (inferred o.AX)
+t2206.scala:13: warning: [quick fix available] Implicit definition should have explicit type (inferred o.AX)
       implicit def ax(a: A) = new AX
                    ^
 1 warning

--- a/test/files/neg/t2206.check
+++ b/test/files/neg/t2206.check
@@ -2,7 +2,7 @@ t2206.scala:10: error: value f is not a member of o.A
  Note: implicit method ax is not applicable here because it comes after the application point and it lacks an explicit result type.
   a.f()
     ^
-t2206.scala:13: warning: [quick fix available] Implicit definition should have explicit type (inferred o.AX)
+t2206.scala:13: warning: Implicit definition should have explicit type (inferred o.AX) [quick fix available]
       implicit def ax(a: A) = new AX
                    ^
 1 warning

--- a/test/files/neg/t2421b.check
+++ b/test/files/neg/t2421b.check
@@ -1,7 +1,7 @@
 t2421b.scala:12: error: could not find implicit value for parameter aa: Test.F[Test.A]
   f
   ^
-t2421b.scala:10: warning: Implicit definition should have explicit type (inferred Test.F[X])
+t2421b.scala:10: warning: [quick fix available] Implicit definition should have explicit type (inferred Test.F[X])
   implicit def b[X <: B] = new F[X]()
                ^
 1 warning

--- a/test/files/neg/t2421b.check
+++ b/test/files/neg/t2421b.check
@@ -1,7 +1,7 @@
 t2421b.scala:12: error: could not find implicit value for parameter aa: Test.F[Test.A]
   f
   ^
-t2421b.scala:10: warning: [quick fix available] Implicit definition should have explicit type (inferred Test.F[X])
+t2421b.scala:10: warning: Implicit definition should have explicit type (inferred Test.F[X]) [quick fix available]
   implicit def b[X <: B] = new F[X]()
                ^
 1 warning

--- a/test/files/neg/t2421b.check
+++ b/test/files/neg/t2421b.check
@@ -1,7 +1,7 @@
 t2421b.scala:12: error: could not find implicit value for parameter aa: Test.F[Test.A]
   f
   ^
-t2421b.scala:10: warning: Implicit definition should have explicit type (inferred Test.F[X]) [quick fix available]
+t2421b.scala:10: warning: Implicit definition should have explicit type (inferred Test.F[X]) [quickfixable]
   implicit def b[X <: B] = new F[X]()
                ^
 1 warning

--- a/test/files/neg/t3006.check
+++ b/test/files/neg/t3006.check
@@ -3,7 +3,7 @@ t3006.scala:8: error: type mismatch;
  required: Int
   println(A(3) + "H")
                  ^
-t3006.scala:6: warning: Implicit definition should have explicit type (inferred Test.Foo)
+t3006.scala:6: warning: [quick fix available] Implicit definition should have explicit type (inferred Test.Foo)
   implicit def aToFoo(x: A) = new Foo(x);
                ^
 1 warning

--- a/test/files/neg/t3006.check
+++ b/test/files/neg/t3006.check
@@ -3,7 +3,7 @@ t3006.scala:8: error: type mismatch;
  required: Int
   println(A(3) + "H")
                  ^
-t3006.scala:6: warning: Implicit definition should have explicit type (inferred Test.Foo) [quick fix available]
+t3006.scala:6: warning: Implicit definition should have explicit type (inferred Test.Foo) [quickfixable]
   implicit def aToFoo(x: A) = new Foo(x);
                ^
 1 warning

--- a/test/files/neg/t3006.check
+++ b/test/files/neg/t3006.check
@@ -3,7 +3,7 @@ t3006.scala:8: error: type mismatch;
  required: Int
   println(A(3) + "H")
                  ^
-t3006.scala:6: warning: [quick fix available] Implicit definition should have explicit type (inferred Test.Foo)
+t3006.scala:6: warning: Implicit definition should have explicit type (inferred Test.Foo) [quick fix available]
   implicit def aToFoo(x: A) = new Foo(x);
                ^
 1 warning

--- a/test/files/neg/t3346i.check
+++ b/test/files/neg/t3346i.check
@@ -4,19 +4,19 @@ t3346i.scala:28: error: value a is not a member of Test.A[T]
 t3346i.scala:29: error: value a is not a member of Test.A[Nothing]
   (new A[Nothing]).a
                    ^
-t3346i.scala:16: warning: Implicit definition should have explicit type (inferred Implicit1[T])
+t3346i.scala:16: warning: [quick fix available] Implicit definition should have explicit type (inferred Implicit1[T])
   implicit def implicit1[T <: Intermediate[_, _]](implicit b: Implicit2[T])                = new Implicit1[T](b)
                ^
-t3346i.scala:18: warning: Implicit definition should have explicit type (inferred Implicit2[T])
+t3346i.scala:18: warning: [quick fix available] Implicit definition should have explicit type (inferred Implicit2[T])
   implicit def implicit2alt1[T <: Intermediate[_ <: String, _]](implicit c: Implicit3[T])  = new Implicit2[T](c)
                ^
-t3346i.scala:19: warning: Implicit definition should have explicit type (inferred Implicit2[T])
+t3346i.scala:19: warning: [quick fix available] Implicit definition should have explicit type (inferred Implicit2[T])
   implicit def implicit2alt2[T <: Intermediate[_ <: Double, _]](implicit c: Implicit3[T])  = new Implicit2[T](c)
                ^
-t3346i.scala:21: warning: Implicit definition should have explicit type (inferred Implicit3[T])
+t3346i.scala:21: warning: [quick fix available] Implicit definition should have explicit type (inferred Implicit3[T])
   implicit def implicit3alt1[T <: Intermediate[_, _ <: Int]]                               = new Implicit3[T]()
                ^
-t3346i.scala:22: warning: Implicit definition should have explicit type (inferred Implicit3[T])
+t3346i.scala:22: warning: [quick fix available] Implicit definition should have explicit type (inferred Implicit3[T])
   implicit def implicit3alt2[T <: Intermediate[_ <: Double, _ <: AnyRef],X]                = new Implicit3[T]()
                ^
 5 warnings

--- a/test/files/neg/t3346i.check
+++ b/test/files/neg/t3346i.check
@@ -4,19 +4,19 @@ t3346i.scala:28: error: value a is not a member of Test.A[T]
 t3346i.scala:29: error: value a is not a member of Test.A[Nothing]
   (new A[Nothing]).a
                    ^
-t3346i.scala:16: warning: [quick fix available] Implicit definition should have explicit type (inferred Implicit1[T])
+t3346i.scala:16: warning: Implicit definition should have explicit type (inferred Implicit1[T]) [quick fix available]
   implicit def implicit1[T <: Intermediate[_, _]](implicit b: Implicit2[T])                = new Implicit1[T](b)
                ^
-t3346i.scala:18: warning: [quick fix available] Implicit definition should have explicit type (inferred Implicit2[T])
+t3346i.scala:18: warning: Implicit definition should have explicit type (inferred Implicit2[T]) [quick fix available]
   implicit def implicit2alt1[T <: Intermediate[_ <: String, _]](implicit c: Implicit3[T])  = new Implicit2[T](c)
                ^
-t3346i.scala:19: warning: [quick fix available] Implicit definition should have explicit type (inferred Implicit2[T])
+t3346i.scala:19: warning: Implicit definition should have explicit type (inferred Implicit2[T]) [quick fix available]
   implicit def implicit2alt2[T <: Intermediate[_ <: Double, _]](implicit c: Implicit3[T])  = new Implicit2[T](c)
                ^
-t3346i.scala:21: warning: [quick fix available] Implicit definition should have explicit type (inferred Implicit3[T])
+t3346i.scala:21: warning: Implicit definition should have explicit type (inferred Implicit3[T]) [quick fix available]
   implicit def implicit3alt1[T <: Intermediate[_, _ <: Int]]                               = new Implicit3[T]()
                ^
-t3346i.scala:22: warning: [quick fix available] Implicit definition should have explicit type (inferred Implicit3[T])
+t3346i.scala:22: warning: Implicit definition should have explicit type (inferred Implicit3[T]) [quick fix available]
   implicit def implicit3alt2[T <: Intermediate[_ <: Double, _ <: AnyRef],X]                = new Implicit3[T]()
                ^
 5 warnings

--- a/test/files/neg/t3346i.check
+++ b/test/files/neg/t3346i.check
@@ -4,19 +4,19 @@ t3346i.scala:28: error: value a is not a member of Test.A[T]
 t3346i.scala:29: error: value a is not a member of Test.A[Nothing]
   (new A[Nothing]).a
                    ^
-t3346i.scala:16: warning: Implicit definition should have explicit type (inferred Implicit1[T]) [quick fix available]
+t3346i.scala:16: warning: Implicit definition should have explicit type (inferred Implicit1[T]) [quickfixable]
   implicit def implicit1[T <: Intermediate[_, _]](implicit b: Implicit2[T])                = new Implicit1[T](b)
                ^
-t3346i.scala:18: warning: Implicit definition should have explicit type (inferred Implicit2[T]) [quick fix available]
+t3346i.scala:18: warning: Implicit definition should have explicit type (inferred Implicit2[T]) [quickfixable]
   implicit def implicit2alt1[T <: Intermediate[_ <: String, _]](implicit c: Implicit3[T])  = new Implicit2[T](c)
                ^
-t3346i.scala:19: warning: Implicit definition should have explicit type (inferred Implicit2[T]) [quick fix available]
+t3346i.scala:19: warning: Implicit definition should have explicit type (inferred Implicit2[T]) [quickfixable]
   implicit def implicit2alt2[T <: Intermediate[_ <: Double, _]](implicit c: Implicit3[T])  = new Implicit2[T](c)
                ^
-t3346i.scala:21: warning: Implicit definition should have explicit type (inferred Implicit3[T]) [quick fix available]
+t3346i.scala:21: warning: Implicit definition should have explicit type (inferred Implicit3[T]) [quickfixable]
   implicit def implicit3alt1[T <: Intermediate[_, _ <: Int]]                               = new Implicit3[T]()
                ^
-t3346i.scala:22: warning: Implicit definition should have explicit type (inferred Implicit3[T]) [quick fix available]
+t3346i.scala:22: warning: Implicit definition should have explicit type (inferred Implicit3[T]) [quickfixable]
   implicit def implicit3alt2[T <: Intermediate[_ <: Double, _ <: AnyRef],X]                = new Implicit3[T]()
                ^
 5 warnings

--- a/test/files/neg/t4271.check
+++ b/test/files/neg/t4271.check
@@ -9,22 +9,22 @@ t4271.scala:11: error: value -> is not a member of Int
 did you mean >>?
   3 -> 5
     ^
-t4271.scala:3: warning: Implicit definition should have explicit type (inferred foo.Donotuseme.type) [quick fix available]
+t4271.scala:3: warning: Implicit definition should have explicit type (inferred foo.Donotuseme.type) [quickfixable]
   implicit def Ensuring[A](x: A) = Donotuseme
                ^
-t4271.scala:4: warning: Implicit definition should have explicit type (inferred foo.Donotuseme.type) [quick fix available]
+t4271.scala:4: warning: Implicit definition should have explicit type (inferred foo.Donotuseme.type) [quickfixable]
   implicit def doubleWrapper(x: Int) = Donotuseme
                ^
-t4271.scala:5: warning: Implicit definition should have explicit type (inferred foo.Donotuseme.type) [quick fix available]
+t4271.scala:5: warning: Implicit definition should have explicit type (inferred foo.Donotuseme.type) [quickfixable]
   implicit def floatWrapper(x: Int) = Donotuseme
                ^
-t4271.scala:6: warning: Implicit definition should have explicit type (inferred foo.Donotuseme.type) [quick fix available]
+t4271.scala:6: warning: Implicit definition should have explicit type (inferred foo.Donotuseme.type) [quickfixable]
   implicit def intWrapper(x: Int) = Donotuseme
                ^
-t4271.scala:7: warning: Implicit definition should have explicit type (inferred foo.Donotuseme.type) [quick fix available]
+t4271.scala:7: warning: Implicit definition should have explicit type (inferred foo.Donotuseme.type) [quickfixable]
   implicit def longWrapper(x: Int) = Donotuseme
                ^
-t4271.scala:8: warning: Implicit definition should have explicit type (inferred foo.Donotuseme.type) [quick fix available]
+t4271.scala:8: warning: Implicit definition should have explicit type (inferred foo.Donotuseme.type) [quickfixable]
   implicit def ArrowAssoc[A](x: A) = Donotuseme
                ^
 6 warnings

--- a/test/files/neg/t4271.check
+++ b/test/files/neg/t4271.check
@@ -9,22 +9,22 @@ t4271.scala:11: error: value -> is not a member of Int
 did you mean >>?
   3 -> 5
     ^
-t4271.scala:3: warning: [quick fix available] Implicit definition should have explicit type (inferred foo.Donotuseme.type)
+t4271.scala:3: warning: Implicit definition should have explicit type (inferred foo.Donotuseme.type) [quick fix available]
   implicit def Ensuring[A](x: A) = Donotuseme
                ^
-t4271.scala:4: warning: [quick fix available] Implicit definition should have explicit type (inferred foo.Donotuseme.type)
+t4271.scala:4: warning: Implicit definition should have explicit type (inferred foo.Donotuseme.type) [quick fix available]
   implicit def doubleWrapper(x: Int) = Donotuseme
                ^
-t4271.scala:5: warning: [quick fix available] Implicit definition should have explicit type (inferred foo.Donotuseme.type)
+t4271.scala:5: warning: Implicit definition should have explicit type (inferred foo.Donotuseme.type) [quick fix available]
   implicit def floatWrapper(x: Int) = Donotuseme
                ^
-t4271.scala:6: warning: [quick fix available] Implicit definition should have explicit type (inferred foo.Donotuseme.type)
+t4271.scala:6: warning: Implicit definition should have explicit type (inferred foo.Donotuseme.type) [quick fix available]
   implicit def intWrapper(x: Int) = Donotuseme
                ^
-t4271.scala:7: warning: [quick fix available] Implicit definition should have explicit type (inferred foo.Donotuseme.type)
+t4271.scala:7: warning: Implicit definition should have explicit type (inferred foo.Donotuseme.type) [quick fix available]
   implicit def longWrapper(x: Int) = Donotuseme
                ^
-t4271.scala:8: warning: [quick fix available] Implicit definition should have explicit type (inferred foo.Donotuseme.type)
+t4271.scala:8: warning: Implicit definition should have explicit type (inferred foo.Donotuseme.type) [quick fix available]
   implicit def ArrowAssoc[A](x: A) = Donotuseme
                ^
 6 warnings

--- a/test/files/neg/t4271.check
+++ b/test/files/neg/t4271.check
@@ -9,22 +9,22 @@ t4271.scala:11: error: value -> is not a member of Int
 did you mean >>?
   3 -> 5
     ^
-t4271.scala:3: warning: Implicit definition should have explicit type (inferred foo.Donotuseme.type)
+t4271.scala:3: warning: [quick fix available] Implicit definition should have explicit type (inferred foo.Donotuseme.type)
   implicit def Ensuring[A](x: A) = Donotuseme
                ^
-t4271.scala:4: warning: Implicit definition should have explicit type (inferred foo.Donotuseme.type)
+t4271.scala:4: warning: [quick fix available] Implicit definition should have explicit type (inferred foo.Donotuseme.type)
   implicit def doubleWrapper(x: Int) = Donotuseme
                ^
-t4271.scala:5: warning: Implicit definition should have explicit type (inferred foo.Donotuseme.type)
+t4271.scala:5: warning: [quick fix available] Implicit definition should have explicit type (inferred foo.Donotuseme.type)
   implicit def floatWrapper(x: Int) = Donotuseme
                ^
-t4271.scala:6: warning: Implicit definition should have explicit type (inferred foo.Donotuseme.type)
+t4271.scala:6: warning: [quick fix available] Implicit definition should have explicit type (inferred foo.Donotuseme.type)
   implicit def intWrapper(x: Int) = Donotuseme
                ^
-t4271.scala:7: warning: Implicit definition should have explicit type (inferred foo.Donotuseme.type)
+t4271.scala:7: warning: [quick fix available] Implicit definition should have explicit type (inferred foo.Donotuseme.type)
   implicit def longWrapper(x: Int) = Donotuseme
                ^
-t4271.scala:8: warning: Implicit definition should have explicit type (inferred foo.Donotuseme.type)
+t4271.scala:8: warning: [quick fix available] Implicit definition should have explicit type (inferred foo.Donotuseme.type)
   implicit def ArrowAssoc[A](x: A) = Donotuseme
                ^
 6 warnings

--- a/test/files/neg/t4457_1.check
+++ b/test/files/neg/t4457_1.check
@@ -4,19 +4,19 @@ and  method aFunc in object ImplicitConvAmbiguity2 of type [A](a: ImplicitConvAm
 match argument types (Float)
     val x = aFunc(4F)
             ^
-t4457_1.scala:11: warning: [quick fix available] Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.NE[Float])
+t4457_1.scala:11: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.NE[Float]) [quick fix available]
   implicit def conv1(i: Float) = new NE[Float]
                ^
-t4457_1.scala:12: warning: [quick fix available] Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[java.util.TooManyListenersException])
+t4457_1.scala:12: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[java.util.TooManyListenersException]) [quick fix available]
   implicit def conv3(op: AA[java.util.TooManyListenersException]) = new N[java.util.TooManyListenersException]
                ^
-t4457_1.scala:13: warning: [quick fix available] Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[Float])
+t4457_1.scala:13: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[Float]) [quick fix available]
   implicit def conv4(op: AA[Float]) = new N[Float]
                ^
-t4457_1.scala:14: warning: [quick fix available] Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.NZ[Float])
+t4457_1.scala:14: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.NZ[Float]) [quick fix available]
   implicit def conv7(i: Float) = new NZ[Float]
                ^
-t4457_1.scala:15: warning: [quick fix available] Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[java.util.GregorianCalendar])
+t4457_1.scala:15: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[java.util.GregorianCalendar]) [quick fix available]
   implicit def conv5(e: BB[java.util.GregorianCalendar]) = new N[java.util.GregorianCalendar]
                ^
 5 warnings

--- a/test/files/neg/t4457_1.check
+++ b/test/files/neg/t4457_1.check
@@ -4,19 +4,19 @@ and  method aFunc in object ImplicitConvAmbiguity2 of type [A](a: ImplicitConvAm
 match argument types (Float)
     val x = aFunc(4F)
             ^
-t4457_1.scala:11: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.NE[Float]) [quick fix available]
+t4457_1.scala:11: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.NE[Float]) [quickfixable]
   implicit def conv1(i: Float) = new NE[Float]
                ^
-t4457_1.scala:12: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[java.util.TooManyListenersException]) [quick fix available]
+t4457_1.scala:12: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[java.util.TooManyListenersException]) [quickfixable]
   implicit def conv3(op: AA[java.util.TooManyListenersException]) = new N[java.util.TooManyListenersException]
                ^
-t4457_1.scala:13: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[Float]) [quick fix available]
+t4457_1.scala:13: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[Float]) [quickfixable]
   implicit def conv4(op: AA[Float]) = new N[Float]
                ^
-t4457_1.scala:14: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.NZ[Float]) [quick fix available]
+t4457_1.scala:14: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.NZ[Float]) [quickfixable]
   implicit def conv7(i: Float) = new NZ[Float]
                ^
-t4457_1.scala:15: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[java.util.GregorianCalendar]) [quick fix available]
+t4457_1.scala:15: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[java.util.GregorianCalendar]) [quickfixable]
   implicit def conv5(e: BB[java.util.GregorianCalendar]) = new N[java.util.GregorianCalendar]
                ^
 5 warnings

--- a/test/files/neg/t4457_1.check
+++ b/test/files/neg/t4457_1.check
@@ -4,19 +4,19 @@ and  method aFunc in object ImplicitConvAmbiguity2 of type [A](a: ImplicitConvAm
 match argument types (Float)
     val x = aFunc(4F)
             ^
-t4457_1.scala:11: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.NE[Float])
+t4457_1.scala:11: warning: [quick fix available] Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.NE[Float])
   implicit def conv1(i: Float) = new NE[Float]
                ^
-t4457_1.scala:12: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[java.util.TooManyListenersException])
+t4457_1.scala:12: warning: [quick fix available] Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[java.util.TooManyListenersException])
   implicit def conv3(op: AA[java.util.TooManyListenersException]) = new N[java.util.TooManyListenersException]
                ^
-t4457_1.scala:13: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[Float])
+t4457_1.scala:13: warning: [quick fix available] Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[Float])
   implicit def conv4(op: AA[Float]) = new N[Float]
                ^
-t4457_1.scala:14: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.NZ[Float])
+t4457_1.scala:14: warning: [quick fix available] Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.NZ[Float])
   implicit def conv7(i: Float) = new NZ[Float]
                ^
-t4457_1.scala:15: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[java.util.GregorianCalendar])
+t4457_1.scala:15: warning: [quick fix available] Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[java.util.GregorianCalendar])
   implicit def conv5(e: BB[java.util.GregorianCalendar]) = new N[java.util.GregorianCalendar]
                ^
 5 warnings

--- a/test/files/neg/t4457_2.check
+++ b/test/files/neg/t4457_2.check
@@ -10,19 +10,19 @@ and  method aFunc in object ImplicitConvAmbiguity2 of type [A](a: ImplicitConvAm
 match argument types (Float)
     bFunc(aFunc(4F))
           ^
-t4457_2.scala:11: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.NE[Float]) [quick fix available]
+t4457_2.scala:11: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.NE[Float]) [quickfixable]
   implicit def conv1(i: Float) = new NE[Float]
                ^
-t4457_2.scala:12: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[java.util.TooManyListenersException]) [quick fix available]
+t4457_2.scala:12: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[java.util.TooManyListenersException]) [quickfixable]
   implicit def conv3(op: AA[java.util.TooManyListenersException]) = new N[java.util.TooManyListenersException]
                ^
-t4457_2.scala:13: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[Float]) [quick fix available]
+t4457_2.scala:13: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[Float]) [quickfixable]
   implicit def conv4(op: AA[Float]) = new N[Float]
                ^
-t4457_2.scala:14: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.NZ[Float]) [quick fix available]
+t4457_2.scala:14: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.NZ[Float]) [quickfixable]
   implicit def conv7(i: Float) = new NZ[Float]
                ^
-t4457_2.scala:15: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[java.util.GregorianCalendar]) [quick fix available]
+t4457_2.scala:15: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[java.util.GregorianCalendar]) [quickfixable]
   implicit def conv5(e: BB[java.util.GregorianCalendar]) = new N[java.util.GregorianCalendar]
                ^
 5 warnings

--- a/test/files/neg/t4457_2.check
+++ b/test/files/neg/t4457_2.check
@@ -10,19 +10,19 @@ and  method aFunc in object ImplicitConvAmbiguity2 of type [A](a: ImplicitConvAm
 match argument types (Float)
     bFunc(aFunc(4F))
           ^
-t4457_2.scala:11: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.NE[Float])
+t4457_2.scala:11: warning: [quick fix available] Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.NE[Float])
   implicit def conv1(i: Float) = new NE[Float]
                ^
-t4457_2.scala:12: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[java.util.TooManyListenersException])
+t4457_2.scala:12: warning: [quick fix available] Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[java.util.TooManyListenersException])
   implicit def conv3(op: AA[java.util.TooManyListenersException]) = new N[java.util.TooManyListenersException]
                ^
-t4457_2.scala:13: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[Float])
+t4457_2.scala:13: warning: [quick fix available] Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[Float])
   implicit def conv4(op: AA[Float]) = new N[Float]
                ^
-t4457_2.scala:14: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.NZ[Float])
+t4457_2.scala:14: warning: [quick fix available] Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.NZ[Float])
   implicit def conv7(i: Float) = new NZ[Float]
                ^
-t4457_2.scala:15: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[java.util.GregorianCalendar])
+t4457_2.scala:15: warning: [quick fix available] Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[java.util.GregorianCalendar])
   implicit def conv5(e: BB[java.util.GregorianCalendar]) = new N[java.util.GregorianCalendar]
                ^
 5 warnings

--- a/test/files/neg/t4457_2.check
+++ b/test/files/neg/t4457_2.check
@@ -10,19 +10,19 @@ and  method aFunc in object ImplicitConvAmbiguity2 of type [A](a: ImplicitConvAm
 match argument types (Float)
     bFunc(aFunc(4F))
           ^
-t4457_2.scala:11: warning: [quick fix available] Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.NE[Float])
+t4457_2.scala:11: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.NE[Float]) [quick fix available]
   implicit def conv1(i: Float) = new NE[Float]
                ^
-t4457_2.scala:12: warning: [quick fix available] Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[java.util.TooManyListenersException])
+t4457_2.scala:12: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[java.util.TooManyListenersException]) [quick fix available]
   implicit def conv3(op: AA[java.util.TooManyListenersException]) = new N[java.util.TooManyListenersException]
                ^
-t4457_2.scala:13: warning: [quick fix available] Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[Float])
+t4457_2.scala:13: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[Float]) [quick fix available]
   implicit def conv4(op: AA[Float]) = new N[Float]
                ^
-t4457_2.scala:14: warning: [quick fix available] Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.NZ[Float])
+t4457_2.scala:14: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.NZ[Float]) [quick fix available]
   implicit def conv7(i: Float) = new NZ[Float]
                ^
-t4457_2.scala:15: warning: [quick fix available] Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[java.util.GregorianCalendar])
+t4457_2.scala:15: warning: Implicit definition should have explicit type (inferred ImplicitConvAmbiguity2.N[java.util.GregorianCalendar]) [quick fix available]
   implicit def conv5(e: BB[java.util.GregorianCalendar]) = new N[java.util.GregorianCalendar]
                ^
 5 warnings

--- a/test/files/neg/t4568.check
+++ b/test/files/neg/t4568.check
@@ -1,7 +1,7 @@
 t4568.scala:8: error: recursive method isSubListOf needs result type
         case h :: t => y.contains(h) && (t.isSubListOf(y.drop(y.indexOf(h) + 1)))
                                            ^
-t4568.scala:2: warning: [quick fix available] Implicit definition should have explicit type (inferred SubList.SubListable[A])
+t4568.scala:2: warning: Implicit definition should have explicit type (inferred SubList.SubListable[A]) [quick fix available]
   implicit def sublistable[A](x: List[A]) = new SubListable(x)
                ^
 1 warning

--- a/test/files/neg/t4568.check
+++ b/test/files/neg/t4568.check
@@ -1,7 +1,7 @@
 t4568.scala:8: error: recursive method isSubListOf needs result type
         case h :: t => y.contains(h) && (t.isSubListOf(y.drop(y.indexOf(h) + 1)))
                                            ^
-t4568.scala:2: warning: Implicit definition should have explicit type (inferred SubList.SubListable[A]) [quick fix available]
+t4568.scala:2: warning: Implicit definition should have explicit type (inferred SubList.SubListable[A]) [quickfixable]
   implicit def sublistable[A](x: List[A]) = new SubListable(x)
                ^
 1 warning

--- a/test/files/neg/t4568.check
+++ b/test/files/neg/t4568.check
@@ -1,7 +1,7 @@
 t4568.scala:8: error: recursive method isSubListOf needs result type
         case h :: t => y.contains(h) && (t.isSubListOf(y.drop(y.indexOf(h) + 1)))
                                            ^
-t4568.scala:2: warning: Implicit definition should have explicit type (inferred SubList.SubListable[A])
+t4568.scala:2: warning: [quick fix available] Implicit definition should have explicit type (inferred SubList.SubListable[A])
   implicit def sublistable[A](x: List[A]) = new SubListable(x)
                ^
 1 warning

--- a/test/files/neg/t4851.check
+++ b/test/files/neg/t4851.check
@@ -10,22 +10,22 @@ S.scala:5: warning: adaptation of an empty argument list by inserting () is depr
  after adaptation: new J((): Unit)
   val x2 = new J()
            ^
-S.scala:6: warning: [quick fix available] adapted the argument list to the expected 5-tuple: add additional parens instead
+S.scala:6: warning: adapted the argument list to the expected 5-tuple: add additional parens instead
         signature: J(x: Object): J
   given arguments: 1, 2, 3, 4, 5
- after adaptation: new J((1, 2, 3, 4, 5): (Int, Int, Int, Int, Int))
+ after adaptation: new J((1, 2, 3, 4, 5): (Int, Int, Int, Int, Int)) [quick fix available]
   val x3 = new J(1, 2, 3, 4, 5)
            ^
-S.scala:8: warning: [quick fix available] adapted the argument list to the expected 3-tuple: add additional parens instead
+S.scala:8: warning: adapted the argument list to the expected 3-tuple: add additional parens instead
         signature: Some.apply[A](value: A): Some[A]
   given arguments: 1, 2, 3
- after adaptation: Some((1, 2, 3): (Int, Int, Int))
+ after adaptation: Some((1, 2, 3): (Int, Int, Int)) [quick fix available]
   val y1 = Some(1, 2, 3)
                ^
-S.scala:9: warning: [quick fix available] adapted the argument list to the expected 3-tuple: add additional parens instead
+S.scala:9: warning: adapted the argument list to the expected 3-tuple: add additional parens instead
         signature: Some(value: A): Some[A]
   given arguments: 1, 2, 3
- after adaptation: new Some((1, 2, 3): (Int, Int, Int))
+ after adaptation: new Some((1, 2, 3): (Int, Int, Int)) [quick fix available]
   val y2 = new Some(1, 2, 3)
            ^
 S.scala:11: warning: adaptation of an empty argument list by inserting () is deprecated: this is unlikely to be what you want
@@ -40,10 +40,10 @@ S.scala:12: warning: adaptation of an empty argument list by inserting () is dep
  after adaptation: new J2((): Unit)
   val z2 = new J2()
            ^
-S.scala:16: warning: [quick fix available] adapted the argument list to the expected 3-tuple: add additional parens instead
+S.scala:16: warning: adapted the argument list to the expected 3-tuple: add additional parens instead
         signature: Test.anyId(a: Any): Any
   given arguments: 1, 2, 3
- after adaptation: Test.anyId((1, 2, 3): (Int, Int, Int))
+ after adaptation: Test.anyId((1, 2, 3): (Int, Int, Int)) [quick fix available]
   val w1 = anyId(1, 2 ,3)
                 ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t4851.check
+++ b/test/files/neg/t4851.check
@@ -10,19 +10,19 @@ S.scala:5: warning: adaptation of an empty argument list by inserting () is depr
  after adaptation: new J((): Unit)
   val x2 = new J()
            ^
-S.scala:6: warning: adapted the argument list to the expected 5-tuple: add additional parens instead
+S.scala:6: warning: [quick fix available] adapted the argument list to the expected 5-tuple: add additional parens instead
         signature: J(x: Object): J
   given arguments: 1, 2, 3, 4, 5
  after adaptation: new J((1, 2, 3, 4, 5): (Int, Int, Int, Int, Int))
   val x3 = new J(1, 2, 3, 4, 5)
            ^
-S.scala:8: warning: adapted the argument list to the expected 3-tuple: add additional parens instead
+S.scala:8: warning: [quick fix available] adapted the argument list to the expected 3-tuple: add additional parens instead
         signature: Some.apply[A](value: A): Some[A]
   given arguments: 1, 2, 3
  after adaptation: Some((1, 2, 3): (Int, Int, Int))
   val y1 = Some(1, 2, 3)
                ^
-S.scala:9: warning: adapted the argument list to the expected 3-tuple: add additional parens instead
+S.scala:9: warning: [quick fix available] adapted the argument list to the expected 3-tuple: add additional parens instead
         signature: Some(value: A): Some[A]
   given arguments: 1, 2, 3
  after adaptation: new Some((1, 2, 3): (Int, Int, Int))
@@ -40,7 +40,7 @@ S.scala:12: warning: adaptation of an empty argument list by inserting () is dep
  after adaptation: new J2((): Unit)
   val z2 = new J2()
            ^
-S.scala:16: warning: adapted the argument list to the expected 3-tuple: add additional parens instead
+S.scala:16: warning: [quick fix available] adapted the argument list to the expected 3-tuple: add additional parens instead
         signature: Test.anyId(a: Any): Any
   given arguments: 1, 2, 3
  after adaptation: Test.anyId((1, 2, 3): (Int, Int, Int))

--- a/test/files/neg/t4851.check
+++ b/test/files/neg/t4851.check
@@ -13,19 +13,19 @@ S.scala:5: warning: adaptation of an empty argument list by inserting () is depr
 S.scala:6: warning: adapted the argument list to the expected 5-tuple: add additional parens instead
         signature: J(x: Object): J
   given arguments: 1, 2, 3, 4, 5
- after adaptation: new J((1, 2, 3, 4, 5): (Int, Int, Int, Int, Int)) [quick fix available]
+ after adaptation: new J((1, 2, 3, 4, 5): (Int, Int, Int, Int, Int)) [quickfixable]
   val x3 = new J(1, 2, 3, 4, 5)
            ^
 S.scala:8: warning: adapted the argument list to the expected 3-tuple: add additional parens instead
         signature: Some.apply[A](value: A): Some[A]
   given arguments: 1, 2, 3
- after adaptation: Some((1, 2, 3): (Int, Int, Int)) [quick fix available]
+ after adaptation: Some((1, 2, 3): (Int, Int, Int)) [quickfixable]
   val y1 = Some(1, 2, 3)
                ^
 S.scala:9: warning: adapted the argument list to the expected 3-tuple: add additional parens instead
         signature: Some(value: A): Some[A]
   given arguments: 1, 2, 3
- after adaptation: new Some((1, 2, 3): (Int, Int, Int)) [quick fix available]
+ after adaptation: new Some((1, 2, 3): (Int, Int, Int)) [quickfixable]
   val y2 = new Some(1, 2, 3)
            ^
 S.scala:11: warning: adaptation of an empty argument list by inserting () is deprecated: this is unlikely to be what you want
@@ -43,7 +43,7 @@ S.scala:12: warning: adaptation of an empty argument list by inserting () is dep
 S.scala:16: warning: adapted the argument list to the expected 3-tuple: add additional parens instead
         signature: Test.anyId(a: Any): Any
   given arguments: 1, 2, 3
- after adaptation: Test.anyId((1, 2, 3): (Int, Int, Int)) [quick fix available]
+ after adaptation: Test.anyId((1, 2, 3): (Int, Int, Int)) [quickfixable]
   val w1 = anyId(1, 2 ,3)
                 ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t4889.check
+++ b/test/files/neg/t4889.check
@@ -1,7 +1,7 @@
 t4889.scala:19: error: could not find implicit value for parameter ma1: t4889.MatrixAdder[Int,[S]t4889.SparseMatrix[S]]
   m1.foo
      ^
-t4889.scala:14: warning: Implicit definition should have explicit type (inferred t4889.MatrixAdder[S,R]) [quick fix available]
+t4889.scala:14: warning: Implicit definition should have explicit type (inferred t4889.MatrixAdder[S,R]) [quickfixable]
   implicit def adderImplicit[S, R[s] <: Matrix[s, R]] = new MatrixAdder[S, R] {
                ^
 1 warning

--- a/test/files/neg/t4889.check
+++ b/test/files/neg/t4889.check
@@ -1,7 +1,7 @@
 t4889.scala:19: error: could not find implicit value for parameter ma1: t4889.MatrixAdder[Int,[S]t4889.SparseMatrix[S]]
   m1.foo
      ^
-t4889.scala:14: warning: Implicit definition should have explicit type (inferred t4889.MatrixAdder[S,R])
+t4889.scala:14: warning: [quick fix available] Implicit definition should have explicit type (inferred t4889.MatrixAdder[S,R])
   implicit def adderImplicit[S, R[s] <: Matrix[s, R]] = new MatrixAdder[S, R] {
                ^
 1 warning

--- a/test/files/neg/t4889.check
+++ b/test/files/neg/t4889.check
@@ -1,7 +1,7 @@
 t4889.scala:19: error: could not find implicit value for parameter ma1: t4889.MatrixAdder[Int,[S]t4889.SparseMatrix[S]]
   m1.foo
      ^
-t4889.scala:14: warning: [quick fix available] Implicit definition should have explicit type (inferred t4889.MatrixAdder[S,R])
+t4889.scala:14: warning: Implicit definition should have explicit type (inferred t4889.MatrixAdder[S,R]) [quick fix available]
   implicit def adderImplicit[S, R[s] <: Matrix[s, R]] = new MatrixAdder[S, R] {
                ^
 1 warning

--- a/test/files/neg/t5265a.check
+++ b/test/files/neg/t5265a.check
@@ -1,16 +1,16 @@
-t5265a.scala:7: warning: Implicit definition should have explicit type (inferred T[String]) [quick fix available]
+t5265a.scala:7: warning: Implicit definition should have explicit type (inferred T[String]) [quickfixable]
   implicit val tsMissing = new T[String] {}   // warn val in trait
                ^
-t5265a.scala:20: warning: Implicit definition should have explicit type (inferred T[String]) [quick fix available]
+t5265a.scala:20: warning: Implicit definition should have explicit type (inferred T[String]) [quickfixable]
   implicit val tsChild = new T[String] {}     // warn because inferred from RHS
                ^
-t5265a.scala:22: warning: Implicit definition should have explicit type (inferred Int) [quick fix available]
+t5265a.scala:22: warning: Implicit definition should have explicit type (inferred Int) [quickfixable]
   implicit private[this] val pChild = 42      // also warn
                              ^
-t5265a.scala:27: warning: Implicit definition should have explicit type (inferred Int) [quick fix available]
+t5265a.scala:27: warning: Implicit definition should have explicit type (inferred Int) [quickfixable]
   implicit private[this] val y = 42           // also warn
                              ^
-t5265a.scala:25: warning: Implicit definition should have explicit type (inferred T[String]) [quick fix available]
+t5265a.scala:25: warning: Implicit definition should have explicit type (inferred T[String]) [quickfixable]
   implicit val tsD = new T[String] {}         // warn val in class
                ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t5265a.check
+++ b/test/files/neg/t5265a.check
@@ -1,16 +1,16 @@
-t5265a.scala:7: warning: Implicit definition should have explicit type (inferred T[String])
+t5265a.scala:7: warning: [quick fix available] Implicit definition should have explicit type (inferred T[String])
   implicit val tsMissing = new T[String] {}   // warn val in trait
                ^
-t5265a.scala:20: warning: Implicit definition should have explicit type (inferred T[String])
+t5265a.scala:20: warning: [quick fix available] Implicit definition should have explicit type (inferred T[String])
   implicit val tsChild = new T[String] {}     // warn because inferred from RHS
                ^
-t5265a.scala:22: warning: Implicit definition should have explicit type (inferred Int)
+t5265a.scala:22: warning: [quick fix available] Implicit definition should have explicit type (inferred Int)
   implicit private[this] val pChild = 42      // also warn
                              ^
-t5265a.scala:27: warning: Implicit definition should have explicit type (inferred Int)
+t5265a.scala:27: warning: [quick fix available] Implicit definition should have explicit type (inferred Int)
   implicit private[this] val y = 42           // also warn
                              ^
-t5265a.scala:25: warning: Implicit definition should have explicit type (inferred T[String])
+t5265a.scala:25: warning: [quick fix available] Implicit definition should have explicit type (inferred T[String])
   implicit val tsD = new T[String] {}         // warn val in class
                ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t5265a.check
+++ b/test/files/neg/t5265a.check
@@ -1,16 +1,16 @@
-t5265a.scala:7: warning: [quick fix available] Implicit definition should have explicit type (inferred T[String])
+t5265a.scala:7: warning: Implicit definition should have explicit type (inferred T[String]) [quick fix available]
   implicit val tsMissing = new T[String] {}   // warn val in trait
                ^
-t5265a.scala:20: warning: [quick fix available] Implicit definition should have explicit type (inferred T[String])
+t5265a.scala:20: warning: Implicit definition should have explicit type (inferred T[String]) [quick fix available]
   implicit val tsChild = new T[String] {}     // warn because inferred from RHS
                ^
-t5265a.scala:22: warning: [quick fix available] Implicit definition should have explicit type (inferred Int)
+t5265a.scala:22: warning: Implicit definition should have explicit type (inferred Int) [quick fix available]
   implicit private[this] val pChild = 42      // also warn
                              ^
-t5265a.scala:27: warning: [quick fix available] Implicit definition should have explicit type (inferred Int)
+t5265a.scala:27: warning: Implicit definition should have explicit type (inferred Int) [quick fix available]
   implicit private[this] val y = 42           // also warn
                              ^
-t5265a.scala:25: warning: [quick fix available] Implicit definition should have explicit type (inferred T[String])
+t5265a.scala:25: warning: Implicit definition should have explicit type (inferred T[String]) [quick fix available]
   implicit val tsD = new T[String] {}         // warn val in class
                ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t5265b.check
+++ b/test/files/neg/t5265b.check
@@ -1,9 +1,9 @@
-t5265b.scala:7: error: Implicit definition must have explicit type (inferred T[String]) [quick fix available]
+t5265b.scala:7: error: Implicit definition must have explicit type (inferred T[String]) [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=Missing.tsMissing
   implicit val tsMissing = new T[String] {}   // warn val in trait
                ^
-t5265b.scala:20: error: under -Xsource:3, inferred T[String] [quick fix available]
+t5265b.scala:20: error: under -Xsource:3, inferred T[String] [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=Child.tsChild
   implicit val tsChild = new T[String] {}     // nowarn because inferred from overridden

--- a/test/files/neg/t5265b.check
+++ b/test/files/neg/t5265b.check
@@ -1,9 +1,9 @@
-t5265b.scala:7: error: Implicit definition must have explicit type (inferred T[String])
+t5265b.scala:7: error: [quick fix available] Implicit definition must have explicit type (inferred T[String])
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=Missing.tsMissing
   implicit val tsMissing = new T[String] {}   // warn val in trait
                ^
-t5265b.scala:20: error: under -Xsource:3, inferred T[String]
+t5265b.scala:20: error: [quick fix available] under -Xsource:3, inferred T[String]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=Child.tsChild
   implicit val tsChild = new T[String] {}     // nowarn because inferred from overridden

--- a/test/files/neg/t5265b.check
+++ b/test/files/neg/t5265b.check
@@ -1,9 +1,9 @@
-t5265b.scala:7: error: [quick fix available] Implicit definition must have explicit type (inferred T[String])
+t5265b.scala:7: error: Implicit definition must have explicit type (inferred T[String]) [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=Missing.tsMissing
   implicit val tsMissing = new T[String] {}   // warn val in trait
                ^
-t5265b.scala:20: error: [quick fix available] under -Xsource:3, inferred T[String]
+t5265b.scala:20: error: under -Xsource:3, inferred T[String] [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=Child.tsChild
   implicit val tsChild = new T[String] {}     // nowarn because inferred from overridden

--- a/test/files/neg/t5429.check
+++ b/test/files/neg/t5429.check
@@ -115,7 +115,7 @@ t5429.scala:73: error: stable, immutable value required to override:
 lazy val lazyvalue: Any (defined in class A0)
   override def lazyvalue = 2  // fail
                ^
-t5429.scala:75: warning: method without a parameter list overrides a method with a single empty one [quick fix available]
+t5429.scala:75: warning: method without a parameter list overrides a method with a single empty one [quickfixable]
   override def emptyArg = 10  // override
                ^
 t5429.scala:76: error: method oneArg overrides nothing.

--- a/test/files/neg/t5429.check
+++ b/test/files/neg/t5429.check
@@ -115,7 +115,7 @@ t5429.scala:73: error: stable, immutable value required to override:
 lazy val lazyvalue: Any (defined in class A0)
   override def lazyvalue = 2  // fail
                ^
-t5429.scala:75: warning: method without a parameter list overrides a method with a single empty one
+t5429.scala:75: warning: [quick fix available] method without a parameter list overrides a method with a single empty one
   override def emptyArg = 10  // override
                ^
 t5429.scala:76: error: method oneArg overrides nothing.

--- a/test/files/neg/t5429.check
+++ b/test/files/neg/t5429.check
@@ -115,7 +115,7 @@ t5429.scala:73: error: stable, immutable value required to override:
 lazy val lazyvalue: Any (defined in class A0)
   override def lazyvalue = 2  // fail
                ^
-t5429.scala:75: warning: [quick fix available] method without a parameter list overrides a method with a single empty one
+t5429.scala:75: warning: method without a parameter list overrides a method with a single empty one [quick fix available]
   override def emptyArg = 10  // override
                ^
 t5429.scala:76: error: method oneArg overrides nothing.

--- a/test/files/neg/t5606.check
+++ b/test/files/neg/t5606.check
@@ -1,7 +1,7 @@
-t5606.scala:5: error: using `?` as a type name requires backticks. [quick fix available]
+t5606.scala:5: error: using `?` as a type name requires backticks. [quickfixable]
 case class CaseTest_?[?](someData: String)
                       ^
-t5606.scala:23: error: using `?` as a type name requires backticks. [quick fix available]
+t5606.scala:23: error: using `?` as a type name requires backticks. [quickfixable]
   def regress_?[F[?]]   = 2
                   ^
 t5606.scala:3: error: Top-level wildcard is not allowed

--- a/test/files/neg/t5606.check
+++ b/test/files/neg/t5606.check
@@ -1,7 +1,7 @@
-t5606.scala:5: error: using `?` as a type name requires backticks.
+t5606.scala:5: error: [quick fix available] using `?` as a type name requires backticks.
 case class CaseTest_?[?](someData: String)
                       ^
-t5606.scala:23: error: using `?` as a type name requires backticks.
+t5606.scala:23: error: [quick fix available] using `?` as a type name requires backticks.
   def regress_?[F[?]]   = 2
                   ^
 t5606.scala:3: error: Top-level wildcard is not allowed

--- a/test/files/neg/t5606.check
+++ b/test/files/neg/t5606.check
@@ -1,7 +1,7 @@
-t5606.scala:5: error: [quick fix available] using `?` as a type name requires backticks.
+t5606.scala:5: error: using `?` as a type name requires backticks. [quick fix available]
 case class CaseTest_?[?](someData: String)
                       ^
-t5606.scala:23: error: [quick fix available] using `?` as a type name requires backticks.
+t5606.scala:23: error: using `?` as a type name requires backticks. [quick fix available]
   def regress_?[F[?]]   = 2
                   ^
 t5606.scala:3: error: Top-level wildcard is not allowed

--- a/test/files/neg/t5715.check
+++ b/test/files/neg/t5715.check
@@ -1,4 +1,4 @@
-t5715.scala:19: warning: Wrap `then` in backticks to use it as an identifier, it will become a keyword in Scala 3. [quick fix available]
+t5715.scala:19: warning: Wrap `then` in backticks to use it as an identifier, it will become a keyword in Scala 3. [quickfixable]
   object then                         // keyword
          ^
 t5715.scala:12: warning: class then in package example is deprecated (since 0.1): that was then

--- a/test/files/neg/t5715.check
+++ b/test/files/neg/t5715.check
@@ -1,4 +1,4 @@
-t5715.scala:19: warning: [quick fix available] Wrap `then` in backticks to use it as an identifier, it will become a keyword in Scala 3.
+t5715.scala:19: warning: Wrap `then` in backticks to use it as an identifier, it will become a keyword in Scala 3. [quick fix available]
   object then                         // keyword
          ^
 t5715.scala:12: warning: class then in package example is deprecated (since 0.1): that was then

--- a/test/files/neg/t5715.check
+++ b/test/files/neg/t5715.check
@@ -1,4 +1,4 @@
-t5715.scala:19: warning: Wrap `then` in backticks to use it as an identifier, it will become a keyword in Scala 3.
+t5715.scala:19: warning: [quick fix available] Wrap `then` in backticks to use it as an identifier, it will become a keyword in Scala 3.
   object then                         // keyword
          ^
 t5715.scala:12: warning: class then in package example is deprecated (since 0.1): that was then

--- a/test/files/neg/t5728.check
+++ b/test/files/neg/t5728.check
@@ -1,7 +1,7 @@
 t5728.scala:3: error: implicit classes must accept exactly one primary constructor parameter
   implicit class Foo
                  ^
-t5728.scala:5: warning: Implicit definition should have explicit type (inferred Test.Foo)
+t5728.scala:5: warning: [quick fix available] Implicit definition should have explicit type (inferred Test.Foo)
   implicit def Foo = new Foo
                ^
 1 warning

--- a/test/files/neg/t5728.check
+++ b/test/files/neg/t5728.check
@@ -1,7 +1,7 @@
 t5728.scala:3: error: implicit classes must accept exactly one primary constructor parameter
   implicit class Foo
                  ^
-t5728.scala:5: warning: Implicit definition should have explicit type (inferred Test.Foo) [quick fix available]
+t5728.scala:5: warning: Implicit definition should have explicit type (inferred Test.Foo) [quickfixable]
   implicit def Foo = new Foo
                ^
 1 warning

--- a/test/files/neg/t5728.check
+++ b/test/files/neg/t5728.check
@@ -1,7 +1,7 @@
 t5728.scala:3: error: implicit classes must accept exactly one primary constructor parameter
   implicit class Foo
                  ^
-t5728.scala:5: warning: [quick fix available] Implicit definition should have explicit type (inferred Test.Foo)
+t5728.scala:5: warning: Implicit definition should have explicit type (inferred Test.Foo) [quick fix available]
   implicit def Foo = new Foo
                ^
 1 warning

--- a/test/files/neg/t6436.check
+++ b/test/files/neg/t6436.check
@@ -7,10 +7,10 @@ Note that implicit conversions are not applicable because they are ambiguous:
  are possible conversion functions from StringContext to ?{def q: ?}
   println(q"a")
           ^
-t6436.scala:2: warning: Implicit definition should have explicit type (inferred AnyRef{def q: Nothing}) [quick fix available]
+t6436.scala:2: warning: Implicit definition should have explicit type (inferred AnyRef{def q: Nothing}) [quickfixable]
   implicit def foo1(ctx: StringContext) = new { def q = ??? }
                ^
-t6436.scala:3: warning: Implicit definition should have explicit type (inferred AnyRef{def q: Nothing}) [quick fix available]
+t6436.scala:3: warning: Implicit definition should have explicit type (inferred AnyRef{def q: Nothing}) [quickfixable]
   implicit def foo2(ctx: StringContext) = new { def q = ??? }
                ^
 2 warnings

--- a/test/files/neg/t6436.check
+++ b/test/files/neg/t6436.check
@@ -7,10 +7,10 @@ Note that implicit conversions are not applicable because they are ambiguous:
  are possible conversion functions from StringContext to ?{def q: ?}
   println(q"a")
           ^
-t6436.scala:2: warning: [quick fix available] Implicit definition should have explicit type (inferred AnyRef{def q: Nothing})
+t6436.scala:2: warning: Implicit definition should have explicit type (inferred AnyRef{def q: Nothing}) [quick fix available]
   implicit def foo1(ctx: StringContext) = new { def q = ??? }
                ^
-t6436.scala:3: warning: [quick fix available] Implicit definition should have explicit type (inferred AnyRef{def q: Nothing})
+t6436.scala:3: warning: Implicit definition should have explicit type (inferred AnyRef{def q: Nothing}) [quick fix available]
   implicit def foo2(ctx: StringContext) = new { def q = ??? }
                ^
 2 warnings

--- a/test/files/neg/t6436.check
+++ b/test/files/neg/t6436.check
@@ -7,10 +7,10 @@ Note that implicit conversions are not applicable because they are ambiguous:
  are possible conversion functions from StringContext to ?{def q: ?}
   println(q"a")
           ^
-t6436.scala:2: warning: Implicit definition should have explicit type (inferred AnyRef{def q: Nothing})
+t6436.scala:2: warning: [quick fix available] Implicit definition should have explicit type (inferred AnyRef{def q: Nothing})
   implicit def foo1(ctx: StringContext) = new { def q = ??? }
                ^
-t6436.scala:3: warning: Implicit definition should have explicit type (inferred AnyRef{def q: Nothing})
+t6436.scala:3: warning: [quick fix available] Implicit definition should have explicit type (inferred AnyRef{def q: Nothing})
   implicit def foo2(ctx: StringContext) = new { def q = ??? }
                ^
 2 warnings

--- a/test/files/neg/t6436b.check
+++ b/test/files/neg/t6436b.check
@@ -7,10 +7,10 @@ Note that implicit conversions are not applicable because they are ambiguous:
  are possible conversion functions from StringContext to ?{def q: ?}
   println(StringContext("a").q())
                        ^
-t6436b.scala:2: warning: [quick fix available] Implicit definition should have explicit type (inferred AnyRef{def q: Nothing})
+t6436b.scala:2: warning: Implicit definition should have explicit type (inferred AnyRef{def q: Nothing}) [quick fix available]
   implicit def foo1(ctx: StringContext) = new { def q = ??? }
                ^
-t6436b.scala:3: warning: [quick fix available] Implicit definition should have explicit type (inferred AnyRef{def q: Nothing})
+t6436b.scala:3: warning: Implicit definition should have explicit type (inferred AnyRef{def q: Nothing}) [quick fix available]
   implicit def foo2(ctx: StringContext) = new { def q = ??? }
                ^
 2 warnings

--- a/test/files/neg/t6436b.check
+++ b/test/files/neg/t6436b.check
@@ -7,10 +7,10 @@ Note that implicit conversions are not applicable because they are ambiguous:
  are possible conversion functions from StringContext to ?{def q: ?}
   println(StringContext("a").q())
                        ^
-t6436b.scala:2: warning: Implicit definition should have explicit type (inferred AnyRef{def q: Nothing}) [quick fix available]
+t6436b.scala:2: warning: Implicit definition should have explicit type (inferred AnyRef{def q: Nothing}) [quickfixable]
   implicit def foo1(ctx: StringContext) = new { def q = ??? }
                ^
-t6436b.scala:3: warning: Implicit definition should have explicit type (inferred AnyRef{def q: Nothing}) [quick fix available]
+t6436b.scala:3: warning: Implicit definition should have explicit type (inferred AnyRef{def q: Nothing}) [quickfixable]
   implicit def foo2(ctx: StringContext) = new { def q = ??? }
                ^
 2 warnings

--- a/test/files/neg/t6436b.check
+++ b/test/files/neg/t6436b.check
@@ -7,10 +7,10 @@ Note that implicit conversions are not applicable because they are ambiguous:
  are possible conversion functions from StringContext to ?{def q: ?}
   println(StringContext("a").q())
                        ^
-t6436b.scala:2: warning: Implicit definition should have explicit type (inferred AnyRef{def q: Nothing})
+t6436b.scala:2: warning: [quick fix available] Implicit definition should have explicit type (inferred AnyRef{def q: Nothing})
   implicit def foo1(ctx: StringContext) = new { def q = ??? }
                ^
-t6436b.scala:3: warning: Implicit definition should have explicit type (inferred AnyRef{def q: Nothing})
+t6436b.scala:3: warning: [quick fix available] Implicit definition should have explicit type (inferred AnyRef{def q: Nothing})
   implicit def foo2(ctx: StringContext) = new { def q = ??? }
                ^
 2 warnings

--- a/test/files/neg/t6567.check
+++ b/test/files/neg/t6567.check
@@ -1,4 +1,4 @@
-t6567.scala:8: warning: Implicit definition should have explicit type (inferred B)
+t6567.scala:8: warning: [quick fix available] Implicit definition should have explicit type (inferred B)
   implicit def a2b(a: A) = new B
                ^
 t6567.scala:10: warning: Suspicious application of an implicit view (Test.this.a2b) in the argument to Option.apply.

--- a/test/files/neg/t6567.check
+++ b/test/files/neg/t6567.check
@@ -1,4 +1,4 @@
-t6567.scala:8: warning: Implicit definition should have explicit type (inferred B) [quick fix available]
+t6567.scala:8: warning: Implicit definition should have explicit type (inferred B) [quickfixable]
   implicit def a2b(a: A) = new B
                ^
 t6567.scala:10: warning: Suspicious application of an implicit view (Test.this.a2b) in the argument to Option.apply.

--- a/test/files/neg/t6567.check
+++ b/test/files/neg/t6567.check
@@ -1,4 +1,4 @@
-t6567.scala:8: warning: [quick fix available] Implicit definition should have explicit type (inferred B)
+t6567.scala:8: warning: Implicit definition should have explicit type (inferred B) [quick fix available]
   implicit def a2b(a: A) = new B
                ^
 t6567.scala:10: warning: Suspicious application of an implicit view (Test.this.a2b) in the argument to Option.apply.

--- a/test/files/neg/t6667.check
+++ b/test/files/neg/t6667.check
@@ -10,7 +10,7 @@ t6667.scala:9: error: ambiguous implicit values:
  match expected type C
   implicitly[C]       // ambiguity reported, rather than falling back to C.companion
             ^
-t6667.scala:3: warning: [quick fix available] Implicit definition should have explicit type (inferred C)
+t6667.scala:3: warning: Implicit definition should have explicit type (inferred C) [quick fix available]
   implicit def companion = new C
                ^
 1 warning

--- a/test/files/neg/t6667.check
+++ b/test/files/neg/t6667.check
@@ -10,7 +10,7 @@ t6667.scala:9: error: ambiguous implicit values:
  match expected type C
   implicitly[C]       // ambiguity reported, rather than falling back to C.companion
             ^
-t6667.scala:3: warning: Implicit definition should have explicit type (inferred C)
+t6667.scala:3: warning: [quick fix available] Implicit definition should have explicit type (inferred C)
   implicit def companion = new C
                ^
 1 warning

--- a/test/files/neg/t6667.check
+++ b/test/files/neg/t6667.check
@@ -10,7 +10,7 @@ t6667.scala:9: error: ambiguous implicit values:
  match expected type C
   implicitly[C]       // ambiguity reported, rather than falling back to C.companion
             ^
-t6667.scala:3: warning: Implicit definition should have explicit type (inferred C) [quick fix available]
+t6667.scala:3: warning: Implicit definition should have explicit type (inferred C) [quickfixable]
   implicit def companion = new C
                ^
 1 warning

--- a/test/files/neg/t692.check
+++ b/test/files/neg/t692.check
@@ -16,7 +16,7 @@ t692.scala:14: error: class Foo takes type parameters
 t692.scala:19: error: class Foo takes type parameters
   class Bar[A <: Foo](implicit tpeA : Type[A]) extends Foo;
                  ^
-t692.scala:11: warning: Implicit definition should have explicit type (inferred test3.this.FooType)
+t692.scala:11: warning: [quick fix available] Implicit definition should have explicit type (inferred test3.this.FooType)
   implicit def typeOfFoo = FooType();
                ^
 1 warning

--- a/test/files/neg/t692.check
+++ b/test/files/neg/t692.check
@@ -16,7 +16,7 @@ t692.scala:14: error: class Foo takes type parameters
 t692.scala:19: error: class Foo takes type parameters
   class Bar[A <: Foo](implicit tpeA : Type[A]) extends Foo;
                  ^
-t692.scala:11: warning: [quick fix available] Implicit definition should have explicit type (inferred test3.this.FooType)
+t692.scala:11: warning: Implicit definition should have explicit type (inferred test3.this.FooType) [quick fix available]
   implicit def typeOfFoo = FooType();
                ^
 1 warning

--- a/test/files/neg/t692.check
+++ b/test/files/neg/t692.check
@@ -16,7 +16,7 @@ t692.scala:14: error: class Foo takes type parameters
 t692.scala:19: error: class Foo takes type parameters
   class Bar[A <: Foo](implicit tpeA : Type[A]) extends Foo;
                  ^
-t692.scala:11: warning: Implicit definition should have explicit type (inferred test3.this.FooType) [quick fix available]
+t692.scala:11: warning: Implicit definition should have explicit type (inferred test3.this.FooType) [quickfixable]
   implicit def typeOfFoo = FooType();
                ^
 1 warning

--- a/test/files/neg/t712.check
+++ b/test/files/neg/t712.check
@@ -1,10 +1,10 @@
 t712.scala:10: error: overloaded method coerce needs result type
   implicit def coerce(p : ParentImpl) = p.self;
                                           ^
-t712.scala:3: warning: Implicit definition should have explicit type (inferred A.this.Node) [quick fix available]
+t712.scala:3: warning: Implicit definition should have explicit type (inferred A.this.Node) [quickfixable]
   implicit def coerce(n : NodeImpl) = n.self;
                ^
-t712.scala:10: warning: Implicit definition should have explicit type [quick fix available]
+t712.scala:10: warning: Implicit definition should have explicit type [quickfixable]
   implicit def coerce(p : ParentImpl) = p.self;
                ^
 2 warnings

--- a/test/files/neg/t712.check
+++ b/test/files/neg/t712.check
@@ -1,10 +1,10 @@
 t712.scala:10: error: overloaded method coerce needs result type
   implicit def coerce(p : ParentImpl) = p.self;
                                           ^
-t712.scala:3: warning: [quick fix available] Implicit definition should have explicit type (inferred A.this.Node)
+t712.scala:3: warning: Implicit definition should have explicit type (inferred A.this.Node) [quick fix available]
   implicit def coerce(n : NodeImpl) = n.self;
                ^
-t712.scala:10: warning: [quick fix available] Implicit definition should have explicit type
+t712.scala:10: warning: Implicit definition should have explicit type [quick fix available]
   implicit def coerce(p : ParentImpl) = p.self;
                ^
 2 warnings

--- a/test/files/neg/t712.check
+++ b/test/files/neg/t712.check
@@ -1,10 +1,10 @@
 t712.scala:10: error: overloaded method coerce needs result type
   implicit def coerce(p : ParentImpl) = p.self;
                                           ^
-t712.scala:3: warning: Implicit definition should have explicit type (inferred A.this.Node)
+t712.scala:3: warning: [quick fix available] Implicit definition should have explicit type (inferred A.this.Node)
   implicit def coerce(n : NodeImpl) = n.self;
                ^
-t712.scala:10: warning: Implicit definition should have explicit type
+t712.scala:10: warning: [quick fix available] Implicit definition should have explicit type
   implicit def coerce(p : ParentImpl) = p.self;
                ^
 2 warnings

--- a/test/files/neg/t7131.check
+++ b/test/files/neg/t7131.check
@@ -4,10 +4,10 @@ t7131.scala:21: error: type mismatch;
  Note: implicit method convertToSimpleMappable is not applicable here because it comes after the application point and it lacks an explicit result type.
         x.value.map(f)
                    ^
-t7131.scala:28: warning: [quick fix available] Implicit definition should have explicit type (inferred ObservableValue.TraversableMappable[T,Container])
+t7131.scala:28: warning: Implicit definition should have explicit type (inferred ObservableValue.TraversableMappable[T,Container]) [quick fix available]
   implicit def convertToTraversableMappable[T, Container[X] <: Traversable[X]](x: ObservableValue[Container[T]]) =
                ^
-t7131.scala:43: warning: [quick fix available] Implicit definition should have explicit type (inferred ObservableValue.NestedMappable[T,Container])
+t7131.scala:43: warning: Implicit definition should have explicit type (inferred ObservableValue.NestedMappable[T,Container]) [quick fix available]
   implicit def convertToSimpleMappable[T, Container[X] <: ObservableValue.HasMap[X, Container]](x: ObservableValue[Container[T]]) =
                ^
 2 warnings

--- a/test/files/neg/t7131.check
+++ b/test/files/neg/t7131.check
@@ -4,10 +4,10 @@ t7131.scala:21: error: type mismatch;
  Note: implicit method convertToSimpleMappable is not applicable here because it comes after the application point and it lacks an explicit result type.
         x.value.map(f)
                    ^
-t7131.scala:28: warning: Implicit definition should have explicit type (inferred ObservableValue.TraversableMappable[T,Container])
+t7131.scala:28: warning: [quick fix available] Implicit definition should have explicit type (inferred ObservableValue.TraversableMappable[T,Container])
   implicit def convertToTraversableMappable[T, Container[X] <: Traversable[X]](x: ObservableValue[Container[T]]) =
                ^
-t7131.scala:43: warning: Implicit definition should have explicit type (inferred ObservableValue.NestedMappable[T,Container])
+t7131.scala:43: warning: [quick fix available] Implicit definition should have explicit type (inferred ObservableValue.NestedMappable[T,Container])
   implicit def convertToSimpleMappable[T, Container[X] <: ObservableValue.HasMap[X, Container]](x: ObservableValue[Container[T]]) =
                ^
 2 warnings

--- a/test/files/neg/t7131.check
+++ b/test/files/neg/t7131.check
@@ -4,10 +4,10 @@ t7131.scala:21: error: type mismatch;
  Note: implicit method convertToSimpleMappable is not applicable here because it comes after the application point and it lacks an explicit result type.
         x.value.map(f)
                    ^
-t7131.scala:28: warning: Implicit definition should have explicit type (inferred ObservableValue.TraversableMappable[T,Container]) [quick fix available]
+t7131.scala:28: warning: Implicit definition should have explicit type (inferred ObservableValue.TraversableMappable[T,Container]) [quickfixable]
   implicit def convertToTraversableMappable[T, Container[X] <: Traversable[X]](x: ObservableValue[Container[T]]) =
                ^
-t7131.scala:43: warning: Implicit definition should have explicit type (inferred ObservableValue.NestedMappable[T,Container]) [quick fix available]
+t7131.scala:43: warning: Implicit definition should have explicit type (inferred ObservableValue.NestedMappable[T,Container]) [quickfixable]
   implicit def convertToSimpleMappable[T, Container[X] <: ObservableValue.HasMap[X, Container]](x: ObservableValue[Container[T]]) =
                ^
 2 warnings

--- a/test/files/neg/t7187-3.check
+++ b/test/files/neg/t7187-3.check
@@ -13,7 +13,7 @@ t7187-3.scala:16: error: type mismatch;
  required: SamZero
   val t2Sam: SamZero = m2         // error, nilary methods don't eta-expand to SAM types
                        ^
-t7187-3.scala:27: error: Methods without a parameter list and by-name params can not be converted to functions as `m _`, write a function literal `() => m` instead
+t7187-3.scala:27: error: Methods without a parameter list and by-name params can not be converted to functions as `m _`, write a function literal `() => m` instead [quick fix available]
   val t7 = m1 _ // error: eta-expanding a nullary method
            ^
 t7187-3.scala:14: warning: An unapplied 0-arity method was eta-expanded (due to the expected type () => Any), rather than applied to `()`.

--- a/test/files/neg/t7187-3.check
+++ b/test/files/neg/t7187-3.check
@@ -13,7 +13,7 @@ t7187-3.scala:16: error: type mismatch;
  required: SamZero
   val t2Sam: SamZero = m2         // error, nilary methods don't eta-expand to SAM types
                        ^
-t7187-3.scala:27: error: Methods without a parameter list and by-name params can not be converted to functions as `m _`, write a function literal `() => m` instead [quick fix available]
+t7187-3.scala:27: error: Methods without a parameter list and by-name params can not be converted to functions as `m _`, write a function literal `() => m` instead [quickfixable]
   val t7 = m1 _ // error: eta-expanding a nullary method
            ^
 t7187-3.scala:14: warning: An unapplied 0-arity method was eta-expanded (due to the expected type () => Any), rather than applied to `()`.

--- a/test/files/neg/t7187-deprecation.check
+++ b/test/files/neg/t7187-deprecation.check
@@ -13,17 +13,17 @@ t7187-deprecation.scala:20: error: type mismatch;
  required: SamZero
   val t2Sam: SamZero = m2         // error, nilary methods don't eta-expand to SAM types
                        ^
-t7187-deprecation.scala:31: error: Methods without a parameter list and by-name params can not be converted to functions as `m _`, write a function literal `() => m` instead
+t7187-deprecation.scala:31: error: Methods without a parameter list and by-name params can not be converted to functions as `m _`, write a function literal `() => m` instead [quick fix available]
   val t7 = m1 _ // error: eta-expanding a nullary method
            ^
-t7187-deprecation.scala:24: warning: [quick fix available] Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method m2,
+t7187-deprecation.scala:24: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method m2,
 or remove the empty argument list from its definition (Java-defined methods are exempt).
-In Scala 3, an unapplied method like this will be eta-expanded into a function.
+In Scala 3, an unapplied method like this will be eta-expanded into a function. [quick fix available]
   val t5 = m2 // warn: apply, ()-insertion
            ^
-t7187-deprecation.scala:40: warning: [quick fix available] Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method boom,
+t7187-deprecation.scala:40: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method boom,
 or remove the empty argument list from its definition (Java-defined methods are exempt).
-In Scala 3, an unapplied method like this will be eta-expanded into a function.
+In Scala 3, an unapplied method like this will be eta-expanded into a function. [quick fix available]
   a.boom // warning: apply, ()-insertion
     ^
 2 warnings

--- a/test/files/neg/t7187-deprecation.check
+++ b/test/files/neg/t7187-deprecation.check
@@ -13,17 +13,17 @@ t7187-deprecation.scala:20: error: type mismatch;
  required: SamZero
   val t2Sam: SamZero = m2         // error, nilary methods don't eta-expand to SAM types
                        ^
-t7187-deprecation.scala:31: error: Methods without a parameter list and by-name params can not be converted to functions as `m _`, write a function literal `() => m` instead [quick fix available]
+t7187-deprecation.scala:31: error: Methods without a parameter list and by-name params can not be converted to functions as `m _`, write a function literal `() => m` instead [quickfixable]
   val t7 = m1 _ // error: eta-expanding a nullary method
            ^
 t7187-deprecation.scala:24: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method m2,
 or remove the empty argument list from its definition (Java-defined methods are exempt).
-In Scala 3, an unapplied method like this will be eta-expanded into a function. [quick fix available]
+In Scala 3, an unapplied method like this will be eta-expanded into a function. [quickfixable]
   val t5 = m2 // warn: apply, ()-insertion
            ^
 t7187-deprecation.scala:40: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method boom,
 or remove the empty argument list from its definition (Java-defined methods are exempt).
-In Scala 3, an unapplied method like this will be eta-expanded into a function. [quick fix available]
+In Scala 3, an unapplied method like this will be eta-expanded into a function. [quickfixable]
   a.boom // warning: apply, ()-insertion
     ^
 2 warnings

--- a/test/files/neg/t7187.check
+++ b/test/files/neg/t7187.check
@@ -26,15 +26,15 @@ t7187.scala:12: warning: An unapplied 0-arity method was eta-expanded (due to th
 Write foo() to invoke method foo, or change the expected type.
   val t1b: () => Any = foo   // eta-expansion, but lint warning
                        ^
-t7187.scala:13: warning: [quick fix available] Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method foo,
+t7187.scala:13: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method foo,
 or remove the empty argument list from its definition (Java-defined methods are exempt).
-In Scala 3, an unapplied method like this will be eta-expanded into a function.
+In Scala 3, an unapplied method like this will be eta-expanded into a function. [quick fix available]
   val t1c: () => Any = { val t = foo; t } // `()`-insertion because no expected type
                                  ^
-t7187.scala:21: warning: [quick fix available] Methods without a parameter list and by-name params can no longer be converted to functions as `m _`, write a function literal `() => m` instead
+t7187.scala:21: warning: Methods without a parameter list and by-name params can no longer be converted to functions as `m _`, write a function literal `() => m` instead [quick fix available]
   val t2c: () => Any = bar _ // warning: eta-expanding a nullary method
                        ^
-t7187.scala:22: warning: [quick fix available] Methods without a parameter list and by-name params can no longer be converted to functions as `m _`, write a function literal `() => m` instead
+t7187.scala:22: warning: Methods without a parameter list and by-name params can no longer be converted to functions as `m _`, write a function literal `() => m` instead [quick fix available]
   val t2d: Any       = bar _ // warning: eta-expanding a nullary method
                        ^
 t7187.scala:26: warning: An unapplied 0-arity method was eta-expanded (due to the expected type () => Any), rather than applied to `()`.

--- a/test/files/neg/t7187.check
+++ b/test/files/neg/t7187.check
@@ -28,13 +28,13 @@ Write foo() to invoke method foo, or change the expected type.
                        ^
 t7187.scala:13: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method foo,
 or remove the empty argument list from its definition (Java-defined methods are exempt).
-In Scala 3, an unapplied method like this will be eta-expanded into a function. [quick fix available]
+In Scala 3, an unapplied method like this will be eta-expanded into a function. [quickfixable]
   val t1c: () => Any = { val t = foo; t } // `()`-insertion because no expected type
                                  ^
-t7187.scala:21: warning: Methods without a parameter list and by-name params can no longer be converted to functions as `m _`, write a function literal `() => m` instead [quick fix available]
+t7187.scala:21: warning: Methods without a parameter list and by-name params can no longer be converted to functions as `m _`, write a function literal `() => m` instead [quickfixable]
   val t2c: () => Any = bar _ // warning: eta-expanding a nullary method
                        ^
-t7187.scala:22: warning: Methods without a parameter list and by-name params can no longer be converted to functions as `m _`, write a function literal `() => m` instead [quick fix available]
+t7187.scala:22: warning: Methods without a parameter list and by-name params can no longer be converted to functions as `m _`, write a function literal `() => m` instead [quickfixable]
   val t2d: Any       = bar _ // warning: eta-expanding a nullary method
                        ^
 t7187.scala:26: warning: An unapplied 0-arity method was eta-expanded (due to the expected type () => Any), rather than applied to `()`.

--- a/test/files/neg/t7187.check
+++ b/test/files/neg/t7187.check
@@ -31,10 +31,10 @@ or remove the empty argument list from its definition (Java-defined methods are 
 In Scala 3, an unapplied method like this will be eta-expanded into a function.
   val t1c: () => Any = { val t = foo; t } // `()`-insertion because no expected type
                                  ^
-t7187.scala:21: warning: Methods without a parameter list and by-name params can no longer be converted to functions as `m _`, write a function literal `() => m` instead
+t7187.scala:21: warning: [quick fix available] Methods without a parameter list and by-name params can no longer be converted to functions as `m _`, write a function literal `() => m` instead
   val t2c: () => Any = bar _ // warning: eta-expanding a nullary method
                        ^
-t7187.scala:22: warning: Methods without a parameter list and by-name params can no longer be converted to functions as `m _`, write a function literal `() => m` instead
+t7187.scala:22: warning: [quick fix available] Methods without a parameter list and by-name params can no longer be converted to functions as `m _`, write a function literal `() => m` instead
   val t2d: Any       = bar _ // warning: eta-expanding a nullary method
                        ^
 t7187.scala:26: warning: An unapplied 0-arity method was eta-expanded (due to the expected type () => Any), rather than applied to `()`.

--- a/test/files/neg/t7212.check
+++ b/test/files/neg/t7212.check
@@ -13,13 +13,13 @@ t7212.scala:21: error: type mismatch;
  required: String
   val s: String = w.f
                     ^
-t7212.scala:5: warning: under -Xsource:3, inferred Object instead of String
+t7212.scala:5: warning: [quick fix available] under -Xsource:3, inferred Object instead of String
 class K extends T { def f = "" }
                         ^
-t7212.scala:11: warning: under -Xsource:3, inferred Object instead of String
+t7212.scala:11: warning: [quick fix available] under -Xsource:3, inferred Object instead of String
 class F extends T { val f = "" }
                         ^
-t7212.scala:17: warning: under -Xsource:3, inferred Object instead of String
+t7212.scala:17: warning: [quick fix available] under -Xsource:3, inferred Object instead of String
 trait V extends T { var f = "" }
                         ^
 3 warnings

--- a/test/files/neg/t7212.check
+++ b/test/files/neg/t7212.check
@@ -13,13 +13,13 @@ t7212.scala:21: error: type mismatch;
  required: String
   val s: String = w.f
                     ^
-t7212.scala:5: warning: [quick fix available] under -Xsource:3, inferred Object instead of String
+t7212.scala:5: warning: under -Xsource:3, inferred Object instead of String [quick fix available]
 class K extends T { def f = "" }
                         ^
-t7212.scala:11: warning: [quick fix available] under -Xsource:3, inferred Object instead of String
+t7212.scala:11: warning: under -Xsource:3, inferred Object instead of String [quick fix available]
 class F extends T { val f = "" }
                         ^
-t7212.scala:17: warning: [quick fix available] under -Xsource:3, inferred Object instead of String
+t7212.scala:17: warning: under -Xsource:3, inferred Object instead of String [quick fix available]
 trait V extends T { var f = "" }
                         ^
 3 warnings

--- a/test/files/neg/t7212.check
+++ b/test/files/neg/t7212.check
@@ -13,13 +13,13 @@ t7212.scala:21: error: type mismatch;
  required: String
   val s: String = w.f
                     ^
-t7212.scala:5: warning: under -Xsource:3, inferred Object instead of String [quick fix available]
+t7212.scala:5: warning: under -Xsource:3, inferred Object instead of String [quickfixable]
 class K extends T { def f = "" }
                         ^
-t7212.scala:11: warning: under -Xsource:3, inferred Object instead of String [quick fix available]
+t7212.scala:11: warning: under -Xsource:3, inferred Object instead of String [quickfixable]
 class F extends T { val f = "" }
                         ^
-t7212.scala:17: warning: under -Xsource:3, inferred Object instead of String [quick fix available]
+t7212.scala:17: warning: under -Xsource:3, inferred Object instead of String [quickfixable]
 trait V extends T { var f = "" }
                         ^
 3 warnings

--- a/test/files/neg/t729.check
+++ b/test/files/neg/t729.check
@@ -3,10 +3,10 @@ t729.scala:20: error: type mismatch;
  required: ScalaParserAutoEdit.this.NodeImpl(in trait ScalaParserAutoEdit)
       val yyy : NodeImpl = link.from;
                                 ^
-t729.scala:3: warning: Implicit definition should have explicit type (inferred Parser.this.Node) [quick fix available]
+t729.scala:3: warning: Implicit definition should have explicit type (inferred Parser.this.Node) [quickfixable]
   implicit def coerce(n : NodeImpl) = n.self;
                ^
-t729.scala:14: warning: Implicit definition should have explicit type (inferred ScalaParserAutoEdit.this.Node) [quick fix available]
+t729.scala:14: warning: Implicit definition should have explicit type (inferred ScalaParserAutoEdit.this.Node) [quickfixable]
   implicit def coerce(node : NodeImpl) = node.self;
                ^
 2 warnings

--- a/test/files/neg/t729.check
+++ b/test/files/neg/t729.check
@@ -3,10 +3,10 @@ t729.scala:20: error: type mismatch;
  required: ScalaParserAutoEdit.this.NodeImpl(in trait ScalaParserAutoEdit)
       val yyy : NodeImpl = link.from;
                                 ^
-t729.scala:3: warning: Implicit definition should have explicit type (inferred Parser.this.Node)
+t729.scala:3: warning: [quick fix available] Implicit definition should have explicit type (inferred Parser.this.Node)
   implicit def coerce(n : NodeImpl) = n.self;
                ^
-t729.scala:14: warning: Implicit definition should have explicit type (inferred ScalaParserAutoEdit.this.Node)
+t729.scala:14: warning: [quick fix available] Implicit definition should have explicit type (inferred ScalaParserAutoEdit.this.Node)
   implicit def coerce(node : NodeImpl) = node.self;
                ^
 2 warnings

--- a/test/files/neg/t729.check
+++ b/test/files/neg/t729.check
@@ -3,10 +3,10 @@ t729.scala:20: error: type mismatch;
  required: ScalaParserAutoEdit.this.NodeImpl(in trait ScalaParserAutoEdit)
       val yyy : NodeImpl = link.from;
                                 ^
-t729.scala:3: warning: [quick fix available] Implicit definition should have explicit type (inferred Parser.this.Node)
+t729.scala:3: warning: Implicit definition should have explicit type (inferred Parser.this.Node) [quick fix available]
   implicit def coerce(n : NodeImpl) = n.self;
                ^
-t729.scala:14: warning: [quick fix available] Implicit definition should have explicit type (inferred ScalaParserAutoEdit.this.Node)
+t729.scala:14: warning: Implicit definition should have explicit type (inferred ScalaParserAutoEdit.this.Node) [quick fix available]
   implicit def coerce(node : NodeImpl) = node.self;
                ^
 2 warnings

--- a/test/files/neg/t8015-ffb.check
+++ b/test/files/neg/t8015-ffb.check
@@ -1,4 +1,4 @@
-t8015-ffb.scala:12: warning: side-effecting nullary methods are discouraged: suggest defining as `def w()` instead [quick fix available]
+t8015-ffb.scala:12: warning: side-effecting nullary methods are discouraged: suggest defining as `def w()` instead [quickfixable]
   def w = { x\u000c() }       // ^L is colored blue on this screen, hardly visible
       ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t8015-ffb.check
+++ b/test/files/neg/t8015-ffb.check
@@ -1,4 +1,4 @@
-t8015-ffb.scala:12: warning: [quick fix available] side-effecting nullary methods are discouraged: suggest defining as `def w()` instead
+t8015-ffb.scala:12: warning: side-effecting nullary methods are discouraged: suggest defining as `def w()` instead [quick fix available]
   def w = { x\u000c() }       // ^L is colored blue on this screen, hardly visible
       ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t8015-ffb.check
+++ b/test/files/neg/t8015-ffb.check
@@ -1,4 +1,4 @@
-t8015-ffb.scala:12: warning: side-effecting nullary methods are discouraged: suggest defining as `def w()` instead
+t8015-ffb.scala:12: warning: [quick fix available] side-effecting nullary methods are discouraged: suggest defining as `def w()` instead
   def w = { x\u000c() }       // ^L is colored blue on this screen, hardly visible
       ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t8035-removed.check
+++ b/test/files/neg/t8035-removed.check
@@ -16,10 +16,10 @@ t8035-removed.scala:11: error: adaptation of an empty argument list by inserting
 t8035-removed.scala:4: warning: a type was inferred to be `AnyVal`; this may indicate a programming error.
   List(1,2,3).toSet()
               ^
-t8035-removed.scala:14: warning: [quick fix available] adapted the argument list to the expected 2-tuple: add additional parens instead
+t8035-removed.scala:14: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
         signature: List.::[B >: A](elem: B): List[B]
   given arguments: 42, 27
- after adaptation: List.::((42, 27): (Int, Int))
+ after adaptation: List.::((42, 27): (Int, Int)) [quick fix available]
   Nil.::(42, 27)      // yeswarn
         ^
 2 warnings

--- a/test/files/neg/t8035-removed.check
+++ b/test/files/neg/t8035-removed.check
@@ -19,7 +19,7 @@ t8035-removed.scala:4: warning: a type was inferred to be `AnyVal`; this may ind
 t8035-removed.scala:14: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
         signature: List.::[B >: A](elem: B): List[B]
   given arguments: 42, 27
- after adaptation: List.::((42, 27): (Int, Int)) [quick fix available]
+ after adaptation: List.::((42, 27): (Int, Int)) [quickfixable]
   Nil.::(42, 27)      // yeswarn
         ^
 2 warnings

--- a/test/files/neg/t8035-removed.check
+++ b/test/files/neg/t8035-removed.check
@@ -16,7 +16,7 @@ t8035-removed.scala:11: error: adaptation of an empty argument list by inserting
 t8035-removed.scala:4: warning: a type was inferred to be `AnyVal`; this may indicate a programming error.
   List(1,2,3).toSet()
               ^
-t8035-removed.scala:14: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
+t8035-removed.scala:14: warning: [quick fix available] adapted the argument list to the expected 2-tuple: add additional parens instead
         signature: List.::[B >: A](elem: B): List[B]
   given arguments: 42, 27
  after adaptation: List.::((42, 27): (Int, Int))

--- a/test/files/neg/t8322.check
+++ b/test/files/neg/t8322.check
@@ -13,10 +13,10 @@ t8322.scala:19: error: type mismatch;
  required: scala.util.Either[?,?]
   Right(0).right.flatMap(_ => new String())
                               ^
-t8322.scala:15: warning: Implicit definition should have explicit type (inferred Writes[Seq[E]])
+t8322.scala:15: warning: [quick fix available] Implicit definition should have explicit type (inferred Writes[Seq[E]])
   implicit def rw[E] = Writes[Seq[E]] { _ => "" }
                ^
-t8322.scala:17: warning: Implicit definition should have explicit type
+t8322.scala:17: warning: [quick fix available] Implicit definition should have explicit type
   implicit def wr[E] = jw(implicitly, implicitly)
                ^
 2 warnings

--- a/test/files/neg/t8322.check
+++ b/test/files/neg/t8322.check
@@ -13,10 +13,10 @@ t8322.scala:19: error: type mismatch;
  required: scala.util.Either[?,?]
   Right(0).right.flatMap(_ => new String())
                               ^
-t8322.scala:15: warning: [quick fix available] Implicit definition should have explicit type (inferred Writes[Seq[E]])
+t8322.scala:15: warning: Implicit definition should have explicit type (inferred Writes[Seq[E]]) [quick fix available]
   implicit def rw[E] = Writes[Seq[E]] { _ => "" }
                ^
-t8322.scala:17: warning: [quick fix available] Implicit definition should have explicit type
+t8322.scala:17: warning: Implicit definition should have explicit type [quick fix available]
   implicit def wr[E] = jw(implicitly, implicitly)
                ^
 2 warnings

--- a/test/files/neg/t8322.check
+++ b/test/files/neg/t8322.check
@@ -13,10 +13,10 @@ t8322.scala:19: error: type mismatch;
  required: scala.util.Either[?,?]
   Right(0).right.flatMap(_ => new String())
                               ^
-t8322.scala:15: warning: Implicit definition should have explicit type (inferred Writes[Seq[E]]) [quick fix available]
+t8322.scala:15: warning: Implicit definition should have explicit type (inferred Writes[Seq[E]]) [quickfixable]
   implicit def rw[E] = Writes[Seq[E]] { _ => "" }
                ^
-t8322.scala:17: warning: Implicit definition should have explicit type [quick fix available]
+t8322.scala:17: warning: Implicit definition should have explicit type [quickfixable]
   implicit def wr[E] = jw(implicitly, implicitly)
                ^
 2 warnings

--- a/test/files/neg/t8417.check
+++ b/test/files/neg/t8417.check
@@ -1,10 +1,10 @@
-t8417.scala:7: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
+t8417.scala:7: warning: [quick fix available] adapted the argument list to the expected 2-tuple: add additional parens instead
         signature: T.f(x: Any)(y: Any): String
   given arguments: "hello", "world"
  after adaptation: T.f(("hello", "world"): (String, String))
   def g = f("hello", "world")("holy", "moly")
            ^
-t8417.scala:7: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
+t8417.scala:7: warning: [quick fix available] adapted the argument list to the expected 2-tuple: add additional parens instead
         signature: T.f(x: Any)(y: Any): String
   given arguments: "holy", "moly"
  after adaptation: T.f(("holy", "moly"): (String, String))

--- a/test/files/neg/t8417.check
+++ b/test/files/neg/t8417.check
@@ -1,13 +1,13 @@
-t8417.scala:7: warning: [quick fix available] adapted the argument list to the expected 2-tuple: add additional parens instead
+t8417.scala:7: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
         signature: T.f(x: Any)(y: Any): String
   given arguments: "hello", "world"
- after adaptation: T.f(("hello", "world"): (String, String))
+ after adaptation: T.f(("hello", "world"): (String, String)) [quick fix available]
   def g = f("hello", "world")("holy", "moly")
            ^
-t8417.scala:7: warning: [quick fix available] adapted the argument list to the expected 2-tuple: add additional parens instead
+t8417.scala:7: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
         signature: T.f(x: Any)(y: Any): String
   given arguments: "holy", "moly"
- after adaptation: T.f(("holy", "moly"): (String, String))
+ after adaptation: T.f(("holy", "moly"): (String, String)) [quick fix available]
   def g = f("hello", "world")("holy", "moly")
                              ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t8417.check
+++ b/test/files/neg/t8417.check
@@ -1,13 +1,13 @@
 t8417.scala:7: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
         signature: T.f(x: Any)(y: Any): String
   given arguments: "hello", "world"
- after adaptation: T.f(("hello", "world"): (String, String)) [quick fix available]
+ after adaptation: T.f(("hello", "world"): (String, String)) [quickfixable]
   def g = f("hello", "world")("holy", "moly")
            ^
 t8417.scala:7: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
         signature: T.f(x: Any)(y: Any): String
   given arguments: "holy", "moly"
- after adaptation: T.f(("holy", "moly"): (String, String)) [quick fix available]
+ after adaptation: T.f(("holy", "moly"): (String, String)) [quickfixable]
   def g = f("hello", "world")("holy", "moly")
                              ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t8525.check
+++ b/test/files/neg/t8525.check
@@ -1,13 +1,13 @@
-t8525.scala:9: warning: [quick fix available] adapted the argument list to the expected 2-tuple: add additional parens instead
+t8525.scala:9: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
         signature: X.f(p: (Int, Int)): Int
   given arguments: 3, 4
- after adaptation: X.f((3, 4): (Int, Int))
+ after adaptation: X.f((3, 4): (Int, Int)) [quick fix available]
   def g = f(3, 4)       // adapted
            ^
 t8525.scala:11: warning: private[this] value name in class X shadows mutable name inherited from class Named. Changes to name will not be visible within class X; you may want to give them distinct names.
   override def toString = name // shadowing mutable var name
                           ^
-t8525.scala:10: warning: [quick fix available] side-effecting nullary methods are discouraged: suggest defining as `def u()` instead
+t8525.scala:10: warning: side-effecting nullary methods are discouraged: suggest defining as `def u()` instead [quick fix available]
   def u: Unit = ()      // unitarian universalist
       ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t8525.check
+++ b/test/files/neg/t8525.check
@@ -1,13 +1,13 @@
 t8525.scala:9: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
         signature: X.f(p: (Int, Int)): Int
   given arguments: 3, 4
- after adaptation: X.f((3, 4): (Int, Int)) [quick fix available]
+ after adaptation: X.f((3, 4): (Int, Int)) [quickfixable]
   def g = f(3, 4)       // adapted
            ^
 t8525.scala:11: warning: private[this] value name in class X shadows mutable name inherited from class Named. Changes to name will not be visible within class X; you may want to give them distinct names.
   override def toString = name // shadowing mutable var name
                           ^
-t8525.scala:10: warning: side-effecting nullary methods are discouraged: suggest defining as `def u()` instead [quick fix available]
+t8525.scala:10: warning: side-effecting nullary methods are discouraged: suggest defining as `def u()` instead [quickfixable]
   def u: Unit = ()      // unitarian universalist
       ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t8525.check
+++ b/test/files/neg/t8525.check
@@ -1,4 +1,4 @@
-t8525.scala:9: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
+t8525.scala:9: warning: [quick fix available] adapted the argument list to the expected 2-tuple: add additional parens instead
         signature: X.f(p: (Int, Int)): Int
   given arguments: 3, 4
  after adaptation: X.f((3, 4): (Int, Int))
@@ -7,7 +7,7 @@ t8525.scala:9: warning: adapted the argument list to the expected 2-tuple: add a
 t8525.scala:11: warning: private[this] value name in class X shadows mutable name inherited from class Named. Changes to name will not be visible within class X; you may want to give them distinct names.
   override def toString = name // shadowing mutable var name
                           ^
-t8525.scala:10: warning: side-effecting nullary methods are discouraged: suggest defining as `def u()` instead
+t8525.scala:10: warning: [quick fix available] side-effecting nullary methods are discouraged: suggest defining as `def u()` instead
   def u: Unit = ()      // unitarian universalist
       ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t8610-arg.check
+++ b/test/files/neg/t8610-arg.check
@@ -1,4 +1,4 @@
-t8610-arg.scala:10: warning: [quick fix available] side-effecting nullary methods are discouraged: suggest defining as `def u()` instead
+t8610-arg.scala:10: warning: side-effecting nullary methods are discouraged: suggest defining as `def u()` instead [quick fix available]
   def u: Unit = ()      // unitarian universalist
       ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t8610-arg.check
+++ b/test/files/neg/t8610-arg.check
@@ -1,4 +1,4 @@
-t8610-arg.scala:10: warning: side-effecting nullary methods are discouraged: suggest defining as `def u()` instead
+t8610-arg.scala:10: warning: [quick fix available] side-effecting nullary methods are discouraged: suggest defining as `def u()` instead
   def u: Unit = ()      // unitarian universalist
       ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t8610-arg.check
+++ b/test/files/neg/t8610-arg.check
@@ -1,4 +1,4 @@
-t8610-arg.scala:10: warning: side-effecting nullary methods are discouraged: suggest defining as `def u()` instead [quick fix available]
+t8610-arg.scala:10: warning: side-effecting nullary methods are discouraged: suggest defining as `def u()` instead [quickfixable]
   def u: Unit = ()      // unitarian universalist
       ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t8610.check
+++ b/test/files/neg/t8610.check
@@ -4,13 +4,13 @@ t8610.scala:7: warning: possible missing interpolator: detected interpolated ide
 t8610.scala:9: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
         signature: X.f(p: (Int, Int)): Int
   given arguments: 3, 4
- after adaptation: X.f((3, 4): (Int, Int)) [quick fix available]
+ after adaptation: X.f((3, 4): (Int, Int)) [quickfixable]
   def g = f(3, 4)       // adapted
            ^
 t8610.scala:11: warning: private[this] value name in class X shadows mutable name inherited from class Named. Changes to name will not be visible within class X; you may want to give them distinct names.
   override def toString = name // shadowing mutable var name
                           ^
-t8610.scala:10: warning: side-effecting nullary methods are discouraged: suggest defining as `def u()` instead [quick fix available]
+t8610.scala:10: warning: side-effecting nullary methods are discouraged: suggest defining as `def u()` instead [quickfixable]
   def u: Unit = ()      // unitarian universalist
       ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t8610.check
+++ b/test/files/neg/t8610.check
@@ -1,7 +1,7 @@
 t8610.scala:7: warning: possible missing interpolator: detected interpolated identifier `$name`
   def x = "Hi, $name"   // missing interp
           ^
-t8610.scala:9: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
+t8610.scala:9: warning: [quick fix available] adapted the argument list to the expected 2-tuple: add additional parens instead
         signature: X.f(p: (Int, Int)): Int
   given arguments: 3, 4
  after adaptation: X.f((3, 4): (Int, Int))
@@ -10,7 +10,7 @@ t8610.scala:9: warning: adapted the argument list to the expected 2-tuple: add a
 t8610.scala:11: warning: private[this] value name in class X shadows mutable name inherited from class Named. Changes to name will not be visible within class X; you may want to give them distinct names.
   override def toString = name // shadowing mutable var name
                           ^
-t8610.scala:10: warning: side-effecting nullary methods are discouraged: suggest defining as `def u()` instead
+t8610.scala:10: warning: [quick fix available] side-effecting nullary methods are discouraged: suggest defining as `def u()` instead
   def u: Unit = ()      // unitarian universalist
       ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t8610.check
+++ b/test/files/neg/t8610.check
@@ -1,16 +1,16 @@
 t8610.scala:7: warning: possible missing interpolator: detected interpolated identifier `$name`
   def x = "Hi, $name"   // missing interp
           ^
-t8610.scala:9: warning: [quick fix available] adapted the argument list to the expected 2-tuple: add additional parens instead
+t8610.scala:9: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
         signature: X.f(p: (Int, Int)): Int
   given arguments: 3, 4
- after adaptation: X.f((3, 4): (Int, Int))
+ after adaptation: X.f((3, 4): (Int, Int)) [quick fix available]
   def g = f(3, 4)       // adapted
            ^
 t8610.scala:11: warning: private[this] value name in class X shadows mutable name inherited from class Named. Changes to name will not be visible within class X; you may want to give them distinct names.
   override def toString = name // shadowing mutable var name
                           ^
-t8610.scala:10: warning: [quick fix available] side-effecting nullary methods are discouraged: suggest defining as `def u()` instead
+t8610.scala:10: warning: side-effecting nullary methods are discouraged: suggest defining as `def u()` instead [quick fix available]
   def u: Unit = ()      // unitarian universalist
       ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/unicode-arrows-deprecation.check
+++ b/test/files/neg/unicode-arrows-deprecation.check
@@ -1,10 +1,10 @@
-unicode-arrows-deprecation.scala:4: warning: The unicode arrow `⇒` is deprecated, use `=>` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code. [quick fix available]
+unicode-arrows-deprecation.scala:4: warning: The unicode arrow `⇒` is deprecated, use `=>` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code. [quickfixable]
   val a: Int ⇒ Int = x ⇒ x
              ^
-unicode-arrows-deprecation.scala:4: warning: The unicode arrow `⇒` is deprecated, use `=>` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code. [quick fix available]
+unicode-arrows-deprecation.scala:4: warning: The unicode arrow `⇒` is deprecated, use `=>` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code. [quickfixable]
   val a: Int ⇒ Int = x ⇒ x
                        ^
-unicode-arrows-deprecation.scala:6: warning: The unicode arrow `←` is deprecated, use `<-` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code. [quick fix available]
+unicode-arrows-deprecation.scala:6: warning: The unicode arrow `←` is deprecated, use `<-` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code. [quickfixable]
   val b = for { x ← (1 to 10) } yield x
                   ^
 unicode-arrows-deprecation.scala:8: warning: method → in class ArrowAssoc is deprecated (since 2.13.0): Use `->` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code.

--- a/test/files/neg/unicode-arrows-deprecation.check
+++ b/test/files/neg/unicode-arrows-deprecation.check
@@ -1,10 +1,10 @@
-unicode-arrows-deprecation.scala:4: warning: The unicode arrow `⇒` is deprecated, use `=>` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code.
+unicode-arrows-deprecation.scala:4: warning: [quick fix available] The unicode arrow `⇒` is deprecated, use `=>` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code.
   val a: Int ⇒ Int = x ⇒ x
              ^
-unicode-arrows-deprecation.scala:4: warning: The unicode arrow `⇒` is deprecated, use `=>` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code.
+unicode-arrows-deprecation.scala:4: warning: [quick fix available] The unicode arrow `⇒` is deprecated, use `=>` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code.
   val a: Int ⇒ Int = x ⇒ x
                        ^
-unicode-arrows-deprecation.scala:6: warning: The unicode arrow `←` is deprecated, use `<-` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code.
+unicode-arrows-deprecation.scala:6: warning: [quick fix available] The unicode arrow `←` is deprecated, use `<-` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code.
   val b = for { x ← (1 to 10) } yield x
                   ^
 unicode-arrows-deprecation.scala:8: warning: method → in class ArrowAssoc is deprecated (since 2.13.0): Use `->` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code.

--- a/test/files/neg/unicode-arrows-deprecation.check
+++ b/test/files/neg/unicode-arrows-deprecation.check
@@ -1,10 +1,10 @@
-unicode-arrows-deprecation.scala:4: warning: [quick fix available] The unicode arrow `⇒` is deprecated, use `=>` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code.
+unicode-arrows-deprecation.scala:4: warning: The unicode arrow `⇒` is deprecated, use `=>` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code. [quick fix available]
   val a: Int ⇒ Int = x ⇒ x
              ^
-unicode-arrows-deprecation.scala:4: warning: [quick fix available] The unicode arrow `⇒` is deprecated, use `=>` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code.
+unicode-arrows-deprecation.scala:4: warning: The unicode arrow `⇒` is deprecated, use `=>` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code. [quick fix available]
   val a: Int ⇒ Int = x ⇒ x
                        ^
-unicode-arrows-deprecation.scala:6: warning: [quick fix available] The unicode arrow `←` is deprecated, use `<-` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code.
+unicode-arrows-deprecation.scala:6: warning: The unicode arrow `←` is deprecated, use `<-` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code. [quick fix available]
   val b = for { x ← (1 to 10) } yield x
                   ^
 unicode-arrows-deprecation.scala:8: warning: method → in class ArrowAssoc is deprecated (since 2.13.0): Use `->` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code.

--- a/test/files/neg/using-source3.check
+++ b/test/files/neg/using-source3.check
@@ -2,7 +2,7 @@ using-source3.scala:14: error: reference to f is ambiguous;
 it is both defined in the enclosing class D and inherited in the enclosing class E as method f (defined in class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.f`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=D.E.g
     def g = f

--- a/test/files/neg/using-source3.check
+++ b/test/files/neg/using-source3.check
@@ -1,8 +1,8 @@
-using-source3.scala:14: error: [quick fix available] reference to f is ambiguous;
+using-source3.scala:14: error: reference to f is ambiguous;
 it is both defined in the enclosing class D and inherited in the enclosing class E as method f (defined in class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.f`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=D.E.g
     def g = f

--- a/test/files/neg/using-source3b.check
+++ b/test/files/neg/using-source3b.check
@@ -2,7 +2,7 @@ using-source3b.scala:13: error: reference to f is ambiguous;
 it is both defined in the enclosing class D and inherited in the enclosing class E as method f (defined in class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.f`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=D.E.g
     def g = f

--- a/test/files/neg/using-source3b.check
+++ b/test/files/neg/using-source3b.check
@@ -1,8 +1,8 @@
-using-source3b.scala:13: error: [quick fix available] reference to f is ambiguous;
+using-source3b.scala:13: error: reference to f is ambiguous;
 it is both defined in the enclosing class D and inherited in the enclosing class E as method f (defined in class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
 Such references are ambiguous in Scala 3. To continue using the inherited symbol, write `this.f`.
-Or use `-Wconf:msg=legacy-binding:s` to silence this warning.
+Or use `-Wconf:msg=legacy-binding:s` to silence this warning. [quick fix available]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=D.E.g
     def g = f

--- a/test/files/run/infixPostfixAttachments.check
+++ b/test/files/run/infixPostfixAttachments.check
@@ -1,11 +1,11 @@
 newSource1.scala:15: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method d,
 or remove the empty argument list from its definition (Java-defined methods are exempt).
-In Scala 3, an unapplied method like this will be eta-expanded into a function. [quick fix available]
+In Scala 3, an unapplied method like this will be eta-expanded into a function. [quickfixable]
   def t6 = this d
                 ^
 newSource1.scala:16: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method d,
 or remove the empty argument list from its definition (Java-defined methods are exempt).
-In Scala 3, an unapplied method like this will be eta-expanded into a function. [quick fix available]
+In Scala 3, an unapplied method like this will be eta-expanded into a function. [quickfixable]
   def t7 = this.d
                 ^
 t1 this.a(0) List(InfixAttachment)

--- a/test/files/run/infixPostfixAttachments.check
+++ b/test/files/run/infixPostfixAttachments.check
@@ -1,11 +1,11 @@
-newSource1.scala:15: warning: [quick fix available] Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method d,
+newSource1.scala:15: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method d,
 or remove the empty argument list from its definition (Java-defined methods are exempt).
-In Scala 3, an unapplied method like this will be eta-expanded into a function.
+In Scala 3, an unapplied method like this will be eta-expanded into a function. [quick fix available]
   def t6 = this d
                 ^
-newSource1.scala:16: warning: [quick fix available] Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method d,
+newSource1.scala:16: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method d,
 or remove the empty argument list from its definition (Java-defined methods are exempt).
-In Scala 3, an unapplied method like this will be eta-expanded into a function.
+In Scala 3, an unapplied method like this will be eta-expanded into a function. [quick fix available]
   def t7 = this.d
                 ^
 t1 this.a(0) List(InfixAttachment)

--- a/test/files/run/literals.check
+++ b/test/files/run/literals.check
@@ -1,12 +1,12 @@
-literals.scala:63: warning: Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead
+literals.scala:63: warning: [quick fix available] Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead
     check_success("1l == 1L", 1l, 1L)
                                ^
-literals.scala:64: warning: Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead
+literals.scala:64: warning: [quick fix available] Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead
     check_success("1L == 1l", 1L, 1l)
                                    ^
-literals.scala:65: warning: Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead
+literals.scala:65: warning: [quick fix available] Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead
     check_success("1.asInstanceOf[Long] == 1l", 1.asInstanceOf[Long], 1l)
                                                                        ^
-literals.scala:112: warning: Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead
+literals.scala:112: warning: [quick fix available] Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead
     check_success("1l.asInstanceOf[Double] == 1.0", 1l.asInstanceOf[Double], 1.0)
                                                      ^

--- a/test/files/run/literals.check
+++ b/test/files/run/literals.check
@@ -1,12 +1,12 @@
-literals.scala:63: warning: Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead [quick fix available]
+literals.scala:63: warning: Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead [quickfixable]
     check_success("1l == 1L", 1l, 1L)
                                ^
-literals.scala:64: warning: Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead [quick fix available]
+literals.scala:64: warning: Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead [quickfixable]
     check_success("1L == 1l", 1L, 1l)
                                    ^
-literals.scala:65: warning: Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead [quick fix available]
+literals.scala:65: warning: Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead [quickfixable]
     check_success("1.asInstanceOf[Long] == 1l", 1.asInstanceOf[Long], 1l)
                                                                        ^
-literals.scala:112: warning: Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead [quick fix available]
+literals.scala:112: warning: Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead [quickfixable]
     check_success("1l.asInstanceOf[Double] == 1.0", 1l.asInstanceOf[Double], 1.0)
                                                      ^

--- a/test/files/run/literals.check
+++ b/test/files/run/literals.check
@@ -1,12 +1,12 @@
-literals.scala:63: warning: [quick fix available] Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead
+literals.scala:63: warning: Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead [quick fix available]
     check_success("1l == 1L", 1l, 1L)
                                ^
-literals.scala:64: warning: [quick fix available] Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead
+literals.scala:64: warning: Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead [quick fix available]
     check_success("1L == 1l", 1L, 1l)
                                    ^
-literals.scala:65: warning: [quick fix available] Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead
+literals.scala:65: warning: Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead [quick fix available]
     check_success("1.asInstanceOf[Long] == 1l", 1.asInstanceOf[Long], 1l)
                                                                        ^
-literals.scala:112: warning: [quick fix available] Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead
+literals.scala:112: warning: Lowercase el for long is not recommended because it is easy to confuse with numeral 1; use uppercase L instead [quick fix available]
     check_success("1l.asInstanceOf[Double] == 1.0", 1l.asInstanceOf[Double], 1.0)
                                                      ^

--- a/test/files/run/repl-errors.check
+++ b/test/files/run/repl-errors.check
@@ -5,7 +5,7 @@ scala> '\060'
 
 scala> def foo() { }
                  ^
-       warning: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `foo`'s return type [quick fix available]
+       warning: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `foo`'s return type [quickfixable]
 def foo(): Unit
 
 scala> @annotation.nowarn def sshhh() { }

--- a/test/files/run/repl-errors.check
+++ b/test/files/run/repl-errors.check
@@ -5,7 +5,7 @@ scala> '\060'
 
 scala> def foo() { }
                  ^
-       warning: [quick fix available] procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `foo`'s return type
+       warning: procedure syntax is deprecated: instead, add `: Unit =` to explicitly declare `foo`'s return type [quick fix available]
 def foo(): Unit
 
 scala> @annotation.nowarn def sshhh() { }

--- a/test/files/run/t11402.check
+++ b/test/files/run/t11402.check
@@ -6,7 +6,7 @@ scala> def f = {
 }
          val x = 'abc
                  ^
-On line 2: warning: symbol literal is deprecated; use Symbol("abc") instead [quick fix available]
+On line 2: warning: symbol literal is deprecated; use Symbol("abc") instead [quickfixable]
 def f: String
 
 scala> :quit

--- a/test/files/run/t11402.check
+++ b/test/files/run/t11402.check
@@ -6,7 +6,7 @@ scala> def f = {
 }
          val x = 'abc
                  ^
-On line 2: warning: symbol literal is deprecated; use Symbol("abc") instead
+On line 2: warning: [quick fix available] symbol literal is deprecated; use Symbol("abc") instead
 def f: String
 
 scala> :quit

--- a/test/files/run/t11402.check
+++ b/test/files/run/t11402.check
@@ -6,7 +6,7 @@ scala> def f = {
 }
          val x = 'abc
                  ^
-On line 2: warning: [quick fix available] symbol literal is deprecated; use Symbol("abc") instead
+On line 2: warning: symbol literal is deprecated; use Symbol("abc") instead [quick fix available]
 def f: String
 
 scala> :quit

--- a/test/files/run/t8610.check
+++ b/test/files/run/t8610.check
@@ -1,4 +1,4 @@
-t8610.scala:8: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
+t8610.scala:8: warning: [quick fix available] adapted the argument list to the expected 2-tuple: add additional parens instead
         signature: X.f(p: (Int, Int)): Int
   given arguments: 3, 4
  after adaptation: X.f((3, 4): (Int, Int))

--- a/test/files/run/t8610.check
+++ b/test/files/run/t8610.check
@@ -1,7 +1,7 @@
 t8610.scala:8: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
         signature: X.f(p: (Int, Int)): Int
   given arguments: 3, 4
- after adaptation: X.f((3, 4): (Int, Int)) [quick fix available]
+ after adaptation: X.f((3, 4): (Int, Int)) [quickfixable]
   def g = f(3, 4)       // adapted
            ^
 Hi, $name

--- a/test/files/run/t8610.check
+++ b/test/files/run/t8610.check
@@ -1,7 +1,7 @@
-t8610.scala:8: warning: [quick fix available] adapted the argument list to the expected 2-tuple: add additional parens instead
+t8610.scala:8: warning: adapted the argument list to the expected 2-tuple: add additional parens instead
         signature: X.f(p: (Int, Int)): Int
   given arguments: 3, 4
- after adaptation: X.f((3, 4): (Int, Int))
+ after adaptation: X.f((3, 4): (Int, Int)) [quick fix available]
   def g = f(3, 4)       // adapted
            ^
 Hi, $name

--- a/test/junit/scala/tools/nsc/reporters/AbstractCodeActionTest.scala
+++ b/test/junit/scala/tools/nsc/reporters/AbstractCodeActionTest.scala
@@ -5,56 +5,57 @@ import org.junit.Assert._
 
 import scala.reflect.internal.util.CodeAction
 import scala.tools.testkit.BytecodeTesting
+import scala.tools.testkit.Compiler
 
 abstract class AbstractCodeActionTest extends BytecodeTesting {
-  override def compilerArgs: String = "-Ystop-after:typer -Yvalidate-pos:typer -Yrangepos -deprecation -Xsource:3"
-  protected def reporter = compiler.global.reporter.asInstanceOf[StoreReporter]
-
   @Test
-  def testProcedureSyntaxDecl(): Unit =
+  def procedureSyntax(): Unit =
     assertCodeSuggestion(
       """trait Test {
         |  def foo
         |  def bar;
-        |  def pub { print() }
-        |  def club{ print() }
-        |  def saloon = { print() }
+        |  def pub { println() }
+        |  def club{ println() }
+        |  def saloon = { println() }
         |}""".stripMargin,
       """trait Test {
         |  def foo: Unit
         |  def bar: Unit;
-        |  def pub: Unit = { print() }
-        |  def club: Unit ={ print() }
-        |  def saloon = { print() }
+        |  def pub: Unit = { println() }
+        |  def club: Unit ={ println() }
+        |  def saloon = { println() }
         |}""".stripMargin,
-    )
+      // disable lint to avoid conflicting patches with `nullaryUnit`
+      BytecodeTesting.newCompiler(extraArgs = compilerArgs.replaceAll("-Xlint", "")))
 
   @Test
-  def testGreatParenInsert(): Unit = {
+  def autoApplication(): Unit = {
     assertCodeSuggestion(
-      """trait Test {
+      """import scala.language.postfixOps
+        |trait Test {
         |  def foo = {
         |    println
         |    Predef.println
         |    toString + this.toString
         |  }
-        |  def bar: Unit = Predef println()
+        |  def bar: Unit = Predef println
         |}
       """.stripMargin,
-      """trait Test {
+      """import scala.language.postfixOps
+        |trait Test {
         |  def foo = {
         |    println()
         |    Predef.println()
         |    toString + this.toString
         |  }
-        |  def bar: Unit = Predef println()
+        |  def bar(): Unit = Predef println()
         |}
       """.stripMargin,
     )
   }
 
   @Test
-  def testValInFor(): Unit =
+  def valInFor(): Unit =
     assertCodeSuggestion(
       """trait Test {
         |  def foo: Unit = {
@@ -91,9 +92,90 @@ abstract class AbstractCodeActionTest extends BytecodeTesting {
     )
   }
 
-  def assertCodeSuggestion(original: String, expected: String): Unit = {
-    val run = compiler.newRun()
-    run.compileSources(compiler.global.newSourceFile(original) :: Nil)
+  @Test
+  def unitLiteralType(): Unit = {
+    assertCodeSuggestion("class C { def f: () = () }", "class C { def f: Unit = () }")
+    assertCodeSuggestion("class C { def f(a: Any) = a match { case _: () => 0 } }", "class C { def f(a: Any) = a match { case _: Unit => 0 } }")
+  }
+
+  @Test
+  def constructorProcedureSyntax(): Unit = {
+    assertCodeSuggestion("class C { def this(x: Int) { this() } }", "class C { def this(x: Int) = { this() } }")
+  }
+
+  @Test
+  def symbolLiteral(): Unit = {
+    assertCodeSuggestion("class C { 'hai }", """class C { Symbol("hai") }""")
+  }
+
+  @Test
+  def unaryNilary(): Unit = {
+    assertCodeSuggestion("class C { def unary_-() = 1 }", "class C { def unary_- = 1 }")
+  }
+
+  @Test
+  def symbolicExtends(): Unit = {
+    assertCodeSuggestion("trait T <: Object", "trait T extends Object")
+  }
+
+  @Test
+  def unicodeArrow(): Unit = {
+    assertCodeSuggestion("class C { val f = (x: Int) ⇒ x }", "class C { val f = (x: Int) => x }")
+    assertCodeSuggestion("class C { for (x ← List(1)) yield x }", "class C { for (x <- List(1)) yield x }")
+  }
+
+  @Test
+  def lowerLongL(): Unit = {
+    assertCodeSuggestion("class C { val lo = 1l }", "class C { val lo = 1L }")
+  }
+
+  @Test
+  def inharomnicNumeric(): Unit = {
+    assertCodeSuggestion("class C { val a = 1L; val b: Double = a }", "class C { val a = 1L; val b: Double = a.toDouble }")
+    assertCodeSuggestion("class C { val a = 1L; val b: Double = a + a }", "class C { val a = 1L; val b: Double = (a + a).toDouble }")
+  }
+
+  @Test
+  def widenedDiv(): Unit = {
+    assertCodeSuggestion("class C { val a = 1; val b: Double = a / 2 }", "class C { val a = 1; val b: Double = (a / 2).toDouble }")
+  }
+
+  @Test
+  def etaNullary(): Unit = {
+    assertCodeSuggestion("class C { def f = 1; val g = f _ }", "class C { def f = 1; val g = () => f }")
+  }
+
+  @Test
+  def explicitImplicit(): Unit = {
+    assertCodeSuggestion("class C { implicit val x = 1 }", "class C { implicit val x: Int = 1 }")
+  }
+
+  @Test
+  def adaptToTuple(): Unit = {
+    assertCodeSuggestion("class C { def f(x: (Int, Int)) = 0; f(1, 1) }", "class C { def f(x: (Int, Int)) = 0; f((1, 1)) }")
+  }
+
+  @Test
+  def nilaryNullaryOverride(): Unit = {
+    assertCodeSuggestion(
+      """trait T { def f(): Int; def g: Int }
+        |class C extends T { def f: Int = 1; def g() = 2 }
+        |""".stripMargin,
+      """trait T { def f(): Int; def g: Int }
+        |class C extends T { def f(): Int = 1; def g = 2 }
+        |""".stripMargin
+    )
+  }
+
+  @Test
+  def nullaryUnit(): Unit = {
+    assertCodeSuggestion("class C { def f: Unit = println() }", "class C { def f(): Unit = println() }")
+  }
+
+  def assertCodeSuggestion(original: String, expected: String, comp: Compiler = compiler): Unit = {
+    val run = comp.newRun()
+    run.compileSources(comp.global.newSourceFile(original) :: Nil)
+    val reporter = comp.global.reporter.asInstanceOf[StoreReporter]
     val actions = reporter.infos.flatMap(_.actions).toList
     val newCode = applyChanges(original, actions)
     assertEquals(s"\n$newCode", expected, newCode)

--- a/test/junit/scala/tools/nsc/reporters/CodeActionTest.scala
+++ b/test/junit/scala/tools/nsc/reporters/CodeActionTest.scala
@@ -5,5 +5,5 @@ import org.junit.runners.JUnit4
 
 @RunWith(classOf[JUnit4])
 class CodeActionTest extends AbstractCodeActionTest {
-  override def compilerArgs: String = "-Ystop-after:typer -Yvalidate-pos:typer -Yrangepos -deprecation"
+  override def compilerArgs: String = "-Ystop-after:refchecks -deprecation -Xlint"
 }

--- a/test/junit/scala/tools/nsc/reporters/CodeActionXsource3Test.scala
+++ b/test/junit/scala/tools/nsc/reporters/CodeActionXsource3Test.scala
@@ -6,10 +6,10 @@ import org.junit.runners.JUnit4
 
 @RunWith(classOf[JUnit4])
 class CodeActionXsource3Test extends AbstractCodeActionTest {
-  override def compilerArgs: String = "-Ystop-after:typer -Yvalidate-pos:typer -Yrangepos -deprecation -Xsource:3"
+  override def compilerArgs: String = "-Ystop-after:refchecks -deprecation -Xlint -Xsource:3"
 
   @Test
-  def testLambdaParameterList(): Unit =
+  def lambdaParameterParens(): Unit =
     assertCodeSuggestion(
       """trait Test {
         |  def foo: Any = {
@@ -36,4 +36,32 @@ class CodeActionXsource3Test extends AbstractCodeActionTest {
         |}
       """.stripMargin,
     )
+
+  @Test
+  def qmark(): Unit = {
+    assertCodeSuggestion("class C[?]", "class C[`?`]")
+  }
+
+  @Test
+  def scala3Keyword(): Unit = {
+    assertCodeSuggestion("class C { val export = 1 }", "class C { val `export` = 1 }")
+  }
+
+  @Test
+  def infixTypeArg(): Unit = {
+    assertCodeSuggestion("class C { List apply[Int] 1 }", "class C { List.apply[Int](1) }")
+    assertCodeSuggestion("class C { List apply 1 map[Int] identity }", "class C { (List apply 1).map[Int](identity) }")
+    assertCodeSuggestion("class C { List apply 1 map[Int] (_ + 1) }", "class C { (List apply 1).map[Int](_ + 1) }")
+  }
+
+  @Test
+  def overrideInferredType(): Unit = {
+    assertCodeSuggestion(
+      """trait T { def f: Object }
+        |class C extends T { def f = "" }
+        |""".stripMargin,
+      """trait T { def f: Object }
+        |class C extends T { def f: String = "" }
+        |""".stripMargin)
+  }
 }

--- a/test/scaladoc/run/diagrams-base.check
+++ b/test/scaladoc/run/diagrams-base.check
@@ -1,10 +1,10 @@
-newSource:10: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.T) [quick fix available]
+newSource:10: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.T) [quickfixable]
       object E { implicit def eToT(e: E) = new T }
                               ^
-newSource:18: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.E) [quick fix available]
+newSource:18: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.E) [quickfixable]
       object X { implicit def xToE(x: X) = new E}
                               ^
-newSource:21: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.E) [quick fix available]
+newSource:21: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.E) [quickfixable]
       object Z { implicit def zToE(z: Z) = new E}
                               ^
 Done.

--- a/test/scaladoc/run/diagrams-base.check
+++ b/test/scaladoc/run/diagrams-base.check
@@ -1,10 +1,10 @@
-newSource:10: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.T)
+newSource:10: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.T) [quick fix available]
       object E { implicit def eToT(e: E) = new T }
                               ^
-newSource:18: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.E)
+newSource:18: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.E) [quick fix available]
       object X { implicit def xToE(x: X) = new E}
                               ^
-newSource:21: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.E)
+newSource:21: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.E) [quick fix available]
       object Z { implicit def zToE(z: Z) = new E}
                               ^
 Done.

--- a/test/scaladoc/run/diagrams-base.check
+++ b/test/scaladoc/run/diagrams-base.check
@@ -1,10 +1,10 @@
-newSource:10: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.T)
+newSource:10: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.T)
       object E { implicit def eToT(e: E) = new T }
                               ^
-newSource:18: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.E)
+newSource:18: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.E)
       object X { implicit def xToE(x: X) = new E}
                               ^
-newSource:21: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.E)
+newSource:21: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.E)
       object Z { implicit def zToE(z: Z) = new E}
                               ^
 Done.

--- a/test/scaladoc/run/diagrams-filtering.check
+++ b/test/scaladoc/run/diagrams-filtering.check
@@ -1,7 +1,7 @@
-newSource:30: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.T)
+newSource:30: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.T)
             implicit def eToT(e: E) = new T
                          ^
-newSource:31: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.A)
+newSource:31: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.A)
             implicit def eToA(e: E) = new A { }
                          ^
 Done.

--- a/test/scaladoc/run/diagrams-filtering.check
+++ b/test/scaladoc/run/diagrams-filtering.check
@@ -1,7 +1,7 @@
-newSource:30: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.T) [quick fix available]
+newSource:30: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.T) [quickfixable]
             implicit def eToT(e: E) = new T
                          ^
-newSource:31: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.A) [quick fix available]
+newSource:31: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.A) [quickfixable]
             implicit def eToA(e: E) = new A { }
                          ^
 Done.

--- a/test/scaladoc/run/diagrams-filtering.check
+++ b/test/scaladoc/run/diagrams-filtering.check
@@ -1,7 +1,7 @@
-newSource:30: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.T)
+newSource:30: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.T) [quick fix available]
             implicit def eToT(e: E) = new T
                          ^
-newSource:31: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.A)
+newSource:31: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.diagrams.A) [quick fix available]
             implicit def eToA(e: E) = new A { }
                          ^
 Done.

--- a/test/scaladoc/run/implicits-ambiguating.check
+++ b/test/scaladoc/run/implicits-ambiguating.check
@@ -1,7 +1,7 @@
-newSource:70: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.ambiguating.X[T])
+newSource:70: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.ambiguating.X[T]) [quick fix available]
   implicit def AtoX[T](a: A[T]) = new X[T]
                ^
-newSource:71: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.ambiguating.Z[T])
+newSource:71: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.ambiguating.Z[T]) [quick fix available]
   implicit def AtoZ[T](a: A[T]) = new Z[T]
                ^
 Done.

--- a/test/scaladoc/run/implicits-ambiguating.check
+++ b/test/scaladoc/run/implicits-ambiguating.check
@@ -1,7 +1,7 @@
-newSource:70: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.ambiguating.X[T]) [quick fix available]
+newSource:70: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.ambiguating.X[T]) [quickfixable]
   implicit def AtoX[T](a: A[T]) = new X[T]
                ^
-newSource:71: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.ambiguating.Z[T]) [quick fix available]
+newSource:71: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.ambiguating.Z[T]) [quickfixable]
   implicit def AtoZ[T](a: A[T]) = new Z[T]
                ^
 Done.

--- a/test/scaladoc/run/implicits-ambiguating.check
+++ b/test/scaladoc/run/implicits-ambiguating.check
@@ -1,7 +1,7 @@
-newSource:70: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.ambiguating.X[T])
+newSource:70: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.ambiguating.X[T])
   implicit def AtoX[T](a: A[T]) = new X[T]
                ^
-newSource:71: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.ambiguating.Z[T])
+newSource:71: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.ambiguating.Z[T])
   implicit def AtoZ[T](a: A[T]) = new Z[T]
                ^
 Done.

--- a/test/scaladoc/run/implicits-base.check
+++ b/test/scaladoc/run/implicits-base.check
@@ -1,19 +1,19 @@
-newSource:36: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.EnrichedA[V])
+newSource:36: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.EnrichedA[V]) [quick fix available]
   implicit def enrichA0[V](a: A[V]) = new EnrichedA(a)
                ^
-newSource:37: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.NumericA[ZBUR])
+newSource:37: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.NumericA[ZBUR]) [quick fix available]
   implicit def enrichA1[ZBUR: Numeric](a: A[ZBUR]) = new NumericA[ZBUR](a)
                ^
-newSource:38: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.IntA)
+newSource:38: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.IntA) [quick fix available]
   implicit def enrichA2(a: A[Int]) = new IntA(a)
                ^
-newSource:39: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.GtColonDoubleA)
+newSource:39: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.GtColonDoubleA) [quick fix available]
   implicit def enrichA3(a: A[T] forSome { type T <: Double }) = new GtColonDoubleA(a)
                ^
-newSource:42: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.MyNumericA[Z])
+newSource:42: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.MyNumericA[Z]) [quick fix available]
   implicit def enrichA6[Z: MyNumeric](a: A[Z]) = new MyNumericA[Z](a)
                ^
-newSource:44: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.ManifestA[H] with scala.test.scaladoc.implicits.base.MyTraversableOps[H])
+newSource:44: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.ManifestA[H] with scala.test.scaladoc.implicits.base.MyTraversableOps[H]) [quick fix available]
   implicit def enrichA7[H <: Double : Manifest](a: A[H]) = new ManifestA[H](a) with MyTraversableOps[H] { def convToTraversableOps(x: H): H = sys.error("no") }
                ^
 Done.

--- a/test/scaladoc/run/implicits-base.check
+++ b/test/scaladoc/run/implicits-base.check
@@ -1,19 +1,19 @@
-newSource:36: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.EnrichedA[V])
+newSource:36: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.EnrichedA[V])
   implicit def enrichA0[V](a: A[V]) = new EnrichedA(a)
                ^
-newSource:37: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.NumericA[ZBUR])
+newSource:37: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.NumericA[ZBUR])
   implicit def enrichA1[ZBUR: Numeric](a: A[ZBUR]) = new NumericA[ZBUR](a)
                ^
-newSource:38: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.IntA)
+newSource:38: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.IntA)
   implicit def enrichA2(a: A[Int]) = new IntA(a)
                ^
-newSource:39: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.GtColonDoubleA)
+newSource:39: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.GtColonDoubleA)
   implicit def enrichA3(a: A[T] forSome { type T <: Double }) = new GtColonDoubleA(a)
                ^
-newSource:42: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.MyNumericA[Z])
+newSource:42: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.MyNumericA[Z])
   implicit def enrichA6[Z: MyNumeric](a: A[Z]) = new MyNumericA[Z](a)
                ^
-newSource:44: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.ManifestA[H] with scala.test.scaladoc.implicits.base.MyTraversableOps[H])
+newSource:44: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.ManifestA[H] with scala.test.scaladoc.implicits.base.MyTraversableOps[H])
   implicit def enrichA7[H <: Double : Manifest](a: A[H]) = new ManifestA[H](a) with MyTraversableOps[H] { def convToTraversableOps(x: H): H = sys.error("no") }
                ^
 Done.

--- a/test/scaladoc/run/implicits-base.check
+++ b/test/scaladoc/run/implicits-base.check
@@ -1,19 +1,19 @@
-newSource:36: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.EnrichedA[V]) [quick fix available]
+newSource:36: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.EnrichedA[V]) [quickfixable]
   implicit def enrichA0[V](a: A[V]) = new EnrichedA(a)
                ^
-newSource:37: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.NumericA[ZBUR]) [quick fix available]
+newSource:37: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.NumericA[ZBUR]) [quickfixable]
   implicit def enrichA1[ZBUR: Numeric](a: A[ZBUR]) = new NumericA[ZBUR](a)
                ^
-newSource:38: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.IntA) [quick fix available]
+newSource:38: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.IntA) [quickfixable]
   implicit def enrichA2(a: A[Int]) = new IntA(a)
                ^
-newSource:39: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.GtColonDoubleA) [quick fix available]
+newSource:39: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.GtColonDoubleA) [quickfixable]
   implicit def enrichA3(a: A[T] forSome { type T <: Double }) = new GtColonDoubleA(a)
                ^
-newSource:42: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.MyNumericA[Z]) [quick fix available]
+newSource:42: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.MyNumericA[Z]) [quickfixable]
   implicit def enrichA6[Z: MyNumeric](a: A[Z]) = new MyNumericA[Z](a)
                ^
-newSource:44: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.ManifestA[H] with scala.test.scaladoc.implicits.base.MyTraversableOps[H]) [quick fix available]
+newSource:44: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.base.ManifestA[H] with scala.test.scaladoc.implicits.base.MyTraversableOps[H]) [quickfixable]
   implicit def enrichA7[H <: Double : Manifest](a: A[H]) = new ManifestA[H](a) with MyTraversableOps[H] { def convToTraversableOps(x: H): H = sys.error("no") }
                ^
 Done.

--- a/test/scaladoc/run/implicits-chaining.check
+++ b/test/scaladoc/run/implicits-chaining.check
@@ -1,16 +1,16 @@
-newSource:22: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit1[T])
+newSource:22: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit1[T]) [quick fix available]
     implicit def implicit1[T <: Intermediate[_, _]](implicit b: Implicit2[T])                = new Implicit1[T](b)
                  ^
-newSource:24: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit2[T])
+newSource:24: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit2[T]) [quick fix available]
     implicit def implicit2alt1[T <: Intermediate[_ <: String, _]](implicit c: Implicit3[T])  = new Implicit2[T](c)
                  ^
-newSource:25: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit2[T])
+newSource:25: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit2[T]) [quick fix available]
     implicit def implicit2alt2[T <: Intermediate[_ <: Double, _]](implicit c: Implicit3[T])  = new Implicit2[T](c)
                  ^
-newSource:27: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit3[T])
+newSource:27: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit3[T]) [quick fix available]
     implicit def implicit3alt1[T <: Intermediate[_, _ <: Int]]                               = new Implicit3[T]()
                  ^
-newSource:28: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit3[T])
+newSource:28: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit3[T]) [quick fix available]
     implicit def implicit3alt2[T <: Intermediate[_ <: Double, _ <: AnyRef],X]                = new Implicit3[T]()
                  ^
 Done.

--- a/test/scaladoc/run/implicits-chaining.check
+++ b/test/scaladoc/run/implicits-chaining.check
@@ -1,16 +1,16 @@
-newSource:22: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit1[T])
+newSource:22: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit1[T])
     implicit def implicit1[T <: Intermediate[_, _]](implicit b: Implicit2[T])                = new Implicit1[T](b)
                  ^
-newSource:24: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit2[T])
+newSource:24: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit2[T])
     implicit def implicit2alt1[T <: Intermediate[_ <: String, _]](implicit c: Implicit3[T])  = new Implicit2[T](c)
                  ^
-newSource:25: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit2[T])
+newSource:25: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit2[T])
     implicit def implicit2alt2[T <: Intermediate[_ <: Double, _]](implicit c: Implicit3[T])  = new Implicit2[T](c)
                  ^
-newSource:27: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit3[T])
+newSource:27: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit3[T])
     implicit def implicit3alt1[T <: Intermediate[_, _ <: Int]]                               = new Implicit3[T]()
                  ^
-newSource:28: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit3[T])
+newSource:28: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit3[T])
     implicit def implicit3alt2[T <: Intermediate[_ <: Double, _ <: AnyRef],X]                = new Implicit3[T]()
                  ^
 Done.

--- a/test/scaladoc/run/implicits-chaining.check
+++ b/test/scaladoc/run/implicits-chaining.check
@@ -1,16 +1,16 @@
-newSource:22: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit1[T]) [quick fix available]
+newSource:22: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit1[T]) [quickfixable]
     implicit def implicit1[T <: Intermediate[_, _]](implicit b: Implicit2[T])                = new Implicit1[T](b)
                  ^
-newSource:24: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit2[T]) [quick fix available]
+newSource:24: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit2[T]) [quickfixable]
     implicit def implicit2alt1[T <: Intermediate[_ <: String, _]](implicit c: Implicit3[T])  = new Implicit2[T](c)
                  ^
-newSource:25: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit2[T]) [quick fix available]
+newSource:25: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit2[T]) [quickfixable]
     implicit def implicit2alt2[T <: Intermediate[_ <: Double, _]](implicit c: Implicit3[T])  = new Implicit2[T](c)
                  ^
-newSource:27: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit3[T]) [quick fix available]
+newSource:27: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit3[T]) [quickfixable]
     implicit def implicit3alt1[T <: Intermediate[_, _ <: Int]]                               = new Implicit3[T]()
                  ^
-newSource:28: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit3[T]) [quick fix available]
+newSource:28: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.Implicit3[T]) [quickfixable]
     implicit def implicit3alt2[T <: Intermediate[_ <: Double, _ <: AnyRef],X]                = new Implicit3[T]()
                  ^
 Done.

--- a/test/scaladoc/run/implicits-known-type-classes.check
+++ b/test/scaladoc/run/implicits-known-type-classes.check
@@ -1,49 +1,49 @@
-newSource:13: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[Numeric[T]])
+newSource:13: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[Numeric[T]])
     implicit def convertNumeric       [T: Numeric]       (a: A[T]) = new B(implicitly[Numeric[T]])
                  ^
-newSource:14: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[Integral[T]])
+newSource:14: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[Integral[T]])
     implicit def convertIntegral      [T: Integral]      (a: A[T]) = new B(implicitly[Integral[T]])
                  ^
-newSource:15: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[Fractional[T]])
+newSource:15: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[Fractional[T]])
     implicit def convertFractional    [T: Fractional]    (a: A[T]) = new B(implicitly[Fractional[T]])
                  ^
-newSource:16: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[Manifest[T]])
+newSource:16: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[Manifest[T]])
     implicit def convertManifest      [T: Manifest]      (a: A[T]) = new B(implicitly[Manifest[T]])
                  ^
-newSource:17: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[reflect.ClassManifest[T]])
+newSource:17: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[reflect.ClassManifest[T]])
     implicit def convertClassManifest [T: ClassManifest] (a: A[T]) = new B(implicitly[ClassManifest[T]])
                  ^
-newSource:18: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[OptManifest[T]])
+newSource:18: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[OptManifest[T]])
     implicit def convertOptManifest   [T: OptManifest]   (a: A[T]) = new B(implicitly[OptManifest[T]])
                  ^
-newSource:19: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.reflect.ClassTag[T]])
+newSource:19: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.reflect.ClassTag[T]])
     implicit def convertClassTag      [T: ClassTag]      (a: A[T]) = new B(implicitly[ClassTag[T]])
                  ^
-newSource:20: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[reflect.runtime.universe.TypeTag[T]])
+newSource:20: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[reflect.runtime.universe.TypeTag[T]])
     implicit def convertTypeTag       [T: TypeTag]       (a: A[T]) = new B(implicitly[TypeTag[T]])
                  ^
-newSource:29: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.K[T]])
+newSource:29: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.K[T]])
     implicit def convertK [T: K] (a: A[T]) = new B(implicitly[K[T]])
                  ^
-newSource:30: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.L[T]])
+newSource:30: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.L[T]])
     implicit def convertL [T: L] (a: A[T]) = new B(implicitly[L[T]])
                  ^
-newSource:31: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.M[T]])
+newSource:31: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.M[T]])
     implicit def convertM [T: M] (a: A[T]) = new B(implicitly[M[T]])
                  ^
-newSource:32: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.N[T]])
+newSource:32: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.N[T]])
     implicit def convertN [T: N] (a: A[T]) = new B(implicitly[N[T]])
                  ^
-newSource:33: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.O[T]])
+newSource:33: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.O[T]])
     implicit def convertO [T: O] (a: A[T]) = new B(implicitly[O[T]])
                  ^
-newSource:34: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.P[T]])
+newSource:34: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.P[T]])
     implicit def convertP [T: P] (a: A[T]) = new B(implicitly[P[T]])
                  ^
-newSource:35: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.Q[T]])
+newSource:35: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.Q[T]])
     implicit def convertQ [T: Q] (a: A[T]) = new B(implicitly[Q[T]])
                  ^
-newSource:36: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.R[T]])
+newSource:36: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.R[T]])
     implicit def convertR [T: R] (a: A[T]) = new B(implicitly[R[T]])
                  ^
 Done.

--- a/test/scaladoc/run/implicits-known-type-classes.check
+++ b/test/scaladoc/run/implicits-known-type-classes.check
@@ -1,49 +1,49 @@
-newSource:13: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[Numeric[T]])
+newSource:13: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[Numeric[T]]) [quick fix available]
     implicit def convertNumeric       [T: Numeric]       (a: A[T]) = new B(implicitly[Numeric[T]])
                  ^
-newSource:14: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[Integral[T]])
+newSource:14: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[Integral[T]]) [quick fix available]
     implicit def convertIntegral      [T: Integral]      (a: A[T]) = new B(implicitly[Integral[T]])
                  ^
-newSource:15: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[Fractional[T]])
+newSource:15: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[Fractional[T]]) [quick fix available]
     implicit def convertFractional    [T: Fractional]    (a: A[T]) = new B(implicitly[Fractional[T]])
                  ^
-newSource:16: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[Manifest[T]])
+newSource:16: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[Manifest[T]]) [quick fix available]
     implicit def convertManifest      [T: Manifest]      (a: A[T]) = new B(implicitly[Manifest[T]])
                  ^
-newSource:17: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[reflect.ClassManifest[T]])
+newSource:17: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[reflect.ClassManifest[T]]) [quick fix available]
     implicit def convertClassManifest [T: ClassManifest] (a: A[T]) = new B(implicitly[ClassManifest[T]])
                  ^
-newSource:18: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[OptManifest[T]])
+newSource:18: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[OptManifest[T]]) [quick fix available]
     implicit def convertOptManifest   [T: OptManifest]   (a: A[T]) = new B(implicitly[OptManifest[T]])
                  ^
-newSource:19: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.reflect.ClassTag[T]])
+newSource:19: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.reflect.ClassTag[T]]) [quick fix available]
     implicit def convertClassTag      [T: ClassTag]      (a: A[T]) = new B(implicitly[ClassTag[T]])
                  ^
-newSource:20: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[reflect.runtime.universe.TypeTag[T]])
+newSource:20: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[reflect.runtime.universe.TypeTag[T]]) [quick fix available]
     implicit def convertTypeTag       [T: TypeTag]       (a: A[T]) = new B(implicitly[TypeTag[T]])
                  ^
-newSource:29: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.K[T]])
+newSource:29: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.K[T]]) [quick fix available]
     implicit def convertK [T: K] (a: A[T]) = new B(implicitly[K[T]])
                  ^
-newSource:30: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.L[T]])
+newSource:30: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.L[T]]) [quick fix available]
     implicit def convertL [T: L] (a: A[T]) = new B(implicitly[L[T]])
                  ^
-newSource:31: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.M[T]])
+newSource:31: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.M[T]]) [quick fix available]
     implicit def convertM [T: M] (a: A[T]) = new B(implicitly[M[T]])
                  ^
-newSource:32: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.N[T]])
+newSource:32: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.N[T]]) [quick fix available]
     implicit def convertN [T: N] (a: A[T]) = new B(implicitly[N[T]])
                  ^
-newSource:33: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.O[T]])
+newSource:33: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.O[T]]) [quick fix available]
     implicit def convertO [T: O] (a: A[T]) = new B(implicitly[O[T]])
                  ^
-newSource:34: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.P[T]])
+newSource:34: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.P[T]]) [quick fix available]
     implicit def convertP [T: P] (a: A[T]) = new B(implicitly[P[T]])
                  ^
-newSource:35: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.Q[T]])
+newSource:35: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.Q[T]]) [quick fix available]
     implicit def convertQ [T: Q] (a: A[T]) = new B(implicitly[Q[T]])
                  ^
-newSource:36: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.R[T]])
+newSource:36: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.R[T]]) [quick fix available]
     implicit def convertR [T: R] (a: A[T]) = new B(implicitly[R[T]])
                  ^
 Done.

--- a/test/scaladoc/run/implicits-known-type-classes.check
+++ b/test/scaladoc/run/implicits-known-type-classes.check
@@ -1,49 +1,49 @@
-newSource:13: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[Numeric[T]]) [quick fix available]
+newSource:13: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[Numeric[T]]) [quickfixable]
     implicit def convertNumeric       [T: Numeric]       (a: A[T]) = new B(implicitly[Numeric[T]])
                  ^
-newSource:14: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[Integral[T]]) [quick fix available]
+newSource:14: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[Integral[T]]) [quickfixable]
     implicit def convertIntegral      [T: Integral]      (a: A[T]) = new B(implicitly[Integral[T]])
                  ^
-newSource:15: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[Fractional[T]]) [quick fix available]
+newSource:15: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[Fractional[T]]) [quickfixable]
     implicit def convertFractional    [T: Fractional]    (a: A[T]) = new B(implicitly[Fractional[T]])
                  ^
-newSource:16: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[Manifest[T]]) [quick fix available]
+newSource:16: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[Manifest[T]]) [quickfixable]
     implicit def convertManifest      [T: Manifest]      (a: A[T]) = new B(implicitly[Manifest[T]])
                  ^
-newSource:17: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[reflect.ClassManifest[T]]) [quick fix available]
+newSource:17: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[reflect.ClassManifest[T]]) [quickfixable]
     implicit def convertClassManifest [T: ClassManifest] (a: A[T]) = new B(implicitly[ClassManifest[T]])
                  ^
-newSource:18: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[OptManifest[T]]) [quick fix available]
+newSource:18: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[OptManifest[T]]) [quickfixable]
     implicit def convertOptManifest   [T: OptManifest]   (a: A[T]) = new B(implicitly[OptManifest[T]])
                  ^
-newSource:19: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.reflect.ClassTag[T]]) [quick fix available]
+newSource:19: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.reflect.ClassTag[T]]) [quickfixable]
     implicit def convertClassTag      [T: ClassTag]      (a: A[T]) = new B(implicitly[ClassTag[T]])
                  ^
-newSource:20: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[reflect.runtime.universe.TypeTag[T]]) [quick fix available]
+newSource:20: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[reflect.runtime.universe.TypeTag[T]]) [quickfixable]
     implicit def convertTypeTag       [T: TypeTag]       (a: A[T]) = new B(implicitly[TypeTag[T]])
                  ^
-newSource:29: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.K[T]]) [quick fix available]
+newSource:29: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.K[T]]) [quickfixable]
     implicit def convertK [T: K] (a: A[T]) = new B(implicitly[K[T]])
                  ^
-newSource:30: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.L[T]]) [quick fix available]
+newSource:30: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.L[T]]) [quickfixable]
     implicit def convertL [T: L] (a: A[T]) = new B(implicitly[L[T]])
                  ^
-newSource:31: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.M[T]]) [quick fix available]
+newSource:31: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.M[T]]) [quickfixable]
     implicit def convertM [T: M] (a: A[T]) = new B(implicitly[M[T]])
                  ^
-newSource:32: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.N[T]]) [quick fix available]
+newSource:32: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.N[T]]) [quickfixable]
     implicit def convertN [T: N] (a: A[T]) = new B(implicitly[N[T]])
                  ^
-newSource:33: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.O[T]]) [quick fix available]
+newSource:33: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.O[T]]) [quickfixable]
     implicit def convertO [T: O] (a: A[T]) = new B(implicitly[O[T]])
                  ^
-newSource:34: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.P[T]]) [quick fix available]
+newSource:34: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.P[T]]) [quickfixable]
     implicit def convertP [T: P] (a: A[T]) = new B(implicitly[P[T]])
                  ^
-newSource:35: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.Q[T]]) [quick fix available]
+newSource:35: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.Q[T]]) [quickfixable]
     implicit def convertQ [T: Q] (a: A[T]) = new B(implicitly[Q[T]])
                  ^
-newSource:36: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.R[T]]) [quick fix available]
+newSource:36: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.typeclasses.B[scala.test.scaladoc.implicits.typeclasses.A.R[T]]) [quickfixable]
     implicit def convertR [T: R] (a: A[T]) = new B(implicitly[R[T]])
                  ^
 Done.

--- a/test/scaladoc/run/implicits-shadowing.check
+++ b/test/scaladoc/run/implicits-shadowing.check
@@ -1,4 +1,4 @@
-newSource:63: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.shadowing.Z[T])
+newSource:63: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.shadowing.Z[T]) [quick fix available]
   implicit def AtoZ[T](a: A[T]) = new Z[T]
                ^
 Done.

--- a/test/scaladoc/run/implicits-shadowing.check
+++ b/test/scaladoc/run/implicits-shadowing.check
@@ -1,4 +1,4 @@
-newSource:63: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.shadowing.Z[T]) [quick fix available]
+newSource:63: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.shadowing.Z[T]) [quickfixable]
   implicit def AtoZ[T](a: A[T]) = new Z[T]
                ^
 Done.

--- a/test/scaladoc/run/implicits-shadowing.check
+++ b/test/scaladoc/run/implicits-shadowing.check
@@ -1,4 +1,4 @@
-newSource:63: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.shadowing.Z[T])
+newSource:63: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.implicits.shadowing.Z[T])
   implicit def AtoZ[T](a: A[T]) = new Z[T]
                ^
 Done.

--- a/test/scaladoc/run/implicits-var-exp.check
+++ b/test/scaladoc/run/implicits-var-exp.check
@@ -1,7 +1,7 @@
-newSource:8: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.variable.expansion.C) [quick fix available]
+newSource:8: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.variable.expansion.C) [quickfixable]
             implicit def aToC(a: A) = new C
                          ^
-newSource:9: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.variable.expansion.E with scala.test.scaladoc.variable.expansion.F) [quick fix available]
+newSource:9: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.variable.expansion.E with scala.test.scaladoc.variable.expansion.F) [quickfixable]
             implicit def aToE(a: A) = new E with F
                          ^
 Done.

--- a/test/scaladoc/run/implicits-var-exp.check
+++ b/test/scaladoc/run/implicits-var-exp.check
@@ -1,7 +1,7 @@
-newSource:8: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.variable.expansion.C)
+newSource:8: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.variable.expansion.C) [quick fix available]
             implicit def aToC(a: A) = new C
                          ^
-newSource:9: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.variable.expansion.E with scala.test.scaladoc.variable.expansion.F)
+newSource:9: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.variable.expansion.E with scala.test.scaladoc.variable.expansion.F) [quick fix available]
             implicit def aToE(a: A) = new E with F
                          ^
 Done.

--- a/test/scaladoc/run/implicits-var-exp.check
+++ b/test/scaladoc/run/implicits-var-exp.check
@@ -1,7 +1,7 @@
-newSource:8: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.variable.expansion.C)
+newSource:8: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.variable.expansion.C)
             implicit def aToC(a: A) = new C
                          ^
-newSource:9: warning: Implicit definition should have explicit type (inferred scala.test.scaladoc.variable.expansion.E with scala.test.scaladoc.variable.expansion.F)
+newSource:9: warning: [quick fix available] Implicit definition should have explicit type (inferred scala.test.scaladoc.variable.expansion.E with scala.test.scaladoc.variable.expansion.F)
             implicit def aToE(a: A) = new E with F
                          ^
 Done.


### PR DESCRIPTION
Looked through Parser, Scanner, Namer, Typer and RefChecks.

Some ad hocery in
  - finding positions, for example from a synthetic accessor DefDef that has only an offset position to get the end of the name where to add an explicit return type
  - identifying qualifiers of a selection that require parentheses (`a.toDouble` vs `(a + a).toDouble`)

Hopefully acceptable for the use case.