### PR TITLE
Skip exhaustiveness check on wildcard

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
@@ -96,7 +96,7 @@ trait MatchTranslation {
       private def typeTestStep(sub: Symbol, subPt: Type)     = step(TypeTestTreeMaker(sub, binder, subPt, subPt)(pos))()
       private def alternativesStep(alts: List[Tree])         = step(AlternativesTreeMaker(binder, translatedAlts(alts), alts.head.pos))()
       private def translatedAlts(alts: List[Tree])           = alts map (alt => rebindTo(alt).translate())
-      private def noStep()                                   = step()()
+      private def noStep()                                   = step(DummyTreeMaker)()
 
       private def unsupportedPatternMsg = sm"""
         |unsupported pattern: ${tree.shortClass} / $this (this is a scalac bug.)


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/12874

**Problem**
compiler could spend a long time checking for exhaustiveness when one of the `case` is `_`.

**Solution**
This creates a dummy tree maker called `DummyTreeMaker` for `_` pattern, which will skip exhaustiveness checking.

MatchAnalysis only considers four kinds of TreeMaker, so adding this new one triggers `backoff = true`, and skips the exhaustiveness analysis:
https://github.com/scala/scala/blob/e67d287447c09720468f8bebcb0302bd92d75f43/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala#L535-L543

**Notes**
- Using the [scala-match-on-huge-enum](https://github.com/KisaragiEffective/scala-match-on-huge-enum) repo, the compilation time reduced from 163s to 90s. (It's still checking for reachability)
- Compiling scalac didn't make noticeable difference, since it probably doesn't have huge ADTs. After five round of `clean` and `compiler/compile` it converged to 51s with or without this change.