### PR TITLE
Uniform -opt in tests

### DIFF
--- a/test/files/instrumented/InstrumentationTest.scala
+++ b/test/files/instrumented/InstrumentationTest.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:none
+//> using options -opt:none
 import scala.tools.partest.instrumented.Instrumentation._
 
 /** We check if classes put in empty package are properly instrumented */

--- a/test/files/jvm/bytecode-test-example/Foo_1.scala
+++ b/test/files/jvm/bytecode-test-example/Foo_1.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:none
+//> using options -opt:none
 class Foo_1 {
   def foo(x: AnyRef): Int = {
     val bool = x == null

--- a/test/files/jvm/bytecode-test-example/Test.scala
+++ b/test/files/jvm/bytecode-test-example/Test.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:none
+//> using options -opt:none
 import scala.tools.partest.BytecodeTest
 
 import scala.tools.nsc.util.JavaClassPath

--- a/test/files/jvm/matchbox/Test.scala
+++ b/test/files/jvm/matchbox/Test.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:method -Xlint
+//> using options -opt:local -Xlint
 import scala.jdk.CollectionConverters._
 import scala.reflect.{classTag, ClassTag}
 import scala.tools.asm, asm.ClassReader, asm.tree

--- a/test/files/jvm/matchbox/matchbox_1.scala
+++ b/test/files/jvm/matchbox/matchbox_1.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:method
+//> using options -opt:local
 object Matchbox {
   import scala.{specialized => sp}
 

--- a/test/files/jvm/unreachable/Foo_1.scala
+++ b/test/files/jvm/unreachable/Foo_1.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:default
+//> using options -opt:default
 import scala.sys.error
 
 class Foo_1 {

--- a/test/files/neg/deprecated.scala
+++ b/test/files/neg/deprecated.scala
@@ -1,4 +1,4 @@
-// scalac: -Xlint:deprecation -Werror -opt:inline:<sources>
+//> using options -Xlint:deprecation -Werror -opt:inline:<sources>
 //
 
 trait T {

--- a/test/files/run/anyval-box-types.scala
+++ b/test/files/run/anyval-box-types.scala
@@ -1,4 +1,4 @@
-// scalac: -Xmaxwarns 0 -opt:l:method
+//> using options -Xmaxwarns 0 -opt:local
 //
 object Test extends App {
 

--- a/test/files/run/nothingTypeNoOpt.scala
+++ b/test/files/run/nothingTypeNoOpt.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:none
+//> using options -opt:none
 //
 // See comment in BCodeBodyBuilder
 

--- a/test/files/run/t7407.scala
+++ b/test/files/run/t7407.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:none
+//> using options -opt:none
 //
 // scala/bug#7407
 object Test {

--- a/test/files/run/t7852.scala
+++ b/test/files/run/t7852.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:none
+//> using options -opt:none
 //
 import scala.tools.partest.BytecodeTest
 import scala.tools.asm

--- a/test/files/run/t8925.scala
+++ b/test/files/run/t8925.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:none
+//> using options -opt:none
 //
 object Ex {
   def unapply(t: Throwable): Option[Throwable] = Some(t)

--- a/test/files/specialized/spec-patmatch.scala
+++ b/test/files/specialized/spec-patmatch.scala
@@ -1,4 +1,4 @@
-// scalac: -opt:l:none
+//> using options -opt:none
 class Foo[@specialized A] {
   def test(x: A) = println(x match {
    case _: Boolean => "bool"


### PR DESCRIPTION
Bring optimizer options up to date in tests.

Did not attempt to use scala-cli style everywhere in the known universe.