### PR TITLE
Align a return type in collections internals with Scala 3

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -39,6 +39,8 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.concurrent.impl.FutureConvertersImpl#P.accept"),
     ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.concurrent.impl.FutureConvertersImpl#P.andThen"),
 
+    // 2.13.13; it's okay because the class is private
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.MapNodeRemoveAllSetNodeIterator.next"),
   )
 
   override val buildSettings = Seq(

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -2181,7 +2181,7 @@ private final class MapNodeRemoveAllSetNodeIterator[K](rootSetNode: SetNode[K]) 
     curr
   }
 
-  override def next() = Iterator.empty.next()
+  override def next(): K = Iterator.empty.next()
 }
 
 /**


### PR DESCRIPTION
context: lampepfl/dotty#18525, which upgrades Scala 3 to use the 2.13.12 stdlib; MiMa there is complaining

it's because of the Scala 3 change where the inferred return type of an override now comes from the parent, not from the child