### PR TITLE
Clarify language.implicitConversions

### DIFF
--- a/src/library/scala/language.scala
+++ b/src/library/scala/language.scala
@@ -95,22 +95,29 @@ object language {
    */
   implicit lazy val reflectiveCalls: reflectiveCalls = languageFeature.reflectiveCalls
 
-  /** Where this feature is enabled, definitions of implicit conversions are allowed.
+  /** Where this feature is enabled, definitions of implicit conversion methods are allowed.
    *  If `implicitConversions` is not enabled, the definition of an implicit
-   *  conversion will trigger a warning from the compiler.
+   *  conversion method will trigger a warning from the compiler.
    *
    *  An implicit conversion is an implicit value of unary function type `A => B`,
    *  or an implicit method that has in its first parameter section a single,
    *  non-implicit parameter. Examples:
    *
    *  {{{
-   *     implicit def stringToInt(s: String): Int = s.length
-   *     implicit val conv = (s: String) => s.length
-   *     implicit def listToX(xs: List[T])(implicit f: T => X): X = ...
+   *     implicit def intToString(i: Int): String = s"$i"
+   *     implicit val conv: Int => String = i => s"$i"
+   *     implicit val numerals: List[String] = List("zero", "one", "two", "three")
+   *     implicit val strlen: String => Int = _.length
+   *     implicit def listToInt[T](xs: List[T])(implicit f: T => Int): Int = xs.map(f).sum
    *  }}}
    *
-   *  Implicit classes and implicit values of other types are not governed by this
-   *  language feature.
+   *  This language feature warns only for implicit conversions introduced by methods.
+   *
+   *  Other values, including functions or data types which extend `Function1`,
+   *  such as `Map`, `Set`, and `List`, do not warn.
+   *
+   *  Implicit class definitions, which introduce a conversion to the wrapping class,
+   *  also do not warn.
    *
    *  '''Why keep the feature?''' Implicit conversions are central to many aspects
    *  of Scala’s core libraries.

--- a/test/files/neg/t10392.check
+++ b/test/files/neg/t10392.check
@@ -1,0 +1,14 @@
+t10392.scala:9: warning: implicit conversion method cv2 should be enabled
+by making the implicit value scala.language.implicitConversions visible.
+This can be achieved by adding the import clause 'import scala.language.implicitConversions'
+or by setting the compiler option -language:implicitConversions.
+See the Scaladoc for value scala.language.implicitConversions for a discussion
+why the feature should be explicitly enabled.
+  private implicit def cv2(i: Int): String = i.toString * 2
+                       ^
+t10392.scala:9: warning: private method cv2 in class C is never used
+  private implicit def cv2(i: Int): String = i.toString * 2
+                       ^
+error: No warnings can be incurred under -Werror.
+2 warnings
+1 error

--- a/test/files/neg/t10392.scala
+++ b/test/files/neg/t10392.scala
@@ -1,0 +1,19 @@
+
+//> using options -feature -Werror -Wunused
+
+// warn when conversion method is present but unused
+
+class C {
+  implicit val cv0: List[String] = List("zero", "one", "two", "three")
+  //implicit val cv1: Int => String = _.toString
+  private implicit def cv2(i: Int): String = i.toString * 2
+
+  def f(i: Int): String = i
+}
+
+object Test extends App {
+  val c = new C
+  println {
+    c.f(3)
+  }
+}


### PR DESCRIPTION
Fixes scala/bug#10392

Add test that the conversion is unused but warns.