### PR TITLE
[SUPERSEDED] Version can be future

### DIFF
--- a/test/files/pos/source-future.scala
+++ b/test/files/pos/source-future.scala
@@ -1,0 +1,8 @@
+
+//> using options -Werror -Xlint -Xsource:future
+
+import scala.util.*
+
+class C {
+  def f[A](body: => A): Try[A] = Try(body)
+}

--- a/test/junit/scala/tools/nsc/settings/ScalaVersionTest.scala
+++ b/test/junit/scala/tools/nsc/settings/ScalaVersionTest.scala
@@ -38,7 +38,11 @@ class ScalaVersionTest {
 
     // oh really
     assertEquals(NoScalaVersion, ScalaVersion("none"))
+    assertSame(NoScalaVersion, ScalaVersion("none"))
+    assertEquals(FutureScalaVersion, ScalaVersion("future"))
+    assertSame(FutureScalaVersion, ScalaVersion("future"))
     assertEquals(AnyScalaVersion, ScalaVersion("any"))
+    assertSame(AnyScalaVersion, ScalaVersion("any"))
 
     assertThrows[NumberFormatException] { ScalaVersion("2.11.7.2") }
     assertThrows[NumberFormatException] { ScalaVersion("2.11.7.beta") }


### PR DESCRIPTION
Support `-Xsource:3-X` https://github.com/scala/scala/pull/10573 by accepting `-Xsource:future` to mean a version that compares greater than any version, much like `none` but with a less "cryptic" name.

They hate cryptic.
