### PR TITLE
Fix position of return type inserted by quick fix

### DIFF
--- a/src/compiler/scala/tools/nsc/CompilationUnits.scala
+++ b/src/compiler/scala/tools/nsc/CompilationUnits.scala
@@ -47,9 +47,6 @@ trait CompilationUnits { global: Global =>
     def freshTermName(prefix: String = nme.FRESH_TERM_NAME_PREFIX) = global.freshTermName(prefix)
     def freshTypeName(prefix: String)                              = global.freshTypeName(prefix)
 
-    def sourceAt(pos: Position): String =
-      if (pos.start < pos.end) new String(source.content.slice(pos.start, pos.end)) else ""
-
     /** the content of the compilation unit in tree form */
     var body: Tree = EmptyTree
 

--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -353,7 +353,7 @@ trait Reporting extends internal.Reporting { self: ast.Positions with Compilatio
       issueIfNotSuppressed(Message.Origin(pos, msg, category, siteName(site), origin, actions = Nil))
 
     def codeAction(title: String, pos: Position, newText: String, desc: String, expected: Option[(String, CompilationUnit)] = None) =
-      CodeAction(title, pos, newText, desc, expected.forall(e => e._1 == e._2.sourceAt(pos)))
+      CodeAction(title, pos, newText, desc, expected.forall(e => e._1 == e._2.source.sourceAt(pos)))
 
     // Remember CodeActions that match `-quickfix` and report the error through the reporter
     def error(pos: Position, msg: String, actions: List[CodeAction]): Unit = {

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -816,7 +816,7 @@ self =>
         val wrn = sm"""|$msg
                        |Use '-Wconf:msg=lambda-parens:s' to silence this warning."""
         def actions =
-          if (tree.pos.isRange) runReporting.codeAction("add parentheses", tree.pos, s"(${unit.sourceAt(tree.pos)})", msg)
+          if (tree.pos.isRange) runReporting.codeAction("add parentheses", tree.pos, s"(${unit.source.sourceAt(tree.pos)})", msg)
           else Nil
         migrationWarning(tree.pos.point, wrn, "2.13.11", actions)
         List(convertToParam(tree))
@@ -1032,9 +1032,9 @@ self =>
       val pos                   = lhs.pos.union(rhs.pos).union(operatorPos).withEnd(in.lastOffset).withPoint(offset)
 
       if (targs.nonEmpty) {
-        val qual = unit.sourceAt(lhs.pos)
-        val fun = s"${CodeAction.maybeWrapInParens(qual)}.${unit.sourceAt(operatorPos.withEnd(rhs.pos.start))}".trim
-        val fix = s"$fun${CodeAction.wrapInParens(unit.sourceAt(rhs.pos))}"
+        val qual = unit.source.sourceAt(lhs.pos)
+        val fun = s"${CodeAction.maybeWrapInParens(qual)}.${unit.source.sourceAt(operatorPos.withEnd(rhs.pos.start))}".trim
+        val fix = s"$fun${CodeAction.wrapInParens(unit.source.sourceAt(rhs.pos))}"
         val msg = "type application is not allowed for infix operators"
         migrationWarning(offset, msg, "2.13.11",
           runReporting.codeAction("use selection", pos, fix, msg))

--- a/src/compiler/scala/tools/nsc/typechecker/Adaptations.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Adaptations.scala
@@ -103,7 +103,7 @@ trait Adaptations {
             s"adapted the argument list to the expected ${args.size}-tuple: add additional parens instead")
           val pos = wrappingPos(args)
           context.warning(t.pos, msg, WarningCategory.LintAdaptedArgs,
-            runReporting.codeAction("add wrapping parentheses", pos, s"(${currentUnit.sourceAt(pos)})", msg))
+            runReporting.codeAction("add wrapping parentheses", pos, s"(${currentUnit.source.sourceAt(pos)})", msg))
         }
         true // keep adaptation
       }

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -200,7 +200,7 @@ trait ContextErrors extends splain.SplainErrors {
       // DefTree doesn't give the name position; also it can be a synthetic accessor DefDef with only offset pos.
       val namePos = tree.pos.focus.withEnd(tree.pos.point + tree.symbol.decodedName.length)
       val action =
-        if (currentUnit.sourceAt(namePos) == tree.symbol.decodedName) runReporting.codeAction("insert explicit type", namePos.focusEnd, s": $inferred", msg)
+        if (namePos.source.sourceAt(namePos) == tree.symbol.decodedName) runReporting.codeAction("insert explicit type", namePos.focusEnd, s": $inferred", msg)
         else Nil
       if (currentRun.isScala3) cx.warning(tree.pos, msg, WarningCategory.Scala3Migration, action)
       else cx.warning(tree.pos, msg, WarningCategory.OtherImplicitType, action)

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -467,7 +467,7 @@ abstract class RefChecks extends Transform {
                 val msg = s"$mbr without a parameter list overrides ${other.fullLocationString} defined with a single empty parameter list"
                 val namePos = member.pos
                 val action =
-                  if (namePos.isDefined && currentUnit.sourceAt(namePos) == member.decodedName)
+                  if (namePos.isDefined && currentUnit.source.sourceAt(namePos) == member.decodedName)
                     runReporting.codeAction("add empty parameter list", namePos.focusEnd, "()", msg)
                   else Nil
                 overrideErrorOrNullaryWarning(msg, action)
@@ -477,7 +477,7 @@ abstract class RefChecks extends Transform {
                 val msg = s"$mbr with a single empty parameter list overrides ${other.fullLocationString} defined without a parameter list"
                 val namePos = member.pos
                 val action =
-                  if (namePos.isDefined && currentUnit.sourceAt(namePos) == member.decodedName)
+                  if (namePos.isDefined && currentUnit.source.sourceAt(namePos) == member.decodedName)
                     runReporting.codeAction("remove empty parameter list", namePos.focusEnd.withEnd(namePos.end + 2), "", msg, expected = Some(("()", currentUnit)))
                   else Nil
                 overrideErrorOrNullaryWarning(msg, action)
@@ -1779,7 +1779,7 @@ abstract class RefChecks extends Transform {
           val msg = s"side-effecting nullary methods are discouraged: suggest defining as `def ${sym.name.decode}()` instead"
           val namePos = sym.pos.focus.withEnd(sym.pos.point + sym.decodedName.length)
           val action =
-            if (currentUnit.sourceAt(namePos) == sym.decodedName)
+            if (currentUnit.source.sourceAt(namePos) == sym.decodedName)
               runReporting.codeAction("add empty parameter list", namePos.focusEnd, "()", msg)
             else Nil
           refchecksWarning(sym.pos, msg, WarningCategory.LintNullaryUnit, action)

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1136,7 +1136,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             if (isInharmonic) {
               // not `context.deprecationWarning` because they are not buffered in silent mode
               val msg = s"Widening conversion from ${tpSym.name} to ${ptSym.name} is deprecated because it loses precision. Write `.to${ptSym.name}` instead."
-              val orig = currentUnit.sourceAt(tree.pos)
+              val orig = currentUnit.source.sourceAt(tree.pos)
               context.warning(tree.pos, msg, WarningCategory.Deprecation,
                 runReporting.codeAction("add conversion", tree.pos, s"${CodeAction.maybeWrapInParens(orig)}.to${ptSym.name}", msg))
             } else {
@@ -1146,7 +1146,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                   case Apply(Select(q, nme.DIV), _) if isInt(q) =>
                     val msg = s"integral division is implicitly converted (widened) to floating point. Add an explicit `.to${ptSym.name}`."
                     context.warning(tree.pos, msg, WarningCategory.LintIntDivToFloat,
-                      runReporting.codeAction("add conversion", tree.pos, s"(${currentUnit.sourceAt(tree.pos)}).to${ptSym.name}", msg))
+                      runReporting.codeAction("add conversion", tree.pos, s"(${currentUnit.source.sourceAt(tree.pos)}).to${ptSym.name}", msg))
                   case Apply(Select(a1, _), List(a2)) if isInt(tree) && isInt(a1) && isInt(a2) => traverse(a1); traverse(a2)
                   case Select(q, _) if isInt(tree) && isInt(q) => traverse(q)
                   case _ =>
@@ -4977,8 +4977,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
           val action = {
             val etaPos = pos.withEnd(pos.end + 2)
-            if (currentUnit.sourceAt(etaPos).endsWith(" _"))
-              runReporting.codeAction("replace by function literal", etaPos, s"() => ${currentUnit.sourceAt(pos)}", msg)
+            if (currentUnit.source.sourceAt(etaPos).endsWith(" _"))
+              runReporting.codeAction("replace by function literal", etaPos, s"() => ${currentUnit.source.sourceAt(pos)}", msg)
             else Nil
           }
 

--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -1278,7 +1278,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
         val source = pos.source
 
         val nameStart: Int = (focus1.pos.end - 1 to effectiveQualEnd by -1).find(p =>
-          source.identifier(source.position(p)).exists(_.length == 0)
+          source.identFrom(source.position(p)).exists(_.length == 0)
         ).map(_ + 1).getOrElse(fallback)
         typeCompletions(sel, qual, nameStart, name)
       case Ident(name) =>

--- a/test/junit/scala/tools/nsc/reporters/CodeActionXsource3Test.scala
+++ b/test/junit/scala/tools/nsc/reporters/CodeActionXsource3Test.scala
@@ -8,6 +8,48 @@ import org.junit.runners.JUnit4
 class CodeActionXsource3Test extends AbstractCodeActionTest {
   override def compilerArgs: String = "-Ystop-after:refchecks -deprecation -Xlint -Xsource:3"
 
+  @Test def t12860(): Unit = {
+    assertCodeSuggestion(
+      """class A {
+        |  def f(x: Int) = new A
+        |  def g(x: Int = 1.max(2)) = new A
+        |  def h() = new A
+        |  def i(h: Int)() = new A
+        |  def j = new A
+        |  def k[T] = new A
+        |}
+        |class B extends A {
+        |  override def f(x: Int)
+        |    = new B
+        |  override def g(x: Int = 1.max(2)) = new B
+        |  override def h() = new B
+        |  override def i(h: Int)() = new B
+        |  override val j =
+        |    new B
+        |  def k[T] = new B
+        |}
+        |""".stripMargin,
+      """class A {
+        |  def f(x: Int) = new A
+        |  def g(x: Int = 1.max(2)) = new A
+        |  def h() = new A
+        |  def i(h: Int)() = new A
+        |  def j = new A
+        |  def k[T] = new A
+        |}
+        |class B extends A {
+        |  override def f(x: Int): B
+        |    = new B
+        |  override def g(x: Int = 1.max(2)): B = new B
+        |  override def h(): B = new B
+        |  override def i(h: Int)(): B = new B
+        |  override val j: B =
+        |    new B
+        |  def k[T]: B = new B
+        |}
+        |""".stripMargin)
+  }
+
   @Test
   def lambdaParameterParens(): Unit =
     assertCodeSuggestion(


### PR DESCRIPTION
Under -Xsource:3, there is a warning for overriding methods that have a more precise inferred return type. The corresponding quick fix was adding the return type right after the name, ignoring parameters lists.

Fixes https://github.com/scala/bug/issues/12860