### PR TITLE
Optimize `NonFatal` tests

### DIFF
--- a/src/compiler/scala/tools/nsc/CloseableRegistry.scala
+++ b/src/compiler/scala/tools/nsc/CloseableRegistry.scala
@@ -28,7 +28,7 @@ final class CloseableRegistry extends Closeable {
       try {
         c.close()
       } catch {
-        case NonFatal(_) =>
+        case ex if NonFatal(ex) =>
       }
     }
     closeables = Nil

--- a/src/compiler/scala/tools/nsc/ObjectRunner.scala
+++ b/src/compiler/scala/tools/nsc/ObjectRunner.scala
@@ -35,7 +35,7 @@ trait CommonRunner {
    */
   def runAndCatch(urls: Seq[URL], objectName: String, arguments: Seq[String]): Option[Throwable] =
     try   { run(urls, objectName, arguments) ; None }
-    catch { case NonFatal(e) => Some(rootCause(e)) }
+    catch { case e if NonFatal(e) => Some(rootCause(e)) }
 }
 
 /** An object that runs another object specified by name.

--- a/src/compiler/scala/tools/nsc/ScriptRunner.scala
+++ b/src/compiler/scala/tools/nsc/ScriptRunner.scala
@@ -131,7 +131,7 @@ abstract class AbstractScriptRunner(settings: GenericRunnerSettings) extends Scr
                   Jar.create(jarFile, compiledPath.toDirectory, mainClass)
                   None
                 } catch {
-                  case NonFatal(e) => jarFile.delete() ; Some(e)
+                  case e if NonFatal(e) => jarFile.delete() ; Some(e)
                 }
               } else None
             } else Some(NoScriptError)
@@ -184,7 +184,7 @@ abstract class AbstractScriptRunner(settings: GenericRunnerSettings) extends Scr
 
     try withCompiledScript(scriptFile.path) { runCompiled(_, scriptArgs) }
     catch {
-      case NonFatal(e) => Some(e)
+      case e if NonFatal(e) => Some(e)
     }
     finally scriptFile.delete()  // in case there was a compilation error
   }

--- a/src/compiler/scala/tools/nsc/backend/jvm/GeneratedClassHandler.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/GeneratedClassHandler.scala
@@ -173,7 +173,7 @@ private[jvm] object GeneratedClassHandler {
           unitInPostProcess.task.value.get.get
         } catch {
           case _: ClosedByInterruptException => throw new InterruptedException()
-          case NonFatal(t) =>
+          case t if NonFatal(t) =>
             t.printStackTrace()
             frontendAccess.backendReporting.error(NoPosition, s"unable to write ${unitInPostProcess.sourceFile} $t")
         }

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
@@ -959,7 +959,7 @@ object BackendUtils {
 
       @inline def safely(f: => Unit): Unit = try f catch {
         case Aborted =>
-        case NonFatal(e) => raiseError(s"Exception thrown during signature parsing", sig, Some(e))
+        case e if NonFatal(e) => raiseError(s"Exception thrown during signature parsing", sig, Some(e))
       }
 
       private def current = {

--- a/src/compiler/scala/tools/nsc/fsc/CompileSocket.scala
+++ b/src/compiler/scala/tools/nsc/fsc/CompileSocket.scala
@@ -214,7 +214,7 @@ class CompileSocket extends CompileOutputCommon {
   }
 
   private def chmodFailHandler(msg: String): PartialFunction[Throwable, Unit] = {
-    case NonFatal(e) =>
+    case e if NonFatal(e) =>
       if (verbose) e.printStackTrace()
       fatal(msg)
   }

--- a/src/compiler/scala/tools/nsc/fsc/ResidentScriptRunner.scala
+++ b/src/compiler/scala/tools/nsc/fsc/ResidentScriptRunner.scala
@@ -48,6 +48,6 @@ final class DaemonKiller(settings: GenericRunnerSettings) extends ScriptRunner {
       new StandardCompileClient().process(Array("-shutdown"))
       None
     } catch {
-      case NonFatal(t) => Some(t)
+      case t if NonFatal(t) => Some(t)
     }
 }

--- a/src/compiler/scala/tools/nsc/plugins/Plugin.scala
+++ b/src/compiler/scala/tools/nsc/plugins/Plugin.scala
@@ -122,7 +122,7 @@ object Plugin {
     try {
       Success[AnyClass](loader loadClass classname)
     } catch {
-      case NonFatal (_) =>
+      case ex if NonFatal(ex) =>
         Failure(new PluginLoadException(classname, s"Error: unable to load class: $classname"))
       case e: NoClassDefFoundError =>
         Failure(new PluginLoadException(classname, s"Error: class not found: ${e.getMessage} required by $classname"))

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -993,7 +993,7 @@ abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
     else Some(AnnotationInfo(attrType, List(), nvpairs.toList))
   } catch {
     case f: FatalError => throw f // don't eat fatal errors, they mean a class was not found
-    case NonFatal(ex) =>
+    case ex if NonFatal(ex) =>
       // We want to be robust when annotations are unavailable, so the very least
       // we can do is warn the user about the exception
       // There was a reference to ticket 1135, but that is outdated: a reference to a class not on

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -988,7 +988,7 @@ trait ContextErrors extends splain.SplainErrors {
           } catch {
             // the code above tries various tricks to detect the relevant portion of the stack trace
             // if these tricks fail, just fall back to uninformative, but better than nothing.
-            case NonFatal(ex) =>
+            case ex if NonFatal(ex) =>
               macroLogVerbose("got an exception when processing a macro generated exception\n" +
                               "offender = " + stackTraceString(realex) + "\n" +
                               "error = " + stackTraceString(ex))

--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -817,7 +817,7 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
               case ex: AbortMacroException => MacroGeneratedAbort(expandee, ex)
               case ex: ControlThrowable => throw ex
               case ex: TypeError => MacroGeneratedTypeError(expandee, ex)
-              case NonFatal(_) => MacroGeneratedException(expandee, realex)
+              case ex if NonFatal(ex) => MacroGeneratedException(expandee, realex)
               case fatal => throw fatal
             }
         } finally {

--- a/src/library/scala/sys/process/ProcessBuilderImpl.scala
+++ b/src/library/scala/sys/process/ProcessBuilderImpl.scala
@@ -180,7 +180,7 @@ private[process] trait ProcessBuilderImpl {
         done {
           try process.exitValue()
           catch {
-            case NonFatal(_) => -2
+            case ex if NonFatal(ex) => -2
           }
         }
       }

--- a/src/library/scala/util/control/ControlThrowable.scala
+++ b/src/library/scala/util/control/ControlThrowable.scala
@@ -27,7 +27,7 @@ package scala.util.control
  *        if (p(v)) break
  *        else ???
  *      } catch {
- *        case NonFatal(t) => log(t)  // can't catch a break
+ *        case t if NonFatal(t) => log(t)  // can't catch a break
  *      }
  *    }
  *  }

--- a/src/library/scala/util/control/Exception.scala
+++ b/src/library/scala/util/control/Exception.scala
@@ -272,7 +272,7 @@ object Exception {
   }
 
   final val nothingCatcher: Catcher[Nothing]  = mkThrowableCatcher(_ => false, throw _)
-  final def nonFatalCatcher[T]: Catcher[T]    = mkThrowableCatcher({ case NonFatal(_) => true; case _ => false }, throw _)
+  final def nonFatalCatcher[T]: Catcher[T]    = mkThrowableCatcher({ case ex if NonFatal(ex) => true; case _ => false }, throw _)
   final def allCatcher[T]: Catcher[T]         = mkThrowableCatcher(_ => true, throw _)
 
   /** The empty `Catch` object.

--- a/src/partest/scala/tools/partest/nest/Runner.scala
+++ b/src/partest/scala/tools/partest/nest/Runner.scala
@@ -245,7 +245,7 @@ class Runner(val testInfo: TestInfo, val suiteRunner: AbstractRunner) {
             finally out.close()
           } catch {
             case t: ControlThrowable => throw t
-            case NonFatal(t) =>
+            case t if NonFatal(t) =>
               // We'll let the checkfile diffing report this failure
               Files.write(log.toPath, stackTraceString(t).getBytes(Charset.defaultCharset()), CREATE, APPEND)
             case t: Throwable =>

--- a/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
+++ b/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
@@ -43,7 +43,7 @@ abstract class UnPickler {
       assert(classRoot != NoSymbol && moduleRoot != NoSymbol, s"The Unpickler expects a class and module symbol: $classRoot - $moduleRoot")
       new Scan(bytes, offset, classRoot, moduleRoot, filename).run()
     } catch {
-      case NonFatal(ex) =>
+      case ex if NonFatal(ex) =>
         /*if (settings.debug.value)*/ ex.printStackTrace()
         throw new RuntimeException("error reading Scala signature of "+filename+": "+ex.getMessage())
     }

--- a/src/repl-frontend/scala/tools/nsc/interpreter/jline/Reader.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/jline/Reader.scala
@@ -147,7 +147,7 @@ object Reader {
 
     val reader = builder.build()
     try inputrcFileContents.foreach(f => InputRC.configure(reader, new ByteArrayInputStream(f))) catch {
-      case NonFatal(_) =>
+      case ex if NonFatal(ex) =>
     } //ignore
 
     val keyMap = reader.getKeyMaps.get("main")

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/ReplCompletion.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/ReplCompletion.scala
@@ -64,7 +64,7 @@ class ReplCompletion(intp: Repl, val accumulator: Accumulator = new Accumulator)
         } finally result.cleanup()
       }
     } catch {
-      case NonFatal(e) =>
+      case e if NonFatal(e) =>
         if (intp.settings.debug.value)
           e.printStackTrace()
         NoCompletions

--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -220,7 +220,7 @@ class IMain(val settings: Settings, parentClassLoaderOverride: Option[ClassLoade
     assert(bindExceptions, "withLastExceptionLock called incorrectly.")
     bindExceptions = false
 
-    try reporter.withoutPrintingResults(body) catch { case NonFatal(t) =>
+    try reporter.withoutPrintingResults(body) catch { case t if NonFatal(t) =>
       repldbg("withLastExceptionLock: " + rootCause(t))
       reporter.trace(stackTraceString(rootCause(t)))
       alt

--- a/src/tastytest/scala/tools/tastytest/Dotc.scala
+++ b/src/tastytest/scala/tools/tastytest/Dotc.scala
@@ -72,7 +72,7 @@ object Dotc extends Script.Command {
       op
     }
     catch {
-      case NonFatal(ex) => throw ReflectionUtils.unwrapThrowable(ex)
+      case ex if NonFatal(ex) => throw ReflectionUtils.unwrapThrowable(ex)
     }
   }
 

--- a/src/tastytest/scala/tools/tastytest/Runner.scala
+++ b/src/tastytest/scala/tools/tastytest/Runner.scala
@@ -39,7 +39,7 @@ class Runner private (classloader: ScalaClassLoader) {
     def kernel(out: OutputStream, err: OutputStream): Try[Unit] = Try {
       try classloader.asContext[Unit](Runner_run.invoke(null, name, out, err))
       catch {
-        case NonFatal(ex) => throw ReflectionUtils.unwrapThrowable(ex)
+        case ex if NonFatal(ex) => throw ReflectionUtils.unwrapThrowable(ex)
       }
     }
     val outStream = new ByteArrayOutputStream(50)
@@ -76,7 +76,7 @@ object Runner extends Script.Command {
       classloader.asContext[Unit](main.invoke(null, Array.empty[String]))
     }
     catch {
-      case NonFatal(ex) => throw ReflectionUtils.unwrapThrowable(ex)
+      case ex if NonFatal(ex) => throw ReflectionUtils.unwrapThrowable(ex)
     }
   }
 

--- a/src/testkit/scala/tools/testkit/AssertUtil.scala
+++ b/src/testkit/scala/tools/testkit/AssertUtil.scala
@@ -148,7 +148,7 @@ object AssertUtil {
         val ae = new AssertionError(s"Exception failed check: $failed")
         ae.addSuppressed(failed)
         throw ae
-      case NonFatal(other) =>
+      case other if NonFatal(other) =>
         val ae = new AssertionError(s"Wrong exception: expected ${implicitly[ClassTag[T]]} but was ${other.getClass.getName}")
         ae.addSuppressed(other)
         throw ae

--- a/test/junit/scala/concurrent/impl/DefaultPromiseTest.scala
+++ b/test/junit/scala/concurrent/impl/DefaultPromiseTest.scala
@@ -314,7 +314,7 @@ class DefaultPromiseTest {
               f
               doneLatch.countDown()
             } catch {
-              case NonFatal(e) => ec.reportFailure(e)
+              case e if NonFatal(e) => ec.reportFailure(e)
             }
           }
         })

--- a/test/junit/scala/util/control/ControlThrowableTest.scala
+++ b/test/junit/scala/util/control/ControlThrowableTest.scala
@@ -30,7 +30,7 @@ class ControlThrowableTest {
   @Test
   def fatal(): Unit =
     new MyCtl match {
-      case NonFatal(_) => fail("ControlThrowable was NonFatal")
+      case ex if NonFatal(ex) => fail("ControlThrowable was NonFatal")
       case _ => ()
     }
 

--- a/test/tasty/run/pre/tastytest/Suite.scala
+++ b/test/tasty/run/pre/tastytest/Suite.scala
@@ -48,7 +48,7 @@ class Suite(val name: String) {
     for ((ctx, test) <- tests) {
       try test()
       catch {
-        case NonFatal(err) => errors += (ctx -> err)
+        case err if NonFatal(err) => errors += (ctx -> err)
       }
     }
     if (errors.nonEmpty) {


### PR DESCRIPTION
In theory this avoids an allocation (see https://github.com/typelevel/cats/pull/4282) but in practice we haven't measured a performance difference (see https://github.com/typelevel/cats-effect/pull/3223).

If we want to do it anyway I bet there's some other places in the library that we could apply this to e.g. `Future`.