### PR TITLE
Fix enabling IncOptions.useOptimizedSealed causing under-compilation in Scala 2.13

### DIFF
--- a/src/sbt-bridge/scala/tools/xsbt/ExtractUsedNames.scala
+++ b/src/sbt-bridge/scala/tools/xsbt/ExtractUsedNames.scala
@@ -252,6 +252,9 @@ class ExtractUsedNames[GlobalType <: CallbackGlobal](val global: GlobalType)
 
     private def handleClassicTreeNode(tree: Tree): Unit = tree match {
       // Register names from pattern match target type in PatMatTarget scope
+      case matchNode: Match =>
+        updateCurrentOwner()
+        PatMatDependencyTraverser.traverse(matchNode.selector.tpe)
       case ValDef(mods, _, tpt, _) if mods.isCase && mods.isSynthetic =>
         updateCurrentOwner()
         PatMatDependencyTraverser.traverse(tpt.tpe)

--- a/test/junit/scala/tools/xsbt/ExtractUsedNamesTest.scala
+++ b/test/junit/scala/tools/xsbt/ExtractUsedNamesTest.scala
@@ -2,6 +2,7 @@ package scala.tools.xsbt
 
 import org.junit.Assert._
 import org.junit.{Ignore, Test}
+import xsbti.UseScope
 
 class ExtractUsedNamesTest extends BridgeTesting {
 
@@ -251,6 +252,22 @@ class ExtractUsedNamesTest extends BridgeTesting {
     assertEquals(usedNames("TuplerInstances.<refinement>"), expectedNamesForTuplerInstancesRefinement)
   }
 
+  @Test
+  def `zinc/issues/753`(): Unit = {
+    val src =
+      """sealed trait T
+        |class O extends T
+        |object Arr {
+        |  def test(x: T): Int = x match {
+        |    case _: O => 1
+        |  }
+        |}
+        |""".stripMargin
+    withTemporaryDirectory { tmpDir =>
+      val (_, analysisCallback) = compileSrcs(tmpDir, src)
+      assertTrue(analysisCallback.usedNamesAndScopes("Arr").find(_.name == "T").get.scopes.contains(UseScope.PatMatTarget))
+    }
+  }
 
   /**
    * Standard names that appear in every compilation unit that has any class


### PR DESCRIPTION
Backports fix from https://github.com/sbt/zinc/pull/1278.

Related Issue: https://github.com/sbt/zinc/issues/753 https://github.com/sbt/zinc/issues/1229