### PR TITLE
Use type of function literal param for PF synthesis [ci: last-only]

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
@@ -200,7 +200,7 @@ trait MatchTranslation {
       if (phase.id >= currentRun.uncurryPhase.id)
         devWarning(s"running translateMatch past uncurry (at $phase) on $selector match $cases")
 
-      debug.patmat("translating "+ cases.mkString("{", "\n", "}"))
+      debug.patmat(cases.mkString("translating {", "\n", "}"))
 
       val start = if (settings.areStatisticsEnabled) statistics.startTimer(statistics.patmatNanos) else null
 

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2739,6 +2739,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       }
     }
 
+    private lazy val topTypes: Set[Symbol] = Set(AnyClass, AnyValClass, ObjectClass)
+
     /** synthesize and type check a PartialFunction implementation based on the match in `tree`
      *
      *  `param => sel match { cases }` becomes:
@@ -2761,17 +2763,25 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
      * an alternative TODO: add partial function AST node or equivalent and get rid of this synthesis --> do everything in uncurry (or later)
      * however, note that pattern matching codegen is designed to run *before* uncurry
      */
-    def synthesizePartialFunction(paramName: TermName, paramPos: Position, paramSynthetic: Boolean,
+    def synthesizePartialFunction(paramName: TermName, paramPos: Position, paramType: Type, paramSynthetic: Boolean,
                                   tree: Tree, mode: Mode, pt: Type): Tree = {
       assert(pt.typeSymbol == PartialFunctionClass, s"PartialFunction synthesis for match in $tree requires PartialFunction expected type, but got $pt.")
-      val (argTp, resTp) = partialFunctionArgResTypeFromProto(pt)
+      val (argTp0, resTp) = partialFunctionArgResTypeFromProto(pt)
 
       // if argTp isn't fully defined, we can't translate --> error
       // NOTE: resTp still might not be fully defined
-      if (!isFullyDefined(argTp)) {
+      if (!isFullyDefined(argTp0)) {
         MissingParameterTypeAnonMatchError(tree, pt)
         return setError(tree)
       }
+      val argTp =
+        if (paramType.eq(NoType) || argTp0 <:< paramType) argTp0
+        else {
+          val argTp1 = lub(List(argTp0, paramType))
+          if (settings.warnInferAny && topTypes(argTp1.typeSymbol))
+            context.warning(paramPos, s"a type was inferred to be `${argTp1.typeSymbol.name}` when constructing a PartialFunction", WarningCategory.LintInferAny)
+          argTp1
+        }
 
       // targs must conform to Any for us to synthesize an applyOrElse (fallback to apply otherwise -- typically for @cps annotated targs)
       val targsValidParams = (argTp <:< AnyTpe) && (resTp <:< AnyTpe)
@@ -3178,9 +3188,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             // you won't know you're using the wrong owner until lambda lift crashes (unless you know better than to use the wrong owner)
             val outerTyper = newTyper(context.outer)
             val p = vparams.head
-            if (p.tpt.tpe == null) p.tpt setType outerTyper.typedType(p.tpt).tpe
-
-            outerTyper.synthesizePartialFunction(p.name, p.pos, paramSynthetic = false, funBody, mode, pt)
+            if (p.tpt.tpe == null) p.tpt.setType(outerTyper.typedType(p.tpt).tpe)
+            outerTyper.synthesizePartialFunction(p.name, p.pos, p.tpt.tpe, paramSynthetic = false, funBody, mode, pt)
           } else doTypedFunction(fun, resProto)
         }
       }
@@ -4916,7 +4925,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         val cases = tree.cases
         if (selector == EmptyTree) {
           if (pt.typeSymbol == PartialFunctionClass)
-            synthesizePartialFunction(newTermName(fresh.newName("x")), tree.pos, paramSynthetic = true, tree, mode, pt)
+            synthesizePartialFunction(newTermName(fresh.newName("x")), tree.pos, paramType = NoType, paramSynthetic = true, tree, mode, pt)
           else {
             val arity = functionArityFromType(pt) match { case -1 => 1 case arity => arity } // scala/bug#8429: consider sam and function type equally in determining function arity
 

--- a/test/files/neg/t4940.check
+++ b/test/files/neg/t4940.check
@@ -1,0 +1,12 @@
+t4940.scala:3: warning: a type was inferred to be `Any` when constructing a PartialFunction
+  val f: PartialFunction[String, Int] = (x: Int) => x match { case "x" => 3 }   // error
+                                          ^
+t4940.scala:5: warning: a type was inferred to be `Object` when constructing a PartialFunction
+  val g: PartialFunction[String, Int] = (x: X) => x match { case "x" => 3 }     // error
+                                          ^
+t4940.scala:7: warning: a type was inferred to be `AnyVal` when constructing a PartialFunction
+  val m: PartialFunction[Int, Int] = (x: Double) => x match { case 3.14 => 3 }  // error
+                                       ^
+error: No warnings can be incurred under -Werror.
+3 warnings
+1 error

--- a/test/files/neg/t4940.check
+++ b/test/files/neg/t4940.check
@@ -1,12 +1,31 @@
-t4940.scala:3: warning: a type was inferred to be `Any` when constructing a PartialFunction
+t4940.scala:3: error: type mismatch;
+ found   : String("x")
+ required: Int
   val f: PartialFunction[String, Int] = (x: Int) => x match { case "x" => 3 }   // error
-                                          ^
-t4940.scala:5: warning: a type was inferred to be `Object` when constructing a PartialFunction
+                                                                   ^
+t4940.scala:3: error: type mismatch;
+ found   : scala.runtime.AbstractPartialFunction[Int,Int] with java.io.Serializable
+ required: PartialFunction[String,Int]
+  val f: PartialFunction[String, Int] = (x: Int) => x match { case "x" => 3 }   // error
+                                                      ^
+t4940.scala:5: error: type mismatch;
+ found   : String("x")
+ required: X
   val g: PartialFunction[String, Int] = (x: X) => x match { case "x" => 3 }     // error
-                                          ^
-t4940.scala:7: warning: a type was inferred to be `AnyVal` when constructing a PartialFunction
+                                                                 ^
+t4940.scala:5: error: type mismatch;
+ found   : scala.runtime.AbstractPartialFunction[X,Int] with java.io.Serializable
+ required: PartialFunction[String,Int]
+  val g: PartialFunction[String, Int] = (x: X) => x match { case "x" => 3 }     // error
+                                                    ^
+t4940.scala:7: error: type mismatch;
+ found   : scala.runtime.AbstractPartialFunction[Double,Int] with java.io.Serializable
+ required: PartialFunction[Int,Int]
   val m: PartialFunction[Int, Int] = (x: Double) => x match { case 3.14 => 3 }  // error
-                                       ^
-error: No warnings can be incurred under -Werror.
-3 warnings
-1 error
+                                                      ^
+t4940.scala:9: error: type mismatch;
+ found   : scala.runtime.AbstractPartialFunction[X,Int] with java.io.Serializable
+ required: PartialFunction[Y,Int]
+  val g3: PartialFunction[Y, Int] = (x: X) => x match { case _: X => 3 }        // error
+                                                ^
+6 errors

--- a/test/files/neg/t4940.scala
+++ b/test/files/neg/t4940.scala
@@ -1,0 +1,18 @@
+//> using options -Werror -Xlint
+class C {
+  val f: PartialFunction[String, Int] = (x: Int) => x match { case "x" => 3 }   // error
+
+  val g: PartialFunction[String, Int] = (x: X) => x match { case "x" => 3 }     // error
+
+  val m: PartialFunction[Int, Int] = (x: Double) => x match { case 3.14 => 3 }  // error
+}
+
+class X
+
+object Test extends App {
+  val c = new C
+  println(c.f.applyOrElse("hello, world", (s: String) => -1))
+  println(c.f.applyOrElse("x", (s: String) => -1))
+  println(c.g.applyOrElse("hello, world", (s: String) => -1))
+  println(c.m.applyOrElse(42, (n: Int) => -1))
+}

--- a/test/files/neg/t4940.scala
+++ b/test/files/neg/t4940.scala
@@ -5,9 +5,12 @@ class C {
   val g: PartialFunction[String, Int] = (x: X) => x match { case "x" => 3 }     // error
 
   val m: PartialFunction[Int, Int] = (x: Double) => x match { case 3.14 => 3 }  // error
+
+  val g3: PartialFunction[Y, Int] = (x: X) => x match { case _: X => 3 }        // error
 }
 
-class X
+class Y
+class X extends Y
 
 object Test extends App {
   val c = new C

--- a/test/files/pos/t4940.scala
+++ b/test/files/pos/t4940.scala
@@ -1,0 +1,39 @@
+//> using options -Werror -Xlint
+class C {
+  val f: PartialFunction[String, Int] = (x: String) => x match { case "x" => 3 }
+  val f2: PartialFunction[String, Int] = (x: String) => x match { case "x" => x.toString.toInt }
+
+  val g: PartialFunction[X, Int] = (x: X) => x match { case X(i) => i }
+  val g2: PartialFunction[X, Int] = (x: Y) => x match { case X(i) => i }
+  val g3: PartialFunction[Y, Int] = (x: X) => x match { case X(i) => i }
+
+  val m: PartialFunction[Double, Int] = (x: Double) => x match { case 3.14 => 3 }
+}
+
+class D {
+  val f: PartialFunction[String, Int] = _ match { case "x" => 3 }
+
+  val g: PartialFunction[X, Int] = _ match { case X(i) => i }
+
+  val m: PartialFunction[Double, Int] = _ match { case 3.14 => 3 }
+}
+
+class E {
+  val f: PartialFunction[String, Int] = x => x.toInt
+
+  val g: PartialFunction[X, Int] = x => x.x
+
+  val m: PartialFunction[Double, Long] = d => d.round
+}
+
+trait Y
+case class X(x: Int) extends Y
+
+class ActuallyOK {
+  val map = Map(42 -> "foo")
+  def k = List(27).collect {
+    map.get(_) match {
+      case Some(i) => i
+    }
+  }
+}

--- a/test/files/pos/t4940.scala
+++ b/test/files/pos/t4940.scala
@@ -5,7 +5,7 @@ class C {
 
   val g: PartialFunction[X, Int] = (x: X) => x match { case X(i) => i }
   val g2: PartialFunction[X, Int] = (x: Y) => x match { case X(i) => i }
-  val g3: PartialFunction[Y, Int] = (x: X) => x match { case X(i) => i }
+  //val g3: PartialFunction[Y, Int] = (x: X) => x match { case X(i) => i }
 
   val m: PartialFunction[Double, Int] = (x: Double) => x match { case 3.14 => 3 }
 }


### PR DESCRIPTION
When "adapting" a function literal to a `PartialFunction`, don't ignore an explicit parameter type but use it directly.

Fixes scala/bug#4940

```Scala
➜  ~ scala
Welcome to Scala 2.13.15 (OpenJDK 64-Bit Server VM, Java 23).
Type in expressions for evaluation. Or try :help.

scala> List(42).collect((x: String) => x match { case "42" => 27 })
                                                      ^
       error: type mismatch;
        found   : String("42")
        required: Int

scala>
:quit
➜  ~ skala
Welcome to Scala 2.13.16-20241122-141607-6782503 (OpenJDK 64-Bit Server VM, Java 23).
Type in expressions for evaluation. Or try :help.

scala> List(42).collect((x: String) => x match { case "42" => 27 })
                                         ^
       error: type mismatch;
        found   : scala.runtime.AbstractPartialFunction[String,27] with java.io.Serializable
        required: PartialFunction[Int,?]

scala>
:quit
```
~For edge case syntax, `List(42).collect((x: String) => x match { case "42" => 27 })`, use the explicit param type to widen the type arg of the partial function. (Previously it was ignored.) Warn under `-Xlint:infer-any`.~
