### PR TITLE
Flaky IteratorTest bails not fails

### DIFF
--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -589,8 +589,8 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     /** Trillium logic boolean: -1 = unknown, 0 = false, 1 = true */
     private[this] var _hasNext: Int = -1
 
-    private[this] def nextCur(): Unit = {
-      cur = null
+    def nextCur(): Unit = {
+      cur = Iterator.empty
       cur = f(self.next()).iterator
       _hasNext = -1
     }

--- a/src/testkit/scala/tools/testkit/AssertUtil.scala
+++ b/src/testkit/scala/tools/testkit/AssertUtil.scala
@@ -24,7 +24,7 @@ import scala.runtime.ScalaRunTime.stringOf
 import scala.util.{Failure, Success, Try}
 import scala.util.chaining._
 import scala.util.control.{ControlThrowable, NonFatal}
-import java.lang.ref._
+import java.lang.ref.{Reference, ReferenceQueue, SoftReference}
 import java.lang.reflect.{Array => _, _}
 import java.time.Duration
 import java.util.concurrent.{CountDownLatch, TimeUnit}
@@ -87,9 +87,10 @@ object AssertUtil {
 
   private final val timeout = 60 * 1000L                 // wait a minute
 
-  private implicit class `ref helper`[A](val r: Reference[A]) extends AnyVal {
-    def isEmpty: Boolean  = r.get == null
+  private implicit class `ref helper`[A <: AnyRef](val r: Reference[A]) extends AnyVal {
+    def isEmpty: Boolean  = r.get == null // r.refersTo(null) to avoid influencing collection
     def nonEmpty: Boolean = !isEmpty
+    def hasReferent(x: AnyRef): Boolean = r.get eq x
   }
   private implicit class `class helper`(val clazz: Class[_]) extends AnyVal {
     def allFields: List[Field] = {
@@ -200,24 +201,29 @@ object AssertUtil {
   /** Value is not strongly reachable from roots after body is evaluated.
    */
   def assertNotReachable[A <: AnyRef](a: => A, roots: AnyRef*)(body: => Unit): Unit = {
-    val wkref = new WeakReference(a)
+    val refq = new ReferenceQueue[A]
+    val ref: Reference[A] = new SoftReference(a, refq)
     // fail if following strong references from root discovers referent. Quit if ref is empty.
     def assertNoRef(root: AnyRef): Unit = {
       val seen  = new IdentityHashMap[AnyRef, Unit]
       val stack = mutable.Stack.empty[AnyRef]
-      def loop(): Unit = if (wkref.nonEmpty && stack.nonEmpty) {
+      def loop(): Unit = if (ref.nonEmpty && stack.nonEmpty) {
         val o: AnyRef = stack.pop()
         if (o != null && !seen.containsKey(o)) {
           seen.put(o, ())
-          assertFalse(s"Root $root held reference $o", o eq wkref.get)
+          assertFalse(s"Root $root held reference $o", ref.hasReferent(o))
           o match {
             case a: Array[AnyRef] =>
-              a.foreach(e => if (!e.isInstanceOf[Reference[_]]) stack.push(e))
+              a.foreach(e => if (e != null && !e.isInstanceOf[Reference[_]]) stack.push(e))
             case _ =>
               for (f <- o.getClass.allFields)
                 if (!Modifier.isStatic(f.getModifiers) && !f.getType.isPrimitive && !classOf[Reference[_]].isAssignableFrom(f.getType))
                   stack.push(f.follow(o))
           }
+        }
+        refq.poll() match {
+          case null  =>
+          case r @ _ => fail("assertNotReachable dropped reference value")
         }
         loop()
       }

--- a/src/testkit/scala/tools/testkit/AssertUtil.scala
+++ b/src/testkit/scala/tools/testkit/AssertUtil.scala
@@ -45,6 +45,15 @@ object AssertUtil {
   // junit fail is Unit
   def fail(message: String): Nothing = throw new AssertionError(message)
 
+  private val Bail = new ControlThrowable {}
+
+  def bail(): Nothing = throw Bail
+
+  // maybe there is a way to communicate that the test was skipped
+  def bailable(name: String)(test: => Unit): Unit =
+    try test
+    catch { case _: Bail.type => println(s"$name skipped bail!") }
+
   private val printable = raw"\p{Print}".r
 
   def hexdump(s: String): Iterator[String] = {

--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -8,7 +8,7 @@ import org.junit.runners.JUnit4
 import scala.tools.testkit.AssertUtil._
 import scala.util.chaining._
 
-import java.lang.ref._
+import java.lang.ref.SoftReference
 
 @RunWith(classOf[JUnit4])
 class IteratorTest {
@@ -172,7 +172,7 @@ class IteratorTest {
   }
   @Test def `grouped does not hold elements`: Unit = {
     val thing = new Object
-    val ref = new WeakReference(thing)
+    val ref = new SoftReference(thing)
     locally {
       val it = Iterator(thing).grouped(1)
       assertEquals(List(thing), it.next())
@@ -184,7 +184,7 @@ class IteratorTest {
   }
   @Test def `sliding must hold elements`: Unit = {
     val thing = new Object
-    val ref = new WeakReference(thing)
+    val ref = new SoftReference(thing)
     val it = Iterator.continually(ref.get()).sliding(2,1)
     assertFails(_.contains("Root <iterator> held reference")) { assertNotReachable(thing, it)(it.next()) }
   }
@@ -821,7 +821,7 @@ class IteratorTest {
 
       def apply(i: Int) = ss(i)
     }
-    val seq1 = new WeakReference(new C)
+    val seq1 = new SoftReference(new C)
     val seq2 = List("third")
     val it0: Iterator[Int] = Iterator(1, 2)
     lazy val it: Iterator[String] = it0.flatMap {


### PR DESCRIPTION
Fixes https://github.com/scala/scala-dev/issues/854

The test is just for reachability, but since we wish to probe from the flatMap function, that the old result is not reachable while we create the next result, a naive check will always show reachable via the test object itself. So for convenience, the test uses a reference, which may be inadvertently cleared. Now we shrug and abort the test. (The previous behavior was that the flatMapper would not deliver the expected values.)

It would be nice if `bail` could signal "skipped" instead of "passed".

While in the neighborhood or neck of the woods, use `empty` to permit gc in `nextCur`, as is also done in `hasNext`. Since `nextCur` is effectively private, we drop its access modifier.

`import Seq.empty`, even in test code, is gratuitously poor style, Past Self, when `Nil` is so conveniently at hand. If you had a reason for choosing `empty`, a comment is needed. This isn't some weird overloaded assert issue, is it? `assertSameElements` takes an array or seq and iterable or seq and iterableonce oh never mind.

Sample naive check that fails:
```
  @Test def `flatMap is memory efficient in previous element`(): Unit = {
    def flatMapper: Int => Iterable[String] = new Function[Int, Iterable[String]] {
      var data = Array("data")
      def apply(i: Int): Iterable[String] = {
        if (i == 1) {
          val res = data
          data = null
          res
        }
        else {
          check()
          Nil
        }
      }
    }
    lazy val it: Iterator[String] = Iterator(1, 2).flatMap(flatMapper)
    lazy val data: String = it.next()
    def check(): Unit = assertNotReachable(data, it)(())

    assert(it.hasNext)
    assertEquals("data", data)
    assert(!it.hasNext)
  }
```
