### PR TITLE
Fix spec build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,7 @@ jobs:
 
       # build the spec using jekyll
       - stage: build
-        # bionic for newer ruby ("bundler requires Ruby version >= 2.6.0")
-        dist: bionic
+        dist: focal
         language: ruby
         # ruby 3.x is default, need to upgrade jekyll. using 2.7 for now.
         rvm: 2.7


### PR DESCRIPTION
at e.g. https://app.travis-ci.com/github/scala/scala/jobs/607977062 we're seeing

```
$ sudo apt-get update
Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease
Hit:3 http://archive.ubuntu.com/ubuntu bionic-updates InRelease
Hit:4 http://security.ubuntu.com/ubuntu bionic-security InRelease
Hit:5 http://apt.postgresql.org/pub/repos/apt bionic-pgdg InRelease
Hit:6 https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu bionic InRelease
Hit:7 http://archive.ubuntu.com/ubuntu bionic-backports InRelease
Get:2 http://package.perforce.com/apt/ubuntu bionic InRelease [3,655 B]
Err:2 http://package.perforce.com/apt/ubuntu bionic InRelease
  The following signatures were invalid: EXPKEYSIG 7123CB760FF18869 Perforce Software (Package Signing) <support+packaging@perforce.com>
Reading package lists...
W: GPG error: http://package.perforce.com/apt/ubuntu bionic InRelease: The following signatures were invalid: EXPKEYSIG 7123CB760FF18869 Perforce Software (Package Signing) <support+packaging@perforce.com>
E: The repository 'http://package.perforce.com/apt/ubuntu bionic InRelease' is not signed.
```

one way to fix it might be to add `Acquire::Check-Valid-Until false;` to `/etc/apt/apt.conf`, as per https://askubuntu.com/questions/74345/how-do-i-bypass-ignore-the-gpg-signature-checks-of-apt

but maybe we could try first to get on a newer Ubuntu, since Travis-CI presumably won't support bionic indefinitely

the 2.12 and 2.13 spec builds are a bit different, so I might need to do experiments on both branches

we have been frozen on bionic because of a libssl version issue with wkhtmltopdf, so this might get painful

another possibility might be to move the spec build off Travis-CI and onto GitHub Actions.

previously: #10310, #10312

also https://github.com/scala/scala-dev/issues/832 which has a brief remark about how the 2.12/2.13 divergence came about