### PR TITLE
Optimize tail recursion on effectively final methods even when `final` keyword is absent

### DIFF
--- a/test/files/neg/t9414.check
+++ b/test/files/neg/t9414.check
@@ -1,0 +1,10 @@
+t9414.scala:6: error: could not optimize @tailrec annotated method bar: it is neither private nor final so can be overridden
+      @tailrec def bar: Int = {
+                   ^
+t9414.scala:20: error: could not optimize @tailrec annotated method bar: it is neither private nor final so can be overridden
+      @tailrec def bar: Int = {
+                   ^
+t9414.scala:34: error: could not optimize @tailrec annotated method bar: it is neither private nor final so can be overridden
+    @tailrec def bar: Int = {
+                 ^
+3 errors

--- a/test/files/neg/t9414.scala
+++ b/test/files/neg/t9414.scala
@@ -1,0 +1,42 @@
+import annotation._
+
+class C {
+  def foo = {
+    class Parent {
+      @tailrec def bar: Int = {
+        println("here we go again")
+        bar
+      }
+    }
+    class Child extends Parent {
+      override def bar = 42
+    }
+  }
+}
+
+class D {
+  def foo = {
+    class Parent {
+      @tailrec def bar: Int = {
+        println("here we go again")
+        bar
+      }
+    }
+    class Child extends Parent
+    class GrandChild extends Child {
+      override def bar = 42
+    }
+  }
+}
+
+object E {
+  sealed class Parent {
+    @tailrec def bar: Int = {
+      println("here we go again")
+      bar
+    }
+  }
+  final class Child extends Parent {
+    override def bar = 42
+  }
+}

--- a/test/files/pos/t9414.scala
+++ b/test/files/pos/t9414.scala
@@ -1,0 +1,78 @@
+import annotation._
+
+class C {
+  def foo = {
+    class Parent {
+      @tailrec def bar: Int = {
+        println("here we go again")
+        bar
+      }
+    }
+    class Child extends Parent {
+      def notBar = 42
+    }
+  }
+}
+
+class D {
+  def foo = {
+    class Parent {
+      @tailrec def bar: Int = {
+        println("here we go again")
+        bar
+      }
+    }
+    class Child extends Parent
+    class GrandChild extends Child {
+      def notBar = 42
+    }
+  }
+}
+
+object E {
+  sealed class Parent {
+    @tailrec def bar: Int = {
+      println("here we go again")
+      bar
+    }
+  }
+  final class Child extends Parent {
+    def notBar = 42
+  }
+}
+
+class F {
+  def foo = {
+    class Parent {
+      @tailrec def bar: Int = {
+        println("here we go again")
+        bar
+      }
+    }
+    class K {
+      class Child extends Parent {
+        def notBar = 42
+      }
+      class GrandChild extends Child {
+        def neitherBar = 42
+      }
+    }
+  }
+}
+
+class G {
+  sealed class Parent {
+    @tailrec def bar: Int = {
+      println("here we go again")
+      bar
+    }
+  }
+  def foo = {
+    class Child extends Parent {
+      def notBar = 42
+    }
+    class GrandChild extends Child {
+      def neitherBar = 42
+    }
+  }
+}


### PR DESCRIPTION
Infer finality by consulting sealed/local hierarchy for overrides.

This permits more tailrec in the absence of final.

Fixes scala/bug#9414

Pursues the retronym branch.