### PR TITLE
Warn when synchronizing on boxed primitive

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1719,7 +1719,7 @@ abstract class RefChecks extends Transform {
     }
 
     private def transformSelect(tree: Select): Tree = {
-      val Select(qual, _) = tree
+      val Select(qual, name) = tree
       val sym = tree.symbol
 
       checkUndesiredProperties(sym, tree.pos)
@@ -1727,6 +1727,9 @@ abstract class RefChecks extends Transform {
 
       if (!sym.exists)
         devWarning("Select node has NoSymbol! " + tree + " / " + tree.tpe)
+
+      if (name == nme.synchronized_ && isBoxedValueClass(qual.tpe.typeSymbol))
+        refchecksWarning(tree.pos, s"Suspicious `synchronized` call involving boxed primitive `${qual.tpe.typeSymbol.name}`", WarningCategory.LintUniversalMethods)
 
       def checkSuper(mix: Name) =
         // term should have been eliminated by super accessors

--- a/test/files/neg/i17266.check
+++ b/test/files/neg/i17266.check
@@ -10,6 +10,9 @@ i17266.scala:32: warning: notify not selected from this instance
 i17266.scala:33: warning: notifyAll not selected from this instance
   def `maybe notifyAll`(): Unit = notifyAll()
                                   ^
+i17266.scala:53: warning: Suspicious `synchronized` call involving boxed primitive `Integer`
+    1.synchronized { // warn
+      ^
 error: No warnings can be incurred under -Werror.
-4 warnings
+5 warnings
 1 error

--- a/test/files/neg/i17266.scala
+++ b/test/files/neg/i17266.scala
@@ -50,7 +50,7 @@ class ObjectHolder {
   */
 
   def test4 =
-    1.synchronized { // not an error (should be?)
+    1.synchronized { // warn
       println("hello")
     }
 

--- a/test/files/neg/i17284.check
+++ b/test/files/neg/i17284.check
@@ -1,0 +1,15 @@
+i17284.scala:4: warning: Suspicious `synchronized` call involving boxed primitive `Integer`
+  def literal = 451.synchronized {} // error
+                    ^
+i17284.scala:8: warning: Suspicious `synchronized` call involving boxed primitive `Integer`
+    x.synchronized {} // error
+      ^
+i17284.scala:13: warning: Suspicious `synchronized` call involving boxed primitive `Integer`
+    x.synchronized {} // error
+      ^
+i17284.scala:16: warning: Suspicious `synchronized` call involving boxed primitive `Boolean`
+  def bool = true.synchronized {} // error
+                  ^
+error: No warnings can be incurred under -Werror.
+4 warnings
+1 error

--- a/test/files/neg/i17284.scala
+++ b/test/files/neg/i17284.scala
@@ -1,0 +1,20 @@
+//> using options -Werror
+
+class C {
+  def literal = 451.synchronized {} // error
+
+  def integral = {
+    val x = 451
+    x.synchronized {} // error
+  }
+
+  def boxed = {
+    val x: Integer = 451
+    x.synchronized {} // error
+  }
+
+  def bool = true.synchronized {} // error
+
+  // hard error
+  //def unit = ().synchronized {} // error
+}


### PR DESCRIPTION
Backport the lint from dotty.

Observed by @fommil at https://discord.com/channels/632150470000902164/632628489719382036/1167148256166412379