### PR TITLE
Don't issue spurious nilary-overrides-nullary warning

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -461,7 +461,8 @@ abstract class RefChecks extends Transform {
               }
               else if (other.paramss.isEmpty && !member.paramss.isEmpty &&
                 !javaDetermined(member) && !member.overrides.exists(javaDetermined) &&
-                !member.hasAnnotation(BeanPropertyAttr) && !member.hasAnnotation(BooleanBeanPropertyAttr)
+                !member.hasAnnotation(BeanPropertyAttr) && !member.hasAnnotation(BooleanBeanPropertyAttr) &&
+                member.pos.isDefined  // scala/bug#12851
               ) {
                 val msg = "method with a single empty parameter list overrides method without any parameter list"
                 val namePos = member.pos.focus.withEnd(member.pos.point + member.decodedName.length)

--- a/test/files/pos/t12851/C_2.scala
+++ b/test/files/pos/t12851/C_2.scala
@@ -1,0 +1,2 @@
+// scalac: -Werror
+class C extends T2

--- a/test/files/pos/t12851/T_1.scala
+++ b/test/files/pos/t12851/T_1.scala
@@ -1,0 +1,7 @@
+
+trait T1 {
+  def f: Int
+}
+trait T2 extends T1 {
+  def f() = 42
+}


### PR DESCRIPTION
fixes scala/bug#12851

My ambition had only been to fix the crasher stemming from #10484, but this fixes the underlying spurious-warning bug, too.

@som-snytt I gather from one of your other messages that you've already written a partest for this. So I didn't write one, on the assumption either that your own PR will supersede this PR, or that you'll kindly add your partest to this PR.

What I did do, though, was manually verify that it fixes what I reported in scala/bug#12851, as well as fixing it in the Ammonite repo where the problem originally turned up.