### PR TITLE
REPL versioned prompt includes -Xsource

### DIFF
--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
@@ -1011,6 +1011,8 @@ object ILoop {
     def doCompletion: Boolean = delegate.doCompletion
     def haveInteractiveConsole: Boolean = delegate.haveInteractiveConsole
 
+    def xsource: String = ""
+
     override val colorOk = delegate.colorOk
 
     // No truncated output, because the result changes on Windows because of line endings


### PR DESCRIPTION
For extreme perspicacity, add `-Xsource` value (if set) to the REPL versioned prompt (as enabled by `-Dscala.repl.info=true`).

```
scala 2.13.13-20231217-200123-a7b9a34 -Xsource:3.0.0>
```