### PR TITLE
in CI, upgrade JDK 21 from EA to GA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java-distribution: [temurin]
-        java: [8, 11, 17, 20]
-        # 21 will presumably be available from Temurin eventually, but for now:
-        include:
-          - os: ubuntu-latest
-            java-distribution: zulu
-            java: 21
-          - os: windows-latest
-            java-distribution: zulu
-            java: 21
+        java: [8, 11, 17, 21]
     runs-on: ${{matrix.os}}
     steps:
       - run: git config --global core.autocrlf false
@@ -35,7 +26,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          distribution: ${{matrix.java-distribution}}
+          distribution: temurin
           java-version: ${{matrix.java}}
           cache: sbt
 


### PR DESCRIPTION
already tested at #10572, so we can merge this as soon as it's green