### PR TITLE
Floor for NewVectorIterator.slice limit

### DIFF
--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -2389,12 +2389,14 @@ private final class NewVectorIterator[A](v: Vector[A], private[this] var totalLe
   }
 
   override def slice(from: Int, until: Int): Iterator[A] = {
-    val _until =
+    val _until = mmax(until, 0)
+
+    val n =
       if(from > 0) {
         drop(from)
-        until - from
-      } else until
-    take(_until)
+        _until - from
+      } else _until
+    take(n)
   }
 
   override def copyToArray[B >: A](xs: Array[B], start: Int, len: Int): Int = {

--- a/test/junit/scala/collection/immutable/VectorTest.scala
+++ b/test/junit/scala/collection/immutable/VectorTest.scala
@@ -585,6 +585,12 @@ class VectorTest {
     assertTrue("slice max to min should be empty", Vector(42).slice(Int.MaxValue, Int.MinValue).isEmpty)
   }
 
+  @Test def `test Vector#iterator slice to MinValue`: Unit = {
+    assertTrue(Vector(1, 2).iterator.slice(1, Int.MinValue).isEmpty)
+    assertTrue("slice almost max to min should be empty", Vector(1, 2).iterator.slice(Int.MaxValue - 1, Int.MinValue).isEmpty)
+    assertTrue("slice max to min should be empty", Vector(1, 2).iterator.slice(Int.MaxValue, Int.MinValue).isEmpty)
+  }
+
   @Test
   def testTail(): Unit = for(size <- verySmallSizes) {
     var i = 0


### PR DESCRIPTION
Fixes scala/bug#12823
Adds a floor of 0 to the limit parameter of NewVectorIterator.slice. This matches the base behavior of Iterator.slice and Vector.slice.