### PR TITLE
=coll Add quick return for Iterator drop and take.

### DIFF
--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -626,7 +626,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
 
   @`inline` final def ++ [B >: A](xs: => IterableOnce[B]): Iterator[B] = concat(xs)
 
-  def take(n: Int): Iterator[A] = sliceIterator(0, n max 0)
+  def take(n: Int): Iterator[A] = if (n <= 0) Iterator.empty else if (n == Int.MaxValue) this else sliceIterator(0, n max 0)
 
   def takeWhile(p: A => Boolean): Iterator[A] = new AbstractIterator[A] {
     private[this] var hd: A = _
@@ -642,7 +642,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     def next() = if (hasNext) { hdDefined = false; hd } else Iterator.empty.next()
   }
 
-  def drop(n: Int): Iterator[A] = sliceIterator(n, -1)
+  def drop(n: Int): Iterator[A] = if (n <= 0) this else if (n == Int.MaxValue) Iterator.empty else sliceIterator(n, -1)
 
   def dropWhile(p: A => Boolean): Iterator[A] = new AbstractIterator[A] {
     // Magic value: -1 = hasn't dropped, 0 = found first, 1 = defer to parent iterator

--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -213,6 +213,16 @@ class IteratorTest {
     assertEquals(it.drop(1).next(), it.drop(1).drop(1).next())
   }
 
+  @Test def dropNegativeReturnsSelf():Unit= {
+    val iterator = List(1).iterator
+    assertSame(iterator.drop(Int.MinValue), iterator)
+  }
+
+  @Test def dropMaxValueReturnsEmpty() :Unit = {
+    val iterator = List(1).iterator
+    assertSame(iterator.drop(Int.MaxValue), Iterator.empty)
+  }
+
   @Test def dropIsChainable(): Unit = {
     assertSameElements(1 to 4, Iterator from 0 take 5 drop 1)
     assertSameElements(3 to 4, Iterator from 0 take 5 drop 3)
@@ -331,6 +341,17 @@ class IteratorTest {
   @Test def take(): Unit = {
     assertEquals(10, (Iterator from 0 take 10).size)
   }
+
+  @Test def takeNegativeReturnsEmpty(): Unit = {
+    val iterator = List(1).iterator
+    assertSame(iterator.take(Int.MinValue), Iterator.empty)
+  }
+
+  @Test def takeMaxValueReturnsSelf(): Unit = {
+    val iterator = List(1).iterator
+    assertSame(iterator.take(Int.MaxValue), iterator)
+  }
+
   @Test def foreach(): Unit = {
     val it1 = Iterator.from(0) take 20
     var n = 0


### PR DESCRIPTION
Motivation:
Do quick return when we know it. 

Currently, the `take` and `drop` both leverage the `splitIterator` and the `upperbound` is `-1` sometime, and can not do a quick return. but in the `take` and `drop` function, we knew more information of that the caller want to do.

Result:
Quick return for some eage cases, and more check for others .

BTW, I think the current `take` and `drop` with an `Int` parameter is wrong, what if the underling iterator is a LinkedList?
