### PR TITLE
[backport] Fixes implicit `javaBigDecimal2bigDecimal` to return `null`, when a `null` is used by the implicit

### DIFF
--- a/src/library/scala/math/BigDecimal.scala
+++ b/src/library/scala/math/BigDecimal.scala
@@ -344,7 +344,7 @@ object BigDecimal {
   implicit def double2bigDecimal(d: Double): BigDecimal = decimal(d)
 
   /** Implicit conversion from `java.math.BigDecimal` to `scala.BigDecimal`. */
-  implicit def javaBigDecimal2bigDecimal(x: BigDec): BigDecimal = apply(x)
+  implicit def javaBigDecimal2bigDecimal(x: BigDec): BigDecimal = if (x == null) null else apply(x)
 }
 
 /**

--- a/src/library/scala/math/BigInt.scala
+++ b/src/library/scala/math/BigInt.scala
@@ -105,7 +105,7 @@ object BigInt {
 
   /** Implicit conversion from `java.math.BigInteger` to `scala.BigInt`.
    */
-  implicit def javaBigInteger2bigInt(x: BigInteger): BigInt = apply(x)
+  implicit def javaBigInteger2bigInt(x: BigInteger): BigInt = if (x eq null) null else apply(x)
 }
 
 /**

--- a/test/junit/scala/math/BigDecimalTest.scala
+++ b/test/junit/scala/math/BigDecimalTest.scala
@@ -265,4 +265,13 @@ class BigDecimalTest {
   def testIsComparable() {
     assert(BigDecimal(0.1).isInstanceOf[java.lang.Comparable[_]])
   }
+
+  @Test
+  def testImplicitBigDecimalConversionJavaToScalaHandlesNull(): Unit = {
+    val bdNull: BigDecimal = (null: java.math.BigDecimal): BigDecimal
+    assert(bdNull == null)
+
+    val bdValue: BigDecimal = (BD.ONE: java.math.BigDecimal): BigDecimal
+    assert(bdValue.bigDecimal == BD.ONE)
+  }
 }

--- a/test/junit/scala/math/BigIntTest.scala
+++ b/test/junit/scala/math/BigIntTest.scala
@@ -1,6 +1,7 @@
 package scala.math
 
 
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -12,4 +13,6 @@ class BigIntTest {
   def testIsComparable() {
     assert(BigInt(1).isInstanceOf[java.lang.Comparable[_]])
   }
+
+  @Test def `BitInteger to BitInt respects null`: Unit = assertNull(null.asInstanceOf[java.math.BigInteger]: BigInt)
 }


### PR DESCRIPTION
Backports https://github.com/scala/scala/pull/9221 and https://github.com/scala/scala/pull/10593 to Scala 2.12