### PR TITLE
`-Yrelease` supplements `-release`, allows access to additional JVM packages

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -146,9 +146,10 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
   def optimizerClassPath(base: ClassPath): ClassPath =
     base match {
       case AggregateClassPath(entries) if entries.head.isInstanceOf[CtSymClassPath] =>
-        JrtClassPath(release = None, closeableRegistry)
-          .map(jrt => AggregateClassPath(entries.drop(1).prepended(jrt)))
-          .getOrElse(base)
+        JrtClassPath(release = None, unsafe = None, closeableRegistry) match {
+          case jrt :: Nil => AggregateClassPath(entries.drop(1).prepended(jrt))
+          case _ => base
+        }
       case _ => base
     }
 

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -264,6 +264,7 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
 
   val Youtline        = BooleanSetting    ("-Youtline", "Don't compile method bodies. Use together with `-Ystop-after:pickler` to generate the pickled signatures for all source files.").internalOnly()
 
+  val unsafe = MultiStringSetting("-Yrelease", "packages", "Expose platform packages hidden under --release")
   val exposeEmptyPackage = BooleanSetting ("-Yexpose-empty-package", "Internal only: expose the empty package.").internalOnly()
   val Ydelambdafy        = ChoiceSetting  ("-Ydelambdafy", "strategy", "Strategy used for translating lambdas into JVM code.", List("inline", "method"), "method")
 

--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -257,8 +257,9 @@ final class PathResolver(settings: Settings, closeableRegistry: CloseableRegistr
 
     // Assemble the elements!
     def basis = List[Iterable[ClassPath]](
-      jrt                                           // 0. The Java 9+ classpath (backed by the ct.sym or jrt:/ virtual system, if available)
-        .filter(_ => !settings.javabootclasspath.isSetByUser), // respect explicit `-javabootclasspath rt.jar`
+      if (settings.javabootclasspath.isSetByUser)   // respect explicit `-javabootclasspath rt.jar`
+        Nil
+      else jrt,                                     // 0. The Java 9+ classpath (backed by the ct.sym or jrt:/ virtual system, if available)
       classesInPath(javaBootClassPath),             // 1. The Java bootstrap class path.
       contentsOfDirsInPath(javaExtDirs),            // 2. The Java extension class path.
       classesInExpandedPath(javaUserClassPath),     // 3. The Java application class path.
@@ -269,7 +270,7 @@ final class PathResolver(settings: Settings, closeableRegistry: CloseableRegistr
       sourcesInPath(sourcePath)                     // 7. The Scala source path.
     )
 
-    private def jrt: Option[ClassPath] = JrtClassPath.apply(settings.releaseValue, closeableRegistry)
+    private def jrt: List[ClassPath] = JrtClassPath.apply(settings.releaseValue, settings.unsafe.valueSetByUser, closeableRegistry)
 
     lazy val containers = basis.flatten.distinct
 

--- a/test/files/neg/unsafe.check
+++ b/test/files/neg/unsafe.check
@@ -1,0 +1,4 @@
+unsafe.scala:9: error: value threadId is not a member of Thread
+  def f(t: Thread) = t.threadId
+                       ^
+1 error

--- a/test/files/neg/unsafe.scala
+++ b/test/files/neg/unsafe.scala
@@ -1,0 +1,10 @@
+
+// scalac: --release:8 -Yrelease:java.lang
+// javaVersion: 19+
+
+// -Yrelease opens packages but does not override class definitions
+// because ct.sym comes first
+
+class C {
+  def f(t: Thread) = t.threadId
+}

--- a/test/files/pos/unsafe.scala
+++ b/test/files/pos/unsafe.scala
@@ -1,0 +1,21 @@
+
+// scalac: --release:8 -Yrelease:sun.misc
+
+import sun.misc.Unsafe
+
+class C {
+  val f = classOf[Unsafe].getDeclaredField("theUnsafe")
+  f.setAccessible(true)
+  val unsafe = f.get(null).asInstanceOf[Unsafe]
+
+  val k = unsafe.allocateInstance(classOf[K]).asInstanceOf[K]
+  assert(k.value == 0)
+}
+
+class K {
+  val value = 42
+}
+
+object Test extends App {
+  new C
+}

--- a/test/junit/scala/tools/nsc/classpath/JrtClassPathTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/JrtClassPathTest.scala
@@ -27,7 +27,7 @@ class JrtClassPathTest {
         val elements = new ClassPathFactory(settings, closeableRegistry).classesInPath(resolver.Calculated.javaBootClassPath)
         AggregateClassPath(elements)
       }
-      else JrtClassPath(None, closeableRegistry).get
+      else JrtClassPath(None, None, closeableRegistry).head
 
     assertEquals(Nil, cp.classes(""))
     assertTrue(cp.packages("java").toString, cp.packages("java").exists(_.name == "java.lang"))


### PR DESCRIPTION
Legacy usage of `sun.misc.Unsafe` makes it difficult to leverage `-release` in a build, since the internal class is not available as API. To enable this common use case, `-Yrelease` is introduced to allow access to specified platform packages. 

For example, `-release:8 -Yrelease:sun.misc`.

This "private" option is a convenience intended to support a project while migrating away from using `Unsafe`.

Fixes scala/bug#12643
