### PR TITLE
Implement `indexOf` and `lastIndexOf` on `NumericRange` efficiently

### DIFF
--- a/src/library/scala/collection/immutable/NumericRange.scala
+++ b/src/library/scala/collection/immutable/NumericRange.scala
@@ -118,6 +118,38 @@ sealed class NumericRange[T](
     }
   }
 
+  private[this] def indexOfTyped(elem: T, from: Int): Int =
+    posOf(elem) match {
+      case pos if pos >= from => pos
+      case _                  => -1
+    }
+
+  final override def indexOf[B >: T](elem: B, from: Int): Int =
+    try indexOfTyped(elem.asInstanceOf[T], from)
+    catch { case _: ClassCastException => super.indexOf(elem, from) }
+
+  private[this] def lastIndexOfTyped(elem: T, end: Int): Int =
+    posOf(elem) match {
+      case pos if pos <= end => pos
+      case _                 => -1
+    }
+
+  final override def lastIndexOf[B >: T](elem: B, end: Int = length - 1): Int =
+    try lastIndexOfTyped(elem.asInstanceOf[T], end)
+    catch { case _: ClassCastException => super.lastIndexOf(elem, end) }
+
+  private[this] def posOf(i: T): Int =
+      /*
+      If i is in this NumericRange, its position can simply be calculated by taking the amount of values up till i.
+      NumericRange.count does this in an most efficient manner.
+      Note that the contains() method throws an exception if the range has more than Int.MaxValue elements, but so did
+      the original indexOf / lastIndexOf functions, so no functionality changed. */
+    if (contains(i)) {
+      /* Because of zero indexing, the count is always one higher than the index. This can be simply solved by setting
+      isInclusive = false. */
+      NumericRange.count(this.start, i, this.step, isInclusive = false)
+    } else -1
+
   // TODO: these private methods are straight copies from Range, duplicated
   // to guard against any (most likely illusory) performance drop.  They should
   // be eliminated one way or another.

--- a/test/junit/scala/collection/immutable/NumericRangeTest.scala
+++ b/test/junit/scala/collection/immutable/NumericRangeTest.scala
@@ -327,6 +327,86 @@ class NumericRangeTest {
     assertTrue(dropped.end == range.end && dropped.step == range.step && dropped.start == (amount * step) + range.start)
   }
 
+  @Test
+  def indexOfAndLastIndexOfShouldBeCorrect(): Unit = {
+
+    // For a range, because every value exists at most once, without the optional from/end param,
+    // indexOf and lastIndexOf should be equal.
+
+    // General checks.
+    assertEquals(0, NumericRange(0, 1, 1).indexOf(0))
+    assertEquals(0, NumericRange(0, 1, 1).lastIndexOf(0))
+
+    assertEquals(0, NumericRange.inclusive(0, 0, 1).indexOf(0))
+    assertEquals(0, NumericRange.inclusive(0, 0, 1).lastIndexOf(0))
+
+    assertEquals(300, NumericRange(0, Int.MaxValue, 1).indexOf(300))
+    assertEquals(300, NumericRange(0, Int.MaxValue, 1).lastIndexOf(300))
+
+    assertEquals(Int.MaxValue - 1, NumericRange(0, Int.MaxValue, 1).indexOf(Int.MaxValue - 1))
+    assertEquals(Int.MaxValue - 1, NumericRange(0, Int.MaxValue, 1).lastIndexOf(Int.MaxValue - 1))
+
+    assertEquals(300 / 5, NumericRange(0, Int.MaxValue, 5).indexOf(300))
+    assertEquals(300 / 5, NumericRange(0, Int.MaxValue, 5).lastIndexOf(300))
+
+    assertEquals(700, NumericRange(-1000, 0, 1).indexOf(-300))
+    assertEquals(700, NumericRange(-1000, 0, 1).lastIndexOf(-300))
+
+    assertEquals(350, NumericRange(-1000, 0, 2).indexOf(-300))
+    assertEquals(350, NumericRange(-1000, 0, 2).lastIndexOf(-300))
+
+    // If a value is below or over the limits of the range, or fall between steps, should be -1
+    assertEquals(-1, NumericRange(0, 10, 1).indexOf(20))
+    assertEquals(-1, NumericRange(0, 10, 1).lastIndexOf(20))
+
+    assertEquals(-1, NumericRange(0, 10, 2).indexOf(20))
+    assertEquals(-1, NumericRange(0, 10, 2).lastIndexOf(20))
+
+    assertEquals(-1, NumericRange(0, 10, 1).indexOf(-5))
+    assertEquals(-1, NumericRange(0, 10, 1).lastIndexOf(-5))
+
+    assertEquals(-1, NumericRange(0, 10, 2).indexOf(1))
+    assertEquals(-1, NumericRange(0, 10, 2).lastIndexOf(1))
+
+    assertEquals(-1, NumericRange(0, 10, 2).indexOf(3))
+    assertEquals(-1, NumericRange(0, 10, 2).lastIndexOf(3))
+
+    // indexOf should return -1 if the index is less than the from value
+    assertEquals(300, NumericRange(0, Int.MaxValue, 1).indexOf(300, 100))
+    assertEquals(-1, NumericRange(0, Int.MaxValue, 1).indexOf(300, 400))
+    assertEquals(300, NumericRange(0, Int.MaxValue, 1).indexOf(300, 300))
+
+    assertEquals(150, NumericRange(0, Int.MaxValue, 2).indexOf(300, 140))
+    assertEquals(-1, NumericRange(0, Int.MaxValue, 2).indexOf(300, 160))
+
+    // lastIndexOf should return -1 if the index is more than the end value
+    assertEquals(-1, NumericRange(0, Int.MaxValue, 1).lastIndexOf(300, 100))
+    assertEquals(300, NumericRange(0, Int.MaxValue, 1).lastIndexOf(300, 400))
+    assertEquals(300, NumericRange(0, Int.MaxValue, 1).lastIndexOf(300, 300))
+
+    assertEquals(-1, NumericRange(0, Int.MaxValue, 2).lastIndexOf(300, 140))
+    assertEquals(150, NumericRange(0, Int.MaxValue, 2).lastIndexOf(300, 160))
+
+    // Sanity check - does it work with other types.
+    assertEquals(300 / 5, NumericRange(0L, Int.MaxValue.toLong, 5L).indexOf(300L))
+    assertEquals(300 / 5, NumericRange(0L, Int.MaxValue.toLong, 5L).lastIndexOf(300L))
+
+    assertEquals(300 / 5, NumericRange(BigInt(0), BigInt(Int.MaxValue), BigInt(5)).indexOf(BigInt(300)))
+    assertEquals(300 / 5, NumericRange(BigInt(0), BigInt(Int.MaxValue), BigInt(5)).lastIndexOf(BigInt(300)))
+
+    // indexOf different type returns -1
+    assertEquals(-1, NumericRange(0L, Int.MaxValue.toLong, 5L).indexOf(300))
+    assertEquals(-1, NumericRange(0L, Int.MaxValue.toLong, 5L).lastIndexOf(300))
+
+    /* Attempting an indexOf of a Range with more than Int.MaxValue elements always throws an error.
+    Not ideal, but this tests whether backwards compatibility is conserved. */
+    assertThrows[IllegalArgumentException](NumericRange(0L, Int.MaxValue.toLong + 1, 1L).indexOf(300L))
+    assertThrows[IllegalArgumentException](NumericRange(0L, Int.MaxValue.toLong + 1, 1L).lastIndexOf(300L))
+
+    assertThrows[IllegalArgumentException](NumericRange(Int.MinValue, Int.MaxValue, 1).indexOf(300))
+    assertThrows[IllegalArgumentException](NumericRange(Int.MinValue, Int.MaxValue, 1).lastIndexOf(300))
+  }
+
 }
 
 object NumericRangeTest {


### PR DESCRIPTION
# Outline of changes

This PR introduces a more performant version of `indexOf` and `lastIndexOf` in `NumericRange`.

It makes use of the fact that the index of a value can easily be arithmetically derived for a range, using the start value and the step size. This works similary to the same methods in `Range`. The original version would iterate over the entire range until it found the value. This change improves the methods from linear time to constant time.

The main complication is that the type of the methods' argument is wider than the type of the values in NumericRange. Because of type erasure this is hard to check safely. The existing `contains` method handles this with an `asInstanceOf` and catching the exception if necessary. I couldn't find any better way than doing the same. In case this exception is thrown, the method calls the original `indexOf` in the super-type. It is unlikely that that one would do any better, but I did that to prevent possible changes in the method's behavior in any edge cases.

--------

# Original discussion

This PR is not complete yet. It is missing unit tests.

Before putting too much time into it I first would like to discuss whether you think this is sensible contribution.

The problem I am trying to solve is the fact that calling `indexOf()` and `lastIndexOf()` in `NumericRange`, calls those functions in `SeqOps`, which makes an iterator from the range, which may be rather slow for large ranges.

The regular Range class solves that through this nice function:

```scala
  private[this] def posOf(i: Int): Int =
    if (contains(i)) (i - start) / step else -1
```

It is used in both `indexOf` and `lastIndexOf`. This returns the index in constant time.

Since NumericRange requires evidence that its type `T` is an `Integral`, we can use basically the same function here. The only problem is that the arithmetic operations on `T` return another instance of `T`.

At a first glance it seems like `NumericRange` supports ranges with a size larger than `Int.MaxValue`. You can certainly instantiate them! However, in practice this is not the case, because almost every method in `NumericRange` evaluates the `length`, which throws an exception if it's larger than `Int.MaxValue`. This makes the problem slightly easier, we can just return an `Int`, overriding the function in `SeqOps`, and make sure the exception from `length` is thrown if the range is too large.

In fact, this makes the changes backwards compatible. the current slow implementation in `SeqOps` indirectly also calls `length`, and will also throw the exception if the range is too large.

Now, in principle the arithmetic solution doesn't require `length` at all. I decided to evaluate `length` in `posOf` for the sole purpose of throwing the correct exception if the `NumericRange` is too large.

The next step, I am not sure is necessary. I added it so we can discuss it here.

I considered the possibility that the range size is less than `Int.MaxValue`, but a user could implement a custom `Integral` type where the `toInt` doesn't work as expected. I decided to reuse the trick used in `NumericRange.count()` that checks if the start, end and step values all fit within the Int range, namely `fromInt(value.toInt) == value`. If this is not the case, the original `iterator` solution should still work, so I use a somewhat clunky solution to call the `super.indexOf`.
It'd probably be better to handle this in a typed way rather than by using a magic value, but my guess was that low class instantiation overhead is preferred in stdlib private methods.

Summary of my questions at this point:
1. Do you agree with the general idea of implementing these methods?
2. Is the workaround for the edge case where `toInt` doesn't work as expected necessary? If so, would you propose doing this in a cleaner way than I did here?
3. Are there some guidelines for where to write unit tests? Should they go in a new file? Should I add to an existing test file?
4. Do I need to do anything to get this change in Scala 3 as well? I looked in the Dotty repo and I saw a copy of `NumericRange` in a test directory, but other than that I couldn't find it, so I think Scala 3 just reuses the Scala 2.13 stdlib at this time?