### PR TITLE
Detune two tests from 2.7.3

### DIFF
--- a/test/files/pos/comp-rec-test.scala
+++ b/test/files/pos/comp-rec-test.scala
@@ -1,4 +1,4 @@
-// scalac: -Yrecursion 1
+// was: -Yrecursion 1
 object Comp extends App {
 
    trait Family {

--- a/test/files/pos/proj-rec-test.scala
+++ b/test/files/pos/proj-rec-test.scala
@@ -1,5 +1,5 @@
 
-// scalac: -Yrecursion 1
+// was: -Yrecursion 1
 //
 object ProjTest {
   trait MInt { type Type }


### PR DESCRIPTION
Fixes scala/bug#12914

Yrecursion isn't required for these urtests that have progressed, but tickets could contribute a test that Yrecursion provides a benefit, even if the target moves. Or the goalpost?
