### PR TITLE
Scala 3 migration warning for implicits found in package prefix

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1098,7 +1098,7 @@ trait Contexts { self: Analyzer =>
 
     private def collectImplicits(syms: Scope, pre: Type): List[ImplicitInfo] =
       for (sym <- syms.toList if isQualifyingImplicit(sym.name, sym, pre, imported = false))
-      yield new ImplicitInfo(sym.name, pre, sym)
+      yield new ImplicitInfo(sym.name, pre, sym, inPackagePrefix = false)
 
     private def collectImplicitImports(imp: ImportInfo): List[ImplicitInfo] = if (isExcludedRootImport(imp)) List() else {
       val qual = imp.qual
@@ -1114,12 +1114,12 @@ trait Contexts { self: Analyzer =>
           // Looking up implicit members in the package, rather than package object, here is at least
           // consistent with what is done just below for named imports.
           for (sym <- qual.tpe.implicitMembers.toList if isQualifyingImplicit(sym.name, sym, pre, imported = true))
-          yield new ImplicitInfo(sym.name, pre, sym, imp, sel)
+          yield new ImplicitInfo(sym.name, pre, sym, importInfo = imp, importSelector = sel)
         case (sel @ ImportSelector(from, _, to, _)) :: sels1 =>
           var impls = collect(sels1).filter(_.name != from)
           if (!sel.isMask)
             withQualifyingImplicitAlternatives(imp, to, pre) { sym =>
-              impls = new ImplicitInfo(to, pre, sym, imp, sel) :: impls
+              impls = new ImplicitInfo(to, pre, sym, importInfo = imp, importSelector = sel) :: impls
             }
           impls
       }

--- a/test/files/neg/t12919-3cross.check
+++ b/test/files/neg/t12919-3cross.check
@@ -1,0 +1,4 @@
+t12919-3cross.scala:24: error: No implicit Ordering defined for a.A.
+    def f(xs: List[a.A]) = xs.sorted // not found
+                              ^
+1 error

--- a/test/files/neg/t12919-3cross.scala
+++ b/test/files/neg/t12919-3cross.scala
@@ -1,0 +1,36 @@
+// scalac: -Xsource:3-cross
+
+package object a {
+  implicit val aOrd: Ordering[A] = null
+  implicit val bOrd: Ordering[b.B] = null
+}
+
+package a {
+  class A
+
+  package aa {
+    class U {
+      // implicit is in an enclosing package of the callsite, not in the path of the implicit's type
+      def f(xs: List[a.A]) = xs.sorted // ok
+      def g(xs: List[b.B]) = xs.sorted // ok
+    }
+  }
+}
+
+package b {
+  class B
+
+  class V {
+    def f(xs: List[a.A]) = xs.sorted // not found
+  }
+}
+
+package c {
+  import a._
+
+  class W {
+    def f(xs: List[a.A]) = xs.sorted // ok
+    def g(xs: List[b.B]) = xs.sorted // ok
+  }
+}
+

--- a/test/files/neg/t12919.check
+++ b/test/files/neg/t12919.check
@@ -1,0 +1,7 @@
+t12919.scala:24: error: Implicit value aOrd was found in a package prefix of the required type, which is not part of the implicit scope in Scala 3.
+For migration, add `import a.aOrd`.
+Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=b.V.f
+    def f(xs: List[a.A]) = xs.sorted // warn
+                              ^
+1 error

--- a/test/files/neg/t12919.scala
+++ b/test/files/neg/t12919.scala
@@ -1,0 +1,36 @@
+// scalac: -Xsource:3 -Werror
+
+package object a {
+  implicit val aOrd: Ordering[A] = null
+  implicit val bOrd: Ordering[b.B] = null
+}
+
+package a {
+  class A
+
+  package aa {
+    class U {
+      // implicit is in an enclosing package of the callsite, not in the path of the implicit's type
+      def f(xs: List[a.A]) = xs.sorted // ok
+      def g(xs: List[b.B]) = xs.sorted // ok
+    }
+  }
+}
+
+package b {
+  class B
+
+  class V {
+    def f(xs: List[a.A]) = xs.sorted // warn
+  }
+}
+
+package c {
+  import a._
+
+  class W {
+    def f(xs: List[a.A]) = xs.sorted // ok
+    def g(xs: List[b.B]) = xs.sorted // ok
+  }
+}
+


### PR DESCRIPTION
The implicit scope in Scala 3 no longer includes the requested type's package prefix.

Includes commits of https://github.com/scala/scala/pull/10573.

Fixes https://github.com/scala/bug/issues/12919