### PR TITLE
Merge 2.12.x to 2.13.x [ci: last-only]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java-distribution: [temurin]
-        java: [8, 11, 17, 20]
-        # 21 will presumably be available from Temurin eventually, but for now:
-        include:
-          - os: ubuntu-latest
-            java-distribution: zulu
-            java: 21
-          - os: windows-latest
-            java-distribution: zulu
-            java: 21
+        java: [8, 11, 17, 21]
     runs-on: ${{matrix.os}}
     steps:
       - run: git config --global core.autocrlf false
@@ -35,7 +26,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          distribution: ${{matrix.java-distribution}}
+          distribution: temurin
           java-version: ${{matrix.java}}
           cache: sbt
 

--- a/build.sbt
+++ b/build.sbt
@@ -413,7 +413,7 @@ lazy val compilerOptionsExporter = Project("compilerOptionsExporter", file(".") 
   .settings(disablePublishing)
   .settings(
     libraryDependencies ++= {
-      val jacksonVersion = "2.15.2"
+      val jacksonVersion = "2.15.3"
       Seq(
         "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
         "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,


### PR DESCRIPTION
10569 SKIP
10574 PICK

so, this just merges the JDK-21-final-in-GitHub-Actions change forward