### PR TITLE
Fix incorrect exclusion for matching methods

### DIFF
--- a/test/files/neg/warn-unused-implicits.scala
+++ b/test/files/neg/warn-unused-implicits.scala
@@ -1,4 +1,4 @@
-// scalac: -Ywarn-unused:implicits -Xfatal-warnings
+// scalac: -Werror -Wunused:implicits
 //
 
 trait InterFace {
@@ -31,4 +31,12 @@ trait BadAPI extends InterFace {
   }
 
   def i(implicit s: String, t: Int) = t           // yes, warn
+}
+
+trait T {
+  def f()(implicit i: Int): Int
+}
+trait U { _: T =>
+  override def f()(implicit i: Int): Int = g()  // no warn, required by baseclass, scala/bug#12876
+  def g(): Int
 }


### PR DESCRIPTION
Remove incorrect and extraneous exclusion in `overridingPairs` used for checking whether a method is an override (and therefore should not warn about unused parameters, for the policy that since I can't change the signature, don't warn me about it; also, apparently I am too lazy to add `@unused` to the parameter).

The `isImplementation` (i.e., an override) check only applies to methods; use regular `overridingPairs` is there is no self-type; otherwise, look for matching members in base classes of the self-type.

The warnings need a volume control knob, so that users can select a decibel level of noise.

Fixes scala/bug#12876
