### PR TITLE
Improve detection of case class in refinement vs local

### DIFF
--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -3060,7 +3060,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     // Note also that trait vals are modelled as getters, and thus that user-supplied code appears in their rhs.
     // Originally, it may have been an optimization to skip methods that were not user-defined (getters),
     // but it doesn't even exclude setters, contrary to its original comment (// exclude all accessors)
-    override def isSourceMethod  = !(this hasFlag STABLE)
+    override def isSourceMethod  = !hasStableFlag
 
     // unfortunately having the CASEACCESSOR flag does not actually mean you
     // are a case accessor (you can also be a field.)

--- a/test/files/pos/t5626.scala
+++ b/test/files/pos/t5626.scala
@@ -1,3 +1,4 @@
+//> using options -feature -Wconf:cat=feature-reflective-calls:s -Werror
 class C {
   val blob = {
     new { case class Foo() }
@@ -6,7 +7,11 @@ class C {
     class Inner { case class Foo() }
     new Inner
   }
+  val z: Any { def x: X.type } = new { def x = X }
 
   val foo = blob.Foo()
   val bar = blub.Foo()
+  val baz = z.x()
 }
+
+case class X()

--- a/test/files/run/t9971.scala
+++ b/test/files/run/t9971.scala
@@ -1,0 +1,11 @@
+object Test {
+  def main(args: Array[String]): Unit = assert(f == 42)
+  def f = {
+    object Foo {
+      val bar = Foo(42)
+    }
+    case class Foo(i: Int)
+
+    Foo.bar.i
+  }
+}


### PR DESCRIPTION
Fixes scala/bug#9971

Implements only the smallest suggestion on the linked ticket, namely, to fix the rewrite of "case apply" to "new" in Refchecks.

~It uses the existing `ClassForCaseCompanionAttachment` on the module class symbol to retrieve the symbol from the companion tree. Refchecks needs only to navigate from the module to its companion.~