### PR TITLE
isCompatibleSam allows PartialFunction

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -331,7 +331,7 @@ trait Infer extends Checkable {
         && !isByNameParamType(tp)
         && isCompatible(tp, dropByName(pt))
       )
-      def isCompatibleSam(tp: Type, pt: Type): Boolean = (definitions.isFunctionType(tp) || tp.isInstanceOf[MethodType] || tp.isInstanceOf[PolyType]) &&  {
+      def isCompatibleSam(tp: Type, pt: Type): Boolean = (definitions.isFunctionType(tp) || definitions.isPartialFunctionType(tp) || tp.isInstanceOf[MethodType] || tp.isInstanceOf[PolyType]) &&  {
         val samFun = samToFunctionType(pt)
         (samFun ne NoType) && isCompatible(tp, samFun)
       }

--- a/test/files/pos/t12899.scala
+++ b/test/files/pos/t12899.scala
@@ -1,0 +1,18 @@
+object Kafi {
+  // OK in 2.12, fails in 2.13 with "missing parameter type for expanded function"
+  val c1: Cache[(Seq[String], Class[_]), String] = build {
+    case (sq, cs) => mk(sq, cs)
+  }
+
+  // OK in both 2.12 and 2.13
+  val c2: Cache[(Seq[String], Class[_]), String] = build(
+    key => mk(key._1, key._2)
+  )
+
+  def mk(sq: Seq[String], cs: Class[_]): String = ""
+
+  def build[K, V](): Cache[K, V] = null
+  def build[K, V](c: Cache[K, V]): Cache[K, V] = null
+
+  trait Cache[K, V] { def load(k: K): V }
+}


### PR DESCRIPTION
https://github.com/scala/scala/pull/5698 extended prefiltering overloads by mapping `case { ... }` arguments to `PartialFunction[Any, Nothing]`. If the parameter is a SAM type though this didn't go through because `isCompatibleSam` wasn't adapted to let `PartialFunction` arguments pass.

Fixes https://github.com/scala/bug/issues/12899