### PR TITLE
Respect `java.lang.Deprecated` annotation even in Scala sources

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4180,7 +4180,11 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
           if (hasError) ErroneousAnnotation
           else if (unmappable) UnmappableAnnotation
-          else AnnotationInfo(annType, Nil, nvPairs.map(p => (p._1, p._2.get))).setOriginal(Apply(typedFun, namedArgs).setPos(ann.pos))
+          else {
+            if (annTypeSym == JavaDeprecatedAttr && !context.unit.isJava && settings.lintDeprecation)
+              context.warning(ann.pos, """Prefer the Scala annotation over Java's `@Deprecated` to provide a message and version: @deprecated("message", since = "MyLib 1.0")""", WarningCategory.LintDeprecation)
+            AnnotationInfo(annType, Nil, nvPairs.map(p => (p._1, p._2.get))).setOriginal(Apply(typedFun, namedArgs).setPos(ann.pos))
+          }
         }
       }
       @inline def statically = {
@@ -4230,7 +4234,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               info.args.exists(treeInfo.isDefaultGetter)
           }
           if (annTypeSym == DeprecatedAttr && settings.lintDeprecation && argss.head.lengthIs < 2 && usesDefault)
-            context.warning(ann.pos, """Specify both message and version: @deprecated("message", since = "1.0")""", WarningCategory.LintDeprecation)
+            context.warning(ann.pos, """Specify both message and version: @deprecated("message", since = "MyLib 1.0")""", WarningCategory.LintDeprecation)
           info
         }
       }

--- a/src/library/scala/deprecated.scala
+++ b/src/library/scala/deprecated.scala
@@ -40,6 +40,9 @@ import scala.annotation.meta._
  *  // warning: there were three deprecation warnings in total; re-run with -deprecation for details
  *  }}}
  *
+ *  The Scala compiler also warns about using definitions annotated with [[java.lang.Deprecated]]. However it is
+ *  recommended to use the Scala `@deprecated` annotation in Scala code because it allows providing a deprecation message.
+ *
  *  '''`@deprecated` in the Scala language and its standard library'''<br/>
  *
  *  A deprecated element of the Scala language or a definition in the Scala standard library will

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -900,7 +900,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     @tailrec
     final def isStrictFP: Boolean    = this != NoSymbol && !isDeferred && (hasAnnotation(ScalaStrictFPAttr) || originalOwner.isStrictFP)
     def isSerializable         = info.baseClasses.exists(_ == SerializableClass)
-    def isDeprecated           = hasAnnotation(DeprecatedAttr) || (isJava && hasAnnotation(JavaDeprecatedAttr))
+    def isDeprecated           = hasAnnotation(DeprecatedAttr) || hasAnnotation(JavaDeprecatedAttr)
     def deprecationMessage     = getAnnotation(DeprecatedAttr) flatMap (_ stringArg 0)
     def deprecationVersion     = getAnnotation(DeprecatedAttr).flatMap(_.stringArg(1)) match {
                                    case v @ Some(_) => v

--- a/test/files/neg/deprecated.check
+++ b/test/files/neg/deprecated.check
@@ -1,7 +1,7 @@
-deprecated.scala:5: warning: Specify both message and version: @deprecated("message", since = "1.0")
+deprecated.scala:5: warning: Specify both message and version: @deprecated("message", since = "MyLib 1.0")
   @deprecated def f = ???
    ^
-deprecated.scala:9: warning: Specify both message and version: @deprecated("message", since = "1.0")
+deprecated.scala:9: warning: Specify both message and version: @deprecated("message", since = "MyLib 1.0")
   @deprecated("Don't use it."/*, forRemoval=true*/) def stale = ???
    ^
 deprecated.scala:21: warning: method f in trait T is deprecated

--- a/test/files/neg/t12648.check
+++ b/test/files/neg/t12648.check
@@ -1,10 +1,10 @@
 LogConfig_2.scala:7: warning: value MESSAGE_FORMAT_VERSION_CONFIG in class TopicConfig_1 is deprecated
   val MessageFormatVersionPropX = TopicConfig_1.MESSAGE_FORMAT_VERSION_CONFIG
                                                 ^
-LogConfig_2.scala:10: warning: Specify both message and version: @deprecated("message", since = "1.0")
+LogConfig_2.scala:10: warning: Specify both message and version: @deprecated("message", since = "MyLib 1.0")
   @deprecated("3.0")
    ^
-LogConfig_2.scala:12: warning: Specify both message and version: @deprecated("message", since = "1.0")
+LogConfig_2.scala:12: warning: Specify both message and version: @deprecated("message", since = "MyLib 1.0")
   @deprecated("3.0") @nowarn("cat=deprecation")
    ^
 LogConfig_2.scala:12: warning: @nowarn annotation does not suppress any warnings

--- a/test/files/neg/t12845.check
+++ b/test/files/neg/t12845.check
@@ -1,0 +1,9 @@
+t12845.scala:4: warning: Prefer the Scala annotation over Java's `@Deprecated` to provide a message and version: @deprecated("message", since = "MyLib 1.0")
+  @Deprecated def f = 0
+   ^
+t12845.scala:6: warning: method f in object O is deprecated
+class C { def g = O.f }
+                    ^
+error: No warnings can be incurred under -Werror.
+2 warnings
+1 error

--- a/test/files/neg/t12845.scala
+++ b/test/files/neg/t12845.scala
@@ -1,0 +1,6 @@
+//> using options -Werror -deprecation -Xlint
+
+object O {
+  @Deprecated def f = 0
+}
+class C { def g = O.f }

--- a/test/files/run/t9529.check
+++ b/test/files/run/t9529.check
@@ -1,4 +1,5 @@
 #partest java8
+warning: 1 deprecation; re-run with -deprecation for details
 A: List()
 B: List(@java.lang.Deprecated())
 C: List(@anns.Ann_0(name=C, value=see))
@@ -16,6 +17,7 @@ u: List(@anns.Ann_0$Container(value=[@anns.Ann_0(name=u, value=you), @anns.Ann_0
 List(@anns.Ann_0$Container(value=[@anns.Ann_0(name=<init>, value=constructor), @anns.Ann_0(name=<init>, value=initializer)]))
 
 #partest java11
+warning: 1 deprecation; re-run with -deprecation for details
 A: List()
 B: List(@java.lang.Deprecated(forRemoval=false, since=""))
 C: List(@anns.Ann_0(name="C", value="see"))
@@ -33,6 +35,7 @@ u: List(@anns.Ann_0$Container(value={@anns.Ann_0(name="u", value="you"), @anns.A
 List(@anns.Ann_0$Container(value={@anns.Ann_0(name="<init>", value="constructor"), @anns.Ann_0(name="<init>", value="initializer")}))
 
 #partest java17
+warning: 1 deprecation; re-run with -deprecation for details
 A: List()
 B: List(@java.lang.Deprecated(forRemoval=false, since=""))
 C: List(@anns.Ann_0(name="C", value="see"))
@@ -50,6 +53,7 @@ u: List(@anns.Ann_0$Container({@anns.Ann_0(name="u", value="you"), @anns.Ann_0(n
 List(@anns.Ann_0$Container({@anns.Ann_0(name="<init>", value="constructor"), @anns.Ann_0(name="<init>", value="initializer")}))
 
 #partest java20+
+warning: 1 deprecation; re-run with -deprecation for details
 A: List()
 B: List(@java.lang.Deprecated(forRemoval=false, since=""))
 C: List(@anns.Ann_0(name="C", value="see"))

--- a/test/files/run/t9644.check
+++ b/test/files/run/t9644.check
@@ -1,0 +1,1 @@
+warning: 3 deprecations; re-run with -deprecation for details

--- a/test/files/run/t9644b.check
+++ b/test/files/run/t9644b.check
@@ -1,0 +1,1 @@
+warning: 3 deprecations; re-run with -deprecation for details

--- a/test/junit/scala/tools/nsc/reporters/WConfTest.scala
+++ b/test/junit/scala/tools/nsc/reporters/WConfTest.scala
@@ -90,7 +90,7 @@ class WConfTest extends BytecodeTesting {
       |}
       |""".stripMargin
 
-  val l2 = (2, "Specify both message and version: @deprecated(\"message\", since = \"1.0\")")
+  val l2 = (2, "Specify both message and version: @deprecated(\"message\", since = \"MyLib 1.0\")")
   val l5a = (5, "method f in class A is deprecated")
   val l5b = (5, "method g in class A is deprecated")
   val l7 = (7, "reflective access of structural type member method f should be enabled")


### PR DESCRIPTION
Fixes scala/bug#12845
Removes the restriction of `java.lang.Deprecated` to just Java source.