### PR TITLE
Avoid completableFuture.asScala crash for MinimalStage

### DIFF
--- a/test/files/run/t12918.scala
+++ b/test/files/run/t12918.scala
@@ -1,0 +1,9 @@
+// javaVersion: 9+
+
+import java.util.concurrent._
+import scala.jdk.FutureConverters._
+
+object Test extends App {
+  val cf = CompletableFuture.completedStage("42")
+  assert("42" == cf.asScala.value.get.get)
+}


### PR DESCRIPTION
`CompletableFuture.completedStage` creates a `MinimalStage` instance which extends `CompletableFuture` and overrides most methods with `UnsupportedOperationException`.

Calling `toCompletableFuture` on it creates a fresh `CompletableFuture`.

Fixes https://github.com/scala/bug/issues/12918.