### PR TITLE
In API doc, specify behavior of folds and reduces when operator is not associative or collection is unordered

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -761,20 +761,19 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     true
   }
 
-  /** Applies a binary operator to a start value and all elements of this array,
-    * going left to right.
-    *
-    *  @param   z    the start value.
-    *  @param   op   the binary operator.
-    *  @tparam  B    the result type of the binary operator.
-    *  @return  the result of inserting `op` between consecutive elements of this array,
-    *           going left to right with the start value `z` on the left:
-    *           {{{
-    *             op(...op(z, x_1), x_2, ..., x_n)
-    *           }}}
-    *           where `x,,1,,, ..., x,,n,,` are the elements of this array.
-    *           Returns `z` if this array is empty.
-    */
+  /** Applies the given binary operator `op` to the given initial value `z` and
+   *  all elements of this array, going left to right. Returns the initial value
+   *  if this array is empty.
+   *
+   *  If `x,,1,,`, `x,,2,,`, ..., `x,,n,,` are the elements of this array, the
+   *  result is `op( op( ... op( op(z, x,,1,,), x,,2,,) ... ), x,,n,,)`.
+   *
+   *   @param    z       An initial value.
+   *   @param    op      A binary operator.
+   *   @tparam   B       The result type of the binary operator.
+   *   @return           The result of applying `op` to `z` and all elements of this array,
+   *                     going left to right. Returns `z` if this array is empty.
+   */
   def foldLeft[B](z: B)(op: (B, A) => B): B = {
     def f[@specialized(Specializable.Everything) T](xs: Array[T], op: (Any, Any) => Any, z: Any): Any = {
       val length = xs.length
@@ -867,20 +866,20 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     res
   }
 
-  /** Applies a binary operator to all elements of this array and a start value,
-    * going right to left.
-    *
-    *  @param   z    the start value.
-    *  @param   op   the binary operator.
-    *  @tparam  B    the result type of the binary operator.
-    *  @return  the result of inserting `op` between consecutive elements of this array,
-    *           going right to left with the start value `z` on the right:
-    *           {{{
-    *             op(x_1, op(x_2, ... op(x_n, z)...))
-    *           }}}
-    *           where `x,,1,,, ..., x,,n,,` are the elements of this array.
-    *           Returns `z` if this array is empty.
-    */
+  /** Applies the given binary operator `op` to all elements of this array and
+   *  the given initial value `z`, going right to left. Returns the initial
+   *  value if this array is empty.
+   *
+   *  If `x,,1,,`, `x,,2,,`, ..., `x,,n,,` are the elements of this array, the
+   *  result is `op(x,,1,,, op(x,,2,,, op( ... op(x,,n,,, z) ... )))`.
+   *
+   *   @param    z       An initial value.
+   *   @param    op      A binary operator.
+   *   @tparam   B       The result type of the binary operator.
+   *   @return           The result of applying `op` to all elements of this array
+   *                     and `z`, going right to left. Returns `z` if this array
+   *                     is empty.
+   */
   def foldRight[B](z: B)(op: (A, B) => B): B = {
     def f[@specialized(Specializable.Everything) T](xs: Array[T], op: (Any, Any) => Any, z: Any): Any = {
       var v = z
@@ -907,15 +906,17 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
 
   }
 
-  /** Folds the elements of this array using the specified associative binary operator.
-    *
-    *  @tparam A1     a type parameter for the binary operator, a supertype of `A`.
-    *  @param z       a neutral element for the fold operation; may be added to the result
-    *                 an arbitrary number of times, and must not change the result (e.g., `Nil` for list concatenation,
-    *                 0 for addition, or 1 for multiplication).
-    *  @param op      a binary operator that must be associative.
-    *  @return        the result of applying the fold operator `op` between all the elements, or `z` if this array is empty.
-    */
+  /** Alias for [[foldLeft]].
+   *
+   *  The type parameter is more restrictive than for `foldLeft` to be
+   *  consistent with [[IterableOnceOps.fold]].
+   *
+   *   @tparam A1     The type parameter for the binary operator, a supertype of `A`.
+   *   @param z       An initial value.
+   *   @param op      A binary operator.
+   *   @return        The result of applying `op` to `z` and all elements of this array,
+   *                  going left to right. Returns `z` if this string is empty.
+   */
   def fold[A1 >: A](z: A1)(op: (A1, A1) => A1): A1 = foldLeft(z)(op)
 
   /** Builds a new array by applying a function to all elements of this array.

--- a/src/library/scala/collection/StringOps.scala
+++ b/src/library/scala/collection/StringOps.scala
@@ -1059,20 +1059,19 @@ final class StringOps(private val s: String) extends AnyVal {
     true
   }
 
-  /** Applies a binary operator to a start value and all chars of this string,
-    * going left to right.
-    *
-    *  @param   z    the start value.
-    *  @param   op   the binary operator.
-    *  @tparam  B    the result type of the binary operator.
-    *  @return  the result of inserting `op` between consecutive chars of this string,
-    *           going left to right with the start value `z` on the left:
-    *           {{{
-    *             op(...op(z, x_1), x_2, ..., x_n)
-    *           }}}
-    *           where `x,,1,,, ..., x,,n,,` are the chars of this string.
-    *           Returns `z` if this string is empty.
-    */
+  /** Applies the given binary operator `op` to the given initial value `z` and all chars
+   *  in this string, going left to right. Returns the initial value if this string is
+   *  empty.
+   *
+   *  If `x,,1,,`, `x,,2,,`, ..., `x,,n,,` are the chars in this string, the
+   *  result is `op( op( ... op( op(z, x,,1,,), x,,2,,) ... ), x,,n,,)`.
+   *
+   *   @param    z       An initial value.
+   *   @param    op      A binary operator.
+   *   @tparam   B       The result type of the binary operator.
+   *   @return           The result of applying `op` to `z` and all chars in this string,
+   *                     going left to right. Returns `z` if this string is empty.
+   */
   def foldLeft[B](z: B)(op: (B, Char) => B): B = {
     var v = z
     var i = 0
@@ -1084,20 +1083,20 @@ final class StringOps(private val s: String) extends AnyVal {
     v
   }
 
-  /** Applies a binary operator to all chars of this string and a start value,
-    * going right to left.
-    *
-    *  @param   z    the start value.
-    *  @param   op   the binary operator.
-    *  @tparam  B    the result type of the binary operator.
-    *  @return  the result of inserting `op` between consecutive chars of this string,
-    *           going right to left with the start value `z` on the right:
-    *           {{{
-    *             op(x_1, op(x_2, ... op(x_n, z)...))
-    *           }}}
-    *           where `x,,1,,, ..., x,,n,,` are the chars of this string.
-    *           Returns `z` if this string is empty.
-    */
+  /** Applies the given binary operator `op` to all chars in this string and the given
+   *  initial value `z`, going right to left. Returns the initial value if this string is
+   *  empty.
+   *
+   *  If `x,,1,,`, `x,,2,,`, ..., `x,,n,,` are the chars in this string, the
+   *  result is `op(x,,1,,, op(x,,2,,, op( ... op(x,,n,,, z) ... )))`.
+   *
+   *   @param    z       An initial value.
+   *   @param    op      A binary operator.
+   *   @tparam   B       The result type of the binary operator.
+   *   @return           The result of applying `op` to all chars in this string
+   *                     and `z`, going right to left. Returns `z` if this string
+   *                     is empty.
+   */
   def foldRight[B](z: B)(op: (Char, B) => B): B = {
     var v = z
     var i = s.length - 1
@@ -1108,15 +1107,17 @@ final class StringOps(private val s: String) extends AnyVal {
     v
   }
 
-  /** Folds the chars of this string using the specified associative binary operator.
-    *
-    *  @tparam A1     a type parameter for the binary operator, a supertype of Char.
-    *  @param z       a neutral element for the fold operation; may be added to the result
-    *                 an arbitrary number of times, and must not change the result (e.g., `Nil` for list concatenation,
-    *                 0 for addition, or 1 for multiplication).
-    *  @param op      a binary operator that must be associative.
-    *  @return        the result of applying the fold operator `op` between all the chars and `z`, or `z` if this string is empty.
-    */
+  /** Alias for [[foldLeft]].
+   *
+   *  The type parameter is more restrictive than for `foldLeft` to be
+   *  consistent with [[IterableOnceOps.fold]].
+   *
+   *   @tparam A1     The type parameter for the binary operator, a supertype of `Char`.
+   *   @param z       An initial value.
+   *   @param op      A binary operator.
+   *   @return        The result of applying `op` to `z` and all chars in this string,
+   *                  going left to right. Returns `z` if this string is empty.
+   */
   @`inline` def fold[A1 >: Char](z: A1)(op: (A1, A1) => A1): A1 = foldLeft(z)(op)
 
   /** Selects the first char of this string.


### PR DESCRIPTION
# Summary

I would like to propose some changes to the documentation of `fold{,Left,Right}` and `reduce{,Option,Left,Right}` that clarifies their behavior when the collection is not ordered or when the operator is not associative or commutative. Currently, these methods warn that the result may be different for different runs, unless some conditions are met. `fold`, `reduce`, and `reduceOption` even *require* that their operator argument be associative. If their conditions are unmet, these three methods do not specify their behavior at all, and the other four (`foldLeft` et al.) specify it only weakly. I think they should all specify their baseline behavior and give stronger guarantees when their conditions are met.

I am not proposing any change to the behavior of these methods, only to their documentation.

# Details

## `fold`, `reduce`, and `reduceOption`

Documentation of `reduce` excerpted as a reference example:

```
Reduces the elements of this collection using the specified associative binary
operator.

The order in which operations are performed on elements is unspecified and may
be nondeterministic.

Value parameters
  `op`        A binary operator that must be associative.

Attributes
  Returns     The result of applying reduce operator `op` between all the
              elements if the collection is nonempty.
```

This leaves the behavior unspecified if the operator is not associative, and is not very clear about the order of operations when the collection is ordered. Instead, my proposed specification of `reduce`:
* `reduce` returns the result of repeatedly applying the operator, where each operand is either an element of the collection or another such application of the operator, such that each element appears exactly once in the computation. The order of applications of the operator is unspecified and may be nondeterministic.
* If the collection is ordered, then for any application of the operator, the element(s) appearing in the left operand will precede those in the right.
* The result may be different for different runs, unless any of the following conditions are met:
  + The operator is associative and the collection is ordered.
  + The operator is associative and commutative.

`fold` is similar, with additional conditions about the initial value. My proposal:
* `fold` returns the result of repeatedly applying the operator, where each operand is either an element of the collection, the initial value, or another such application of the operator, such that each element appears exactly once in the computation. The order of applications of the operator is unspecified and may be nondeterministic. The initial value may be used an arbitrary number of times but at least once.
* If the collection is ordered, then for any application of the operator, the element(s) appearing in the left operand will precede those in the right.
* The result may be different for different runs, unless any of the following conditions are met:
  + The operator is associative and the collection is ordered and the initial value is a neutral element for the operator.
  + The operator is associative and commutative and the initial value is a neutral element for the operator.

## `foldLeft`, `foldRight`, `reduceLeft`, and `reduceRight`

Documentation of `reduceLeft` excerpted as a reference example:

```
Applies a binary operator to all elements of this collection, going left to
right.

Note: will not terminate for infinite-sized collections.

Note: might return different results for different runs, unless the underlying
collection type is ordered or the operator is associative and commutative.

Value parameters
  `op`          the binary operator.

Attributes
  Returns       the result of inserting op between consecutive elements of this
                collection, going left to right:
                    `op( op( ... op(x1, x2) ..., xn-1), xn)`
                where `x1, ..., xn` are the elements of this collection.
```

First, we make the same observation as for `reduce`, that the behavior is underspecified if the operator is not associative or commutative and the collection is not ordered. We start with the same proposed specification as for `reduce`.

Second, the `Returns` attribute points at the key additional guarantee `reduceLeft` provides over `reduce`, but does not explicitly put it into words. This guarantee is that the right operand will always be an element of the collection. Then, `foldLeft` adds yet another guarantee, which is that the initial value will be used exactly once as the leftmost operand. This specification is symmetric for the -`Right` methods.

Third, associativity is no longer needed for a deterministic result if the collection is ordered since the order of operations is fully specified. For the `fold`- methods, it is no longer needed for the initial value to be a neutral element since it will always be used exactly once in a fully specified position.

## Why might we want this?

A use case that actually came up recently for some colleagues and me was the following. We have an inductive binary tree type:

```scala
enum Tree[T]:
  case Leaf(value: T)
  case Node(left: Tree[T], right: Tree[T])
```

And we have methods for insertion, balancing, etc. But to quickly construct a tree from a `Seq[T]` of elements, we wanted to do:

```scala
val tree: Tree[T] = elems.map(Leaf).reduce(Node)
```

But we realized that the behavior of `reduce` is unspecified since `Node` is not associative. However, we explicitly don't care about the association of `Node`. It doesn't matter if it creates a line tree (as it would with `reduceLeft`) or a balanced tree (as it would if the collection were recursively halved) as we can address that afterwards if needed. All that matters is that we have the result of applying `Node` to all the `Leaf`s in some order.

# History

I did some git digging to see where the “must be associative” docstrings came from. As far as I can tell, they were introduced in 2010 in e67f560766 “Adding parallel collections to trunk.” Sequential collections at that point had only `reduceLeft` et al., not `reduce`. Subsequent commits (e.g. 3de96153e5, 7237732306f, 4b21b76435) created common abstractions for collections, preserving the parallel collections’ documentation for `reduce` that sequential collections were now inheriting. The commit messages do not seem to discuss this underspecification issue for either `reduce` or `reduceLeft`.

It makes sense to me that this specification was associated with parallelism, because in the presence of parallelism, one might want to give up the exact order in which the reduction operator is applied in exchange for the collection being processed faster in parallel. It also makes sense that the laxer specification was kept as-is for sequential collections instead of special-casing and trying to nail down the sequential behavior. But I think that the original specification was *too* lax even for parallel collections, and that the pre-existing sequential specification was also too lax to a lesser degree.


CC @cpitclaudel because this proposal comes from a discussion we had IRL.