### PR TITLE
Fix spurious "nullary overrides nilary" warning

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -487,9 +487,9 @@ abstract class RefChecks extends Transform {
                   warnAdaptedNullaryOverride()
               }
               else if (member.paramLists.isEmpty) {
-                // NullaryOverrideAdapted is only added to symbols being compiled, so check for a mismatch
-                // if both symbols are mixed in from the classpath
-                if (!member.isStable && other.paramLists.nonEmpty && !exempted)
+                // Definitions that directly override get a parameter list and a `NullaryOverrideAdapted` attachment
+                // in Namers. Here we also warn when there's a mismatch between two mixed-in members.
+                if (!member.isStable && other.paramLists.nonEmpty && !exempted && !other.overrides.exists(javaDetermined))
                   warnAdaptedNullaryOverride()
               }
               else if (other.paramLists.isEmpty) {

--- a/test/files/pos/t12858/A.java
+++ b/test/files/pos/t12858/A.java
@@ -1,0 +1,3 @@
+interface A {
+  int f();
+}

--- a/test/files/pos/t12858/B.scala
+++ b/test/files/pos/t12858/B.scala
@@ -1,0 +1,9 @@
+// scalac: -Werror
+
+trait B1 extends A { def f: Int }
+trait C1 { def f = 2 }
+class T1 extends B1 with C1
+
+trait B2 extends A { def f: Int = 1}
+trait C2 { self: B2 => override def f = 2 }
+class T2 extends B2 with C2


### PR DESCRIPTION
```
interface A { int f(); }          // Java
trait B extends A { def f: Int }  // Scala
trait C { def f = 2 }
class T extends B with C
```

Namer adds an empty parameter list `()` to `B.f`.
There's no override warning at `B.f` because `A.f` is defined in Java.

In class `T`, `C.f` (without parameter list) overrides `B.f()` (with an empty parameter list - added by Namer). There should be no warning.

Fixes https://github.com/scala/bug/issues/12858