### PR TITLE
Don't emit line number for synthetic unit value

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -493,7 +493,7 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
     def isAtProgramPoint(lbl: asm.Label): Boolean = {
       (lastInsn match { case labnode: asm.tree.LabelNode => (labnode.getLabel == lbl); case _ => false } )
     }
-    def lineNumber(tree: Tree): Unit = if (emitLines && tree.pos.isDefined) {
+    def lineNumber(tree: Tree): Unit = if (emitLines && tree.pos.isDefined && !tree.hasAttachment[SyntheticUnitAttachment.type]) {
       val nr = tree.pos.finalPosition.line
       if (nr != lastEmittedLineNr) {
         lastEmittedLineNr = nr

--- a/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
@@ -993,4 +993,14 @@ class BytecodeTest extends BytecodeTesting {
       Op(RETURN),
     ))
   }
+
+  @Test def t12835(): Unit = {
+    val c1 =
+      """def f: Unit = {
+        |  val x = 1
+        |}
+        |""".stripMargin
+    val lines = compileMethod(c1).instructions.collect { case l: LineNumber => l }
+    assertSameCode(List(LineNumber(2, Label(0))), lines)
+  }
 }


### PR DESCRIPTION
Synthetic `()` values are added to blocks without an expression. Don't emit a line number for them.

Implemented by checking the `SyntheticUnitAttachment`. This seems simpler than trying to control the position assigned to synthetic unit trees, as they are created in many places.

Fixes https://github.com/scala/bug/issues/12835