### PR TITLE
Improve name of default value

### DIFF
--- a/src/library/scala/collection/concurrent/Map.scala
+++ b/src/library/scala/collection/concurrent/Map.scala
@@ -32,8 +32,6 @@ import scala.annotation.tailrec
   *  provides all of the methods a `Map` does, with the difference that all the
   *  changes are atomic. It also describes methods specific to concurrent maps.
   *
-  *  '''Note''': The concurrent maps do not accept `'''null'''` for keys or values.
-  *
   *  @define atomicop
   *  This is an atomic operation.
   */
@@ -92,10 +90,10 @@ trait Map[K, V] extends scala.collection.mutable.Map[K, V] {
     */
   def replace(k: K, v: V): Option[V]
 
-  override def getOrElseUpdate(key: K, op: => V): V = get(key) match {
+  override def getOrElseUpdate(key: K, @deprecatedName("op", since="2.13.13") defaultValue: => V): V = get(key) match {
     case Some(v) => v
     case None =>
-      val v = op
+      val v = defaultValue
       putIfAbsent(key, v) match {
         case Some(ov) => ov
         case None => v

--- a/src/library/scala/collection/concurrent/TrieMap.scala
+++ b/src/library/scala/collection/concurrent/TrieMap.scala
@@ -941,25 +941,25 @@ final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater
   // TODO once computeIfAbsent is added to concurrent.Map,
   // move the comment there and tweak the 'at most once' part
   /** If the specified key is not already in the map, computes its value using
-    *  the given thunk `op` and enters it into the map.
-    *
-    *  If the specified mapping function throws an exception,
-    *  that exception is rethrown.
-    *
-    *  Note: This method will invoke op at most once.
-    *  However, `op` may be invoked without the result being added to the map if
-    *  a concurrent process is also trying to add a value corresponding to the
-    *  same key `k`.
-    *
-    *  @param k      the key to modify
-    *  @param op     the expression that computes the value
-    *  @return       the newly added value
-    */
-  override def getOrElseUpdate(k: K, op: => V): V = {
+   *  the given thunk `defaultValue` and enters it into the map.
+   *
+   *  If the specified mapping function throws an exception,
+   *  that exception is rethrown.
+   *
+   *  Note: This method will invoke `defaultValue` at most once.
+   *  However, `defaultValue` may be invoked without the result being added to the map if
+   *  a concurrent process is also trying to add a value corresponding to the
+   *  same key `k`.
+   *
+   *  @param k      the key to modify
+   *  @param defaultValue     the expression that computes the value
+   *  @return       the newly added value
+   */
+  override def getOrElseUpdate(k: K, @deprecatedName("op", since="2.13.13") defaultValue: => V): V = {
     val hc = computeHash(k)
     lookuphc(k, hc) match {
       case INodeBase.NO_SUCH_ELEMENT_SENTINEL =>
-        val v = op
+        val v = defaultValue
         insertifhc(k, hc, v, INode.KEY_ABSENT, fullEquals = false /* unused */) match {
           case Some(oldValue) => oldValue
           case None => v

--- a/src/library/scala/collection/mutable/Map.scala
+++ b/src/library/scala/collection/mutable/Map.scala
@@ -135,15 +135,15 @@ trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
    *  multiple times, or may evaluate `op` without inserting the result.
    *
    *  @param  key the key to test
-   *  @param  op  the computation yielding the value to associate with `key`, if
+   *  @param  defaultValue  the computation yielding the value to associate with `key`, if
    *              `key` is previously unbound.
    *  @return     the value associated with key (either previously or as a result
    *              of executing the method).
    */
-  def getOrElseUpdate(key: K, op: => V): V =
+  def getOrElseUpdate(key: K, @deprecatedName("op", since="2.13.13") defaultValue: => V): V =
     get(key) match {
       case Some(v) => v
-      case None => val d = op; this(key) = d; d
+      case None => val d = defaultValue; this(key) = d; d
     }
 
   /** Removes a key from this map, returning the value associated previously


### PR DESCRIPTION
The odd name was copied from old method `cached`.

https://github.com/scala/scala/commit/873a28d90c6215d91bc024ba124d11030dc77596

Addresses the anomaly noticed at https://github.com/scala/bug/issues/12897