### PR TITLE
[backport] Align package detection in Java with Java

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5269,16 +5269,21 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
           setError(tree)
         }
-          // ignore current variable scope in patterns to enforce linearity
+        // ignore current variable scope in patterns to enforce linearity
         val startContext = if (mode.typingPatternOrTypePat) context.outer else context
 
         def asTypeName = if (mode.inAll(MonoQualifierModes) && unit.isJava && name.isTermName) {
           startContext.lookupSymbol(name.toTypeName, qualifies).symbol
         } else NoSymbol
 
-        val nameLookup   = tree.symbol match {
-          case NoSymbol   => startContext.lookupSymbol(name, qualifies)
-          case sym        => LookupSucceeded(EmptyTree, sym)
+        // in Java, only pick a package if it is rooted
+        def termQualifies(sym: Symbol) = qualifies(sym) && (
+            !startContext.unit.isJava  || !sym.hasPackageFlag
+          || sym.owner.isEffectiveRoot || sym.owner.isRootPackage || sym.isRootPackage
+        )
+        val nameLookup  = tree.symbol match {
+          case NoSymbol => startContext.lookupSymbol(name, termQualifies)
+          case sym      => LookupSucceeded(EmptyTree, sym)
         }
         import InferErrorGen._
         nameLookup match {
@@ -5300,7 +5305,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               // actual call to the stubbed classOf method is generated, returning null.
               typedClassOf(tree, TypeTree(pt.typeArgs.head).setPos(tree.pos.focus))
             }
-          else {
+            else {
               val pre1  = if (sym.isTopLevel) sym.owner.thisType else if (qual == EmptyTree) NoPrefix else qual.tpe
               val tree1 = if (qual == EmptyTree) tree else {
                 val pos = tree.pos

--- a/test/files/pos/t10350/Bar.scala
+++ b/test/files/pos/t10350/Bar.scala
@@ -1,0 +1,6 @@
+
+package bar
+
+object Bar {
+  def xxx(s: String): foo.Foo = foo.Foo.create(s)
+}

--- a/test/files/pos/t10350/Baz.java
+++ b/test/files/pos/t10350/Baz.java
@@ -1,0 +1,5 @@
+
+package foo.java;
+
+interface Baz {
+}

--- a/test/files/pos/t10350/Foo.java
+++ b/test/files/pos/t10350/Foo.java
@@ -1,0 +1,8 @@
+
+package foo;
+
+public interface Foo {
+  static Foo create(java.lang.String v) {
+    return null;
+  }
+}

--- a/test/files/pos/t10350b/Bot.java
+++ b/test/files/pos/t10350b/Bot.java
@@ -1,0 +1,8 @@
+
+package p.p.q;
+
+public class Bot {
+  public p.Top topper() {
+    return new p.Top();
+  }
+}

--- a/test/files/pos/t10350b/Top.java
+++ b/test/files/pos/t10350b/Top.java
@@ -1,0 +1,5 @@
+
+package p;
+
+public class Top {
+}

--- a/test/files/pos/t10350b/s.scala
+++ b/test/files/pos/t10350b/s.scala
@@ -1,0 +1,6 @@
+
+package s
+
+object Test extends App {
+  println(new p.p.q.Bot().topper)
+}


### PR DESCRIPTION
Backport of https://github.com/scala/scala/pull/8714.

Java packages are absolute, not relative.

So for a package symbol to be a typed identifier,
it must be effectively `_root_`ed.