### PR TITLE
Incremental compilation: register inheritance relationship for SAM-type lambda [ci: last-only]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -947,6 +947,7 @@ def osgiTestProject(p: Project, framework: ModuleID) = p
 //  - `sbtTest/scripted source-dependencies/scalac-options` to run a single test
 //  - `set sbtTest/scriptedBufferLog := false` to see sbt log of test
 //  - add `> set logLevel := Level.Debug` to individual `test` script for debug output
+//  - uncomment `-agentlib:...` below to attach the debugger while running a test
 lazy val sbtTest = project.in(file("test") / "sbt-test")
   .enablePlugins(ScriptedPlugin)
   .settings(disableDocs)
@@ -968,6 +969,7 @@ lazy val sbtTest = project.in(file("test") / "sbt-test")
       "-Dplugin.scalaVersion=" + version.value,
       "-Dsbt.boot.directory=" + (target.value / ".sbt-scripted").getAbsolutePath, // Workaround sbt/sbt#3469
       "-Dscripted.common=" + (baseDirectory.value / "common.sbt.template").getAbsolutePath,
+      // "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005",
     ),
 
     // Pass along ivy home and repositories settings to sbt instances run from the tests

--- a/test/sbt-test/source-dependencies/sam-local-inheritance/A.scala
+++ b/test/sbt-test/source-dependencies/sam-local-inheritance/A.scala
@@ -1,0 +1,3 @@
+trait A {
+  def foo(): Int
+}

--- a/test/sbt-test/source-dependencies/sam-local-inheritance/B.scala
+++ b/test/sbt-test/source-dependencies/sam-local-inheritance/B.scala
@@ -1,0 +1,3 @@
+class B {
+  val f: A = () => 1
+}

--- a/test/sbt-test/source-dependencies/sam-local-inheritance/C.scala
+++ b/test/sbt-test/source-dependencies/sam-local-inheritance/C.scala
@@ -1,0 +1,1 @@
+class C extends B

--- a/test/sbt-test/source-dependencies/sam-local-inheritance/changes/A.scala
+++ b/test/sbt-test/source-dependencies/sam-local-inheritance/changes/A.scala
@@ -1,0 +1,3 @@
+trait A {
+  def foo(): AnyVal
+}

--- a/test/sbt-test/source-dependencies/sam-local-inheritance/project/ScriptedTestPlugin.scala
+++ b/test/sbt-test/source-dependencies/sam-local-inheritance/project/ScriptedTestPlugin.scala
@@ -1,0 +1,24 @@
+import sbt._
+import Keys._
+
+object ScriptedTestPlugin extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+
+  object autoImport {
+    val setup = taskKey[StateTransform]("setup scripted test")
+    val cacheId = AttributeKey[String]("cacheId")
+  }
+  import autoImport._
+
+  override val projectSettings = Seq(
+    scalaVersion := sys.props("plugin.scalaVersion"),
+    setup := {
+      IO.copyFile(Path(sys.props("scripted.common")).asFile, baseDirectory.value / "common.sbt")
+      val id = java.util.UUID.randomUUID().toString
+      StateTransform(_.put(cacheId, id))
+    },
+    // https://github.com/sbt/sbt/issues/7432
+    Compile / compileAnalysisFilename := (Compile / compileAnalysisFilename).value.dropRight(4) + "-" + state.value.get(cacheId).get + ".zip"
+  )
+}

--- a/test/sbt-test/source-dependencies/sam-local-inheritance/test
+++ b/test/sbt-test/source-dependencies/sam-local-inheritance/test
@@ -1,0 +1,15 @@
+> setup; reload
+
+> compile
+
+> checkRecompilations 0 A B C
+
+# change the SAM type
+$ copy-file changes/A.scala A.scala
+
+> compile
+
+> checkIterations 3
+> checkRecompilations 1 A
+# SAM type change does not affect C, hence C should not be recompiled
+> checkRecompilations 2 B

--- a/test/sbt-test/source-dependencies/sam/A.scala
+++ b/test/sbt-test/source-dependencies/sam/A.scala
@@ -1,0 +1,3 @@
+trait A {
+  def foo(): Int
+}

--- a/test/sbt-test/source-dependencies/sam/B.scala
+++ b/test/sbt-test/source-dependencies/sam/B.scala
@@ -1,0 +1,3 @@
+class B {
+  val f: A = () => 1
+}

--- a/test/sbt-test/source-dependencies/sam/changes/A.scala
+++ b/test/sbt-test/source-dependencies/sam/changes/A.scala
@@ -1,0 +1,3 @@
+trait A {
+  def foo(): String
+}

--- a/test/sbt-test/source-dependencies/sam/project/ScriptedTestPlugin.scala
+++ b/test/sbt-test/source-dependencies/sam/project/ScriptedTestPlugin.scala
@@ -1,0 +1,24 @@
+import sbt._
+import Keys._
+
+object ScriptedTestPlugin extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+
+  object autoImport {
+    val setup = taskKey[StateTransform]("setup scripted test")
+    val cacheId = AttributeKey[String]("cacheId")
+  }
+  import autoImport._
+
+  override val projectSettings = Seq(
+    scalaVersion := sys.props("plugin.scalaVersion"),
+    setup := {
+      IO.copyFile(Path(sys.props("scripted.common")).asFile, baseDirectory.value / "common.sbt")
+      val id = java.util.UUID.randomUUID().toString
+      StateTransform(_.put(cacheId, id))
+    },
+    // https://github.com/sbt/sbt/issues/7432
+    Compile / compileAnalysisFilename := (Compile / compileAnalysisFilename).value.dropRight(4) + "-" + state.value.get(cacheId).get + ".zip"
+  )
+}

--- a/test/sbt-test/source-dependencies/sam/test
+++ b/test/sbt-test/source-dependencies/sam/test
@@ -1,0 +1,9 @@
+> setup; reload
+
+> compile
+
+# change the SAM type
+$ copy-file changes/A.scala A.scala
+
+# Both A.scala and B.scala should be recompiled, producing a compile error
+-> compile


### PR DESCRIPTION
During dependency extraction, register inheritance dependency for SAM-type lambda, by fetching SAM type from tree attachment.

Ports https://github.com/sbt/zinc/pull/1288

Fixes https://github.com/sbt/zinc/issues/830