### PR TITLE
Add or improve library doc [ci: last-only]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -418,7 +418,8 @@ lazy val library = configureAsSubproject(project)
       Seq(
         "-doc-no-compile", libraryAuxDir.toString,
         "-skip-packages", "scala.concurrent.impl",
-        "-doc-root-content", (Compile / sourceDirectory).value + "/rootdoc.txt"
+        "-doc-root-content", (Compile / sourceDirectory).value + "/rootdoc.txt",
+        //"-required", // placeholder for internal flag
       )
     },
     Compile / console / scalacOptions := {

--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -401,7 +401,7 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
    *
    *  The matching prefix starts with the first element of this $coll,
    *  and the element following the prefix is the first element that
-   *  does not satisfy the predicate. The matching prefix may empty,
+   *  does not satisfy the predicate. The matching prefix may be empty,
    *  so that this method returns the entire $coll.
    *
    *  Example:
@@ -1188,7 +1188,20 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
     None
   }
 
-  @deprecated("`aggregate` is not relevant for sequential collections. Use `foldLeft(z)(seqop)` instead.", "2.13.0")
+  /** Aggregates the results of applying an operator to subsequent elements.
+   *
+   *  Since this method degenerates to `foldLeft` for sequential (non-parallel) collections,
+   *  where the combining operation is ignored, it is advisable to prefer `foldLeft` for that case.
+   *
+   *  For [[https://github.com/scala/scala-parallel-collections parallel collections]],
+   *  use the `aggregate` method specified by `scala.collection.parallel.ParIterableLike`.
+   *
+   *  @param   z      the start value, a neutral element for `seqop`.
+   *  @param   seqop  the binary operator used to accumulate the result.
+   *  @param   combop an associative operator for combining sequential results, unused for sequential collections.
+   *  @tparam  B      the result type, produced by `seqop`, `combop`, and by this function as a final result.
+   */
+  @deprecated("For sequential collections, prefer `foldLeft(z)(seqop)`. For parallel collections, use `ParIterableLike#aggregate`.", "2.13.0")
   def aggregate[B](z: => B)(seqop: (B, A) => B, combop: (B, B) => B): B = foldLeft(z)(seqop)
 
   /** Tests whether every element of this collection's iterator relates to the

--- a/src/library/scala/collection/Map.scala
+++ b/src/library/scala/collection/Map.scala
@@ -276,13 +276,14 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
   def mapValues[W](f: V => W): MapView[K, W] = new MapView.MapValues(this, f)
 
   /** Defines the default value computation for the map,
-    *  returned when a key is not found
-    *  The method implemented here throws an exception,
-    *  but it might be overridden in subclasses.
-    *
-    *  @param key the given key value for which a binding is missing.
-    *  @throws NoSuchElementException
-    */
+   *  returned when a key is not found.
+   *
+   *  The method implemented here throws an exception,
+   *  but it may be overridden by subclasses.
+   *
+   *  @param key the given key value for which a binding is missing.
+   *  @throws NoSuchElementException if no default value is defined
+   */
   @throws[NoSuchElementException]
   def default(key: K): V =
     throw new NoSuchElementException("key not found: " + key)

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -928,7 +928,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     *
     * Patching at negative indices is the same as patching starting at 0.
     * Patching at indices at or larger than the length of the original $coll appends the patch to the end.
-    * If more values are replaced than actually exist, the excess is ignored.
+    * If the `replaced` count would exceed the available elements, the difference in excess is ignored.
     *
     *  @param  from     the index of the first replaced element
     *  @param  other    the replacement sequence

--- a/src/library/scala/collection/StringOps.scala
+++ b/src/library/scala/collection/StringOps.scala
@@ -973,36 +973,38 @@ final class StringOps(private val s: String) extends AnyVal {
   }
 
   /** Uses the underlying string as a pattern (in a fashion similar to
-    *  printf in C), and uses the supplied arguments to fill in the
-    *  holes.
-    *
-    *    The interpretation of the formatting patterns is described in
-    *    [[java.util.Formatter]], with the addition that
-    *    classes deriving from `ScalaNumber` (such as [[scala.BigInt]] and
-    *    [[scala.BigDecimal]]) are unwrapped to pass a type which `Formatter`
-    *    understands.
-    *
-    *  @param args the arguments used to instantiating the pattern.
-    *  @throws java.lang.IllegalArgumentException
-    */
-  def format(args : Any*): String =
-    java.lang.String.format(s, args map unwrapArg: _*)
+   *  printf in C), and uses the supplied arguments to fill in the
+   *  holes.
+   *
+   *  The interpretation of the formatting patterns is described in
+   *  [[java.util.Formatter]], with the addition that
+   *  classes deriving from `ScalaNumber` (such as [[scala.BigInt]] and
+   *  [[scala.BigDecimal]]) are unwrapped to pass a type which `Formatter` understands.
+   *
+   *  See [[scala.StringContext#f]] for a formatting interpolator that
+   *  checks the format string at compilation.
+   *
+   *  @param args the arguments used to instantiating the pattern.
+   *  @throws java.util.IllegalFormatException if the format contains syntax or conversion errors
+   */
+  def format(args: Any*): String =
+    java.lang.String.format(s, args.map(unwrapArg): _*)
 
   /** Like `format(args*)` but takes an initial `Locale` parameter
-    *  which influences formatting as in `java.lang.String`'s format.
-    *
-    *    The interpretation of the formatting patterns is described in
-    *    [[java.util.Formatter]], with the addition that
-    *    classes deriving from `ScalaNumber` (such as `scala.BigInt` and
-    *    `scala.BigDecimal`) are unwrapped to pass a type which `Formatter`
-    *    understands.
-    *
-    *  @param l    an instance of `java.util.Locale`
-    *  @param args the arguments used to instantiating the pattern.
-    *  @throws java.lang.IllegalArgumentException
-    */
+   *  which influences formatting as in `java.lang.String`'s format.
+   *
+   *    The interpretation of the formatting patterns is described in
+   *    [[java.util.Formatter]], with the addition that
+   *    classes deriving from `ScalaNumber` (such as `scala.BigInt` and
+   *    `scala.BigDecimal`) are unwrapped to pass a type which `Formatter`
+   *    understands.
+   *
+   *  @param l    an instance of `java.util.Locale`
+   *  @param args the arguments used to instantiating the pattern.
+   *  @throws java.util.IllegalFormatException if the format contains syntax or conversion errors
+   */
   def formatLocal(l: java.util.Locale, args: Any*): String =
-    java.lang.String.format(l, s, args map unwrapArg: _*)
+    java.lang.String.format(l, s, args.map(unwrapArg): _*)
 
   def compare(that: String): Int = s.compareTo(that)
 

--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -163,11 +163,11 @@ sealed class Queue[+A] protected(protected val in: List[A], protected val out: L
   def enqueueAll[B >: A](iter: scala.collection.Iterable[B]): Queue[B] = appendedAll(iter)
 
   /** Returns a tuple with the first element in the queue,
-    *  and a new queue with this element removed.
-    *
-    *  @throws NoSuchElementException
-    *  @return the first element of the queue.
-    */
+   *  and a new queue with this element removed.
+   *
+   *  @return the first element of the queue.
+   *  @throws NoSuchElementException if the queue is empty
+   */
   def dequeue: (A, Queue[A]) = out match {
     case Nil if !in.isEmpty => val rev = in.reverse ; (rev.head, new Queue(Nil, rev.tail))
     case x :: xs            => (x, new Queue(in, xs))
@@ -182,11 +182,11 @@ sealed class Queue[+A] protected(protected val in: List[A], protected val out: L
   def dequeueOption: Option[(A, Queue[A])] = if(isEmpty) None else Some(dequeue)
 
   /** Returns the first element in the queue, or throws an error if there
-    *  is no element contained in the queue.
-    *
-    *  @throws NoSuchElementException
-    *  @return the first element.
-    */
+   *  is no element contained in the queue.
+   *
+   *  @throws NoSuchElementException if the queue is empty
+   *  @return the first element.
+   */
   def front: A = head
 
   /** Returns a string representation of this queue.

--- a/src/library/scala/collection/mutable/AnyRefMap.scala
+++ b/src/library/scala/collection/mutable/AnyRefMap.scala
@@ -475,11 +475,30 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K => V, initi
     this
   }
 
-  // The implicit dummy parameter is necessary to distinguish these methods from the base methods they overload (not override)
+  // The implicit dummy parameter is necessary to distinguish these methods from the base methods they overload (not override).
+  // Previously, in Scala 2, f took `K with AnyRef` scala/bug#11035
+  /**
+   * An overload of `map` which produces an `AnyRefMap`.
+   *
+   * @param f the mapping function must produce a key-value pair where the key is an `AnyRef`
+   * @param dummy an implicit placeholder for purposes of distinguishing the (erased) signature of this method
+   */
   def map[K2 <: AnyRef, V2](f: ((K, V)) => (K2, V2))(implicit dummy: DummyImplicit): AnyRefMap[K2, V2] =
     AnyRefMap.from(new View.Map(this, f))
+  /**
+   * An overload of `flatMap` which produces an `AnyRefMap`.
+   *
+   * @param f the mapping function must produce key-value pairs where the key is an `AnyRef`
+   * @param dummy an implicit placeholder for purposes of distinguishing the (erased) signature of this method
+   */
   def flatMap[K2 <: AnyRef, V2](f: ((K, V)) => IterableOnce[(K2, V2)])(implicit dummy: DummyImplicit): AnyRefMap[K2, V2] =
     AnyRefMap.from(new View.FlatMap(this, f))
+  /**
+   * An overload of `collect` which produces an `AnyRefMap`.
+   *
+   * @param pf the mapping function must produce a key-value pair where the key is an `AnyRef`
+   * @param dummy an implicit placeholder for purposes of distinguishing the (erased) signature of this method
+   */
   def collect[K2 <: AnyRef, V2](pf: PartialFunction[(K, V), (K2, V2)])(implicit dummy: DummyImplicit): AnyRefMap[K2, V2] =
     strictOptimizedCollect(AnyRefMap.newBuilder[K2, V2], pf)
 

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -77,6 +77,10 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
     array = ArrayBuffer.ensureSize(array, size0, size0.toLong + n)
   }
 
+  /** Uses the given size to resize internal storage, if necessary.
+   *
+   *  @param size Expected maximum number of elements.
+   */
   def sizeHint(size: Int): Unit =
     if(size > length && size >= 1) ensureSize(size)
 

--- a/src/library/scala/collection/mutable/ArrayBuilder.scala
+++ b/src/library/scala/collection/mutable/ArrayBuilder.scala
@@ -27,8 +27,10 @@ sealed abstract class ArrayBuilder[T]
   protected[this] def elems: Array[T]
   protected var size: Int = 0
 
+  /** Current number of elements. */
   def length: Int = size
 
+  /** Current number of elements. */
   override def knownSize: Int = size
 
   protected[this] final def ensureSize(size: Int): Unit = {

--- a/src/library/scala/collection/mutable/Growable.scala
+++ b/src/library/scala/collection/mutable/Growable.scala
@@ -33,7 +33,7 @@ trait Growable[-A] extends Clearable {
   def addOne(elem: A): this.type
 
   /** Alias for `addOne` */
-  @`inline` final def += (elem: A): this.type = addOne(elem)
+  @inline final def += (elem: A): this.type = addOne(elem)
 
   //TODO This causes a conflict in StringBuilder; looks like a compiler bug
   //@deprecated("Use addOne or += instead of append", "2.13.0")
@@ -47,17 +47,17 @@ trait Growable[-A] extends Clearable {
    *  @return the $coll itself
    */
   @deprecated("Use `++=` aka `addAll` instead of varargs `+=`; infix operations with an operand of multiple args will be deprecated", "2.13.0")
-  @`inline` final def += (elem1: A, elem2: A, elems: A*): this.type = this += elem1 += elem2 ++= (elems: IterableOnce[A])
+  @inline final def += (elem1: A, elem2: A, elems: A*): this.type = this += elem1 += elem2 ++= (elems: IterableOnce[A])
 
   /** ${Add}s all elements produced by an IterableOnce to this $coll.
    *
-   *  @param xs   the IterableOnce producing the elements to $add.
+   *  @param elems   the IterableOnce producing the elements to $add.
    *  @return  the $coll itself.
    */
-  def addAll(xs: IterableOnce[A]): this.type = {
-    if (xs.asInstanceOf[AnyRef] eq this) addAll(Buffer.from(xs)) // avoid mutating under our own iterator
+  def addAll(@deprecatedName("xs") elems: IterableOnce[A]): this.type = {
+    if (elems.asInstanceOf[AnyRef] eq this) addAll(Buffer.from(elems)) // avoid mutating under our own iterator
     else {
-      val it = xs.iterator
+      val it = elems.iterator
       while (it.hasNext) {
         addOne(it.next())
       }
@@ -66,11 +66,12 @@ trait Growable[-A] extends Clearable {
   }
 
   /** Alias for `addAll` */
-  @`inline` final def ++= (xs: IterableOnce[A]): this.type = addAll(xs)
+  @inline final def ++= (@deprecatedName("xs") elems: IterableOnce[A]): this.type = addAll(elems)
 
-  /** @return The number of elements in the collection under construction, if it can be cheaply computed,
-    *  -1 otherwise. The default implementation always returns -1.
-    */
+  /** The number of elements in the collection under construction, if it can be cheaply computed, -1 otherwise.
+   *
+   *  @return The number of elements. The default implementation always returns -1.
+   */
   def knownSize: Int = -1
 }
 

--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -296,6 +296,11 @@ class ListBuffer[A]
     len -= n
   }
 
+  /** Replace the contents of this $coll with the mapped result.
+   *
+   *  @param f the mapping function
+   *  @return this $coll
+   */
   def mapInPlace(f: A => A): this.type = {
     mutationCount += 1
     val buf = new ListBuffer[A]
@@ -306,6 +311,11 @@ class ListBuffer[A]
     this
   }
 
+  /** Replace the contents of this $coll with the flatmapped result.
+   *
+   *  @param f the mapping function
+   *  @return this $coll
+   */
   def flatMapInPlace(f: A => IterableOnce[A]): this.type = {
     mutationCount += 1
     var src = first
@@ -327,6 +337,11 @@ class ListBuffer[A]
     this
   }
 
+  /** Replace the contents of this $coll with the filtered result.
+   *
+   *  @param p the filtering predicate
+   *  @return this $coll
+   */
   def filterInPlace(p: A => Boolean): this.type = {
     ensureUnaliased()
     var prev: Predecessor[A] = null

--- a/src/library/scala/collection/mutable/LongMap.scala
+++ b/src/library/scala/collection/mutable/LongMap.scala
@@ -562,10 +562,22 @@ final class LongMap[V] private[collection] (defaultEntry: Long => V, initialBuff
     this
   }
 
+  /** An overload of `map` which produces a `LongMap`.
+   *
+   *  @param f the mapping function
+   */
   def map[V2](f: ((Long, V)) => (Long, V2)): LongMap[V2] = LongMap.from(new View.Map(coll, f))
 
+  /** An overload of `flatMap` which produces a `LongMap`.
+   *
+   *  @param f the mapping function
+   */
   def flatMap[V2](f: ((Long, V)) => IterableOnce[(Long, V2)]): LongMap[V2] = LongMap.from(new View.FlatMap(coll, f))
 
+  /** An overload of `collect` which produces a `LongMap`.
+   *
+   *  @param pf the mapping function
+   */
   def collect[V2](pf: PartialFunction[(Long, V), (Long, V2)]): LongMap[V2] =
     strictOptimizedCollect(LongMap.newBuilder[V2], pf)
 

--- a/src/library/scala/collection/mutable/PriorityQueue.scala
+++ b/src/library/scala/collection/mutable/PriorityQueue.scala
@@ -104,6 +104,7 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
   // parent and child indices: for a given index k, the parent of k is k / 2,
   // the left child is k * 2, and the right child is k * 2 + 1
   resarr.p_size0 += 1
+  /** Alias for [[size]]. */
   def length: Int = resarr.length - 1  // adjust length accordingly
   override def size: Int = length
   override def knownSize: Int = length
@@ -114,6 +115,11 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
   override protected def newSpecificBuilder: Builder[A, PriorityQueue[A]] = PriorityQueue.newBuilder
   override def empty: PriorityQueue[A] = PriorityQueue.empty
 
+  /** Replace the contents of this $coll with the mapped result.
+   *
+   *  @param f the mapping function
+   *  @return this $coll
+   */
   def mapInPlace(f: A => A): this.type = {
     resarr.mapInPlace(f)
     heapify(1)
@@ -240,11 +246,11 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
   def enqueue(elems: A*): Unit = { this ++= elems }
 
   /** Returns the element with the highest priority in the queue,
-    *  and removes this element from the queue.
-    *
-    *  @throws NoSuchElementException
-    *  @return   the element with the highest priority.
-    */
+   *  and removes this element from the queue.
+   *
+   *  @return the element with the highest priority.
+   *  @throws NoSuchElementException if no element to remove from heap
+   */
   def dequeue(): A =
     if (resarr.p_size0 > 1) {
       resarr.p_size0 = resarr.p_size0 - 1
@@ -256,6 +262,7 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
     } else
       throw new NoSuchElementException("no element to remove from heap")
 
+  /** Dequeues all elements and returns them in a sequence, in priority order. */
   def dequeueAll[A1 >: A]: immutable.Seq[A1] = {
     val b = ArrayBuilder.make[Any]
     b.sizeHint(size)

--- a/src/library/scala/collection/mutable/Stack.scala
+++ b/src/library/scala/collection/mutable/Stack.scala
@@ -106,12 +106,12 @@ class Stack[A] protected (array: Array[AnyRef], start: Int, end: Int)
   def popWhile(f: A => Boolean): scala.collection.Seq[A] = removeHeadWhile(f)
 
   /** Returns the top element of the stack. This method will not remove
-    *  the element from the stack. An error is signaled if there is no
-    *  element on the stack.
-    *
-    *  @throws NoSuchElementException
-    *  @return the top element
-    */
+   *  the element from the stack. An error is signaled if there is no
+   *  element on the stack.
+   *
+   *  @throws NoSuchElementException if the stack is empty
+   *  @return the top element
+   */
   @`inline` final def top: A = head
 
   override protected def klone(): Stack[A] = {

--- a/src/library/scala/collection/mutable/UnrolledBuffer.scala
+++ b/src/library/scala/collection/mutable/UnrolledBuffer.scala
@@ -164,6 +164,11 @@ sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
     if (idx >= 0 && idx < sz) headptr(idx) = newelem
     else throw new IndexOutOfBoundsException(s"$idx is out of bounds (min 0, max ${sz-1})")
 
+  /** Replace the contents of this $coll with the mapped result.
+   *
+   *  @param f the mapping function
+   *  @return this $coll
+   */
   def mapInPlace(f: T => T): this.type = {
     headptr.mapInPlace(f)
     this

--- a/src/scaladoc/scala/tools/nsc/doc/Settings.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/Settings.scala
@@ -208,6 +208,11 @@ class Settings(error: String => Unit, val printMsg: String => Unit = println(_),
     "Avoid warnings for ambiguous and incorrect links."
   )
 
+  val docRequired = BooleanSetting (
+    "-required",
+    "Require documentation for public members."
+  ).internalOnly()
+
   val docSkipPackages = StringSetting (
     "-skip-packages",
     "<package1>:...:<packageN>",

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
@@ -103,7 +103,7 @@ trait EntityPage extends HtmlPage {
                             case _                       => Span(`class`= "separator")
                           }) :: Txt(" ") ::
                           A(`class`= mbr.kind, href=relativeLinkTo(mbr), title=memberToShortCommentTitleTag(mbr)) ::
-                          A(href=relativeLinkTo(mbr), title=memberToShortCommentTitleTag(mbr), elems= Txt(mbr.name)) :: NoElems
+                          A(href=relativeLinkTo(mbr), title=memberToShortCommentTitleTag(mbr), elems=Txt(mbr.name)) :: NoElems
                         )
 
                     // Get path from root
@@ -384,7 +384,7 @@ trait EntityPage extends HtmlPage {
       )
   }
 
-  def memberToCommentHtml(mbr: MemberEntity, inTpl: DocTemplateEntity, isSelf: Boolean): Elems = {
+  def memberToCommentHtml(mbr: MemberEntity, inTpl: DocTemplateEntity, isSelf: Boolean): Elems =
     mbr match {
       // comment of class itself
       case dte: DocTemplateEntity if isSelf =>
@@ -392,8 +392,11 @@ trait EntityPage extends HtmlPage {
       case _ =>
         // comment of non-class member or non-documented inner class
         val commentBody = memberToCommentBodyHtml(mbr, inTpl, isSelf = false)
-        if (commentBody.isEmpty)
+        if (commentBody.isEmpty) {
+          if (universe.settings.docRequired.value && mbr.visibility.isPublic && inTpl.visibility.isPublic && mbr.toString.startsWith("scala.collection") && mbr.isInstanceOf[Def])
+            docletReporter.error(scala.reflect.internal.util.NoPosition, s"Member $mbr is public but has no documentation")
           NoElems
+        }
         else {
           val shortComment = memberToShortCommentHtml(mbr, isSelf)
           val longComment = memberToUseCaseCommentHtml(mbr, isSelf) ++ memberToCommentBodyHtml(mbr, inTpl, isSelf)
@@ -405,7 +408,6 @@ trait EntityPage extends HtmlPage {
           shortComment ++ includedLongComment
         }
     }
-  }
 
   def memberToUseCaseCommentHtml(mbr: MemberEntity, isSelf: Boolean): Elems = {
     mbr match {

--- a/test/files/filters
+++ b/test/files/filters
@@ -5,5 +5,3 @@ OpenJDK .* warning:
 # Hotspot receiving VM options through the $_JAVA_OPTIONS
 # env variable outputs them on stderr
 Picked up _JAVA_OPTIONS:
-# Filter out a message caused by this bug: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8021205
-objc\[\d+\]: Class JavaLaunchHelper is implemented in both .* and .*\. One of the two will be used\. Which one is undefined\.

--- a/test/scaladoc/filters
+++ b/test/scaladoc/filters
@@ -5,5 +5,3 @@ OpenJDK .* warning:
 # Hotspot receiving VM options through the $_JAVA_OPTIONS
 # env variable outputs them on stderr
 Picked up _JAVA_OPTIONS:
-# Filter out a message caused by this bug: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8021205
-objc\[\d+\]: Class JavaLaunchHelper is implemented in both .* and .*\. One of the two will be used\. Which one is undefined\.


### PR DESCRIPTION
Supply some missing doc for some public API, and that part fixes scala/bug#12904. Also fixes https://github.com/scala/bug/issues/12900.

Add an internal-only option to scaladoc to detect missing doc, but requires refinement not to be noisy on stdlib, even restricted to collections.