### PR TITLE
Don't warn about synthetic apply if user-added

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
@@ -156,10 +156,6 @@ trait Unapplies extends ast.TreeDSL {
     val mods =
       if (applyShouldInheritAccess(inheritedMods))
         (caseMods | (inheritedMods.flags & PRIVATE)).copy(privateWithin = inheritedMods.privateWithin)
-          .tap { mods =>
-            if (currentRun.isScala3 && mods != caseMods)
-              runReporting.warning(cdef.pos, "constructor modifiers are assumed by synthetic `apply` method", WarningCategory.Scala3Migration, cdef.symbol)
-          }
       else
         caseMods
     factoryMeth(mods, nme.apply, cdef)
@@ -282,7 +278,7 @@ trait Unapplies extends ast.TreeDSL {
           Modifiers(SYNTHETIC | (inheritedMods.flags & AccessFlags), inheritedMods.privateWithin)
             .tap { mods =>
               if (currentRun.isScala3 && mods != Modifiers(SYNTHETIC))
-                runReporting.warning(cdef.pos, "constructor modifiers are assumed by synthetic `copy` method", WarningCategory.Scala3Migration, cdef.symbol)
+                runReporting.warning(cdef.pos, "access modifiers for `copy` method are copied from the case class constructor", WarningCategory.Scala3Migration, cdef.symbol)
             }
         }
         else Modifiers(SYNTHETIC)

--- a/test/files/neg/t12798-migration.check
+++ b/test/files/neg/t12798-migration.check
@@ -38,16 +38,16 @@ t12798-migration.scala:17: warning: Unicode escapes in raw interpolations are ig
 t12798-migration.scala:18: warning: Unicode escapes in raw interpolations are ignored under -Xsource:3; use literal characters instead
   def g = raw"""\u0043 is for Cat"""
                 ^
-t12798-migration.scala:50: warning: constructor modifiers are assumed by synthetic `copy` method
+t12798-migration.scala:50: warning: access modifiers for `copy` method are copied from the case class constructor
 case class `case mods propagate` private (s: String)
            ^
 t12798-migration.scala:60: warning: under -Xsource:3, inferred Option[Int] instead of Some[Int] [quickfixable]
   override def f = Some(27)
                ^
-t12798-migration.scala:50: warning: constructor modifiers are assumed by synthetic `apply` method
+t12798-migration.scala:50: warning: access modifiers for `apply` method are copied from the case class constructor
 case class `case mods propagate` private (s: String)
            ^
-t12798-migration.scala:52: warning: constructor modifiers are assumed by synthetic `apply` method
+t12798-migration.scala:52: warning: access modifiers for `apply` method are copied from the case class constructor
 case class `copyless case mods propagate` private (s: String) {
            ^
 15 warnings

--- a/test/files/neg/t12798.check
+++ b/test/files/neg/t12798.check
@@ -60,7 +60,7 @@ Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=interpolated unicode such as C.g
   def g = raw"""\u0043 is for Cat"""
                 ^
-t12798.scala:50: error: constructor modifiers are assumed by synthetic `copy` method
+t12798.scala:50: error: access modifiers for `copy` method are copied from the case class constructor
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=case mods propagate
 case class `case mods propagate` private (s: String)
@@ -70,9 +70,9 @@ Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=Child.f
   override def f = Some(27)
                ^
-t12798.scala:52: error: constructor modifiers are assumed by synthetic `apply` method
+t12798.scala:52: error: access modifiers for `apply` method are copied from the case class constructor
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
-Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=copyless case mods propagate
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=copyless case mods propagate.apply
 case class `copyless case mods propagate` private (s: String) {
            ^
 15 errors

--- a/test/files/neg/t12883.check
+++ b/test/files/neg/t12883.check
@@ -1,0 +1,6 @@
+t12883.scala:3: error: access modifiers for `apply` method are copied from the case class constructor
+Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=C.apply
+case class C private (c: Int) {
+           ^
+1 error

--- a/test/files/neg/t12883.scala
+++ b/test/files/neg/t12883.scala
@@ -1,0 +1,5 @@
+//> using options -Xsource:3
+
+case class C private (c: Int) {
+  def copy(c: Int = this.c): C = new C(c)
+}

--- a/test/files/pos/t12883.scala
+++ b/test/files/pos/t12883.scala
@@ -1,0 +1,9 @@
+//> using options -Werror -Xsource:3
+
+case class C private (c: Int) {
+  def copy(c: Int = this.c): C = new C(c)
+}
+
+object C {
+  def apply(c: Int) = new C(c)
+}


### PR DESCRIPTION
Improve message for clarity.

Fix bug where warning for `apply` is emitted too early, as the method may be "retracted" on completion if user-supplied.

Split from https://github.com/scala/scala/pull/10551

Fixes scala/bug#12883