### PR TITLE
in CI, upgrade JDK 21 from EA to GA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,5 +37,5 @@ jobs:
 
       - name: Test
         run: |
-pp          STARR=`cat buildcharacter.properties | grep ^maven.version.number | cut -d= -f2` && echo $STARR
+          STARR=`cat buildcharacter.properties | grep ^maven.version.number | cut -d= -f2` && echo $STARR
           sbt -Dstarr.version=$STARR setupValidateTest test:compile info testAll

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java-distribution: [temurin]
-        java: [8, 11, 17, 20]
-        # 21 will presumably be available from Temurin eventually, but for now:
-        include:
-          - os: ubuntu-latest
-            java-distribution: zulu
-            java: 21
-          - os: windows-latest
-            java-distribution: zulu
-            java: 21
+        java: [8, 11, 17, 21]
     runs-on: ${{matrix.os}}
     steps:
       - run: git config --global core.autocrlf false
@@ -35,7 +26,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          distribution: ${{matrix.java-distribution}}
+          distribution: temurin
           java-version: ${{matrix.java}}
           cache: sbt
 
@@ -45,5 +36,5 @@ jobs:
 
       - name: Test
         run: |
-          STARR=`cat buildcharacter.properties | grep ^maven.version.number | cut -d= -f2` && echo $STARR
+pp          STARR=`cat buildcharacter.properties | grep ^maven.version.number | cut -d= -f2` && echo $STARR
           sbt -Dstarr.version=$STARR setupValidateTest test:compile info testAll

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: Scala Merge CI
 on:
   push:
     branches: ['2.*.x']
+  pull_request:
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
this has to be in-repo and not from a fork to enable CI on the PR, but also I can't force-push, so once this is green, I'll have to submit a clean followup for actual merge