### PR TITLE
BigInt conversion checks for null

### DIFF
--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -254,7 +254,7 @@ final class IterableOnceExtensionMethods[A](private val it: IterableOnce[A]) ext
 }
 
 object IterableOnce {
-  @`inline` implicit def iterableOnceExtensionMethods[A](it: IterableOnce[A]): IterableOnceExtensionMethods[A] =
+  @inline implicit def iterableOnceExtensionMethods[A](it: IterableOnce[A]): IterableOnceExtensionMethods[A] =
     new IterableOnceExtensionMethods[A](it)
 
   /** Computes the number of elements to copy to an array from a source IterableOnce

--- a/src/library/scala/math/BigInt.scala
+++ b/src/library/scala/math/BigInt.scala
@@ -123,7 +123,7 @@ object BigInt {
 
   /** Implicit conversion from `java.math.BigInteger` to `scala.BigInt`.
    */
-  implicit def javaBigInteger2bigInt(x: BigInteger): BigInt = apply(x)
+  implicit def javaBigInteger2bigInt(x: BigInteger): BigInt = if (x eq null) null else apply(x)
 
   // this method is adapted from Google Guava's version at
   //   https://github.com/google/guava/blob/master/guava/src/com/google/common/math/LongMath.java

--- a/src/library/scala/util/ChainingOps.scala
+++ b/src/library/scala/util/ChainingOps.scala
@@ -16,7 +16,7 @@ package util
 import scala.language.implicitConversions
 
 trait ChainingSyntax {
-  @`inline` implicit final def scalaUtilChainingOps[A](a: A): ChainingOps[A] = new ChainingOps(a)
+  @inline implicit final def scalaUtilChainingOps[A](a: A): ChainingOps[A] = new ChainingOps(a)
 }
 
 /** Adds chaining methods `tap` and `pipe` to every type.

--- a/test/junit/scala/math/BigIntTest.scala
+++ b/test/junit/scala/math/BigIntTest.scala
@@ -1,7 +1,7 @@
 package scala.math
 
 import org.junit.Test
-import org.junit.Assert.{assertFalse, assertTrue}
+import org.junit.Assert.{assertFalse, assertNull, assertTrue}
 import scala.tools.testkit.AssertUtil.assertThrows
 
 class BigIntTest {
@@ -33,4 +33,6 @@ class BigIntTest {
   @Test def `testBit respects BigInteger`: Unit = assertThrows[ArithmeticException](bigint.testBit(-3), _.contains("Negative bit address"))
 
   @Test def `testBit 0`: Unit = assertFalse(bigint.testBit(0))
+
+  @Test def `BitInteger to BitInt respects null`: Unit = assertNull(null.asInstanceOf[java.math.BigInteger]: BigInt)
 }


### PR DESCRIPTION
Follow up null check for `BigDecimal` with same check for `BigInt`.

Generally, a conversion to a wrapper should not wrap null, and also should not throw.

As a weak motivating use case, the presence of the implicit value for evidence doesn't care if the value is null.

`ScalaRunTime.wrapIntArray` and friends are all null-aware.

Conversions to a value class for extension methods, where wrapping is not expected, permit null.

After a non-scientific survey, only `BigInt` conversion remains to fix; not sure why it wasn't fixed under the umbrella of `BigDecimal`.

There are dubious conversions in partest and other subprojects; these are conversions of convenience, so NPE sooner or later is OK.

Sample where NPE would be clearly too restrictive:
```
null.asInstanceOf[String].tap(println)
```

Current behavior of converters is as desired:
```
scala 2.13.12> import scala.jdk.CollectionConverters._
import scala.jdk.CollectionConverters._

scala 2.13.12> null.asInstanceOf[java.util.List[String]].asScala
val res0: scala.collection.mutable.Buffer[String] = null
```

Fixes scala/bug#9176