### PR TITLE
Fixes issue with blocking and BatchingExecutor

### DIFF
--- a/src/library/scala/concurrent/BatchingExecutor.scala
+++ b/src/library/scala/concurrent/BatchingExecutor.scala
@@ -60,7 +60,7 @@ private[concurrent] trait BatchingExecutor extends Executor {
           parentBlockContext = prevBlockContext
 
           @tailrec def processBatch(batch: List[Runnable]): Unit = batch match {
-            case Nil => ()
+            case null | Nil => ()
             case head :: tail =>
               _tasksLocal set tail
               try {
@@ -91,7 +91,7 @@ private[concurrent] trait BatchingExecutor extends Executor {
       // if we know there will be blocking, we don't want to keep tasks queued up because it could deadlock.
       {
         val tasks = _tasksLocal.get
-        _tasksLocal set Nil
+        _tasksLocal set null
         if ((tasks ne null) && tasks.nonEmpty)
           unbatchedExecute(new Batch(tasks))
       }


### PR DESCRIPTION
BatchingExecutor has a thread local with internal runnables for Future/Promise. In blockOn method this threadLocal was set to Nil and if there are tasks to execute, it passed to Batch to execute immediately. Howerver, run method of Batch class requires that thread local must be null. It produces IllegalArgumentException and all unexecuted tasks are lost at this point (having Promise/Future onComplete callback never called, meaning - it will never be completed).

Fixes scala/bug#9304