### PR TITLE
Improve performance of Boolean extractors such as `NonFatal`

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
@@ -66,6 +66,14 @@ trait PatternMatching extends Transform
 
   class MatchTransformer(unit: CompilationUnit) extends TypingTransformer(unit) {
     override def transform(tree: Tree): Tree = tree match {
+      case CaseDef(UnApply(Apply(Select(qual, nme.unapply), Ident(nme.SELECTOR_DUMMY) :: Nil), (bind@Bind(b, Ident(nme.WILDCARD))) :: Nil), guard, body)
+        if guard.isEmpty && qual.symbol == definitions.NonFatalModule =>
+        transform(treeCopy.CaseDef(
+          tree,
+          bind,
+          localTyper.typed(atPos(tree.pos)(Apply(gen.mkAttributedRef(definitions.NonFatal_apply), List(Ident(bind.symbol))))),
+          body))
+
       case Match(sel, cases) =>
         val origTp = tree.tpe
 

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2614,13 +2614,23 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
     def typedCase(cdef: CaseDef, pattpe: Type, pt: Type): CaseDef = {
       // verify no _* except in last position
-      for (Apply(_, xs) <- cdef.pat ; x <- xs dropRight 1 ; if treeInfo isStar x)
-        StarPositionInPatternError(x)
+      for (Apply(_, xs) <- cdef.pat; x <- xs.dropRight(1))
+        if (treeInfo.isStar(x)) StarPositionInPatternError(x)
 
       // withoutAnnotations - see continuations-run/z1673.scala
       // This adjustment is awfully specific to continuations, but AFAICS the
       // whole AnnotationChecker framework is.
-      val pat1 = typedPattern(cdef.pat, pattpe.withoutAnnotations)
+      val pat0 = typedPattern(cdef.pat, pattpe.withoutAnnotations)
+      var guard0 = cdef.guard
+
+      // rewrite `case NonFatal(x) =>` to `case x if NonFatal(x) =>`
+      val pat1 = pat0 match {
+        case UnApply(Apply(Select(qual, nme.unapply), Ident(nme.SELECTOR_DUMMY) :: Nil), (bind @ Bind(b, Ident(nme.WILDCARD))) :: Nil)
+        if !pat0.isErroneous && qual.symbol.eq(NonFatalModule) && guard0.isEmpty =>
+          guard0 = Apply(Select(qual, nme.apply), Ident(b) :: Nil)
+          bind
+        case p0 => p0
+      }
 
       for (bind @ Bind(name, _) <- cdef.pat) {
         val sym = bind.symbol
@@ -2633,8 +2643,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         }
       }
 
-      val guard1: Tree = if (cdef.guard == EmptyTree) EmptyTree
-                         else typed(cdef.guard, BooleanTpe)
+      val guard1: Tree = if (guard0 == EmptyTree) EmptyTree
+                         else typed(guard0, BooleanTpe)
       var body1: Tree = typed(cdef.body, pt)
 
       if (context.enclosingCaseDef.savedTypeBounds.nonEmpty) {

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -711,7 +711,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val SuccessClass = requiredClass[scala.util.Success[_]]
     lazy val FutureClass = requiredClass[scala.concurrent.Future[_]]
     lazy val PromiseClass = requiredClass[scala.concurrent.Promise[_]]
-    lazy val NonFatalClass = requiredClass[scala.util.control.NonFatal.type]
+    lazy val NonFatalModule = requiredModule[scala.util.control.NonFatal.type]
 
     def unspecializedSymbol(sym: Symbol): Symbol = {
       if (sym hasFlag SPECIALIZED) {

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -711,7 +711,9 @@ trait Definitions extends api.StandardDefinitions {
     lazy val SuccessClass = requiredClass[scala.util.Success[_]]
     lazy val FutureClass = requiredClass[scala.concurrent.Future[_]]
     lazy val PromiseClass = requiredClass[scala.concurrent.Promise[_]]
+
     lazy val NonFatalModule = requiredModule[scala.util.control.NonFatal.type]
+    lazy val NonFatal_apply = getMemberMethod(NonFatalModule, nme.apply)
 
     def unspecializedSymbol(sym: Symbol): Symbol = {
       if (sym hasFlag SPECIALIZED) {

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -395,6 +395,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.FutureClass
     definitions.PromiseClass
     definitions.NonFatalModule
+    definitions.NonFatal_apply
     definitions.MacroContextType
     definitions.ProductRootClass
     definitions.Any_$eq$eq

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -394,7 +394,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.SuccessClass
     definitions.FutureClass
     definitions.PromiseClass
-    definitions.NonFatalClass
+    definitions.NonFatalModule
     definitions.MacroContextType
     definitions.ProductRootClass
     definitions.Any_$eq$eq

--- a/test/files/run/nonfatal.scala
+++ b/test/files/run/nonfatal.scala
@@ -1,0 +1,23 @@
+
+//> using options -opt:none
+//
+import scala.tools.partest.BytecodeTest
+import scala.tools.testkit.ASMConverters.instructionsFromMethod
+import org.junit.Assert.assertEquals
+
+object Test extends BytecodeTest {
+  def show(): Unit = {
+    val classNode = loadClassNode("C")
+    val f = getMethod(classNode, "f")
+    val g = getMethod(classNode, "g")
+    assertEquals(instructionsFromMethod(f), instructionsFromMethod(g))
+    //sameBytecode(f, g) // prints
+  }
+}
+
+class C {
+  import scala.util.control.NonFatal
+  def x = 42
+  def f = try x catch { case NonFatal(e) => e.printStackTrace(); -1 }
+  def g = try x catch { case e if NonFatal(e) => e.printStackTrace(); -1 }
+}


### PR DESCRIPTION
As suggested by https://github.com/scala/scala/pull/10600
