### PR TITLE
[REVISIT] Avoid compiler crash when overriding lazy val with abstract def [ci: last-only]

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Mixin.scala
+++ b/src/compiler/scala/tools/nsc/transform/Mixin.scala
@@ -395,21 +395,21 @@ abstract class Mixin extends Transform with ast.TreeDSL with AccessorSynthesis {
       }
     }
 
-    if (clazz.isJavaDefined || treatedClassInfos(clazz) == clazz.info)
-      return
+    if (!clazz.isJavaDefined && treatedClassInfos(clazz) != clazz.info) {
 
-    treatedClassInfos(clazz) = clazz.info
-    assert(!clazz.isTrait && clazz.info.parents.nonEmpty, clazz)
+      treatedClassInfos(clazz) = clazz.info
+      assert(!clazz.isTrait && clazz.info.parents.nonEmpty, clazz)
 
-    // first complete the superclass with mixed in members
-    addMixedinMembers(clazz.superClass, unit)
+      // first complete the superclass with mixed in members
+      addMixedinMembers(clazz.superClass, unit)
 
-    for (mc <- clazz.mixinClasses ; if mc.isTrait) {
-      // @SEAN: adding trait tracking so we don't have to recompile transitive closures
-      unit.registerDependency(mc)
-      publicizeTraitMethods(mc)
-      mixinTraitMembers(mc)
-      mixinTraitForwarders(mc)
+      for (mc <- clazz.mixinClasses if mc.isTrait) {
+        // @SEAN: adding trait tracking so we don't have to recompile transitive closures
+        unit.registerDependency(mc)
+        publicizeTraitMethods(mc)
+        mixinTraitMembers(mc)
+        mixinTraitForwarders(mc)
+      }
     }
   }
 

--- a/src/compiler/scala/tools/nsc/transform/Mixin.scala
+++ b/src/compiler/scala/tools/nsc/transform/Mixin.scala
@@ -352,8 +352,7 @@ abstract class Mixin extends Transform with ast.TreeDSL with AccessorSynthesis {
 
           rebindSuper(clazz, mixinMember.alias, mixinClass) match {
             case NoSymbol =>
-              reporter.error(clazz.pos, "Member %s of mixin %s is missing a concrete super implementation.".format(
-                mixinMember.alias, mixinClass))
+              reporter.error(clazz.pos, s"Member ${mixinMember.alias} of mixin $mixinClass is missing a concrete super implementation.")
             case alias1 =>
               registerRequiredDirectInterface(alias1, clazz, parent =>
                 s"Unable to implement a super accessor required by trait ${mixinClass.name} unless $parent is directly extended by $clazz.")
@@ -381,15 +380,11 @@ abstract class Mixin extends Transform with ast.TreeDSL with AccessorSynthesis {
               // so we have a type history entry before erasure
               clazz.newValue(mixinMember.localName, mixinMember.pos).setInfo(mixinMember.tpe.resultType)
             }
-            sym updateInfo mixinMember.tpe.resultType // info at current phase
+            sym.updateInfo(mixinMember.tpe.resultType) // info at current phase
 
-            val newFlags = (
-              (PrivateLocal)
-              | (mixinMember getFlag MUTABLE)
-              | (if (mixinMember.hasStableFlag) 0 else MUTABLE)
-              )
+            val newFlags = PrivateLocal | mixinMember.getFlag(MUTABLE) | (if (mixinMember.hasStableFlag) 0 else MUTABLE)
 
-            addMember(clazz, sym setFlag newFlags setAnnotations accessed.annotations)
+            addMember(clazz, sym.setFlag(newFlags).setAnnotations(accessed.annotations))
           }
         }
       }

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -773,8 +773,8 @@ abstract class RefChecks extends Transform {
             if (decl.isDeferred && !ignoreDeferred(decl)) {
               val impl = decl.matchingSymbol(clazz.thisType, admit = VBRIDGE)
               if (impl == NoSymbol || decl.owner.isSubClass(impl.owner))
-                abstractClassError(s"No implementation found in a subclass for deferred declaration\n" +
-                                          s"${infoString(decl)}${analyzer.abstractVarMessage(decl)}")
+                abstractClassError(sm"""|No implementation found in a subclass for deferred declaration
+                                        |${infoString(decl)}${analyzer.abstractVarMessage(decl)}""")
             }
           }
           if (bc.superClass hasFlag ABSTRACT)

--- a/test/files/pos/t10223.scala
+++ b/test/files/pos/t10223.scala
@@ -1,0 +1,13 @@
+// scalac: -Xsource:3
+
+object BrokenLit {
+  trait T { lazy val x: String = "hello, world" }
+  abstract class Abbie extends T { override def x: Any }
+}
+object Test extends App {
+  import BrokenLit.*
+  class K extends Abbie {
+    override lazy val x: String = "goodbye, cruel world"
+  }
+  println(new K().x)
+}

--- a/test/files/pos/t10223.scala
+++ b/test/files/pos/t10223.scala
@@ -1,13 +1,9 @@
-// scalac: -Xsource:3
 
-object BrokenLit {
-  trait T { lazy val x: String = "hello, world" }
-  abstract class Abbie extends T { override def x: Any }
+trait T { lazy val x: String = "hello, world" }
+abstract class Abbie extends T { override def x: Any }
+class K extends Abbie {
+  override lazy val x: String = "goodbye, cruel world"
 }
 object Test extends App {
-  import BrokenLit.*
-  class K extends Abbie {
-    override lazy val x: String = "goodbye, cruel world"
-  }
   println(new K().x)
 }


### PR DESCRIPTION
Fixes scala/bug#10223