### PR TITLE
TypeDiagnostics traverses original of TypeTrees

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/Printers.scala
+++ b/src/compiler/scala/tools/nsc/ast/Printers.scala
@@ -63,7 +63,7 @@ trait Printers extends scala.reflect.internal.Printers { this: Global =>
       treePrinter.println()
       treePrinter.print(definition)
 
-    case TypeTreeWithDeferredRefCheck() =>
+    case _: TypeTreeWithDeferredRefCheck =>
       treePrinter.print("<tree with deferred refcheck>")
 
     case SelectFromArray(qualifier, name, _) =>

--- a/src/compiler/scala/tools/nsc/ast/Trees.scala
+++ b/src/compiler/scala/tools/nsc/ast/Trees.scala
@@ -66,7 +66,7 @@ trait Trees extends scala.reflect.internal.Trees { self: Global =>
   }
 
   /** emitted by typer, eliminated by refchecks */
-  case class TypeTreeWithDeferredRefCheck()(val check: () => TypeTree) extends TypTree {
+  case class TypeTreeWithDeferredRefCheck(precheck: TypeTree)(val check: () => TypeTree) extends TypTree {
     override def transform(transformer: ApiTransformer): Tree =
       transformer.treeCopy.TypeTreeWithDeferredRefCheck(this)
     override def traverse(traverser: Traverser): Unit = {
@@ -136,8 +136,8 @@ trait Trees extends scala.reflect.internal.Trees { self: Global =>
     def InjectDerivedValue(tree: Tree, arg: Tree) =
       new InjectDerivedValue(arg).copyAttrs(tree)
     def TypeTreeWithDeferredRefCheck(tree: Tree) = tree match {
-      case dc@TypeTreeWithDeferredRefCheck() => new TypeTreeWithDeferredRefCheck()(dc.check).copyAttrs(tree)
-      case x                                 => throw new MatchError(x)
+      case dc@TypeTreeWithDeferredRefCheck(prechk) => new TypeTreeWithDeferredRefCheck(prechk)(dc.check).copyAttrs(tree)
+      case x => throw new MatchError(x)
     }
   }
 
@@ -163,7 +163,7 @@ trait Trees extends scala.reflect.internal.Trees { self: Global =>
       case _ => this.treeCopy.InjectDerivedValue(tree, arg)
     }
     def TypeTreeWithDeferredRefCheck(tree: Tree) = tree match {
-      case t @ TypeTreeWithDeferredRefCheck() => t
+      case t: TypeTreeWithDeferredRefCheck => t
       case _ => this.treeCopy.TypeTreeWithDeferredRefCheck(tree)
     }
   }
@@ -202,7 +202,7 @@ trait Trees extends scala.reflect.internal.Trees { self: Global =>
     case InjectDerivedValue(arg) =>
       transformer.treeCopy.InjectDerivedValue(
         tree, transformer.transform(arg))
-    case TypeTreeWithDeferredRefCheck() =>
+    case _: TypeTreeWithDeferredRefCheck =>
       transformer.treeCopy.TypeTreeWithDeferredRefCheck(tree)
     case x => super.xtransform(transformer, tree)
   }
@@ -373,7 +373,7 @@ trait Trees extends scala.reflect.internal.Trees { self: Global =>
 
    case Parens(expr)                                               (only used during parsing)
    case DocDef(comment, defn) =>                                   (eliminated by typer)
-   case TypeTreeWithDeferredRefCheck() =>                          (created and eliminated by typer)
+   case TypeTreeWithDeferredRefCheck(prechk) =>                    (created by typer and eliminated by refchecks)
    case SelectFromArray(_, _, _) =>                                (created and eliminated by erasure)
    case InjectDerivedValue(_) =>                                   (created and eliminated by erasure)
 

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1606,7 +1606,7 @@ abstract class RefChecks extends Transform {
         case tpt@TypeTree() =>
           if (tpt.original != null)
             tpt.original.foreach {
-              case dc@TypeTreeWithDeferredRefCheck() =>
+              case dc: TypeTreeWithDeferredRefCheck =>
                 applyRefchecksToAnnotations(dc.check()) // #2416
               case _ =>
             }
@@ -1880,11 +1880,11 @@ abstract class RefChecks extends Transform {
               currentOwner.primaryConstructor makeNotPrivate NoSymbol // scala/bug#6601, must be done *after* pickler!
             if (bridges.nonEmpty) deriveTemplate(tree)(_ ::: bridges) else tree
 
-          case dc@TypeTreeWithDeferredRefCheck() => abort("adapt should have turned dc: TypeTreeWithDeferredRefCheck into tpt: TypeTree, with tpt.original == dc")
+          case _: TypeTreeWithDeferredRefCheck => abort("adapt should have turned dc: TypeTreeWithDeferredRefCheck into tpt: TypeTree, with tpt.original == dc")
           case tpt@TypeTree() =>
             if(tpt.original != null) {
               tpt.original foreach {
-                case dc@TypeTreeWithDeferredRefCheck() =>
+                case dc: TypeTreeWithDeferredRefCheck =>
                   transform(dc.check()) // #2416 -- only call transform to do refchecks, but discard results
                   // tpt has the right type if the deferred checks are ok
                 case _ =>

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5460,7 +5460,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               case SelectFromTypeTree(qual@TypeTree(), name) if qual.tpe.typeArgs.nonEmpty => // TODO: somehow the new qual is not checked in refchecks
                 treeCopy.SelectFromTypeTree(
                   result,
-                  TypeTreeWithDeferredRefCheck() { () => val tp = qual.tpe; val sym = tp.typeSymbolDirect
+                  TypeTreeWithDeferredRefCheck(qual) { () => val tp = qual.tpe; val sym = tp.typeSymbolDirect
                     // will execute during refchecks -- TODO: make private checkTypeRef in refchecks public and call that one?
                     checkBounds(qual, tp.prefix, sym.owner, sym.typeParams, tp.typeArgs, "")
                     qual // you only get to see the wrapped tree after running this check :-p
@@ -5698,7 +5698,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             val result = TypeTree(appliedType(tpt1.tpe, argtypes)) setOriginal original
             val isPoly = tpt1.tpe.isInstanceOf[PolyType]
             if (isPoly) // did the type application (performed by appliedType) involve an unchecked beta-reduction?
-              TypeTreeWithDeferredRefCheck() { () =>
+              TypeTreeWithDeferredRefCheck(result) { () =>
                 // wrap the tree and include the bounds check -- refchecks will perform this check (that the beta reduction was indeed allowed) and unwrap
                 // we can't simply use original in refchecks because it does not contains types
                 // (and the only typed trees we have been mangled so they're not quite the original tree anymore)
@@ -6036,7 +6036,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         case tree: SelectFromTypeTree           => typedSelect(tree, typedType(tree.qualifier, mode), tree.name)
         case tree: CompoundTypeTree             => typedCompoundTypeTree(tree)
         case tree: ExistentialTypeTree          => typedExistentialTypeTree(tree)
-        case tree: TypeTreeWithDeferredRefCheck => tree // TODO: retype the wrapped tree? TTWDRC would have to change to hold the wrapped tree (not a closure)
+        case tree: TypeTreeWithDeferredRefCheck => tree // TODO: retype the wrapped tree?
         case _                                  => abort(s"unexpected type-representing tree: ${tree.getClass}\n$tree")
       }
 

--- a/test/files/neg/warn-unused-privates.scala
+++ b/test/files/neg/warn-unused-privates.scala
@@ -1,5 +1,5 @@
 //
-// scalac: -deprecation -Ywarn-unused:privates -Xfatal-warnings
+// scalac: -deprecation -Wunused:privates -Xfatal-warnings
 //
 class Bippy(a: Int, b: Int) {
   private def this(c: Int) = this(c, c)           // warn
@@ -259,4 +259,8 @@ trait `short comings` {
     val x = 42
     17
   }
+}
+
+class `issue 12600 ignore abstract types` {
+  type Abs
 }

--- a/test/files/pos/t12600.scala
+++ b/test/files/pos/t12600.scala
@@ -1,0 +1,6 @@
+// scalac: -Werror -Wunused:_
+class Private {
+  private type Curry[A] = { type T[B] = Either[A, B] }
+  def m2[T[A]]: Unit = ()
+  def f() = m2[Curry[Int]#T]
+}


### PR DESCRIPTION
Fixes scala/bug#12600

Also obeys the comment and allows TTWDRC to expose the prechecked tree. This TypeTree was a select from a qual that was a TTWDRC.