### PR TITLE
Tweak exception message in `LazyListLazinessTest`

### DIFF
--- a/test/junit/scala/collection/immutable/LazyListLazinessTest.scala
+++ b/test/junit/scala/collection/immutable/LazyListLazinessTest.scala
@@ -14,7 +14,7 @@ class LazyListLazinessTest {
   @Test
   def opLazinessChecker_correctness(): Unit = {
     val checker = new OpLazinessChecker
-    val illegalState = (s: String) => new IllegalStateException("sanity check failed: " + s)
+    val illegalState = (s: String) => new IllegalStateException("correctness check failed: " + s)
 
     // check that none start evaluated
     checker.assertAll(evaluated = false, illegalState)


### PR DESCRIPTION
Tweak exception message in `LazyListLazinessTest` to say "correctness check" instead of "sanity check", as the latter is ableist.