### PR TITLE
Avoid checking nc setting

### DIFF
--- a/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
+++ b/src/compiler/scala/tools/nsc/GenericRunnerSettings.scala
@@ -60,6 +60,7 @@ class GenericRunnerSettings(error: String => Unit, pathFactory: PathFactory) ext
       "-save",
       "save the compiled script (assumes the code is a script)") withAbbreviation "-savecompiled" withAbbreviation "--save"
 
+  @deprecated("check Yscriptrunner instead", since="2.13.0")
   val nc = BooleanSetting(
       "-nc",
       "do not use the legacy fsc compilation daemon").withAbbreviation("-nocompdaemon").withAbbreviation("--no-compilation-daemon")

--- a/src/compiler/scala/tools/nsc/ScriptRunner.scala
+++ b/src/compiler/scala/tools/nsc/ScriptRunner.scala
@@ -170,10 +170,11 @@ abstract class AbstractScriptRunner(settings: GenericRunnerSettings) extends Scr
 
   final def runScript(scriptFile: String, scriptArgs: List[String]): Option[Throwable] = {
     val f = File(scriptFile)
+    def usingCompilationServer = settings.Yscriptrunner.valueSetByUser.map(_ != "default").getOrElse(false)
     if (!f.exists) Some(new IOException(s"no such file: $scriptFile"))
     else if (!f.canRead) Some(new IOException(s"can't read: $scriptFile"))
     else if (f.isDirectory) Some(new IOException(s"can't compile a directory: $scriptFile"))
-    else if (!settings.nc.value && !f.isFile) Some(new IOException(s"compile server requires a regular file: $scriptFile"))
+    else if (!f.isFile && usingCompilationServer) Some(new IOException(s"compile server requires a regular file: $scriptFile"))
     else withCompiledScript(scriptFile) { runCompiled(_, scriptArgs) }
   }
 


### PR DESCRIPTION
`settings.nc` should have been deprecated at https://github.com/scala/scala/commit/d6a918aa9d6ca86db114867e6557584c04b1b66e

then it would no longer be checked by https://github.com/scala/scala/commit/353d439645f50ae5c02453a8bca43e51a1abba82

Previously, you had to supply `-nc`:
```
$ skala <(echo 'println("Hello")')
Hello
```