### PR TITLE
Fix incorrectly final flag for mixed-in field

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Fields.scala
+++ b/src/compiler/scala/tools/nsc/transform/Fields.scala
@@ -122,13 +122,18 @@ abstract class Fields extends InfoTransform with ast.TreeDSL with TypingTransfor
   private def setMixedinAccessorFlags(orig: Symbol, cloneInSubclass: Symbol): Unit =
     cloneInSubclass setFlag OVERRIDE | NEEDS_TREES resetFlag DEFERRED | SYNTHESIZE_IMPL_IN_SUBCLASS
 
-  private def setFieldFlags(accessor: Symbol, fieldInSubclass: TermSymbol): Unit =
-    fieldInSubclass setFlag (NEEDS_TREES |
-                             PrivateLocal
-                             | (accessor getFlag MUTABLE | LAZY | DEFAULTINIT)
-                             | (if (accessor hasFlag STABLE) 0 else MUTABLE)
-      )
-
+  private def setFieldFlags(accessor: Symbol, fieldInSubclass: TermSymbol): Unit = {
+    // Since initialization is performed (lexically) outside of the constructor (in the trait setter),
+    // we have to make the field mutable starting with classfile format 53
+    // (it was never allowed, but the verifier enforces this now).
+    fieldInSubclass.setFlag(NEEDS_TREES | PrivateLocal | MUTABLE | accessor.getFlag(LAZY | DEFAULTINIT))
+    if (accessor.hasFlag(STABLE)) {
+      // If the field is for an immutable val, make sure it's safely published
+      val isInStaticModule = fieldInSubclass.owner.isModuleClass && fieldInSubclass.owner.sourceModule.isStaticModule
+      if (!isInStaticModule) // the <clinit> lock is enough.
+        fieldInSubclass.owner.primaryConstructor.updateAttachment(ConstructorNeedsFence)
+    }
+  }
 
   def checkAndClearOverriddenTraitSetter(setter: Symbol) = checkAndClear(OVERRIDDEN_TRAIT_SETTER)(setter)
   def checkAndClearNeedsTrees(setter: Symbol) = checkAndClear(NEEDS_TREES)(setter)
@@ -675,22 +680,9 @@ abstract class Fields extends InfoTransform with ast.TreeDSL with TypingTransfor
         // trait val/var setter mixed into class
         else fieldAccess(setter) match {
           case NoSymbol => EmptyTree
-          case fieldSel =>
-            if (!fieldSel.hasFlag(MUTABLE)) {
-              // If the field is mutable, it won't be final, so we can write to it in a setter.
-              // If it's not, we still need to initialize it, and make sure it's safely published.
-              // Since initialization is performed (lexically) outside of the constructor (in the trait setter),
-              // we have to make the field mutable starting with classfile format 53
-              // (it was never allowed, but the verifier enforces this now).
-              fieldSel.setFlag(MUTABLE)
-              val isInStaticModule = fieldSel.owner.isModuleClass && fieldSel.owner.sourceModule.isStaticModule
-              if (!isInStaticModule) // the <clinit> lock is enough.
-                fieldSel.owner.primaryConstructor.updateAttachment(ConstructorNeedsFence)
-            }
-
-            afterOwnPhase { // the assign only type checks after our phase (assignment to val)
-              mkAccessor(setter)(Assign(Select(This(clazz), fieldSel), castHack(Ident(setter.firstParam), fieldSel.info)))
-            }
+          case fieldSel => afterOwnPhase { // the assign only type checks after our phase (assignment to val)
+            mkAccessor(setter)(Assign(Select(This(clazz), fieldSel), castHack(Ident(setter.firstParam), fieldSel.info)))
+          }
         }
 
       def moduleAccessorBody(module: Symbol): Tree =

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -1595,7 +1595,13 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     /** Set initial info. */
     def setInfo(info: Type): this.type  = { info_=(info); this }
     /** Modifies this symbol's info in place. */
-    def modifyInfo(f: Type => Type): this.type = setInfo(f(info))
+    def modifyInfo(f: Type => Type): this.type = {
+      val i = info
+      val r = f(i)
+      if (r ne i)
+        setInfo(r)
+      this
+    }
     /** Substitute second list of symbols for first in current info.
       *
       * NOTE: this discards the type history (uses setInfo)

--- a/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
@@ -425,6 +425,26 @@ class BytecodeTest extends BytecodeTesting {
     assertInvoke(getMethod(cAnon, "<init>"), "scala/runtime/Statics", "releaseFence")
   }
 
+    @Test
+    def t12881(): Unit = {
+      val code =
+        """trait T {
+          |  val foo = "foo"
+          |}
+          |
+          |class C {
+          |  def f: T = {
+          |    lazy val t = new T {}
+          |    t
+          |  }
+          |}
+          |""".stripMargin
+      val List(_, cAnon, _) = compileClasses(code)
+      // mixed-in field is not final
+      assertEquals(Opcodes.ACC_PRIVATE, cAnon.fields.asScala.find(_.name.startsWith("foo")).get.access)
+      assertInvoke(getMethod(cAnon, "<init>"), "scala/runtime/Statics", "releaseFence")
+    }
+
   @Test def tailrecControlFlow(): Unit = {
     // Without change of the `this` value
 


### PR DESCRIPTION
Fields for mixed-in vals need to be non-final because they are from a separate method, not the constructor body. This is enforced for classfiles compiled with `-target:11` / `-release:11`.

This PR fixes one case where this was missed.

Details in https://github.com/scala/bug/issues/12881#issuecomment-1735413068.

Follow-up for https://github.com/scala/scala/commit/f9ecece3d4.

Fixes https://github.com/scala/bug/issues/12881