### PR TITLE
Improve readability of Stepper test [ci: last-only]

### DIFF
--- a/src/library/scala/collection/immutable/IntMap.scala
+++ b/src/library/scala/collection/immutable/IntMap.scala
@@ -38,7 +38,7 @@ private[immutable] object IntMapUtils extends BitOperations.Int {
   }
 }
 
-import IntMapUtils._
+import IntMapUtils.{Int => _, _}
 
 /** A companion object for integer maps.
   *
@@ -220,7 +220,7 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
     case IntMap.Nil =>
   }
 
-  override def foreachEntry[U](f: (IntMapUtils.Int, T) => U): Unit = this match {
+  override def foreachEntry[U](f: (Int, T) => U): Unit = this match {
     case IntMap.Bin(_, _, left, right) => { left.foreachEntry(f); right.foreachEntry(f) }
     case IntMap.Tip(key, value) => f(key, value)
     case IntMap.Nil =>

--- a/src/library/scala/collection/immutable/LongMap.scala
+++ b/src/library/scala/collection/immutable/LongMap.scala
@@ -40,7 +40,7 @@ private[immutable] object LongMapUtils extends BitOperations.Long {
   }
 }
 
-import LongMapUtils._
+import LongMapUtils.{Long => _, _}
 
 /** A companion object for long maps.
   *

--- a/src/library/scala/collection/immutable/TreeSeqMap.scala
+++ b/src/library/scala/collection/immutable/TreeSeqMap.scala
@@ -362,7 +362,7 @@ object TreeSeqMap extends MapFactory[TreeSeqMap] {
 
   /* The ordering implementation below is an adapted version of immutable.IntMap. */
   private[immutable] object Ordering {
-    import scala.collection.generic.BitOperations.Int._
+    import scala.collection.generic.BitOperations.Int.{Int => _, _}
 
     @inline private[immutable] def toBinaryString(i: Int): String = s"$i/${i.toBinaryString}"
 


### PR DESCRIPTION
Unroll some for comprehensions for comprehensibility.

Scaladoc 2 for LongMap included LongMapUtils.Long in signatures (fixed in Scaladoc 3). That alias is just because of the weird way the helper was written. Don't import the weird alias.
