### PR TITLE
Avoid spurious ambiguity warning with inherited overloaded symbols

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1637,7 +1637,11 @@ trait Contexts { self: Analyzer =>
           done = (cx eq NoContext) || foundCompetingSymbol()
           if (!done && (cx ne NoContext)) cx = cx.outer
         }
-        if (defSym.exists && (defSym ne defSym0)) {
+        val nonOverlapping = defSym.exists && {
+          if (defSym.isOverloaded || defSym0.isOverloaded) !defSym.alternatives.exists(defSym0.alternatives.contains)
+          else defSym ne defSym0
+        }
+        if (nonOverlapping) {
           val ambiguity =
             if (preferDef) ambiguousDefinitions(defSym, defSym0, wasFoundInSuper, cx0.enclClass.owner, thisContext.enclClass.owner)
             else Some(ambiguousDefnAndImport(owner = defSym.owner, imp1))

--- a/test/files/neg/t11921b.check
+++ b/test/files/neg/t11921b.check
@@ -1,6 +1,12 @@
 t11921b.scala:135: error: could not find implicit value for parameter i: Int
     def u = t // doesn't compile in Scala 2 (maybe there's a ticket for that)
             ^
+t11921b.scala:151: error: package object inheritance is deprecated (https://github.com/scala/scala-dev/issues/441);
+drop the `extends` clause or use a regular object instead
+Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
+package object pt12850 extends t12850 {
+                       ^
 t11921b.scala:11: error: reference to x is ambiguous;
 it is both defined in the enclosing object Test and inherited in the enclosing class D as value x (defined in class C)
 In Scala 2, symbols inherited from a superclass shadow symbols defined in an outer scope.
@@ -73,4 +79,4 @@ Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test10.C.v
     def v = t(lo) // error
               ^
-9 errors
+10 errors

--- a/test/files/neg/t11921b.scala
+++ b/test/files/neg/t11921b.scala
@@ -143,3 +143,19 @@ package scala {
     def t = new Option[String] {} // OK, competing scala.Option is not defined in the same compilation unit
   }
 }
+
+trait t12850 {
+  def pm(x: Int) = 1
+  def pm(x: String) = 2
+}
+package object pt12850 extends t12850 {
+  def t = pm(1) // no error
+}
+
+trait t12850b {
+  def pm(x: Int) = 1
+  def pm(x: String) = 2
+  object O extends t12850b {
+    def t = pm(1) // no error
+  }
+}


### PR DESCRIPTION
Follow-up for https://github.com/scala/scala/pull/10321 (which is a follow-up for https://github.com/scala/scala/pull/10220)

Fixes https://github.com/scala/bug/issues/12850