### PR TITLE
Include implicit Manager example in Using doc

### DIFF
--- a/src/library/scala/util/Using.scala
+++ b/src/library/scala/util/Using.scala
@@ -47,20 +47,21 @@ import scala.util.control.{ControlThrowable, NonFatal}
   * val files = List("file1.txt", "file2.txt", "file3.txt", "file4.txt")
   * val lines: Try[Seq[String]] = Using.Manager { use =>
   *   // acquire resources
-  *   def reader(filename: String) = use(new BufferedReader(new FileReader(filename)))
+  *   def mkreader(filename: String) = use(new BufferedReader(new FileReader(filename)))
   *
   *   // use your resources here
   *   def lines(reader: BufferedReader): Iterator[String] =
   *     Iterator.continually(reader.readLine()).takeWhile(_ != null)
   *
-  *   files.map(reader).flatMap(lines)
+  *   files.map(mkreader).flatMap(lines)
   * }
   * }}}
   *
   * Composed or "wrapped" resources may be acquired in order of construction,
-  * if "underlying" resources are not closed:
+  * if "underlying" resources are not closed. Although redundant in this case,
+  * here is the previous example with a wrapped call to `use`:
   * {{{
-  *   def reader(filename: String) = use(new BufferedReader(use(new FileReader(filename))))
+  *   def mkreader(filename: String) = use(new BufferedReader(use(new FileReader(filename))))
   * }}}
   *
   * Custom resources can be registered on construction by requiring an implicit `Manager`.
@@ -76,7 +77,7 @@ import scala.util.control.{ControlThrowable, NonFatal}
   *   val xres = X(x)
   *   override def close() = println(s"CLOSE $y")
   *   // an error during construction releases previously acquired resources
-  *   assert(y != null, "y is null")
+  *   require(y != null, "y is null")
   *   mgr.acquire(this)
   * }
   *
@@ -88,7 +89,7 @@ import scala.util.control.{ControlThrowable, NonFatal}
   *   Using.Manager { implicit mgr =>
   *     Y(null)("X")
   *   }
-  * } // Failure(java.lang.AssertionError: assertion failed: y is null)
+  * } // Failure(java.lang.IllegalArgumentException: requirement failed: y is null)
   * }}}
   *
   * If you wish to avoid wrapping management and operations in a `Try`, you can use

--- a/src/library/scala/util/Using.scala
+++ b/src/library/scala/util/Using.scala
@@ -44,18 +44,51 @@ import scala.util.control.{ControlThrowable, NonFatal}
   * import java.io.{BufferedReader, FileReader}
   * import scala.util.{Try, Using}
   *
+  * val files = List("file1.txt", "file2.txt", "file3.txt", "file4.txt")
   * val lines: Try[Seq[String]] = Using.Manager { use =>
-  *   val r1 = use(new BufferedReader(new FileReader("file1.txt")))
-  *   val r2 = use(new BufferedReader(new FileReader("file2.txt")))
-  *   val r3 = use(new BufferedReader(new FileReader("file3.txt")))
-  *   val r4 = use(new BufferedReader(new FileReader("file4.txt")))
+  *   // acquire resources
+  *   def reader(filename: String) = use(new BufferedReader(new FileReader(filename)))
   *
   *   // use your resources here
   *   def lines(reader: BufferedReader): Iterator[String] =
   *     Iterator.continually(reader.readLine()).takeWhile(_ != null)
   *
-  *   (lines(r1) ++ lines(r2) ++ lines(r3) ++ lines(r4)).toList
+  *   files.map(reader).flatMap(lines)
   * }
+  * }}}
+  *
+  * Composed or "wrapped" resources may be acquired in order of construction,
+  * if "underlying" resources are not closed:
+  * {{{
+  *   def reader(filename: String) = use(new BufferedReader(use(new FileReader(filename))))
+  * }}}
+  *
+  * Custom resources can be registered on construction by requiring an implicit `Manager`.
+  * This ensures they will be released even if composition fails:
+  * {{{
+  * import scala.util.Using
+  *
+  * case class X(x: String)(implicit mgr: Using.Manager) extends AutoCloseable {
+  *   override def close() = println(s"CLOSE $x")
+  *   mgr.acquire(this)
+  * }
+  * case class Y(y: String)(x: String)(implicit mgr: Using.Manager) extends AutoCloseable {
+  *   val xres = X(x)
+  *   override def close() = println(s"CLOSE $y")
+  *   // an error during construction releases previously acquired resources
+  *   assert(y != null, "y is null")
+  *   mgr.acquire(this)
+  * }
+  *
+  * Using.Manager { implicit mgr =>
+  *   val y = Y("Y")("X")
+  *   println(s"USE $y")
+  * }
+  * println {
+  *   Using.Manager { implicit mgr =>
+  *     Y(null)("X")
+  *   }
+  * } // Failure(java.lang.AssertionError: assertion failed: y is null)
   * }}}
   *
   * If you wish to avoid wrapping management and operations in a `Try`, you can use


### PR DESCRIPTION
Someone asked in chat about `Using` a resource composed of other resources, where acquisition may fail.

The doc for `Using.Manager` introduces the recommendation for an implicit manager with which all "custom" resources are registered. Possibly this doc is hidden because it was deemed esoteric knowledge. The example there extends the "file reading" example.

This commit adds a simple example to the "main" doc for `Using` that doesn't try to be useful but only illustrative.

I only use `Using.resource` in unit tests because that is all I can remember how to do. It is simple and adequate. (I wonder if that doc should come first.)

To remember the other conventions, I must read the doc again. I like that the doc explains by use case: one resource is `Using.apply`, more than one is... some complicated API. That is `Using.Manager.apply`, and then you're using `Manager#apply` to register resources. I guess the reason it feels complicated is that the code example shows no types or method names. That is, `manager.acquire` is more overt.

By contrast, the "implicit manager" code is easy to read, even if the idiom "infects" the "custom resources". We call them "custom" only because they are not a pre-existing platform `Closeable`. Probably for unit tests, I would prefer implicit manager with custom resources (or resource wrappers) over custom implicit `Releasable`s.

This commit also simplifies or naturalizes the existing example code.