### PR TITLE
Build library under -Xsource:3 [ci: last-only]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -196,14 +196,15 @@ lazy val commonSettings = instanceSettings ++ clearSourceAndResourceDirectories 
   cleanFiles += (Compile / doc / target).value,
   run / fork := true,
   run / connectInput := true,
-  Compile / scalacOptions ++= Seq("-feature", "-Xlint",
+  Compile / scalacOptions ++= Seq("-Xlint", "-feature", "-Xsource:3-cross",
     //"-Vprint",
     //"-Xmaxerrs", "5", "-Xmaxwarns", "5", // uncomment for ease of development while breaking things
     // work around https://github.com/scala/bug/issues/11534
     "-Wconf:cat=unchecked&msg=The outer reference in this type test cannot be checked at run time.:s",
     // optimizer warnings at INFO since `-Werror` may be turned on.
     // optimizer runs in CI and release builds, though not in local development.
-    "-Wconf:cat=optimizer:is",
+    //"-Wconf:cat=optimizer:is",
+    "-Wopt",
     // we use @nowarn for methods that are deprecated in JDK > 8, but CI/release is under JDK 8
     "-Wconf:cat=unused-nowarn:s",
     "-Wunnamed-boolean-literal-strict",
@@ -450,6 +451,10 @@ lazy val library = configureAsSubproject(project)
     name := "scala-library",
     description := "Scala Standard Library",
     Compile / scalacOptions ++= Seq("-sourcepath", (Compile / scalaSource).value.toString),
+    Compile / scalacOptions ++= Seq("-Xsource-features:-case-companion-function"),
+    Compile / scalacOptions ++= Seq("-Wconf:cat=scala3-migration&msg=elidable&site=scala.Predef:s"),
+    //Compile / scalacOptions ++= Seq("-Wconf:msg=Synthetic case companion&src=src/library/scala/jdk/FunctionWrappers.scala:s"),
+    //Compile / scalacOptions ++= Seq("-Wconf:cat=scala3-migration&msg=constructor modifiers&site=scala.concurrent.duration.Deadline:s"), // for bootstrap until restarr
     Compile / doc / scalacOptions ++= {
       val libraryAuxDir = (ThisBuild / baseDirectory).value / "src/library-aux"
       Seq(
@@ -502,6 +507,7 @@ lazy val reflect = configureAsSubproject(project)
     Osgi.bundleName := "Scala Reflect",
     Compile / scalacOptions ++= Seq(
       "-Wconf:cat=deprecation&msg=early initializers:s", // compiler heavily relies upon early initializers
+      "-Wconf:cat=scala3-migration&msg=early initializers:s", // compiler heavily relies upon early initializers
     ),
     Compile / doc / scalacOptions ++= Seq(
       "-skip-packages", "scala.reflect.macros.internal:scala.reflect.internal:scala.reflect.io"
@@ -576,6 +582,7 @@ lazy val compiler = configureAsSubproject(project)
     Compile / scalacOptions ++= Seq(
       //"-Wunused", //"-Wnonunit-statement",
       "-Wconf:cat=deprecation&msg=early initializers:s", // compiler heavily relies upon early initializers
+      "-Wconf:cat=scala3-migration&msg=early initializers:s", // compiler heavily relies upon early initializers
     ),
     Compile / doc / scalacOptions ++= Seq(
       "-doc-root-content", (Compile / sourceDirectory).value + "/rootdoc.txt"
@@ -614,7 +621,10 @@ lazy val interactive = configureAsSubproject(project)
   .settings(
     name := "scala-compiler-interactive",
     description := "Scala Interactive Compiler",
-    Compile / scalacOptions ++= Seq("-Wconf:cat=deprecation&msg=early initializers:s"),
+    Compile / scalacOptions ++= Seq(
+      "-Wconf:cat=deprecation&msg=early initializers:s",
+      "-Wconf:cat=scala3-migration&msg=early initializers:s", // compiler heavily relies upon early initializers
+    )
   )
   .dependsOn(compiler)
 
@@ -622,7 +632,10 @@ lazy val repl = configureAsSubproject(project)
   .settings(disableDocs)
   .settings(fatalWarningsSettings)
   .settings(publish / skip := true)
-  .settings(Compile / scalacOptions ++= Seq("-Wconf:cat=deprecation&msg=early initializers:s"))
+  .settings(Compile / scalacOptions ++= Seq(
+    "-Wconf:cat=deprecation&msg=early initializers:s",
+    "-Wconf:cat=scala3-migration&msg=early initializers:s",
+  ))
   .dependsOn(compiler, interactive)
 
 lazy val replFrontend = configureAsSubproject(project, srcdir = Some("repl-frontend"))
@@ -651,6 +664,7 @@ lazy val scaladoc = configureAsSubproject(project)
     Compile / resourceGenerators += ScaladocSettings.extractResourcesFromWebjar,
     Compile / scalacOptions ++= Seq(
       "-Wconf:cat=deprecation&msg=early initializers:s",
+      "-Wconf:cat=scala3-migration&msg=early initializers:s",
     ),
   )
   .dependsOn(compiler)
@@ -666,6 +680,7 @@ lazy val sbtBridge = configureAsSubproject(project, srcdir = Some("sbt-bridge"))
     libraryDependencies += compilerInterfaceDep % Provided,
     Compile / scalacOptions ++= Seq(
       "-Wconf:cat=deprecation&msg=early initializers:s", // compiler heavily relies upon early initializers
+      "-Wconf:cat=scala3-migration&msg=early initializers:s", // compiler heavily relies upon early initializers
     ),
     generateServiceProviderResources("xsbti.compile.CompilerInterface2" -> "scala.tools.xsbt.CompilerBridge"),
     generateServiceProviderResources("xsbti.compile.ConsoleInterface1"  -> "scala.tools.xsbt.ConsoleBridge"),
@@ -721,6 +736,14 @@ lazy val scalap = configureAsSubproject(project)
       xs filter { x => !excluded(x.getName) }
     },
     Compile / headerResources := Nil,
+    Compile / scalacOptions ++= Seq(
+      "-Xsource:2.13",
+      "-Xsource-features:-case-apply-copy-access,-case-companion-function,-case-copy-by-name",
+      "-Xsource-features:-implicit-resolution,-infer-override,-any2stringadd,-unicode-escapes-raw",
+      "-Xsource-features:-string-context-scope,-leading-infix,-package-prefix-implicits,-double-definitions",
+      //"-Wconf:cat=scala3-migration&msg=inferred type:s",
+      //"-Wconf:cat=scala3-migration&msg=case companion:s",
+    ),
   )
   .dependsOn(compiler)
 
@@ -735,6 +758,7 @@ lazy val partest = configureAsSubproject(project)
     libraryDependencies ++= List(testInterfaceDep, diffUtilsDep, junitDep),
     Compile / scalacOptions ++= Seq(
       "-Wconf:cat=deprecation&msg=early initializers:s", // compiler heavily relies upon early initializers
+      "-Wconf:cat=scala3-migration&msg=early initializers:s", // compiler heavily relies upon early initializers
     ),
     Compile / javacOptions ++= Seq("-XDenableSunApiLintControl", "-Xlint") ++
       (if (fatalWarnings.value) Seq("-Werror") else Seq()),
@@ -807,8 +831,7 @@ lazy val bench = project.in(file("test") / "benchmarks")
       if (benchmarkScalaVersion == "") Nil
       else "org.scala-lang" % "scala-compiler" % benchmarkScalaVersion :: Nil
     },
-    //scalacOptions ++= Seq("-feature", "-opt:inline:scala/**", "-Wopt"),
-    scalacOptions ++= Seq("-feature", "-opt:l:inline", "-opt-inline-from:scala/**", "-opt-warnings"),
+    scalacOptions ++= Seq("-feature", "-opt:inline:scala/**", "-Wopt"),
     // Skips JMH source generators during IDE import to avoid needing to compile scala-library during the import
     // should not be needed once sbt-jmh 0.4.3 is out (https://github.com/sbt/sbt-jmh/pull/207)
     Jmh / bspEnabled := false
@@ -855,6 +878,8 @@ lazy val junit = project.in(file("test") / "junit")
       "-Wconf:msg=match may not be exhaustive:s", // if we missed a case, all that happens is the test fails
       "-Wconf:cat=lint-nullary-unit&site=.*Test:s", // normal unit test style
       "-Ypatmat-exhaust-depth", "40", // despite not caring about patmat exhaustiveness, we still get warnings for this
+      "-Wconf:cat=deprecation&msg=early initializers:s",
+      "-Wconf:cat=scala3-migration&msg=early initializers:s",
     ),
     Compile / javacOptions ++= Seq("-Xlint"),
     libraryDependencies ++= Seq(junitInterfaceDep, jolDep, diffUtilsDep, compilerInterfaceDep),
@@ -902,6 +927,7 @@ lazy val tasty = project.in(file("test") / "tasty")
     },
     Compile / scalacOptions ++= Seq(
       "-Wconf:cat=lint-nullary-unit&site=.*Test:s", // normal unit test style
+      raw"-Wconf:cat=optimizer&site=scala\.tools\.nsc\.tasty\.bridge\.TreeOps\.tpd\..*:s", // inline -> outline
     ),
   )
 

--- a/project/ScriptCommands.scala
+++ b/project/ScriptCommands.scala
@@ -161,8 +161,7 @@ object ScriptCommands {
   }
 
   private[this] val enableOptimizer = Seq(
-    //ThisBuild / Compile / scalacOptions ++= Seq("-opt:inline:scala/**")
-    ThisBuild / Compile / scalacOptions ++= Seq("-opt:l:inline", "-opt-inline-from:scala/**")
+    ThisBuild / Compile / scalacOptions ++= Seq("-opt:inline:scala/**")
   )
 
   val noDocs = Seq(

--- a/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
+++ b/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
@@ -65,5 +65,5 @@ class GenericRunnerSettings(error: String => Unit, pathFactory: PathFactory) ext
       "-nc",
       "do not use the legacy fsc compilation daemon").withAbbreviation("-nocompdaemon").withAbbreviation("--no-compilation-daemon")
       .withDeprecationMessage("scripts use cold compilation by default; use -Yscriptrunner for custom behavior")
-      .withPostSetHook { x: BooleanSetting => Yscriptrunner.value = if (x.value) "default" else "resident" }
+      .withPostSetHook { (x: BooleanSetting) => Yscriptrunner.value = if (x.value) "default" else "resident" }
 }

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1704,8 +1704,9 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
      */
     @tailrec
     private def resetPackageClass(pclazz: Symbol): Unit = if (typerPhase != NoPhase) {
+      val pinfo = enteringPhase(typerPhase)(pclazz.info)
       enteringPhase[Unit](firstPhase) {
-        pclazz.setInfo(enteringPhase(typerPhase)(pclazz.info))
+        pclazz.setInfo(pinfo)
       }
       if (!pclazz.isRoot) resetPackageClass(pclazz.owner)
     }

--- a/src/compiler/scala/tools/nsc/PipelineMain.scala
+++ b/src/compiler/scala/tools/nsc/PipelineMain.scala
@@ -201,7 +201,7 @@ class PipelineMainClass(argFiles: Seq[Path], pipelineSettings: PipelineMain.Pipe
     }
     strategy match {
       case OutlineTypePipeline =>
-        projects.foreach { p: Task =>
+        projects.foreach { (p: Task) =>
           val depsReady = Future.traverse(dependsOn.getOrElse(p, Nil))(task => p.dependencyReadyFuture(task))
           val f = for {
             _ <- depsReady

--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -832,15 +832,15 @@ object Reporting {
       if (s == "any") {
         Right(Any)
       } else if (s.startsWith("msg=")) {
-        regex(s.substring(4)).map(MessagePattern)
+        regex(s.substring(4)).map(MessagePattern(_))
       } else if (s.startsWith("cat=")) {
         val cs = s.substring(4)
-        val c = WarningCategory.all.get(cs).map(Category)
+        val c = WarningCategory.all.get(cs).map(Category(_))
         c.toRight(s"Unknown category: `$cs`")
       } else if (s.startsWith("site=")) {
-        regex(s.substring(5)).map(SitePattern)
+        regex(s.substring(5)).map(SitePattern(_))
       } else if (s.startsWith("origin=")) {
-        regex(s.substring(7)).map(DeprecatedOrigin)
+        regex(s.substring(7)).map(DeprecatedOrigin(_))
       } else if (s.startsWith("since")) {
         def fail = Left(s"invalid since filter: `$s`; required shape: `since<1.2.3`, `since=3.2`, `since>2`")
         if (s.length < 6) fail
@@ -867,7 +867,7 @@ object Reporting {
         if (!rootDir.endsWith("/") && !arg.startsWith("/")) pat += '/'
         pat ++= arg
         if (!arg.endsWith("$")) pat += '$'
-        regex(pat.toString).map(SourcePattern)
+        regex(pat.toString).map(SourcePattern(_))
       } else {
         Left(s"unknown filter: $s")
       }

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -85,8 +85,10 @@ trait ParsersCommon extends ScannersCommon {
 
     /** Creates an actual Parens node (only used during parsing.)
      */
-    @inline final def makeParens(body: => List[Tree]): Parens =
-      Parens(inParens(if (in.token == RPAREN) Nil else body))
+    @inline final def makeParens(body: => List[Tree]): Parens = {
+      val body0 = inParens(if (in.token == RPAREN) Nil else body)
+      Parens(body0)
+    }
 
     /** {{{ { `sep` part } }}}. */
     def tokenSeparated[T](separator: Token, part: => T): List[T] = {
@@ -544,7 +546,7 @@ self =>
     val assumedClosingParens = mutable.Map(RPAREN -> 0, RBRACKET -> 0, RBRACE -> 0)
 
     private var inFunReturnType = false
-    @inline private def fromWithinReturnType[T](body: => T): T = {
+    private def fromWithinReturnType[T](body: => T): T = {
       val saved = inFunReturnType
       inFunReturnType = true
       try body
@@ -1877,7 +1879,7 @@ self =>
     def prefixExpr(): Tree =
       if (isUnaryOp) {
         val start = in.offset
-        atPos(start) {
+        val result =
           if (lookingAhead(isExprIntro)) {
             val namePos = in.offset
             val uname = nme.toUnaryName(rawIdent().toTermName)
@@ -1888,7 +1890,7 @@ self =>
               Select(stripParens(simpleExpr()), uname)
           }
           else simpleExpr()
-        }
+        atPos(start)(result)
       } else simpleExpr()
 
     def xmlLiteral(): Tree
@@ -3237,9 +3239,8 @@ self =>
         migrationWarning(in.offset, "type parameters should not follow newline", since = "2.13.7")
       def orStart(p: Offset) = if (name == tpnme.ERROR) start else p
       val namePos = NamePos(r2p(orStart(nameOffset), orStart(nameOffset)))
-      atPos(start, orStart(nameOffset)) {
-        savingClassContextBounds {
-          val contextBoundBuf = new ListBuffer[Tree]
+      def finish = savingClassContextBounds {
+          val contextBoundBuf = ListBuffer.empty[Tree]
           val tparams = typeParamClauseOpt(name, contextBoundBuf, ParamOwner.Class)
           classContextBounds = contextBoundBuf.toList
           val tstart = (in.offset :: classContextBounds.map(_.pos.start)).min
@@ -3260,7 +3261,7 @@ self =>
             ensureNonOverlapping(template, tparams)
           result
         }
-      }
+      atPos(start, orStart(nameOffset))(finish)
     }
 
     /** {{{

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -1299,7 +1299,7 @@ trait Scanners extends ScannersCommon {
       if (token == CHARLIT && !negated) charVal.toLong else intConvert
     }
 
-    @`inline` def intVal: Long = intVal(negated = false)
+    @inline final def intVal: Long = intVal(negated = false)
 
     private val zeroFloat = raw"[0.]+(?:[eE][+-]?[0-9]+)?[fFdD]?".r
 
@@ -1321,7 +1321,7 @@ trait Scanners extends ScannersCommon {
       }
     }
 
-    @`inline` def floatVal: Float = floatVal(negated = false)
+    @inline final def floatVal: Float = floatVal(negated = false)
 
     /** Convert current strVal, base to double value.
      */
@@ -1341,15 +1341,15 @@ trait Scanners extends ScannersCommon {
       }
     }
 
-    @`inline` def doubleVal: Double = doubleVal(negated = false)
+    @inline final def doubleVal: Double = doubleVal(negated = false)
 
-    @`inline` def checkNoLetter(): Unit = if (isIdentifierPart(ch) && ch >= ' ') syntaxError("invalid literal number")
+    @inline final def checkNoLetter(): Unit = if (isIdentifierPart(ch) && ch >= ' ') syntaxError("invalid literal number")
 
-    @`inline` private def isNumberSeparator(c: Char): Boolean = c == '_'
+    @inline final private def isNumberSeparator(c: Char): Boolean = c == '_'
 
-    @`inline` private def removeNumberSeparators(s: String): String = if (s.indexOf('_') > 0) s.replace("_", "") else s
+    @inline final private def removeNumberSeparators(s: String): String = if (s.indexOf('_') > 0) s.replace("_", "") else s
 
-    @`inline` private def numberOffset = offset + (if (base == 10) 0 else 2)
+    @inline final private def numberOffset = offset + (if (base == 10) 0 else 2)
 
     // disallow trailing numeric separator char
     def checkNoTrailingSeparator(): Unit =

--- a/src/compiler/scala/tools/nsc/backend/ScalaPrimitives.scala
+++ b/src/compiler/scala/tools/nsc/backend/ScalaPrimitives.scala
@@ -447,6 +447,24 @@ abstract class ScalaPrimitives {
     primitives(s) = code
   }
 
+  def addPrimitives(cls: Symbol, method: Name, code: Int): Unit =
+    cls.info.member(method).alternatives match {
+      case alts if alts.isEmpty => inform(s"Unknown primitive method $cls.$method")
+      case alts =>
+        for (alt <- alts) {
+          val code1 = code match {
+            case ADD =>
+              val info = exitingTyper(alt.info)
+              info.paramTypes match {
+                case tp :: _ if tp =:= StringTpe => CONCAT
+                case _                           => code
+              }
+            case code => code
+          }
+          addPrimitive(alt, code1)
+        }
+    }
+  /*
   def addPrimitives(cls: Symbol, method: Name, code: Int): Unit = {
     val alts = (cls.info member method).alternatives
     if (alts.isEmpty)
@@ -461,6 +479,7 @@ abstract class ScalaPrimitives {
       )
     )
   }
+  */
 
   def isCoercion(code: Int): Boolean = (code >= B2B) && (code <= D2D)
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -83,7 +83,8 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
       // we prevent this, see `nonAnon` in LambdaLift.
       // phase travel necessary: after flatten, the name includes the name of outer classes.
       // if some outer name contains $lambda, a non-lambda class is considered lambda.
-      assert(exitingPickler(!classSym.isDelambdafyFunction), classSym.name)
+      val ok = exitingPickler(!classSym.isDelambdafyFunction)
+      assert(ok, classSym.name)
     }
     r
   }

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -33,7 +33,7 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
   import codeGen.CodeGenImpl._
   import postProcessor.{bTypesFromClassfile, byteCodeRepository}
 
-  val coreBTypes = new CoreBTypesFromSymbols[G] {
+  val coreBTypes: CoreBTypesFromSymbols[G] { val bTypes: BTypesFromSymbols.this.type} = new CoreBTypesFromSymbols[G] {
     val bTypes: BTypesFromSymbols.this.type = BTypesFromSymbols.this
   }
   import coreBTypes._
@@ -352,7 +352,8 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
      * declared but not otherwise referenced in C (from the bytecode or a method / field signature).
      * We collect them here.
      */
-    lazy val nestedClassSymbols = {
+    lazy val nestedClassSymbols = nestedClassSymbolsComputed
+    def nestedClassSymbolsComputed = {
       val linkedClass = exitingPickler(classSym.linkedClassOfClass) // linkedCoC does not work properly in late phases
 
       // The lambdalift phase lifts all nested classes to the enclosing class, so if we collect
@@ -493,7 +494,8 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
         exitingPickler(innerClassSym.rawowner.linkedClassOfClass) match {
           case NoSymbol =>
             // For top-level modules without a companion class, see doc of mirrorClassClassBType.
-            mirrorClassClassBType(exitingPickler(innerClassSym.rawowner))
+            val rawowner = exitingPickler(innerClassSym.rawowner)
+            mirrorClassClassBType(rawowner)
 
           case companionClass =>
             classBTypeFromSymbol(companionClass)
@@ -515,7 +517,8 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
       else Some(s"${innerClassSym.rawname}${innerClassSym.moduleSuffix}") // moduleSuffix for module classes
     }
 
-    Some(NestedInfo(enclosingClass, outerName, innerName, isStaticNestedClass, enteringTyper(innerClassSym.isPrivate)))
+    val isPrivate = enteringTyper(innerClassSym.isPrivate)
+    Some(NestedInfo(enclosingClass, outerName, innerName, isStaticNestedClass, isPrivate))
   }
 
   /**

--- a/src/compiler/scala/tools/nsc/backend/jvm/ClassfileWriters.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/ClassfileWriters.scala
@@ -82,7 +82,7 @@ abstract class ClassfileWriters {
           if (distinctOutputs.size == 1) new SingleClassWriter(FileWriter(global, distinctOutputs.head, jarManifestMainClass))
           else {
             val sourceToOutput: Map[AbstractFile, AbstractFile] = global.currentRun.units.map(unit => (unit.source.file, frontendAccess.compilerSettings.outputDirectory(unit.source.file))).toMap
-            new MultiClassWriter(sourceToOutput, distinctOutputs.iterator.map { output: AbstractFile => output -> FileWriter(global, output, jarManifestMainClass) }.toMap)
+            new MultiClassWriter(sourceToOutput, distinctOutputs.iterator.map { (output: AbstractFile) => output -> FileWriter(global, output, jarManifestMainClass) }.toMap)
           }
       }
 

--- a/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
@@ -199,7 +199,9 @@ abstract class CoreBTypesFromSymbols[G <: Global] extends CoreBTypes {
   private[this] lazy val _jliMethodHandlesRef       : LazyVar[ClassBType] = runLazy(classBTypeFromSymbol(requiredClass[java.lang.invoke.MethodHandles]))
 
   def                     jliMethodHandlesLookupRef : ClassBType = _jliMethodHandlesLookupRef.get
-  private[this] lazy val _jliMethodHandlesLookupRef : LazyVar[ClassBType] = runLazy(classBTypeFromSymbol(exitingPickler(getRequiredClass("java.lang.invoke.MethodHandles.Lookup")))) // didn't find a reliable non-stringly-typed way that works for inner classes in the backend
+  // didn't find a reliable non-stringly-typed way that works for inner classes in the backend
+  private[this] lazy val _jliMethodHandlesLookupRef : LazyVar[ClassBType] = runLazy(classBTypeFromSymbol(_jliMethodHandlesLookupSymbol))
+  private[this] def _jliMethodHandlesLookupSymbol = exitingPickler(getRequiredClass("java.lang.invoke.MethodHandles.Lookup"))
 
   def                     jliMethodTypeRef          : ClassBType = _jliMethodTypeRef.get
   private[this] lazy val _jliMethodTypeRef          : LazyVar[ClassBType] = runLazy(classBTypeFromSymbol(requiredClass[java.lang.invoke.MethodType]))

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
@@ -936,19 +936,26 @@ object BackendUtils {
 
     def raiseError(msg: String, sig: String, e: Option[Throwable] = None): Unit
 
+    private final val Aborted: Throwable = new NoStackTrace { }
+
+    @inline final def safely(sig: String)(f: => Unit): Unit = try f catch {
+      case Aborted =>
+      case NonFatal(e) => raiseError(s"Exception thrown during signature parsing", sig, Some(e))
+    }
+
     def visitClassSignature(sig: String): Unit = if (sig != null) {
       val p = new Parser(sig, nestedOnly)
-      p.safely { p.classSignature() }
+      safely(sig) { p.classSignature() }
     }
 
     def visitMethodSignature(sig: String): Unit = if (sig != null) {
       val p = new Parser(sig, nestedOnly)
-      p.safely { p.methodSignature() }
+      safely(sig) { p.methodSignature() }
     }
 
     def visitFieldSignature(sig: String): Unit = if (sig != null) {
       val p = new Parser(sig, nestedOnly)
-      p.safely { p.fieldSignature() }
+      safely(sig) { p.fieldSignature() }
     }
 
     private final class Parser(sig: String, nestedOnly: Boolean) {
@@ -956,13 +963,7 @@ object BackendUtils {
       private var index = 0
       private val end = sig.length
 
-      private val Aborted: Throwable = new NoStackTrace { }
       private def abort(): Nothing = throw Aborted
-
-      @inline def safely(f: => Unit): Unit = try f catch {
-        case Aborted =>
-        case NonFatal(e) => raiseError(s"Exception thrown during signature parsing", sig, Some(e))
-      }
 
       private def current = {
         if (index >= end) {
@@ -1093,7 +1094,7 @@ object BackendUtils {
         }
       }
 
-      def fieldSignature(): Unit = if (sig != null) safely {
+      def fieldSignature(): Unit = if (sig != null) safely(sig) {
         referenceTypeSignature()
       }
     }

--- a/src/compiler/scala/tools/nsc/classpath/DirectoryClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/DirectoryClassPath.scala
@@ -329,7 +329,7 @@ final class CtSymClassPath(ctSym: java.nio.file.Path, release: Int) extends Clas
 }
 
 case class DirectoryClassPath(dir: File) extends JFileDirectoryLookup[ClassFileEntryImpl] with NoSourcePaths {
-  override def findClass(className: String): Option[ClassRepresentation] = findClassFile(className) map ClassFileEntryImpl
+  override def findClass(className: String): Option[ClassRepresentation] = findClassFile(className).map(ClassFileEntryImpl(_))
 
   def findClassFile(className: String): Option[AbstractFile] = {
     val relativePath = FileUtils.dirPath(className)
@@ -354,7 +354,7 @@ case class DirectorySourcePath(dir: File) extends JFileDirectoryLookup[SourceFil
   protected def createFileEntry(file: AbstractFile): SourceFileEntryImpl = SourceFileEntryImpl(file)
   protected def isMatchingFile(f: File, siblingExists: String => Boolean): Boolean = endsScalaOrJava(f.getName)
 
-  override def findClass(className: String): Option[ClassRepresentation] = findSourceFile(className) map SourceFileEntryImpl
+  override def findClass(className: String): Option[ClassRepresentation] = findSourceFile(className).map(SourceFileEntryImpl(_))
 
   private def findSourceFile(className: String): Option[AbstractFile] = {
     val relativePath = FileUtils.dirPath(className)

--- a/src/compiler/scala/tools/nsc/classpath/VirtualDirectoryClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/VirtualDirectoryClassPath.scala
@@ -39,7 +39,7 @@ case class VirtualDirectoryClassPath(dir: VirtualDirectory) extends ClassPath wi
   // mimic the behavior of the old nsc.util.DirectoryClassPath
   def asURLs: Seq[URL] = Seq(new URI("file://_VIRTUAL_/" + dir.name).toURL)
   def asClassPathStrings: Seq[String] = Seq(dir.path)
-  override def findClass(className: String): Option[ClassRepresentation] = findClassFile(className) map ClassFileEntryImpl
+  override def findClass(className: String): Option[ClassRepresentation] = findClassFile(className).map(ClassFileEntryImpl(_))
 
   def findClassFile(className: String): Option[AbstractFile] = {
     val relativePath = FileUtils.dirPath(className) + ".class"

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -688,7 +688,7 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
   def conflictWarning: Option[String] = {
     @nowarn("cat=deprecation")
     def sourceFeatures: Option[String] =
-      Option.when(XsourceFeatures.value.nonEmpty && !isScala3)(s"${XsourceFeatures.name} requires -Xsource:3")
+      Option.when(XsourceFeatures.value.nonEmpty && !isScala3)(s"${XsourceFeatures.name} requires -Xsource:3 when enabling ${XsourceFeatures.value.mkString(" ,")}")
 
     List(sourceFeatures).flatten match {
       case Nil => None

--- a/src/compiler/scala/tools/nsc/tasty/TreeUnpickler.scala
+++ b/src/compiler/scala/tools/nsc/tasty/TreeUnpickler.scala
@@ -296,31 +296,31 @@ class TreeUnpickler[Tasty <: TastyUniverse](
 
     def readConstant(tag: Int)(implicit ctx: Context): Constant = (tag: @switch) match {
       case UNITconst =>
-        tpd.Constant(())
+        tpd.outline.Constant(())
       case TRUEconst =>
-        tpd.Constant(true)
+        tpd.outline.Constant(true)
       case FALSEconst =>
-        tpd.Constant(false)
+        tpd.outline.Constant(false)
       case BYTEconst =>
-        tpd.Constant(readInt().toByte)
+        tpd.outline.Constant(readInt().toByte)
       case SHORTconst =>
-        tpd.Constant(readInt().toShort)
+        tpd.outline.Constant(readInt().toShort)
       case CHARconst =>
-        tpd.Constant(readNat().toChar)
+        tpd.outline.Constant(readNat().toChar)
       case INTconst =>
-        tpd.Constant(readInt())
+        tpd.outline.Constant(readInt())
       case LONGconst =>
-        tpd.Constant(readLongInt())
+        tpd.outline.Constant(readLongInt())
       case FLOATconst =>
-        tpd.Constant(java.lang.Float.intBitsToFloat(readInt()))
+        tpd.outline.Constant(java.lang.Float.intBitsToFloat(readInt()))
       case DOUBLEconst =>
-        tpd.Constant(java.lang.Double.longBitsToDouble(readLongInt()))
+        tpd.outline.Constant(java.lang.Double.longBitsToDouble(readLongInt()))
       case STRINGconst =>
-        tpd.Constant(readTastyName().asSimpleName.raw)
+        tpd.outline.Constant(readTastyName().asSimpleName.raw)
       case NULLconst =>
-        tpd.Constant(null)
+        tpd.outline.Constant(null)
       case CLASSconst =>
-        tpd.Constant(readType())
+        tpd.outline.Constant(readType())
     }
 
     /** Read a type */
@@ -877,7 +877,7 @@ class TreeUnpickler[Tasty <: TastyUniverse](
             ctx.completeEnumSingleton(sym, tpe)
             defn.NamedType(sym.owner.thisPrefix, sym.objectImplementation)
           }
-          else if (ctx.isJava && repr.tflags.is(FlagSets.JavaEnumCase)) defn.ConstantType(tpd.Constant(sym))
+          else if (ctx.isJava && repr.tflags.is(FlagSets.JavaEnumCase)) defn.ConstantType(tpd.outline.Constant(sym))
           else if (!ctx.isJava && sym.isFinal && isConstantType(tpe)) defn.InlineExprType(tpe)
           else if (sym.isMethod) defn.ExprType(tpe)
           else tpe
@@ -1120,7 +1120,7 @@ class TreeUnpickler[Tasty <: TastyUniverse](
         completeSelect(name)
 
       def completeSelect(name: TastyName)(implicit ctx: Context): Tree =
-        tpd.Select(readTerm(), name)
+        tpd.outline.Select(readTerm(), name)
 
       def completeSelectionParent(name: TastyName)(implicit ctx: Context): Tree = {
         assert(name.isSignedConstructor, s"Parent of ${ctx.owner} is not a constructor.")
@@ -1129,19 +1129,19 @@ class TreeUnpickler[Tasty <: TastyUniverse](
 
       def readSimpleTerm(): Tree = tag match {
         case SHAREDterm => forkAt(readAddr()).readTerm()
-        case IDENT => tpd.Ident(readTastyName())(readType())
-        case IDENTtpt => tpd.Ident(readTastyName().toTypeName)(readType())
+        case IDENT => tpd.outline.Ident(readTastyName())(readType())
+        case IDENTtpt => tpd.outline.Ident(readTastyName().toTypeName)(readType())
         case SELECT =>
           if (inParentCtor) completeSelectionParent(readTastyName())
           else completeSelect(readTastyName())
         case SELECTtpt => completeSelectType(readTastyName().toTypeName)
         case QUALTHIS =>
           val (qual, tref) = readQualId()
-          tpd.This(qual)(tref)
-        case NEW => tpd.New(readTpt())
-        case SINGLETONtpt => tpd.SingletonTypeTree(readTerm())
-        case BYNAMEtpt => tpd.ByNameTypeTree(readTpt())
-        case NAMEDARG => tpd.NamedArg(readTastyName(), readTerm())
+          tpd.outline.This(qual)(tref)
+        case NEW => tpd.outline.New(readTpt())
+        case SINGLETONtpt => tpd.outline.SingletonTypeTree(readTerm())
+        case BYNAMEtpt => tpd.outline.ByNameTypeTree(readTpt())
+        case NAMEDARG => tpd.outline.NamedArg(readTastyName(), readTerm())
         case THROW => unsupportedTermTreeError("throw clause")
         case _     => readPathTerm()
       }
@@ -1243,7 +1243,7 @@ class TreeUnpickler[Tasty <: TastyUniverse](
             case HOLE          => abortMacroHole
             case _             => readPathTerm()
           }
-        assert(currentAddr === end, s"$start $currentAddr $end ${astTagToString(tag)}")
+        assertOutline(currentAddr === end, s"$start $currentAddr $end ${astTagToString(tag)}")
         result
       }
 
@@ -1264,7 +1264,7 @@ class TreeUnpickler[Tasty <: TastyUniverse](
           if (isTypeTreeTag(tag)) readTerm()(ctx.retractMode(OuterTerm))
           else {
             val tp = readType()
-            if (isTypeType(tp)) tpd.TypeTree(tp) else untpd.EmptyTree
+            if (isTypeType(tp)) tpd.outline.TypeTree(tp) else untpd.EmptyTree
           }
       }
       tpt

--- a/src/compiler/scala/tools/nsc/tasty/bridge/ContextOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/ContextOps.scala
@@ -77,6 +77,8 @@ trait ContextOps { self: TastyUniverse =>
     ???
   }
 
+  def assertOutline(assertion: Boolean, msg: => Any): Unit = u.assert(assertion, msg)
+
   @inline final def assert(assertion: Boolean, msg: => Any): Unit =
     u.assert(assertion, msg)
 

--- a/src/compiler/scala/tools/nsc/tasty/bridge/TreeOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/TreeOps.scala
@@ -10,9 +10,10 @@
  * additional information regarding copyright ownership.
  */
 
-package scala.tools.nsc.tasty.bridge
+package scala.tools.nsc.tasty
+package bridge
 
-import scala.tools.nsc.tasty.{TastyUniverse, TastyModes}, TastyModes._
+import TastyModes._
 
 import scala.tools.tasty.TastyName
 import scala.reflect.internal.Flags
@@ -49,6 +50,22 @@ trait TreeOps { self: TastyUniverse =>
   }
 
   object tpd {
+
+    // not inline due to outer pointer; optimizer warns on uninlined calls into tpd
+    object outline {
+      final def Constant(value: Any): Constant = tpd.Constant(value)
+      final def Ident(name: TastyName)(tpe: Type): Tree = tpd.Ident(name)(tpe)
+      final def Select(qual: Tree, name: TastyName)(implicit ctx: Context): Tree = tpd.Select(qual, name)
+      final def Select(owner: Type)(qual: Tree, name: TastyName)(implicit ctx: Context): Tree =
+        tpd.Select(owner)(qual, name)
+      final def This(qual: TastyName.TypeName)(tpe: Type): Tree = tpd.This(qual)(tpe)
+      final def New(tpt: Tree): Tree = tpd.New(tpt)
+      final def SingletonTypeTree(ref: Tree): Tree = tpd.SingletonTypeTree(ref)
+      final def ByNameTypeTree(arg: Tree): Tree = tpd.ByNameTypeTree(arg)
+      final def NamedArg(name: TastyName, value: Tree): Tree = tpd.NamedArg(name, value)
+      final def TypeTree(tp: Type): Tree = tpd.TypeTree(tp)
+      final def Apply(fun: Tree, args: List[Tree]): Tree = tpd.Apply(fun, args)
+    }
 
     @inline final def Constant(value: Any): Constant =
       u.Constant(value)

--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -876,7 +876,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
       sClass
     }
 
-    val decls1 = clazz.info.decls.toList flatMap { m: Symbol =>
+    val decls1 = clazz.info.decls.toList flatMap { (m: Symbol) =>
       if (m.isAnonymousClass) List(m) else {
         normalizeMember(m.owner, m, outerEnv) flatMap { normalizedMember =>
           val ms = specializeMember(m.owner, normalizedMember, outerEnv, clazz.info.typeParams)
@@ -1800,7 +1800,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
             case SpecialOverload(original, env) =>
               debuglog("completing specialized " + symbol.fullName + " calling " + original)
               debuglog("special overload " + original + " -> " + env)
-              val t = DefDef(symbol, { vparamss: List[List[Symbol]] =>
+              val t = DefDef(symbol, { (vparamss: List[List[Symbol]]) =>
                 val fun = Apply(Select(This(symbol.owner), original),
                                 makeArguments(original, vparamss.head))
 

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -407,7 +407,7 @@ trait MatchApproximation extends TreeAndTypeAnalysis with ScalaLogic with MatchT
       val fullRewrite      = (irrefutableExtractor orElse rewriteListPattern)
       val refutableRewrite = irrefutableExtractor
 
-      @inline def onUnknown(handler: TreeMaker => Prop) = new TreeMakerToProp {
+      @inline final def onUnknown(handler: TreeMaker => Prop) = new TreeMakerToProp {
         def handleUnknown(tm: TreeMaker) = handler(tm)
       }
 
@@ -866,23 +866,25 @@ trait MatchAnalysis extends MatchApproximation {
                 }
 
                 cls match {
-                  case ConsClass                                =>
+                  case ConsClass =>
                     args().map {
                       case List(NoExample, l: ListExample) =>
                         // special case for neg/t7020.scala:
                         // if we find a counter example `??::*` we report `*::*` instead
                         // since the `??` originates from uniqueEqualTo containing several instanced of the same type
                         List(WildcardExample, l)
-                      case args                            => args
-                    }.map(ListExample)
-                  case _ if isTupleSymbol(cls)                  => args(brevity = true).map(TupleExample)
+                      case args => args
+                    }.map(ListExample(_))
+                  case _ if isTupleSymbol(cls) =>
+                    args(brevity = true).map(TupleExample(_))
                   case _ if cls.isSealed && (cls.isAbstractClass || cls.hasJavaEnumFlag) =>
                     // don't report sealed abstract classes, since
                     // 1) they can't be instantiated
                     // 2) we are already reporting any missing subclass (since we know the full domain)
                     // (see patmatexhaust.scala)
                     None
-                  case _                                        => args().map(ConstructorExample(cls, _))
+                  case _ =>
+                    args().map(ConstructorExample(cls, _))
                 }
 
               // a definite assignment to a type

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
@@ -259,7 +259,7 @@ trait MatchTranslation {
           val exSym = freshSym(pos, ThrowableTpe, "ex")
           val suppression =
             if (settings.XnoPatmatAnalysis.value) Suppression.FullSuppression
-            else Suppression.NoSuppression.copy(suppressExhaustive = true) // try/catches needn't be exhaustive
+            else Suppression.NoSuppression.suppressingExhaustive // try/catches needn't be exhaustive
 
           val combo = combineCases(REF(exSym), scrutSym, cases, pt, selectorPos, matchOwner, Some(_ => Throw(REF(exSym))), suppression)
           List(atPos(casesPos) {

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
@@ -24,7 +24,9 @@ import scala.tools.nsc.Reporting.WarningCategory
 trait MatchTreeMaking extends MatchCodeGen with Debugging {
   import global._, definitions._, CODE._
 
-  final case class Suppression private (suppressExhaustive: Boolean, suppressUnreachable: Boolean)
+  final case class Suppression private[MatchTreeMaking] (suppressExhaustive: Boolean, suppressUnreachable: Boolean) {
+    def suppressingExhaustive: Suppression = copy(suppressExhaustive = true)
+  }
   object Suppression {
     val NoSuppression = new Suppression(suppressExhaustive=false, suppressUnreachable=false)
     val FullSuppression = new Suppression(suppressExhaustive=true, suppressUnreachable=true)

--- a/src/compiler/scala/tools/nsc/transform/patmat/Solving.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Solving.scala
@@ -553,7 +553,7 @@ trait Solving extends Logic {
               neg.clear()
               for (clause <- clauses) {
                 if (clause != null) {
-                  clause.foreach { lit: Lit =>
+                  clause.foreach { (lit: Lit) =>
                     if (lit.positive) pos.set(lit.variable) else neg.set(lit.variable)
                   }
                 }

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1522,7 +1522,7 @@ trait Namers extends MethodSynthesis {
         if (vparam.mods.hasDefault) {
           val name = nme.defaultGetterName(meth.name, posCounter)
 
-          search.createAndEnter { owner: Symbol =>
+          search.createAndEnter { (owner: Symbol) =>
             methOwner.resetFlag(INTERFACE) // there's a concrete member now
             val default = owner.newMethodSymbol(name, vparam.pos, paramFlagsToDefaultGetter(meth.flags))
             default.setPrivateWithin(meth.privateWithin)

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3348,7 +3348,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     def typedStats(stats: List[Tree], exprOwner: Symbol): List[Tree] = {
       val inBlock = exprOwner == context.owner
       def includesTargetPos(tree: Tree) =
-        tree.pos.isRange && context.unit.exists && (tree.pos includes context.unit.targetPos)
+        tree.pos.isRange && context.unit.exists && tree.pos.includes(context.unit.targetPos)
       val localTarget = stats exists includesTargetPos
       def typedStat(stat: Tree): Tree = stat match {
         case s if context.owner.isRefinementClass && !treeInfo.isDeclarationOrTypeDef(s) => OnlyDeclarationsError(s)

--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -251,7 +251,7 @@ final class PathResolver(settings: Settings, closeableRegistry: CloseableRegistr
      * TODO: we should refactor this as a separate -bootstrap option to have a clean implementation, no? */
     def sourcePath          = if (!settings.isScaladoc) cmdLineOrElse("sourcepath", Defaults.scalaSourcePath) else ""
 
-    def userClassPath = settings.classpath.value  // default is specified by settings and can be overridden there
+    def userClassPath: String = settings.classpath.value  // default is specified by settings and can be overridden there
 
     import classPathFactory._
 

--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -16,16 +16,14 @@ package interactive
 import java.io.{FileReader, FileWriter}
 import java.util.concurrent.ConcurrentHashMap
 
-import scala.annotation.{elidable, nowarn, tailrec}
-import scala.collection.mutable
-import scala.collection.mutable.{HashSet, LinkedHashMap}
+import scala.annotation._
+import scala.collection.mutable, mutable.{HashSet, LinkedHashMap}
 import scala.jdk.javaapi.CollectionConverters
 import scala.language.implicitConversions
 import scala.reflect.internal.util.SourceFile
 import scala.tools.nsc.io.AbstractFile
 import scala.tools.nsc.reporters.Reporter
-import scala.tools.nsc.symtab.Flags.{ACCESSOR, PARAMACCESSOR}
-import scala.tools.nsc.symtab._
+import scala.tools.nsc.symtab._, Flags.{ACCESSOR, PARAMACCESSOR}
 import scala.tools.nsc.typechecker.{Analyzer, Typers}
 import scala.util.control.Breaks._
 import scala.util.control.ControlThrowable
@@ -536,12 +534,9 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
    *
    *  Compiler initialization may happen on a different thread (signalled by globalPhase being NoPhase)
    */
-  @elidable(elidable.WARNING)
-  override def assertCorrectThread(): Unit = {
+  override def assertCorrectThread(): Unit =
     assert(initializing || anyThread || onCompilerThread,
-        "Race condition detected: You are running a presentation compiler method outside the PC thread.[phase: %s]".format(globalPhase) +
-        " Please file a ticket with the current stack trace at https://www.assembla.com/spaces/scala-ide/support/tickets")
-  }
+      s"Race condition detected: You are running a presentation compiler method outside the PC thread.[phase: $globalPhase]")
 
   /** Create a new presentation compiler runner.
    */

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -979,9 +979,9 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
 object Iterator extends IterableFactory[Iterator] {
 
   private[this] val _empty: Iterator[Nothing] = new AbstractIterator[Nothing] {
-    def hasNext = false
-    def next() = throw new NoSuchElementException("next on empty iterator")
-    override def knownSize: Int = 0
+    override def hasNext = false
+    override def next() = throw new NoSuchElementException("next on empty iterator")
+    override def knownSize = 0
     override protected def sliceIterator(from: Int, until: Int): AbstractIterator[Nothing] = this
   }
 

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -2381,7 +2381,7 @@ private[immutable] final class HashMapBuilder[K, V] extends ReusableBuilder[(K, 
             currentValueCursor += 1
           }
 
-          override def next() = Iterator.empty.next()
+          override def next(): Nothing = Iterator.empty.next()
         }
       case hm: collection.mutable.HashMap[K, V] =>
         val iter = hm.nodeIterator

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -2092,7 +2092,7 @@ private[collection] final class HashSetBuilder[A] extends ReusableBuilder[A, Has
             )
             currentValueCursor += 1
           }
-          override def next() = Iterator.empty.next()
+          override def next(): Nothing = Iterator.empty.next()
         }
       case other =>
         val it = other.iterator

--- a/src/library/scala/collection/mutable/ArrayDeque.scala
+++ b/src/library/scala/collection/mutable/ArrayDeque.scala
@@ -20,22 +20,22 @@ import scala.collection.generic.{CommonErrors, DefaultSerializable}
 import scala.reflect.ClassTag
 
 /** An implementation of a double-ended queue that internally uses a resizable circular buffer.
-  *
-  *  Append, prepend, removeHead, removeLast and random-access (indexed-lookup and indexed-replacement)
-  *  take amortized constant time. In general, removals and insertions at i-th index are O(min(i, n-i))
-  *  and thus insertions and removals from end/beginning are fast.
-  *
-  *  @note Subclasses ''must'' override the `ofArray` protected method to return a more specific type.
-  *
-  *  @tparam A  the type of this ArrayDeque's elements.
-  *
-  *  @define Coll `mutable.ArrayDeque`
-  *  @define coll array deque
-  *  @define orderDependent
-  *  @define orderDependentFold
-  *  @define mayNotTerminateInf
-  *  @define willNotTerminateInf
-  */
+ *
+ *  Append, prepend, removeHead, removeLast and random-access (indexed-lookup and indexed-replacement)
+ *  take amortized constant time. In general, removals and insertions at i-th index are O(min(i, n-i))
+ *  and thus insertions and removals from end/beginning are fast.
+ *
+ *  @note Subclasses ''must'' override the `ofArray` protected method to return a more specific type.
+ *
+ *  @tparam A  the type of this ArrayDeque's elements.
+ *
+ *  @define Coll `mutable.ArrayDeque`
+ *  @define coll array deque
+ *  @define orderDependent
+ *  @define orderDependentFold
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
 class ArrayDeque[A] protected (
     protected var array: Array[AnyRef],
     private[ArrayDeque] var start: Int,
@@ -87,13 +87,13 @@ class ArrayDeque[A] protected (
     prependAssumingCapacity(elem)
   }
 
-  @inline private[ArrayDeque] def appendAssumingCapacity(elem: A): this.type = {
+  @inline private[ArrayDeque] final def appendAssumingCapacity(elem: A): this.type = {
     array(end) = elem.asInstanceOf[AnyRef]
     end = end_+(1)
     this
   }
 
-  @inline private[ArrayDeque] def prependAssumingCapacity(elem: A): this.type = {
+  @inline private[ArrayDeque] final def prependAssumingCapacity(elem: A): this.type = {
     start = start_-(1)
     array(start) = elem.asInstanceOf[AnyRef]
     this
@@ -331,7 +331,7 @@ class ArrayDeque[A] protected (
   def removeLast(resizeInternalRepr: Boolean = false): A =
     if (isEmpty) throw new NoSuchElementException(s"empty collection") else removeLastAssumingNonEmpty(resizeInternalRepr)
 
-  @`inline` private[this] def removeLastAssumingNonEmpty(resizeInternalRepr: Boolean = false): A = {
+  @inline private[this] def removeLastAssumingNonEmpty(resizeInternalRepr: Boolean = false): A = {
     end = end_-(1)
     val elem = array(end)
     array(end) = null
@@ -430,7 +430,7 @@ class ArrayDeque[A] protected (
     res.result()
   }
 
-  @inline def ensureSize(hint: Int) = if (hint > length && mustGrow(hint)) resize(hint)
+  @inline final def ensureSize(hint: Int) = if (hint > length && mustGrow(hint)) resize(hint)
 
   def length = end_-(start)
 
@@ -481,35 +481,29 @@ class ArrayDeque[A] protected (
   def trimToSize(): Unit = resize(length)
 
   // Utils for common modular arithmetic:
-  @inline protected def start_+(idx: Int) = (start + idx) & (array.length - 1)
+  @inline protected final def start_+(idx: Int) = (start + idx) & (array.length - 1)
   @inline private[this] def start_-(idx: Int) = (start - idx) & (array.length - 1)
   @inline private[this] def end_+(idx: Int) = (end + idx) & (array.length - 1)
   @inline private[this] def end_-(idx: Int) = (end - idx) & (array.length - 1)
 
   // Note: here be overflow dragons! This is used for int overflow
   // assumptions in resize(). Use caution changing.
-  @inline private[this] def mustGrow(len: Int) = {
-    len >= array.length
-  }
+  @inline private[this] def mustGrow(len: Int) = len >= array.length
 
   // Assumes that 0 <= len < array.length!
-  @inline private[this] def shouldShrink(len: Int) = {
-    // To avoid allocation churn, only shrink when array is large
-    // and less than 2/5 filled.
-    array.length > ArrayDeque.StableSize && array.length - len - (len >> 1) > len
-  }
+  // To avoid allocation churn, only shrink when array is large
+  // and less than 2/5 filled.
+  @inline private[this] def shouldShrink(len: Int) = array.length > ArrayDeque.StableSize && array.length - len - (len >> 1) > len
 
   // Assumes that 0 <= len < array.length!
-  @inline private[this] def canShrink(len: Int) = {
-    array.length > ArrayDeque.DefaultInitialSize && array.length - len > len
-  }
+  @inline private[this] def canShrink(len: Int) = array.length > ArrayDeque.DefaultInitialSize && array.length - len > len
 
   @inline private[this] def _get(idx: Int): A = array(start_+(idx)).asInstanceOf[A]
 
   @inline private[this] def _set(idx: Int, elem: A) = array(start_+(idx)) = elem.asInstanceOf[AnyRef]
 
   // Assumes that 0 <= len.
-  private[this] def resize(len: Int) = if (mustGrow(len) || canShrink(len)) {
+  private[this] final def resize(len: Int) = if (mustGrow(len) || canShrink(len)) {
     val n = length
     val array2 = copySliceToArray(srcStart = 0, dest = ArrayDeque.alloc(len), destStart = 0, maxItems = n)
     reset(array = array2, start = 0, end = n)

--- a/src/library/scala/collection/mutable/HashMap.scala
+++ b/src/library/scala/collection/mutable/HashMap.scala
@@ -60,10 +60,10 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
   override def size: Int = contentSize
 
   /** Performs the inverse operation of improveHash. In this case, it happens to be identical to improveHash*/
-  @`inline` private[collection] def unimproveHash(improvedHash: Int): Int = improveHash(improvedHash)
+  @inline private[collection] final def unimproveHash(improvedHash: Int): Int = improveHash(improvedHash)
 
   /** Computes the improved hash of an original (`any.##`) hash. */
-  @`inline` private[this] def improveHash(originalHash: Int): Int = {
+  @inline private[this] def improveHash(originalHash: Int): Int = {
     // Improve the hash by xoring the high 16 bits into the low 16 bits just in case entropy is skewed towards the
     // high-value bits. We only use the lowest bits to determine the hash bucket. This is the same improvement
     // algorithm as in java.util.HashMap.
@@ -75,13 +75,13 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
   }
 
   /** Computes the improved hash of this key */
-  @`inline` private[this] def computeHash(o: K): Int = improveHash(o.##)
+  @inline private[this] def computeHash(o: K): Int = improveHash(o.##)
 
-  @`inline` private[this] def index(hash: Int) = hash & (table.length - 1)
+  @inline private[this] def index(hash: Int) = hash & (table.length - 1)
 
   override def contains(key: K): Boolean = findNode(key) ne null
 
-  @`inline` private[this] def findNode(key: K): Node[K, V] = {
+  @inline private[this] def findNode(key: K): Node[K, V] = {
     val hash = computeHash(key)
     table(index(hash)) match {
       case null => null

--- a/src/library/scala/collection/mutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/mutable/LinkedHashMap.scala
@@ -187,17 +187,17 @@ class LinkedHashMap[K, V]
   }
 
   /** Computes the improved hash of an original (`any.##`) hash. */
-  @`inline` private[this] def improveHash(originalHash: Int): Int = {
+  @inline private[this] def improveHash(originalHash: Int): Int = {
     originalHash ^ (originalHash >>> 16)
   }
-  @`inline` private[collection] def unimproveHash(improvedHash: Int): Int = improveHash(improvedHash)
+  @inline private[collection] final def unimproveHash(improvedHash: Int): Int = improveHash(improvedHash)
 
   /** Computes the improved hash of this key */
-  @`inline` private[this] def computeHash(o: K): Int = improveHash(o.##)
+  @inline private[this] def computeHash(o: K): Int = improveHash(o.##)
 
-  @`inline` private[this] def index(hash: Int) = hash & (table.length - 1)
+  @inline private[this] def index(hash: Int) = hash & (table.length - 1)
 
-  @`inline` private[this] def findEntry(key: K): Entry = {
+  @inline private[this] def findEntry(key: K): Entry = {
     val hash = computeHash(key)
     table(index(hash)) match {
       case null => null

--- a/src/library/scala/collection/mutable/LinkedHashSet.scala
+++ b/src/library/scala/collection/mutable/LinkedHashSet.scala
@@ -142,18 +142,18 @@ class LinkedHashSet[A]
 
   private[this] def newThreshold(size: Int) = (size.toDouble * LinkedHashSet.defaultLoadFactor).toInt
 
-  @`inline` private[this] def improveHash(originalHash: Int): Int = {
+  @inline private[this] def improveHash(originalHash: Int): Int = {
     originalHash ^ (originalHash >>> 16)
   }
 
-  @`inline` private[collection] def unimproveHash(improvedHash: Int): Int = improveHash(improvedHash)
+  @inline private[collection] final def unimproveHash(improvedHash: Int): Int = improveHash(improvedHash)
 
   /** Computes the improved hash of this key */
-  @`inline` private[this] def computeHash(o: A): Int = improveHash(o.##)
+  @inline private[this] def computeHash(o: A): Int = improveHash(o.##)
 
-  @`inline` private[this] def index(hash: Int) = hash & (table.length - 1)
+  @inline private[this] def index(hash: Int) = hash & (table.length - 1)
 
-  @`inline` private[this] def findEntry(key: A): Entry = {
+  @inline private[this] def findEntry(key: A): Entry = {
     val hash = computeHash(key)
     table(index(hash)) match {
       case null => null

--- a/src/library/scala/concurrent/duration/Deadline.scala
+++ b/src/library/scala/concurrent/duration/Deadline.scala
@@ -12,29 +12,33 @@
 
 package scala.concurrent.duration
 
-/**
- * This class stores a deadline, as obtained via `Deadline.now` or the
- * duration DSL:
+import annotation.nowarn
+
+/** A deadline, as a duration of time remaining, calculated from the present.
  *
- * {{{
- * import scala.concurrent.duration._
- * 3.seconds.fromNow
- * }}}
+ *  Deadlines are obtained via `Deadline.now` or the duration DSL:
  *
- * Its main purpose is to manage repeated attempts to achieve something (like
- * awaiting a condition) by offering the methods `hasTimeLeft` and `timeLeft`.  All
- * durations are measured according to `System.nanoTime`; this
- * does not take into account changes to the system clock (such as leap
- * seconds).
+ *  {{{
+ *  import scala.concurrent.duration._
+ *  3.seconds.fromNow
+ *  }}}
+ *
+ *  The purpose of a deadline is to support managed repeated attempts,
+ *  such as when awaiting a condition, by offering the methods `hasTimeLeft` and `timeLeft`.
+ *
+ *  All durations are measured according to `System.nanoTime`;
+ *  this does not take into account changes to the system clock, such as leap seconds.
  */
 case class Deadline private (time: FiniteDuration) extends Ordered[Deadline] {
   /**
    * Return a deadline advanced (i.e., moved into the future) by the given duration.
    */
+  @nowarn("cat=deprecation")
   def +(other: FiniteDuration): Deadline = copy(time = time + other)
   /**
    * Return a deadline moved backwards (i.e., towards the past) by the given duration.
    */
+  @nowarn("cat=deprecation")
   def -(other: FiniteDuration): Deadline = copy(time = time - other)
   /**
    * Calculate time difference between this and the other deadline, where the result is directed (i.e., may be negative).
@@ -65,6 +69,10 @@ case class Deadline private (time: FiniteDuration) extends Ordered[Deadline] {
    * The natural ordering for deadline is determined by the natural order of the underlying (finite) duration.
    */
   def compare(other: Deadline): Int = time compare other.time
+
+  // expose public copy for backward compatibility under -Xsource:3
+  @deprecated("use now or FiniteDuration#fromNow", since="2.13.13")
+  def copy(time: FiniteDuration = this.time): Deadline = Deadline(time)
 }
 
 object Deadline {
@@ -73,6 +81,7 @@ object Deadline {
    * advancing it to obtain a future deadline, or for sampling the current time exactly once and
    * then comparing it to multiple deadlines (using subtraction).
    */
+  @nowarn("cat=deprecation")
   def now: Deadline = Deadline(Duration(System.nanoTime, NANOSECONDS))
 
   /**
@@ -82,4 +91,7 @@ object Deadline {
     def compare(a: Deadline, b: Deadline): Int = a compare b
   }
 
+  // expose public apply for backward compatibility under -Xsource:3
+  @deprecated("use now or FiniteDuration#fromNow", since="2.13.13")
+  def apply(time: FiniteDuration): Deadline = new Deadline(time)
 }

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -677,10 +677,11 @@ trait Definitions extends api.StandardDefinitions {
     // A unit test checks these are kept in synch with the library.
     val MaxTupleAritySpecialized, MaxProductAritySpecialized, MaxFunctionAritySpecialized = 2
 
-    lazy val ProductClass          = new VarArityClass("Product", MaxProductArity, countFrom = 1, init = Some(UnitClass))
-    lazy val TupleClass            = new VarArityClass("Tuple", MaxTupleArity, countFrom = 1)
-    lazy val FunctionClass         = new VarArityClass("Function", MaxFunctionArity)
-    lazy val AbstractFunctionClass = new VarArityClass("runtime.AbstractFunction", MaxFunctionArity)
+    lazy val ProductClass: VarArityClass =
+      new VarArityClass("Product", MaxProductArity, countFrom = 1, init = Some(UnitClass))
+    lazy val TupleClass: VarArityClass            = new VarArityClass("Tuple", MaxTupleArity, countFrom = 1)
+    lazy val FunctionClass: VarArityClass         = new VarArityClass("Function", MaxFunctionArity)
+    lazy val AbstractFunctionClass: VarArityClass = new VarArityClass("runtime.AbstractFunction", MaxFunctionArity)
 
     /** Creators for TupleN, ProductN, FunctionN. */
     def tupleType(elems: List[Type])                            = TupleClass.specificType(elems)

--- a/src/reflect/scala/reflect/internal/Positions.scala
+++ b/src/reflect/scala/reflect/internal/Positions.scala
@@ -14,7 +14,7 @@ package scala
 package reflect
 package internal
 
-import util._
+import util.{Position => UPos, NoPosition => UNoPos, _}
 
 /** Handling range positions
  *  atPos, the main method in this trait, will add positions to a tree,
@@ -34,8 +34,9 @@ import util._
  *   Otherwise, the singleton consisting of the node itself.
  */
 trait Positions extends api.Positions { self: SymbolTable =>
-  type Position = scala.reflect.internal.util.Position
-  val NoPosition = scala.reflect.internal.util.NoPosition
+  type Position = UPos
+  private val Position: UPos.type = UPos
+  val NoPosition: UNoPos.type = UNoPos
   implicit val PositionTag: ClassTag[Position] = ClassTag[Position](classOf[Position])
 
   def useOffsetPositions: Boolean = true

--- a/src/reflect/scala/reflect/internal/Printers.scala
+++ b/src/reflect/scala/reflect/internal/Printers.scala
@@ -727,7 +727,7 @@ trait Printers extends api.Printers { self: SymbolTable =>
     override def printTParam(td: TypeDef): Unit = printTParam(td, primaryCtorParam = false)
 
     protected def printArgss(argss: List[List[Tree]]) =
-      argss foreach {x: List[Tree] => if (!(x.isEmpty && argss.size == 1)) printRow(x, "(", ", ", ")")}
+      argss.foreach(ps => if (!(ps.isEmpty && argss.size == 1)) printRow(ps, "(", ", ", ")"))
 
     override def printAnnotations(tree: MemberDef) = {
       val annots = tree.mods.annotations

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -16,7 +16,7 @@ package internal
 
 import java.net.URLClassLoader
 
-import scala.annotation.{elidable, nowarn, tailrec}
+import scala.annotation.nowarn
 import scala.collection.mutable
 import util._
 import java.util.concurrent.TimeUnit
@@ -202,8 +202,7 @@ abstract class SymbolTable extends macros.Universe
 
   /** Check that the executing thread is the compiler thread. No-op here,
    *  overridden in interactive.Global. */
-  @elidable(elidable.WARNING)
-  def assertCorrectThread(): Unit = {}
+  def assertCorrectThread(): Unit = ()
 
   /** A last effort if symbol in a select <owner>.<name> is not found.
    *  This is overridden by the reflection compiler to make up a package
@@ -328,7 +327,6 @@ abstract class SymbolTable extends macros.Universe
     }
 
   final def isValidForBaseClasses(period: Period): Boolean = {
-    @tailrec
     def noChangeInBaseClasses(it: InfoTransformer, limit: Phase#Id): Boolean = (
       it.pid >= limit ||
       !it.changesBaseClasses && noChangeInBaseClasses(it.next, limit)

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -3886,7 +3886,9 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
 
     private def phaseString = {
       val phase = phaseOf(validFrom)
-      s"$phase: ${exitingPhase(phase)(info.toString)}"
+      //s"$phase: ${exitingPhase(phase)(info.toString)}"
+      val s = exitingPhase(phase)(info.toString)
+      s"$phase: $s"
     }
     override def toString = toList.reverseIterator map (_.phaseString) mkString ", "
 

--- a/src/reflect/scala/reflect/internal/transform/UnCurry.scala
+++ b/src/reflect/scala/reflect/internal/transform/UnCurry.scala
@@ -101,7 +101,8 @@ trait UnCurry {
           // is anyway faster and safer
           for (decl <- decls if decl.annotations.exists(_.symbol == VarargsClass)) {
             if (mexists(decl.paramss)(sym => definitions.isRepeatedParamType(sym.tpe))) {
-              varargOverloads += varargForwarderSym(clazz, decl, exitingPhase(phase)(decl.info))
+              val declInfo = exitingPhase(phase)(decl.info)
+              varargOverloads += varargForwarderSym(clazz, decl, declInfo)
             }
           }
           if ((parents1 eq parents) && varargOverloads.isEmpty) tp

--- a/src/scaladoc/scala/tools/nsc/doc/ScaladocGlobal.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/ScaladocGlobal.scala
@@ -28,7 +28,7 @@ trait ScaladocGlobalTrait extends Global {
     super.newJavaUnitParser(unit)
   }
 
-  override lazy val syntaxAnalyzer = new ScaladocSyntaxAnalyzer[outer.type](outer) {
+  override lazy val syntaxAnalyzer: ScaladocSyntaxAnalyzer[outer.type] = new ScaladocSyntaxAnalyzer[outer.type](outer) {
     val runsAfter = List[String]()
     val runsRightAfter = None
     override val initial = true

--- a/src/scaladoc/scala/tools/nsc/doc/Settings.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/Settings.scala
@@ -277,7 +277,7 @@ class Settings(error: String => Unit, val printMsg: String => Unit = println(_),
 
   lazy val hiddenImplicits: Set[String] = {
     if (docImplicitsHide.value.isEmpty) hardcoded.commonConversionTargets
-    else docImplicitsHide.value.toSet flatMap { name: String =>
+    else docImplicitsHide.value.toSet flatMap { (name: String) =>
       if(name == ".") hardcoded.commonConversionTargets
       else Set(name)
     }

--- a/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
@@ -466,7 +466,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
     /** listStyle ::= '-' spc | '1.' spc | 'I.' spc | 'i.' spc | 'A.' spc | 'a.' spc
       * Characters used to build lists and their constructors */
     protected val listStyles = Map[String, Seq[Block] => Block]( // TODO Should this be defined at some list companion?
-      "- "  -> UnorderedList,
+      "- "  -> ( UnorderedList(_) ),
       "1. " -> ( OrderedList(_,"decimal") ),
       "I. " -> ( OrderedList(_,"upperRoman") ),
       "i. " -> ( OrderedList(_,"lowerRoman") ),

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
@@ -97,7 +97,7 @@ trait EntityPage extends HtmlPage {
                         Li(`class`= s"current-entities indented$indentation", elems =
                           (mbr match {
                             case dtpl: DocTemplateEntity =>
-                              dtpl.companion.fold(Span(`class`= "separator"): Elem) { c: DocTemplateEntity =>
+                              dtpl.companion.fold(Span(`class`= "separator"): Elem) { (c: DocTemplateEntity) =>
                                 A(`class`= "object", href=relativeLinkTo(c), title= memberToShortCommentTitleTag(c))
                               }
                             case _                       => Span(`class`= "separator")

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/IndexScript.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/IndexScript.scala
@@ -42,7 +42,7 @@ class IndexScript(universe: doc.Universe) extends Page {
            *  class/trait instance. Otherwise one of the member objects will be
            *  overwritten.
            */
-          val pairs = merged(key).flatMap { t: DocTemplateEntity =>
+          val pairs = merged(key).flatMap { (t: DocTemplateEntity) =>
             val kind = kindToString(t)
             Seq(
               kind -> relativeLinkTo(t),

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
@@ -54,7 +54,7 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
     val universe = new Universe { thisUniverse =>
       thisFactory.universe = thisUniverse
       val settings = thisFactory.settings
-      val rootPackage = modelCreation.createRootPackage
+      val rootPackage: PackageImpl = modelCreation.createRootPackage
     }
     _modelFinished = true
     // complete the links between model entities, everything that couldn't have been done before
@@ -132,7 +132,7 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
     lazy val comment = thisFactory.comment(commentCarryingSymbol(sym), linkTarget, inTpl)
 
     def group = comment flatMap (_.group) getOrElse defaultGroup
-    override def inTemplate = inTpl
+    override def inTemplate: DocTemplateImpl = inTpl
     override def toRoot: List[MemberImpl] = this :: inTpl.toRoot
     def inDefinitionTemplates =
         if (inTpl == null)
@@ -489,7 +489,7 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
   }
 
   abstract class PackageImpl(sym: Symbol, inTpl: PackageImpl) extends DocTemplateImpl(sym, inTpl) with Package {
-    override def inTemplate = inTpl
+    override def inTemplate: PackageImpl = inTpl
     override def toRoot: List[PackageImpl] = this :: inTpl.toRoot
     override def reprSymbol = sym.info.members.find (_.isPackageObject) getOrElse sym
 
@@ -690,7 +690,7 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
         Some(new RootPackageImpl(bSym) {
           override lazy val comment = createRootPackageComment
           override val name = "root"
-          override def inTemplate = this
+          override def inTemplate: RootPackageImpl = this
           override def toRoot = this :: Nil
           override def qualifiedName = "_root_"
           override def isRootPackage = true

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactoryImplicitSupport.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactoryImplicitSupport.scala
@@ -108,7 +108,7 @@ trait ModelFactoryImplicitSupport {
         .map(_.hideImplicitConversions.toSet)
         .getOrElse(Set.empty)
 
-      conversions = conversions filterNot { conv: ImplicitConversionImpl =>
+      conversions = conversions filterNot { (conv: ImplicitConversionImpl) =>
         hiddenConversions.contains(conv.conversionShortName) ||
         hiddenConversions.contains(conv.conversionQualifiedName)
       }

--- a/src/scalap/scala/tools/scalap/scalax/rules/Rule.scala
+++ b/src/scalap/scala/tools/scalap/scalax/rules/Rule.scala
@@ -42,7 +42,7 @@ trait Rule[-In, +Out, +A, +X] extends (In => Result[Out, A, X]) {
   def filter(f: A => Boolean) = flatMap { a => out => if(f(a)) Success(out, a) else Failure }
 
   def mapResult[Out2, B, Y](f: Result[Out, A, X] => Result[Out2, B, Y]) = rule {
-    in: In => f(apply(in))
+    (in: In) => f(apply(in))
   }
 
   def orElse[In2 <: In, Out2 >: Out, A2 >: A, X2 >: X](other: => Rule[In2, Out2, A2, X2]): Rule[In2, Out2, A2, X2] = new Choice[In2, Out2, A2, X2] {
@@ -164,7 +164,7 @@ trait Rule[-In, +Out, +A, +X] extends (In => Result[Out, A, X]) {
 
   /** ^-^(f) is equivalent to ^^ { b2 => b1 => f(b1, b2) }
    */
-  def ^-^ [B1, B2 >: A, C](f: (B1, B2) => C) = map { b2: B2 => b1: B1 => f(b1, b2) }
+  def ^-^ [B1, B2 >: A, C](f: (B1, B2) => C) = map { (b2: B2) => (b1: B1) => f(b1, b2) }
 
  /** ^~>~^(f) is equivalent to ^^ { case b2 ~ b3 => b1 => f(b1, b2, b3) }
   */

--- a/src/scalap/scala/tools/scalap/scalax/rules/Rules.scala
+++ b/src/scalap/scala/tools/scalap/scalax/rules/Rules.scala
@@ -45,12 +45,12 @@ trait Rules {
     val factory = Rules.this
   }
 
-  def success[Out, A](out: Out, a: A) = rule { in: Any => Success(out, a) }
+  def success[Out, A](out: Out, a: A) = rule { (in: Any) => Success(out, a) }
 
-  def failure = rule { in: Any => Failure }
+  def failure = rule { (in: Any) => Failure }
 
-  def error[In] = rule { in: In => Error(in) }
-  def error[X](err: X) = rule { in: Any => Error(err) }
+  def error[In] = rule { (in: In) => Error(in) }
+  def error[X](err: X) = rule { (in: Any) => Error(err) }
 
   def oneOf[In, Out, A, X](rules: Rule[In, Out, A, X] *): Rule[In, Out, A, X] = new Choice[In, Out, A, X] {
     val factory = Rules.this
@@ -120,7 +120,7 @@ trait StateRules {
         }
       }
     }
-    in: S => rep(in, rules.toList, Nil)
+    (in: S) => rep(in, rules.toList, Nil)
   }
 
 

--- a/src/scalap/scala/tools/scalap/scalax/rules/SeqRule.scala
+++ b/src/scalap/scala/tools/scalap/scalax/rules/SeqRule.scala
@@ -24,20 +24,20 @@ import scala.collection.immutable.ArraySeq
 class InRule[In, +Out, +A, +X](rule: Rule[In, Out, A, X]) {
 
   def mapRule[Out2, B, Y](f: Result[Out, A, X] => In => Result[Out2, B, Y]): Rule[In, Out2, B, Y] = rule.factory.rule {
-    in: In => f(rule(in))(in)
+    (in: In) => f(rule(in))(in)
   }
 
   /** Creates a rule that succeeds only if the original rule would fail on the given context. */
   def unary_! : Rule[In, In, Unit, Nothing] = mapRule {
-    case Success(_, _) => in: In => Failure
-    case _ => in: In => Success(in, ())
+    case Success(_, _) => (in: In) => Failure
+    case _ => (in: In) => Success(in, ())
   }
 
   /** Creates a rule that succeeds if the original rule succeeds, but returns the original input. */
   def & : Rule[In, In, A, X] = mapRule {
-    case Success(_, a) => in: In => Success(in, a)
-    case Failure => in: In => Failure
-    case Error(x) => in: In => Error(x)
+    case Success(_, a) => (in: In) => Success(in, a)
+    case Failure => (in: In) => Failure
+    case Error(x) => (in: In) => Error(x)
   }
 }
 
@@ -45,9 +45,9 @@ class SeqRule[S, +A, +X](rule: Rule[S, S, A, X]) {
   import rule.factory._
 
   def ? = rule mapRule {
-    case Success(out, a) => in: S => Success(out, Some(a))
-    case Failure => in: S => Success(in, None)
-    case Error(x) => in: S => Error(x)
+    case Success(out, a) => (in: S) => Success(out, Some(a))
+    case Failure => (in: S) => Success(in, None)
+    case Error(x) => (in: S) => Error(x)
   }
 
   /** Creates a rule that always succeeds with a Boolean value.

--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -372,8 +372,8 @@ class IteratorTest {
     assertEquals(-1, List(1, 2, 3, 4, 5).iterator.indexOf(16))
   }
   @Test def indexWhere(): Unit = {
-    assertEquals(3, List(1, 2, 3, 4, 5).iterator.indexWhere { x: Int => x >= 4 })
-    assertEquals(-1, List(1, 2, 3, 4, 5).iterator.indexWhere { x: Int => x >= 16 })
+    assertEquals(3, List(1, 2, 3, 4, 5).iterator.indexWhere { (x: Int) => x >= 4 })
+    assertEquals(-1, List(1, 2, 3, 4, 5).iterator.indexWhere { (x: Int) => x >= 16 })
   }
   @Test def indexOfFrom(): Unit = {
     assertEquals(1, List(1, 2, 3, 4, 5).iterator.indexOf(2, 0))

--- a/test/junit/scala/collection/immutable/HashSetTest.scala
+++ b/test/junit/scala/collection/immutable/HashSetTest.scala
@@ -335,10 +335,10 @@ class HashSetTest {
       subsetTest(HashSet.empty[Int], ListSet.empty[Int], identity, 100)
 
       // test the HashSet/HashSet case for Collision keys
-      subsetTest(HashSet.empty[Collision], HashSet.empty[Collision], Collision, 100)
+      subsetTest(HashSet.empty[Collision], HashSet.empty[Collision], Collision(_), 100)
 
       // test the HashSet/other set case for Collision keys
-      subsetTest(HashSet.empty[Collision], ListSet.empty[Collision], Collision, 100)
+      subsetTest(HashSet.empty[Collision], ListSet.empty[Collision], Collision(_), 100)
     }
 
     /**
@@ -355,8 +355,8 @@ class HashSetTest {
         }
       }
 
-      val a = HashSet.empty ++ (0 until 100).map(HashCodeCounter)
-      val b = HashSet.empty ++ (0 until 50).map(HashCodeCounter)
+      val a = HashSet.empty ++ (0 until 100).map(HashCodeCounter(_))
+      val b = HashSet.empty ++ (0 until 50).map(HashCodeCounter(_))
       val count0 = count
       val result = b.subsetOf(a)
       assertTrue("key.hashCode must not be called during subsetOf of two HashSets", count == count0)

--- a/test/junit/scala/lang/stringinterpol/StringContextTest.scala
+++ b/test/junit/scala/lang/stringinterpol/StringContextTest.scala
@@ -7,6 +7,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
+import scala.annotation._
 import scala.language.implicitConversions
 import scala.tools.testkit.AssertUtil._
 
@@ -80,12 +81,21 @@ class StringContextTest {
 
   @Test def t6631_baseline() = assertEquals("\f\r\n\t", s"""\f\r\n\t""")
 
-  // verifying that the standard interpolators can be supplanted
+  /* verifying that the standard interpolators can be usurped in Scala 2
   @Test def antiHijack_?() = {
     object AllYourStringsAreBelongToMe { case class StringContext(args: Any*) { def s(args: Any*) = "!!!!" } }
     import AllYourStringsAreBelongToMe._
     //assertEquals("????", s"????")
     assertEquals("!!!!", s"????") // OK to hijack core interpolator ids
+  }
+  */
+  // verifying that the standard interpolators cannot be usurped under -Xsource:3-cross
+  @nowarn("msg=Unused import")
+  @Test def `no custom s interpolator any more`: Unit = {
+    object AllYourStringsAreBelongToMe { case class StringContext(args: Any*) { def s(args: Any*) = "!!!!" } }
+    import AllYourStringsAreBelongToMe._
+    assertEquals("????", s"????")
+    //assertEquals("!!!!", s"????") // NOK to hijack core interpolator ids
   }
 
   @Test def fIf() = {
@@ -106,7 +116,7 @@ class StringContextTest {
     assertEquals(expected, res)
   }
 
-  @annotation.nowarn("msg=Boolean format is null test for non-Boolean")
+  @nowarn("msg=Boolean format is null test for non-Boolean")
   @Test def `non booleans as boolean`(): Unit = {
     assertEquals("false", f"${null}%b")
     assertEquals("FALSE", f"${null}%B")

--- a/test/junit/scala/reflect/internal/PositionsTest.scala
+++ b/test/junit/scala/reflect/internal/PositionsTest.scala
@@ -12,7 +12,7 @@ class PositionsTest {
 
   object symbolTable extends SymbolTableForUnitTesting {
     override def useOffsetPositions: Boolean = false
-    override val reporter = new StoreReporter(settings)
+    override val reporter: StoreReporter = new StoreReporter(settings)
   }
   import symbolTable._
 

--- a/test/junit/scala/reflect/internal/util/WeakHashSetTest.scala
+++ b/test/junit/scala/reflect/internal/util/WeakHashSetTest.scala
@@ -38,8 +38,8 @@ class WeakHashSetTest {
   @Test
   def checkPlusEqualsCollisions(): Unit = {
     val hs = new WeakHashSet[Collider]()
-    val elements = List("hello", "goodbye") map Collider
-    elements foreach (hs += _)
+    val elements = List("hello", "goodbye").map(Collider(_))
+    elements.foreach(hs += _)
     assertEquals(2, hs.size)
     assertTrue(hs contains Collider("hello"))
     assertTrue(hs contains Collider("goodbye"))

--- a/test/junit/scala/tools/nsc/classpath/AggregateClassPathTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/AggregateClassPathTest.scala
@@ -110,7 +110,9 @@ class AggregateClassPathTest {
   def testGettingPackages(): Unit = {
     case class ClassPathWithPackages(packagesInPackage: EntryNamesInPackage*) extends TestClassPathBase {
       override def packages(inPackage: PackageName): Seq[PackageEntry] =
-        packagesInPackage.find(_.inPackage == inPackage.dottedString).map(_.names).getOrElse(Nil) map PackageEntryImpl
+        packagesInPackage.find(_.inPackage == inPackage.dottedString)
+          .map(_.names).getOrElse(Nil)
+          .map(PackageEntryImpl(_))
     }
 
     val partialClassPaths = Seq(ClassPathWithPackages(EntryNamesInPackage(pkg1)("pkg1.a", "pkg1.d", "pkg1.f")),


### PR DESCRIPTION
Use `-Xsource:3-cross`, with the exclusion `-Xsource-features:-case-companion-function` in the library.

Stay on `-Xsource:2.13` for `scalap`.

The hardest part was the overrides in Scaladoc's `ModelFactory`.

What worked like a charm is:
```
sbt:scala2> set ThisBuild / scalacOptions += "-quickfix:msg=lambda-parens"
```
Previously:
> I will let mima complain. What is the mima command again?

I did a quick jardiff.