### PR TITLE
fix: SliceIterator to drop a max of Int.MaxValue

### DIFF
--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -1259,7 +1259,10 @@ object Iterator extends IterableFactory[Iterator] {
         else adjustedBound min (until - lo)   // keep lesser bound
       if (rest == 0) empty
       else {
-        dropping += lo
+        dropping = {
+          val sum = dropping + lo
+          if (sum < 0) Int.MaxValue else sum
+        }
         remaining = rest
         this
       }

--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -213,6 +213,16 @@ class IteratorTest {
     assertEquals(it.drop(1).next(), it.drop(1).drop(1).next())
   }
 
+  @Test def dropDoesNotOverflow(): Unit = {
+    assertEquals(List(1, 2, 3).iterator.drop(1).drop(Int.MaxValue).drop(1).toList.isEmpty, true)
+    assertEquals(List(1, 2, 3).iterator.drop(1).drop(Int.MaxValue).toList.isEmpty, true)
+    assertEquals(List(1, 2, 3).iterator.drop(Int.MaxValue).drop(1).toList.isEmpty, true)
+    assertEquals(List(1, 2, 3).reverseIterator.drop(1).drop(Int.MaxValue).toList.isEmpty, true)
+    assertEquals(List(1, 2, 3).reverseIterator.drop(1).drop(Int.MaxValue).drop(1).toList.isEmpty, true)
+    assertEquals(List(1, 2, 3).reverseIterator.drop(1).drop(Int.MaxValue).drop(1).toList.isEmpty, true)
+    assertSameElements(List(3) ++ List(1, 2, 3).reverseIterator.drop(1), List(3, 2, 1))
+  }
+
   @Test def dropIsChainable(): Unit = {
     assertSameElements(1 to 4, Iterator from 0 take 5 drop 1)
     assertSameElements(3 to 4, Iterator from 0 take 5 drop 3)


### PR DESCRIPTION
resolves [#12822](https://github.com/scala/bug/issues/12822)