### PR TITLE
Merge 2.12 to 2.13 20230921 [ci: last-only]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - run: git config --global core.autocrlf false
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Java
         uses: actions/setup-java@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,14 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         java-distribution: [temurin]
         java: [8, 11, 17, 20]
-        # 21-ea will presumably be available from Temurin eventually, but for now:
+        # 21 will presumably be available from Temurin eventually, but for now:
         include:
           - os: ubuntu-latest
             java-distribution: zulu
-            java: 21-ea
+            java: 21
           - os: windows-latest
             java-distribution: zulu
-            java: 21-ea
+            java: 21
     runs-on: ${{matrix.os}}
     steps:
       - run: git config --global core.autocrlf false
@@ -41,9 +41,9 @@ jobs:
 
       - name: Build
         run: |
-          sbt -Dsbt.scala.version=2.12.18 setupPublishCore generateBuildCharacterPropertiesFile headerCheck publishLocal
+          sbt setupPublishCore generateBuildCharacterPropertiesFile headerCheck publishLocal
 
       - name: Test
         run: |
           STARR=`cat buildcharacter.properties | grep ^maven.version.number | cut -d= -f2` && echo $STARR
-          sbt -Dsbt.scala.version=2.12.18 -Dstarr.version=$STARR setupValidateTest test:compile info testAll
+          sbt -Dstarr.version=$STARR setupValidateTest test:compile info testAll

--- a/project/ScaladocSettings.scala
+++ b/project/ScaladocSettings.scala
@@ -7,7 +7,7 @@ object ScaladocSettings {
 
   // when this changes, the integrity check in HtmlFactory.scala also needs updating
   val webjarResources = Seq(
-    "org.webjars" % "jquery" % "3.7.0"
+    "org.webjars" % "jquery" % "3.7.1"
   )
 
   def extractResourcesFromWebjar = Def.task {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.4
+sbt.version=1.9.6

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.3
+sbt.version=1.9.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -39,4 +39,4 @@ concurrentRestrictions in Global := Seq(
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")
 
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.5")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.6")

--- a/src/scaladoc/scala/tools/nsc/doc/html/HtmlFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/HtmlFactory.scala
@@ -95,7 +95,7 @@ class HtmlFactory(val universe: doc.Universe, val reporter: Reporter) {
   )
 
   final def webjarResources = List(
-    ("jquery.min.js", "2Pmvv0kuTBOenSvLm6bvfBSSHrUJ+3A7x6P5Ebd07/g=")
+    ("jquery.min.js", "/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=")
   )
 
   /** Generates the Scaladoc site for a model into the site root.


### PR DESCRIPTION
all version bumps all the time

- Update sbt to 1.9.4 in 2.12.x
- Update sbt-jmh to 0.4.6 in 2.12.x
- Update jquery to 3.7.1 in 2.12.x
- Bump actions/checkout from 3 to 4
- sbt 1.9.6 (was .4)
- GitHub Actions: remove JDK 21-ea, add JDK 21

the jQuery bump is technically user-visible (to users of the Scaladoc), but I'm marking this as "internal" anyway