### PR TITLE
Scaladoc: realign `-doc-source-url` behavior with 2.12

### DIFF
--- a/test/junit/scala/tools/nsc/doc/html/ModelFactoryTest.scala
+++ b/test/junit/scala/tools/nsc/doc/html/ModelFactoryTest.scala
@@ -1,0 +1,30 @@
+package scala.tools.nsc.doc.html
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+import scala.tools.nsc.doc.model.ModelFactory._
+
+class ModelFactoryTest {
+  def t(expected: String, template: String,
+        filePath: String = null, fileExt: String = null, line: Int = 0, tplOwner: String = null, tplName: String = null) =
+    assertEquals(expected, expandUrl(template, filePath, fileExt, filePath + fileExt, line, tplOwner, tplName))
+
+  @Test def sourceUrlReplace(): Unit = {
+    // relative path: insert `/` if path follows a word character
+    t("/base/p/file.scala", "/base€{FILE_PATH_EXT}", filePath = "p/file", fileExt = ".scala")
+    t("/base/p/file.scala", "/base/€{FILE_PATH_EXT}", filePath = "p/file", fileExt = ".scala")
+    t("/base.p/file.scala", "/base.€{FILE_PATH_EXT}", filePath = "p/file", fileExt = ".scala")
+    t("p/file.scala", "€{FILE_PATH_EXT}", filePath = "p/file", fileExt = ".scala")
+
+    t("/base/p/file.scala", "/base€{FILE_PATH_EXT}", filePath = "/p/file", fileExt = ".scala")
+    t("/base//p/file.scala", "/base/€{FILE_PATH_EXT}", filePath = "/p/file", fileExt = ".scala")
+
+    // file extension: don't duplicate `.`
+    t("/base/p/file.scala", "/base€{FILE_PATH}€{FILE_EXT}", filePath = "p/file", fileExt = ".scala")
+    t("/base/p/file.scala", "/base/€{FILE_PATH}.€{FILE_EXT}", filePath = "p/file", fileExt = ".scala")
+    t("p/file.scala", "€{FILE_PATH}.€{FILE_EXT}", filePath = "p/file", fileExt = ".scala")
+    t("p/file", "€{FILE_PATH}", filePath = "p/file", fileExt = ".scala")
+    t(".scala", "€{FILE_EXT}", filePath = "", fileExt = ".scala")
+  }
+}

--- a/test/scaladoc/run/doc-source-url-java.scala
+++ b/test/scaladoc/run/doc-source-url-java.scala
@@ -26,7 +26,7 @@ object Test extends ScaladocModelTest {
 
   override def model: Option[Universe] = newDocFactory.makeUniverse(Left(List(resourceFile)))
 
-  def scaladocSettings = "-doc-source-url file:€{FILE_PATH}@@€{FILE_EXT}@@€{FILE_PATH_EXT}@@€{FILE_LINE}"
+  def scaladocSettings = "-doc-source-url file:€{FILE_PATH}@@€{FILE_EXT}@@€{FILE_PATH_EXT}@@€{FILE_LINE}  -sourcepath ."
 
   def testModel(rootPackage: Package) = {
     import access._

--- a/test/scaladoc/run/doc-source-url.scala
+++ b/test/scaladoc/run/doc-source-url.scala
@@ -26,7 +26,7 @@ object Test extends ScaladocModelTest {
 
   override def model: Option[Universe] = newDocFactory.makeUniverse(Left(List(resourceFile)))
 
-  def scaladocSettings = "-doc-source-url file:€{FILE_PATH}@@€{FILE_EXT}@@€{FILE_PATH_EXT}@@€{FILE_LINE}"
+  def scaladocSettings = "-doc-source-url file:€{FILE_PATH}@@€{FILE_EXT}@@€{FILE_PATH_EXT}@@€{FILE_LINE} -sourcepath ."
 
   def testModel(rootPackage: Package) = {
     import access._


### PR DESCRIPTION
Summary

  - In the common case, build tools pass absolute paths to the compiler for source files to compile
  - `-sourcepath` is used to relativize them
  - In 2.12.11, [the relativized path starts with a `/`](https://github.com/scala/scala/blob/v2.13.11/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala#L316-L320), so `base€{FILE_PATH_EXT}` becomes `base/src/...`
  - [#10502](https://github.com/scala/scala/pull/10502) changed relativization to use `srcpathUri.relativize(fileUri)`, which doesn't have a leading `/`
  - Fix: for a relative path, `foo/€{FILE_PATH}` and `foo€{FILE_PATH}` both emit `foo/relative/path/File` (insert `/` if a word character precedes `€{FILE_PATH}`). No such magic for absolute paths (if `-sourcepath` is not specified or is not a prefix of the file).


What happens without `-sourcepath`:

  - 2.13.11 [used the path that the compiler got on the command line](https://github.com/scala/scala/blob/v2.13.11/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala#L320). So `scaladoc a/B.scala` would insert a relative path.
  - 2.13.12 relativizes source paths to the current directory because `Paths.get("").toUri` is the current directory
  - I changed it to use an absolute path. As build tools pass absolute paths to the compiler, the behavior is the same as in 2.13.11 in the common case.

Fixes https://github.com/scala/bug/issues/12867