### PR TITLE
Use URI to compute Scaladoc URI [ci: last-only]

### DIFF
--- a/src/compiler/scala/reflect/reify/utils/NodePrinters.scala
+++ b/src/compiler/scala/reflect/reify/utils/NodePrinters.scala
@@ -14,6 +14,7 @@ package scala.reflect.reify
 package utils
 
 import java.lang.System.{lineSeparator => EOL}
+import scala.util.matching.Regex.quoteReplacement
 
 trait NodePrinters {
   self: Utils =>
@@ -63,7 +64,7 @@ trait NodePrinters {
           }
 
           val replacement = "Modifiers(" + buf.reverse.mkString(", ")  + ")"
-          java.util.regex.Matcher.quoteReplacement(replacement)
+          quoteReplacement(replacement)
         })
         s
       })

--- a/src/compiler/scala/reflect/reify/utils/SymbolTables.scala
+++ b/src/compiler/scala/reflect/reify/utils/SymbolTables.scala
@@ -13,7 +13,7 @@
 package scala.reflect.reify
 package utils
 
-import scala.collection._
+import scala.collection.{immutable, mutable}, mutable.{ArrayBuffer, ListBuffer}
 import java.lang.System.{lineSeparator => EOL}
 
 trait SymbolTables {
@@ -22,7 +22,7 @@ trait SymbolTables {
   import global._
 
   class SymbolTable private[SymbolTable] (
-    private[SymbolTable] val symtab: immutable.ListMap[Symbol, Tree] = immutable.ListMap[Symbol, Tree](),
+    private[SymbolTable] val symtab: immutable.ListMap[Symbol, Tree] = immutable.ListMap.empty[Symbol, Tree],
     private[SymbolTable] val aliases: List[(Symbol, TermName)] = List[(Symbol, TermName)](),
     private[SymbolTable] val original: Option[List[Tree]] = None) {
 
@@ -166,8 +166,8 @@ trait SymbolTables {
       reifier.state.symtab = symtab0.asInstanceOf[reifier.SymbolTable]
       def currtab = reifier.symtab.asInstanceOf[SymbolTable]
       try {
-        val cumulativeSymtab = mutable.ArrayBuffer[Tree](symtab0.symtab.values.toList: _*)
-        val cumulativeAliases = mutable.ArrayBuffer[(Symbol, TermName)](symtab0.aliases: _*)
+        val cumulativeSymtab = ArrayBuffer[Tree](symtab0.symtab.values.toList: _*)
+        val cumulativeAliases = ArrayBuffer[(Symbol, TermName)](symtab0.aliases: _*)
 
         def fillInSymbol(sym: Symbol): Tree = {
           if (reifyDebug) println("Filling in: %s (%s)".format(sym, sym.accurateKindString))
@@ -203,7 +203,7 @@ trait SymbolTables {
         }
 
         val withAliases = cumulativeSymtab flatMap (entry => {
-          val result = mutable.ListBuffer[Tree]()
+          val result = ListBuffer[Tree]()
           result += entry
           val sym = reifyBinding(entry).symbol
           if (sym != NoSymbol)

--- a/src/compiler/scala/tools/nsc/transform/CleanUp.scala
+++ b/src/compiler/scala/tools/nsc/transform/CleanUp.scala
@@ -15,7 +15,7 @@ package transform
 
 import symtab._
 import Flags._
-import scala.collection._
+import scala.collection.mutable, mutable.{Buffer, ListBuffer}
 import scala.tools.nsc.Reporting.WarningCategory
 import scala.util.chaining._
 
@@ -35,8 +35,8 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
     new CleanUpTransformer(unit)
 
   class CleanUpTransformer(unit: CompilationUnit) extends StaticsTransformer {
-    private val newStaticMembers      = mutable.Buffer.empty[Tree]
-    private val newStaticInits        = mutable.Buffer.empty[Tree]
+    private val newStaticMembers      = Buffer.empty[Tree]
+    private val newStaticInits        = Buffer.empty[Tree]
     private val symbolsStoredAsStatic = mutable.Map.empty[String, Symbol]
     private var transformListApplyLimit = 8
     private def reducingTransformListApply[A](depth: Int)(body: => A): A = {
@@ -438,7 +438,7 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
          * resulting switch may need to correspond to a single case body.
          */
 
-        val labels = mutable.ListBuffer.empty[LabelDef]
+        val labels = ListBuffer.empty[LabelDef]
         var defaultCaseBody = Throw(New(MatchErrorClass.tpe_*, selArg)): Tree
 
         def LABEL(name: String) = currentOwner.newLabel(unit.freshTermName(name), swPos).setFlag(SYNTH_CASE_FLAGS)
@@ -523,7 +523,7 @@ abstract class CleanUp extends Statics with Transform with ast.TreeDSL {
               gen.evalOnce(classTagEvidence, currentOwner, unit) { ev =>
                 val arr = typedWithPos(tree.pos)(gen.mkMethodCall(classTagEvidence, definitions.ClassTagClass.info.decl(nme.newArray), Nil, Literal(Constant(elems.size)) :: Nil))
                 gen.evalOnce(arr, currentOwner, unit) { arr =>
-                  val stats = mutable.ListBuffer[Tree]()
+                  val stats = ListBuffer[Tree]()
                   foreachWithIndex(elems) { (elem, i) =>
                     stats += gen.mkMethodCall(gen.mkAttributedRef(definitions.ScalaRunTimeModule), currentRun.runDefinitions.arrayUpdateMethod,
                                               Nil, arr() :: Literal(Constant(i)) :: elem :: Nil)

--- a/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
+++ b/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
@@ -15,7 +15,7 @@ package transform
 
 import symtab._
 import Flags._
-import scala.collection._
+import scala.collection.mutable
 
 /**
   * This transformer is responsible for preparing Function nodes for runtime,
@@ -68,7 +68,7 @@ abstract class Delambdafy extends Transform with TypingTransformers with ast.Tre
   class DelambdafyTransformer(unit: CompilationUnit) extends TypingTransformer(unit) {
     // we need to know which methods refer to the 'this' reference so that we can determine which lambdas need access to it
     // TODO: this looks expensive, so I made it a lazy val. Can we make it more pay-as-you-go / optimize for common shapes?
-    private[this] lazy val methodReferencesThis: Set[Symbol] =
+    private[this] lazy val methodReferencesThis: collection.Set[Symbol] =
       (new ThisReferringMethodsTraverser).methodReferencesThisIn(unit.body)
 
     private def mkLambdaMetaFactoryCall(fun: Function, target: Symbol, functionalInterface: Symbol, samUserDefined: Symbol, userSamCls: Symbol, isSpecialized: Boolean): Tree = {
@@ -360,12 +360,12 @@ abstract class Delambdafy extends Transform with TypingTransformers with ast.Tre
   // finds all methods that reference 'this'
   class ThisReferringMethodsTraverser extends InternalTraverser {
     // the set of methods that refer to this
-    private val thisReferringMethods = mutable.Set[Symbol]()
+    private val thisReferringMethods = mutable.Set.empty[Symbol]
 
     // the set of lifted lambda body methods that each method refers to
-    private val liftedMethodReferences = mutable.Map[Symbol, mutable.Set[Symbol]]()
+    private val liftedMethodReferences = mutable.Map.empty[Symbol, mutable.Set[Symbol]]
 
-    def methodReferencesThisIn(tree: Tree) = {
+    def methodReferencesThisIn(tree: Tree): collection.Set[Symbol] = {
       traverse(tree)
       liftedMethodReferences.keys foreach refersToThis
 

--- a/src/partest/scala/tools/partest/ReplTest.scala
+++ b/src/partest/scala/tools/partest/ReplTest.scala
@@ -14,8 +14,7 @@ package scala.tools.partest
 
 import scala.tools.nsc.Settings
 import scala.tools.nsc.interpreter.shell.{ILoop, ShellConfig}
-import scala.util.matching.Regex
-import scala.util.matching.Regex.Match
+import scala.util.matching.Regex.{quoteReplacement, Match}
 
 /** Test code or commands in a REPL.
  *
@@ -76,7 +75,7 @@ trait Lambdaless extends ReplTest {
 }
 object Lambdaless {
   private val lambdaless = """\$Lambda(?:\$\d+)?/(?:0x[a-f0-9]{16}|\d+)(?:@[a-fA-F0-9]+)?""".r
-  private def stripLambdaClassName(s: String): String = lambdaless.replaceAllIn(s, Regex.quoteReplacement("<function>"))
+  private def stripLambdaClassName(s: String): String = lambdaless.replaceAllIn(s, quoteReplacement("<function>"))
 }
 
 /** Normalize a REPL stack trace by stripping line numbers and count of elided frames. */
@@ -132,7 +131,7 @@ abstract class SessionTest extends ReplTest  {
   override final def code = pasted.findAllMatchIn(expected.mkString("", "\n", "\n")).map {
     case pasted(null, null, prompted) =>
       def continued(m: Match): Option[String] = m match {
-        case margin(text) => Some(Regex.quoteReplacement(text))
+        case margin(text) => Some(quoteReplacement(text))
         case _            => None
       }
       margin.replaceSomeIn(prompted, continued)

--- a/src/partest/scala/tools/partest/nest/Runner.scala
+++ b/src/partest/scala/tools/partest/nest/Runner.scala
@@ -32,7 +32,7 @@ import scala.util.{Failure, Success, Try, Using}
 import scala.util.Properties.isJavaAtLeast
 import scala.util.chaining._
 import scala.util.control.{ControlThrowable, NonFatal}
-import scala.util.matching.Regex
+import scala.util.matching.Regex.quoteReplacement
 import ClassPath.join
 import FileManager.{compareContents, joinPaths, withTempFile}
 import TestState.{Crash, Fail, Pass, Skip, Updated}
@@ -367,7 +367,7 @@ class Runner(val testInfo: TestInfo, val suiteRunner: AbstractRunner) {
     def canonicalize: String => String = {
       val hiders = toolArgs(ToolName.hide).map(_.r)
       (s: String) => {
-        val pathless = pathFinder.replaceAllIn(s, m => Regex.quoteReplacement(ellipsis + squashSlashes(m.group(1))))
+        val pathless = pathFinder.replaceAllIn(s, m => quoteReplacement(ellipsis + squashSlashes(m.group(1))))
         if (hiders.isEmpty) pathless
         else hiders.foldLeft(pathless)((s, r) => r.replaceAllIn(s, m => "***"))
       }

--- a/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
@@ -17,9 +17,9 @@ package base
 import base.comment._
 import scala.annotation.{nowarn, tailrec}
 import scala.collection._
-import scala.util.matching.Regex
 import scala.reflect.internal.util.Position
 import scala.tools.nsc.Reporting.WarningCategory
+import scala.util.matching.Regex.{quoteReplacement, Match}
 
 /** The comment parser transforms raw comment strings into `Comment` objects.
   * Call `parse` to run the parser. Note that the parser is stateless and
@@ -121,16 +121,16 @@ trait CommentFactoryBase { this: MemberLookupBase =>
   /** The body of a line, dropping the (optional) start star-marker,
     * one leading whitespace and all trailing whitespace. */
   private val CleanCommentLine =
-    new Regex("""(?:\s*\*\s?)?(.*)""")
+    raw"(?:\s*\*\s?)?(.*)".r
 
   /** Dangerous HTML tags that should be replaced by something safer,
     * such as wiki syntax, or that should be dropped. */
   private val DangerousTags =
-    new Regex("""<(/?(div|ol|ul|li|h[1-6]|p))( [^>]*)?/?>|<!--.*-->""")
+    raw"<(/?(div|ol|ul|li|h[1-6]|p))( [^>]*)?/?>|<!--.*-->".r
 
   /** Maps a dangerous HTML tag to a safe wiki replacement, or an empty string
     * if it cannot be salvaged. */
-  private def htmlReplacement(mtch: Regex.Match): String = mtch.group(1) match {
+  private def htmlReplacement(mtch: Match): String = mtch.group(1) match {
     case "p" | "div" => "\n\n"
     case "h1"  => "\n= "
     case "/h1" => " =\n"
@@ -147,10 +147,10 @@ trait CommentFactoryBase { this: MemberLookupBase =>
   /** Javadoc tags that should be replaced by something useful, such as wiki
     * syntax, or that should be dropped. */
   private val JavadocTags =
-    new Regex("""\{\@(code|docRoot|linkplain|link|literal|value)\p{Zs}*([^}]*)\}""")
+    raw"\{\@(code|docRoot|linkplain|link|literal|value)\p{Zs}*([^}]*)\}".r
 
   /** Maps a javadoc tag to a useful wiki replacement, or an empty string if it cannot be salvaged. */
-  private def javadocReplacement(mtch: Regex.Match): String = {
+  private def javadocReplacement(mtch: Match): String = {
     mtch.group(1) match {
       case "code" => "<code>" + mtch.group(2) + "</code>"
       case "docRoot"  => ""
@@ -164,30 +164,30 @@ trait CommentFactoryBase { this: MemberLookupBase =>
 
   /** Safe HTML tags that can be kept. */
   private val SafeTags =
-    new Regex("""((&\w+;)|(&#\d+;)|(</?(abbr|acronym|address|area|a|bdo|big|blockquote|br|button|b|caption|cite|code|col|colgroup|dd|del|dfn|em|fieldset|form|hr|img|input|ins|i|kbd|label|legend|link|map|object|optgroup|option|param|pre|q|samp|select|small|span|strong|sub|sup|table|tbody|td|textarea|tfoot|th|thead|tr|tt|var)( [^>]*)?/?>))""")
+    raw"((&\w+;)|(&#\d+;)|(</?(abbr|acronym|address|area|a|bdo|big|blockquote|br|button|b|caption|cite|code|col|colgroup|dd|del|dfn|em|fieldset|form|hr|img|input|ins|i|kbd|label|legend|link|map|object|optgroup|option|param|pre|q|samp|select|small|span|strong|sub|sup|table|tbody|td|textarea|tfoot|th|thead|tr|tt|var)( [^>]*)?/?>))".r
 
   private val safeTagMarker = '\u000E'  // control-N
 
   /** A Scaladoc tag not linked to a symbol and not followed by text */
   private val SingleTagRegex =
-    new Regex("""\s*@(\S+)\s*""")
+    raw"\s*@(\S+)\s*".r
 
   /** A Scaladoc tag not linked to a symbol. Returns the name of the tag, and the rest of the line. */
   private val SimpleTagRegex =
-    new Regex("""\s*@(\S+)\s+(.*)""")
+    raw"\s*@(\S+)\s+(.*)".r
 
   /** A Scaladoc tag linked to a symbol. Returns the name of the tag, the name
     * of the symbol, and the rest of the line. */
   private val SymbolTagRegex =
-    new Regex("""\s*@(param|tparam|throws|groupdesc|groupname|groupprio)\s+(\S*)\s*(.*)""")
+    raw"\s*@(param|tparam|throws|groupdesc|groupname|groupprio)\s+(\S*)\s*(.*)".r
 
   /** The start of a Scaladoc code block */
   private val CodeBlockStartRegex =
-    new Regex(s"""(.*?)((?:\\{\\{\\{)|(?:$safeTagMarker<pre(?: [^>]*)?>$safeTagMarker))(.*)""")
+    raw"(.*?)((?:\{\{\{)|(?:$safeTagMarker<pre(?: [^>]*)?>$safeTagMarker))(.*)".r
 
   /** The end of a Scaladoc code block */
   private val CodeBlockEndRegex =
-    new Regex(s"""(.*?)((?:\\}\\}\\})|(?:$safeTagMarker</pre>$safeTagMarker))(.*)""")
+    raw"(.*?)((?:\}\}\})|(?:$safeTagMarker</pre>$safeTagMarker))(.*)".r
 
   /** A key used for a tag map. The key is built from the name of the tag and
     * from the linked symbol if the tag has one.
@@ -221,7 +221,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
       val javadoclessComment = JavadocTags.replaceAllIn(safeComment, { javadocReplacement(_) })
       val markedTagComment =
         SafeTags.replaceAllIn(javadoclessComment, { mtch =>
-          java.util.regex.Matcher.quoteReplacement(s"$safeTagMarker${mtch.matched}$safeTagMarker")
+          quoteReplacement(s"$safeTagMarker${mtch.matched}$safeTagMarker")
         })
       markedTagComment.linesIterator.toList map cleanLine
     }

--- a/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
@@ -16,7 +16,7 @@ package base
 
 import base.comment._
 import scala.annotation.{nowarn, tailrec}
-import scala.collection._
+import scala.collection.mutable, mutable.ListBuffer
 import scala.reflect.internal.util.Position
 import scala.tools.nsc.Reporting.WarningCategory
 import scala.util.matching.Regex.{quoteReplacement, Match}
@@ -239,7 +239,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
       * @param inCodeBlock Whether the next line is part of a code block (in which no tags must be read). */
     def parse0 (
       docBody: StringBuilder,
-      tags: immutable.Map[TagKey, List[String]],
+      tags: Map[TagKey, List[String]],
       lastTagKey: Option[TagKey],
       remaining: List[String],
       inCodeBlock: Boolean
@@ -414,7 +414,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
         com
     }
 
-    parse0(new StringBuilder(comment.length), immutable.Map.empty, None, clean(comment), inCodeBlock = false)
+    parse0(new StringBuilder(comment.length), Map.empty, None, clean(comment), inCodeBlock = false)
 
   }
 
@@ -503,14 +503,14 @@ trait CommentFactoryBase { this: MemberLookupBase =>
       /** Consumes all list item blocks (possibly with nested lists) of the
         * same list and returns the list block. */
       def listLevel(indent: Int, style: String): Block = {
-        val lines = mutable.ListBuffer.empty[Block]
+        val lines = ListBuffer.empty[Block]
         var line: Option[Block] = listLine(indent, style)
         while (line.isDefined) {
           lines += line.get
           line = listLine(indent, style)
         }
         val constructor = listStyles(style)
-        constructor(lines)
+        constructor(lines.toList)
       }
 
       val indent = countWhitespace

--- a/src/scaladoc/scala/tools/nsc/doc/base/comment/Body.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/comment/Body.scala
@@ -15,7 +15,7 @@ package doc
 package base
 package comment
 
-import scala.collection._
+import scala.collection.immutable.SortedMap
 
 /** A body of text. A comment has a single body, which is composed of
   * at least one block. Inside every body is exactly one summary.

--- a/src/scaladoc/scala/tools/nsc/doc/base/comment/Comment.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/comment/Comment.scala
@@ -15,7 +15,7 @@ package doc
 package base
 package comment
 
-import scala.collection._
+import scala.collection.mutable.ListBuffer
 
 /** A Scaladoc comment and all its tags.
   *
@@ -29,7 +29,7 @@ abstract class Comment {
   def body: Body
 
   private def closeHtmlTags(inline: Inline): Inline = {
-    val stack = mutable.ListBuffer.empty[HtmlTag]
+    val stack = ListBuffer.empty[HtmlTag]
     def scan(i: Inline): Unit = {
       i match {
         case Chain(list) =>

--- a/src/scaladoc/scala/tools/nsc/doc/doclet/Generator.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/doclet/Generator.scala
@@ -13,7 +13,7 @@
 package scala.tools.nsc.doc
 package doclet
 
-import scala.collection._
+import scala.collection.mutable
 
 /** Custom Scaladoc generators must implement the `Generator` class. A custom generator can be selected in Scaladoc
   * using the `-doc-generator` command line option.

--- a/src/scaladoc/scala/tools/nsc/doc/html/HtmlFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/HtmlFactory.scala
@@ -17,7 +17,7 @@ package html
 import model._
 import java.io.{ File => JFile }
 import io.{ Streamable, Directory }
-import scala.collection._
+import scala.collection.mutable
 import page.diagram._
 import scala.reflect.internal.Reporter
 

--- a/src/scaladoc/scala/tools/nsc/doc/model/CommentFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/CommentFactory.scala
@@ -16,7 +16,7 @@ package model
 
 import base.comment._
 
-import scala.collection._
+import scala.collection.mutable
 import scala.reflect.internal.util.Position
 
 /** The comment parser transforms raw comment strings into `Comment` objects.

--- a/src/scaladoc/scala/tools/nsc/doc/model/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/Entity.scala
@@ -14,7 +14,6 @@ package scala.tools.nsc
 package doc
 package model
 
-import scala.collection._
 import base.comment._
 import diagram._
 

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
@@ -18,13 +18,16 @@ package model
 import base.comment._
 import diagram._
 
-import scala.collection._
-import scala.util.matching.Regex
-import scala.reflect.macros.internal.macroImpl
-import symtab.Flags
+import java.net.URI
+import java.nio.file.Paths
 
-import io._
-import model.{ RootPackage => RootPackageEntity }
+import scala.collection.mutable, mutable.ListBuffer
+import scala.reflect.io._
+import scala.reflect.macros.internal.macroImpl
+import scala.util.matching.Regex.quoteReplacement
+
+import model.{RootPackage => RootPackageEntity}
+import symtab.Flags
 
 /** This trait extracts all required information for documentation from compilation units */
 class ModelFactory(val global: Global, val settings: doc.Settings) {
@@ -156,7 +159,7 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
       }
     }
     def flags = {
-      val fgs = mutable.ListBuffer.empty[Paragraph]
+      val fgs = ListBuffer.empty[Paragraph]
       if (sym.isImplicit) fgs += Paragraph(Text("implicit"))
       if (sym.isSealed) fgs += Paragraph(Text("sealed"))
       if (!sym.isTrait && (sym hasFlag Flags.ABSTRACT)) fgs += Paragraph(Text("abstract"))
@@ -312,26 +315,31 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
     }
 
     def sourceUrl = {
-      def fixPath(s: String) = s.replaceAll("\\" + java.io.File.separator, "/")
-      val assumedSourceRoot  = fixPath(settings.sourcepath.value) stripSuffix "/"
 
       if (!settings.docsourceurl.isDefault)
-        inSource map { case (file, line) =>
-          val filePathExt = fixPath(file.path).replaceFirst("^" + assumedSourceRoot, "")
-          val (filePath, fileExt) = filePathExt.splitAt(filePathExt.indexOf(".", filePathExt.lastIndexOf("/")))
+        inSource.map { case (file, line) =>
+          // file path is relative to source root (-sourcepath)
+          val src = Paths.get(settings.sourcepath.value).toUri
+          val path = file.file.toPath.toUri
+          val filePathExt = src.relativize(path)
+          val rawPath: String = filePathExt.getRawPath
+          val (filePath, fileExt) =
+            rawPath.lastIndexOf('.') match {
+              case -1 => (rawPath, "")
+              case i  => rawPath.splitAt(i)
+            }
           val tplOwner = this.inTemplate.qualifiedName
           val tplName = this.name
-          val patches = new Regex("""€\{(FILE_PATH|FILE_EXT|FILE_PATH_EXT|FILE_LINE|TPL_OWNER|TPL_NAME)\}""")
           def substitute(name: String): String = name match {
-            case "FILE_PATH" => filePath
-            case "FILE_EXT" => fileExt
-            case "FILE_PATH_EXT" => filePathExt
-            case "FILE_LINE" => line.toString
-            case "TPL_OWNER" => tplOwner
-            case "TPL_NAME" => tplName
+            case FILE_PATH     => filePath
+            case FILE_EXT      => fileExt
+            case FILE_PATH_EXT => filePathExt.toString
+            case FILE_LINE     => line.toString
+            case TPL_OWNER     => tplOwner
+            case TPL_NAME      => tplName
           }
-          val patchedString = patches.replaceAllIn(settings.docsourceurl.value, m => java.util.regex.Matcher.quoteReplacement(substitute(m.group(1))) )
-          new java.net.URI(patchedString).toURL
+          val patchedString = tokens.replaceAllIn(settings.docsourceurl.value, m => quoteReplacement(substitute(m.group(1))) )
+          new URI(patchedString).toURL
         }
       else None
     }
@@ -343,7 +351,7 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
     /* Subclass cache */
     private lazy val subClassesCache = (
       if (sym == AnyRefClass || sym == AnyClass) null
-      else mutable.ListBuffer[DocTemplateEntity]()
+      else ListBuffer[DocTemplateEntity]()
     )
     def registerSubClass(sc: DocTemplateEntity): Unit = {
       if (subClassesCache != null)
@@ -352,10 +360,10 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
     def directSubClasses = if (subClassesCache == null) Nil else subClassesCache.toList
 
     /* Implicitly convertible class cache */
-    private var implicitlyConvertibleClassesCache: mutable.ListBuffer[(DocTemplateImpl, ImplicitConversionImpl)] = null
+    private var implicitlyConvertibleClassesCache: ListBuffer[(DocTemplateImpl, ImplicitConversionImpl)] = null
     def registerImplicitlyConvertibleClass(dtpl: DocTemplateImpl, conv: ImplicitConversionImpl): Unit = {
       if (implicitlyConvertibleClassesCache == null)
-        implicitlyConvertibleClassesCache = mutable.ListBuffer[(DocTemplateImpl, ImplicitConversionImpl)]()
+        implicitlyConvertibleClassesCache = ListBuffer[(DocTemplateImpl, ImplicitConversionImpl)]()
       implicitlyConvertibleClassesCache += ((dtpl, conv))
     }
 
@@ -1052,4 +1060,12 @@ object ModelFactory {
   val defaultGroupName = "Ungrouped"
   val defaultGroupDesc = None
   val defaultGroupPriority = 1000
+
+  val tokens = raw"€\{($FILE_PATH|$FILE_EXT|$FILE_PATH_EXT|$FILE_LINE|$TPL_OWNER|$TPL_NAME)\}".r
+  final val FILE_PATH     = "FILE_PATH"
+  final val FILE_EXT      = "FILE_EXT"
+  final val FILE_PATH_EXT = "FILE_PATH_EXT"
+  final val FILE_LINE     = "FILE_LINE"
+  final val TPL_OWNER     = "TPL_OWNER"
+  final val TPL_NAME      = "TPL_NAME"
 }

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactoryImplicitSupport.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactoryImplicitSupport.scala
@@ -15,7 +15,6 @@ package doc
 package model
 
 import scala.annotation.nowarn
-import scala.collection._
 import scala.tools.nsc.Reporting.WarningCategory
 
 /**
@@ -440,7 +439,7 @@ trait ModelFactoryImplicitSupport {
                          inTpl: DocTemplateImpl): Map[MemberEntity, ImplicitMemberShadowing] = {
     assert(modelFinished, "cannot make shadowing table before model is finished")
 
-    val shadowingTable = mutable.Map[MemberEntity, ImplicitMemberShadowing]()
+    val shadowingTable = Map.newBuilder[MemberEntity, ImplicitMemberShadowing]
     val membersByName: Map[Name, List[MemberImpl]] = members.groupBy(_.sym.name)
     val convsByMember = convs.foldLeft(Map.empty[MemberImpl, ImplicitConversionImpl]){
       case (map, conv) => map ++ conv.memberImpls.map (_ -> conv)
@@ -471,12 +470,12 @@ trait ModelFactoryImplicitSupport {
             def ambiguatingMembers: List[MemberEntity] = ambiguous
           }
 
-          shadowingTable += (member -> shadowing)
+          shadowingTable.addOne(member -> shadowing)
         }
       }
     }
 
-    shadowingTable.toMap
+    shadowingTable.result()
   }
 
 

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactoryTypeSupport.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactoryTypeSupport.scala
@@ -17,7 +17,7 @@ package model
 import base._
 import diagram._
 import scala.annotation.nowarn
-import scala.collection._
+import scala.collection.{immutable, mutable}
 
 /** This trait extracts all required information for documentation from compilation units */
 trait ModelFactoryTypeSupport {

--- a/src/scaladoc/scala/tools/nsc/doc/model/TreeEntity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/TreeEntity.scala
@@ -14,8 +14,7 @@ package scala.tools.nsc
 package doc
 package model
 
-import scala.collection._
-
+import scala.collection.immutable.SortedMap
 
 /** A fragment of code. */
 abstract class TreeEntity {

--- a/src/scaladoc/scala/tools/nsc/doc/model/TreeFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/TreeFactory.scala
@@ -14,7 +14,7 @@ package scala.tools.nsc
 package doc
 package model
 
-import scala.collection._
+import scala.collection.immutable
 import scala.reflect.internal.util.{RangePosition, SourceFile}
 
 /** The goal of this trait is, using makeTree,

--- a/src/scaladoc/scala/tools/nsc/doc/model/TypeEntity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/TypeEntity.scala
@@ -14,7 +14,7 @@ package scala.tools.nsc
 package doc
 package model
 
-import scala.collection._
+import scala.collection.immutable.SortedMap
 
 /** A type. Note that types and templates contain the same information only for the simplest types. For example, a type
   * defines how a template's type parameters are instantiated (as in `List[Cow]`), what the template's prefix is

--- a/test/scaladoc/resources/`t12846`.scala
+++ b/test/scaladoc/resources/`t12846`.scala
@@ -1,0 +1,7 @@
+
+package example
+
+/** There is nothing extraordinary about this code,
+ *  but the file name includes backticks, which must be encoded in a URI.
+ */
+final case class `X-Upload-Content-Type` private (contentType: String)

--- a/test/scaladoc/run/t12846.check
+++ b/test/scaladoc/run/t12846.check
@@ -1,0 +1,2 @@
+Some(http://acme.com/source/%60t12846%60.scala#L7)
+Done.

--- a/test/scaladoc/run/t12846.scala
+++ b/test/scaladoc/run/t12846.scala
@@ -1,0 +1,21 @@
+
+import scala.tools.nsc.doc.model._
+import scala.tools.partest.ScaladocModelTest
+
+object Test extends ScaladocModelTest {
+
+  override def resourceFile = "`t12846`.scala"
+
+  // resourcePath has the form ../resources in the test, but that's ok for relativizing
+  override def scaladocSettings = s"-Xlint -doc-source-url http://acme.com/source/€{FILE_PATH_EXT}#L€{FILE_LINE} -sourcepath $resourcePath"
+
+  override def code = ???
+
+  def testModel(root: Package) = {
+    import access._
+    println(root._package("example")._class("X-Upload-Content-Type").sourceUrl)
+  }
+
+  // `makeUniverse` takes either file names or source code, so we override to specify file name
+  override def model = newDocFactory.makeUniverse(Left(List(s"$resourcePath/$resourceFile")))
+}


### PR DESCRIPTION
Fixes scala/bug#12846

`toUri` will perform escapes, but `URI` constructor will not.

Also clean up some imports. Avoid `collection._`. Prefer `raw"".r` for constructing a regex.