### PR TITLE
Merge 2.12.x to 2.13.x [ci: last-only]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{matrix.java}}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.9.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ scalacOptions ++= Seq(
   "-Wconf:msg=IntegrationTest .* is deprecated:s,msg=itSettings .* is deprecated:s"
 )
 
-libraryDependencies += "org.apache.commons" % "commons-lang3" % "3.13.0"
+libraryDependencies += "org.apache.commons" % "commons-lang3" % "3.14.0"
 
 libraryDependencies += "org.pantsbuild" % "jarjar" % "1.7.2"
 


### PR DESCRIPTION
also bump sbt to 1.9.7 (was .6) — somehow this was missed the last time we merged 2.12.x to 2.13.x