### PR TITLE
Fix source links in our own Scaladoc (2.13.12 regression)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -179,7 +179,7 @@ lazy val commonSettings = instanceSettings ++ clearSourceAndResourceDirectories 
     "-doc-version", versionProperties.value.canonicalVersion,
     "-doc-title", description.value,
     "-sourcepath", (ThisBuild / baseDirectory).value.toString,
-    "-doc-source-url", s"https://github.com/scala/scala/tree/${versionProperties.value.githubTree}€{FILE_PATH_EXT}#L€{FILE_LINE}"
+    "-doc-source-url", s"https://github.com/scala/scala/blob/${versionProperties.value.githubTree}/€{FILE_PATH_EXT}#L€{FILE_LINE}"
   ),
   //maxErrors := 10,
   setIncOptions,


### PR DESCRIPTION
fixes scala/bug#12875 (root cause scala/bug#12867)

the insertion of `/` is the actual fix, but note also the `tree` -> `blob` change; it seems to be what GitHub wants, since the former redirects to the latter