### PR TITLE
Don't prefer concrete over deferred methods in lookup in Java classes

### DIFF
--- a/src/reflect/scala/reflect/internal/tpe/FindMembers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/FindMembers.scala
@@ -73,9 +73,12 @@ trait FindMembers {
           case xs => xs.head
         }
       }
-      val deferredSeen = walkBaseClasses(selectorClass, requiredFlags, excludedFlags | DEFERRED)
-      if (deferredSeen) // OPT: the `if` avoids a second pass if the first pass didn't spot any candidates.
-        walkBaseClasses(selectorClass, requiredFlags | DEFERRED, excludedFlags & ~(DEFERRED.toLong))
+      if (selectorClass.isJavaDefined) walkBaseClasses(selectorClass, requiredFlags, excludedFlags)
+      else {
+        val deferredSeen = walkBaseClasses(selectorClass, requiredFlags, excludedFlags | DEFERRED)
+        if (deferredSeen) // OPT: the `if` avoids a second pass if the first pass didn't spot any candidates.
+          walkBaseClasses(selectorClass, requiredFlags | DEFERRED, excludedFlags & ~(DEFERRED.toLong))
+      }
       result
     }
 

--- a/test/files/neg/t12892.check
+++ b/test/files/neg/t12892.check
@@ -1,0 +1,8 @@
+Test.scala:3: error: incompatible type in overriding
+def m(): B (defined in trait B)
+  with <defaultmethod> def m(): A (defined in trait A);
+  (note that def m(): B (defined in trait B) is abstract,
+  and is therefore overridden by concrete <defaultmethod> def m(): A (defined in trait A))
+  def u = new B {}
+              ^
+1 error

--- a/test/files/neg/t12892/A.java
+++ b/test/files/neg/t12892/A.java
@@ -1,0 +1,14 @@
+interface A {
+    default A m() {
+        return this;
+    }
+}
+
+interface B extends A {
+    @Override
+    B m();
+}
+
+class Test {
+  B t(B b) { return b.m(); }
+}

--- a/test/files/neg/t12892/Test.scala
+++ b/test/files/neg/t12892/Test.scala
@@ -1,0 +1,4 @@
+class C {  
+  def t(b: B): B = b.m
+  def u = new B {}
+}

--- a/test/files/pos/t12892/A.java
+++ b/test/files/pos/t12892/A.java
@@ -1,0 +1,14 @@
+interface A {
+    default A m() {
+        return this;
+    }
+}
+
+interface B extends A {
+    @Override
+    B m();
+}
+
+class Test {
+  B t(B b) { return b.m(); }
+}

--- a/test/files/pos/t12892/Test.scala
+++ b/test/files/pos/t12892/Test.scala
@@ -1,0 +1,3 @@
+class C {  
+  def t(b: B): B = b.m
+}


### PR DESCRIPTION
For https://github.com/scala/bug/issues/12892.