### PR TITLE
Try harder to find Enum, warn for Java statics

### DIFF
--- a/test/files/neg/t1211.check
+++ b/test/files/neg/t1211.check
@@ -1,0 +1,11 @@
+test_2.scala:5: error: value E is not a member of J
+did you mean I.E? Static Java members belong to companion objects in Scala;
+they are not inherited, even by subclasses defined in Java.
+    j.f(j.E.E1)
+          ^
+test_2.scala:6: error: value E is not a member of object J
+did you mean I.E? Static Java members belong to companion objects in Scala;
+they are not inherited, even by subclasses defined in Java.
+    j.f(J.E.E1)
+          ^
+2 errors

--- a/test/files/neg/t1211/I.java
+++ b/test/files/neg/t1211/I.java
@@ -1,0 +1,4 @@
+
+interface I {
+	enum E { E1 }
+}

--- a/test/files/neg/t1211/J.java
+++ b/test/files/neg/t1211/J.java
@@ -1,0 +1,4 @@
+
+class J implements I {
+	void f(E e) { }
+}

--- a/test/files/neg/t1211/test_2.scala
+++ b/test/files/neg/t1211/test_2.scala
@@ -1,0 +1,8 @@
+
+object Test extends App {
+  val j = new J
+  println {
+    j.f(j.E.E1)
+    j.f(J.E.E1)
+  }
+}

--- a/test/files/neg/t1211b.check
+++ b/test/files/neg/t1211b.check
@@ -1,0 +1,11 @@
+test.scala:4: error: type K is not a member of object Test
+did you mean I.K? Static Java members belong to companion objects in Scala;
+they are not inherited, even by subclasses defined in Java.
+    new this.K
+             ^
+test.scala:5: error: type K is not a member of object Test
+did you mean I.K? Static Java members belong to companion objects in Scala;
+they are not inherited, even by subclasses defined in Java.
+    new Test.K
+             ^
+2 errors

--- a/test/files/neg/t1211b/I.java
+++ b/test/files/neg/t1211b/I.java
@@ -1,0 +1,4 @@
+
+class I {
+	static class K {}
+}

--- a/test/files/neg/t1211b/test.scala
+++ b/test/files/neg/t1211b/test.scala
@@ -1,0 +1,7 @@
+
+object Test extends I with App {
+  println {
+    new this.K
+    new Test.K
+  }
+}

--- a/test/files/neg/t1211c.check
+++ b/test/files/neg/t1211c.check
@@ -1,0 +1,11 @@
+test.scala:5: error: value E is not a member of J
+did you mean I.E? Static Java members belong to companion objects in Scala;
+they are not inherited, even by subclasses defined in Java.
+    j.f(j.E.E1)
+          ^
+test.scala:6: error: value E is not a member of object J
+did you mean I.E? Static Java members belong to companion objects in Scala;
+they are not inherited, even by subclasses defined in Java.
+    j.f(J.E.E1)
+          ^
+2 errors

--- a/test/files/neg/t1211c/I.java
+++ b/test/files/neg/t1211c/I.java
@@ -1,0 +1,4 @@
+
+interface I {
+	enum E { E1 }
+}

--- a/test/files/neg/t1211c/J.java
+++ b/test/files/neg/t1211c/J.java
@@ -1,0 +1,4 @@
+
+class J implements I {
+	void f(E e) { }
+}

--- a/test/files/neg/t1211c/test.scala
+++ b/test/files/neg/t1211c/test.scala
@@ -1,0 +1,8 @@
+
+object Test extends App {
+  val j = new J
+  println {
+    j.f(j.E.E1)
+    j.f(J.E.E1)
+  }
+}


### PR DESCRIPTION
Fixes scala/bug#1211

We have a nice warning if you try to select a Java static, assuming they are inherited.

For inherited enums, retry lookup of term name as enum type, and on error, look up in any base class from Java for static to warn about.