### PR TITLE
Follow-up for non-warning nilary/nullary override with BeanProperty

### DIFF
--- a/src/library/scala/beans/BeanProperty.scala
+++ b/src/library/scala/beans/BeanProperty.scala
@@ -12,6 +12,8 @@
 
 package scala.beans
 
+import scala.annotation.meta.{beanGetter, beanSetter, field}
+
 /** When attached to a field, this annotation adds a setter and a getter
  *  method following the Java Bean convention. For example:
  *  {{{
@@ -26,6 +28,6 @@ package scala.beans
  *  For fields of type `Boolean`, if you need a getter named `isStatus`,
  *  use the `scala.beans.BooleanBeanProperty` annotation instead.
  */
-@scala.annotation.meta.field
+@field @beanGetter @beanSetter
 @deprecatedInheritance("Scheduled for being final in the future", "2.13.0")
 class BeanProperty extends scala.annotation.StaticAnnotation

--- a/src/library/scala/beans/BooleanBeanProperty.scala
+++ b/src/library/scala/beans/BooleanBeanProperty.scala
@@ -12,10 +12,12 @@
 
 package scala.beans
 
+import scala.annotation.meta.{beanGetter, beanSetter, field}
+
 /** This annotation has the same functionality as
  *  `scala.beans.BeanProperty`, but the generated Bean getter will be
  *  named `isFieldName` instead of `getFieldName`.
  */
-@scala.annotation.meta.field
+@field @beanGetter @beanSetter
 @deprecatedInheritance("Scheduled for being final in the future", "2.13.0")
 class BooleanBeanProperty extends scala.annotation.StaticAnnotation

--- a/test/files/run/reify_ann5.check
+++ b/test/files/run/reify_ann5.check
@@ -1,6 +1,6 @@
 {
   class C extends AnyRef {
-    @new inline @beanGetter() @new BeanProperty() <paramaccessor> val x: Int = _;
+    @new BeanProperty() @new inline @beanGetter() @new BeanProperty() <paramaccessor> val x: Int = _;
     def <init>(x: Int) = {
       super.<init>();
       ()
@@ -10,13 +10,13 @@
 }
 {
   class C extends AnyRef {
-    @scala.beans.BeanProperty <paramaccessor> private[this] val x: Int = _;
+    @scala.beans.BeanProperty @scala.beans.BeanProperty <paramaccessor> private[this] val x: Int = _;
     <stable> <accessor> <paramaccessor> def x: Int = C.this.x;
     def <init>(x: Int): C = {
       C.super.<init>();
       ()
     };
-    @inline @scala.annotation.meta.beanGetter @<notype> def getX(): Int = C.this.x
+    @scala.beans.BeanProperty @inline @scala.annotation.meta.beanGetter @scala.beans.BeanProperty def getX(): Int = C.this.x
   };
   ()
 }


### PR DESCRIPTION
Follow-up for #10450 which stopped the nilary / nullary override warning for synthesized BeanProperty getters.

The fix only worked by accident. The BeanProperty annotation class is only meta-annotated to target the field, not the generated bean getter.

However, `beanGetterSymbol.hasAnnotation(BeanPropertyAttr)` was still true because the annotation is an `ExtraLazyAnnotationInfo`, which overrides `symbol` to always return the initial symbol even after the underlying `LazyAnnotationInfo` is mapped to `UnmappableAnnotation` by annotation filtering (`Namer.annotSig.computeInfo`).

This PR changes `ExtraLazyAnnotationInfo.symbol` to call `super.symbol` if the underlying `LazyAnnotationInfo` is forced.

To fix the check in RefChecks, `BeanProperty` and `BooleanBeanProperty` are now meta-annotated with `@beanGetter` and `@beanSetter`.