### PR TITLE
Don't use multi-deprecatedName yet, just nowarn

### DIFF
--- a/test/junit/scala/collection/immutable/TreeMapTest.scala
+++ b/test/junit/scala/collection/immutable/TreeMapTest.scala
@@ -10,6 +10,7 @@ import org.junit.runners.JUnit4
 import scala.tools.testkit.AllocationTest
 
 @RunWith(classOf[JUnit4])
+@annotation.nowarn("msg=Boolean literals should be passed using named argument syntax for parameter selfEqual")
 class TreeMapTest extends AllocationTest {
 
   @Test
@@ -161,7 +162,7 @@ class TreeMapTest extends AllocationTest {
       override def hashCode(): Int = s.hashCode
 
     }
-    class CustomOrder(@deprecatedName val selfEqual: Boolean) extends Ordering[K] {
+    class CustomOrder(val selfEqual: Boolean) extends Ordering[K] {
       override def compare(x: K, y: K): Int = x.s compareTo y.s
 
       override def equals(obj: Any): Boolean = obj match {

--- a/test/junit/scala/collection/immutable/TreeSetTest.scala
+++ b/test/junit/scala/collection/immutable/TreeSetTest.scala
@@ -11,6 +11,7 @@ import org.junit.runners.JUnit4
 import scala.tools.testkit.AllocationTest
 
 @RunWith(classOf[JUnit4])
+@annotation.nowarn("msg=Boolean literals should be passed using named argument syntax for parameter selfEqual")
 class TreeSetTest extends AllocationTest {
 
   @Test
@@ -214,7 +215,7 @@ class TreeSetTest extends AllocationTest {
         case _ => false
       }
     }
-    class CustomOrder(@deprecatedName val selfEqual: Boolean) extends Ordering[K] {
+    class CustomOrder(val selfEqual: Boolean) extends Ordering[K] {
       override def compare(x: K, y: K): Int = x.s compareTo y.s
 
       override def equals(obj: Any): Boolean = obj match {

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/CallGraphTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/CallGraphTest.scala
@@ -15,6 +15,7 @@ import scala.tools.nsc.reporters.StoreReporter
 import scala.tools.testkit.BytecodeTesting
 import scala.tools.testkit.BytecodeTesting._
 
+@annotation.nowarn("msg=Boolean literals should be passed using named argument syntax for parameter (safeToInline|atInline|atNoInline)")
 class CallGraphTest extends BytecodeTesting {
   override def compilerArgs = "-opt:inline:** -Wopt"
   import compiler._
@@ -37,7 +38,7 @@ class CallGraphTest extends BytecodeTesting {
   }).toList
 
   def checkCallsite(call: MethodInsnNode, callsiteMethod: MethodNode, target: MethodNode, calleeDeclClass: ClassBType,
-                    @deprecatedName safeToInline: Boolean, @deprecatedName atInline: Boolean, @deprecatedName atNoInline: Boolean, argInfos: IntMap[ArgInfo] = IntMap.empty): Unit = {
+                    safeToInline: Boolean, atInline: Boolean, atNoInline: Boolean, argInfos: IntMap[ArgInfo] = IntMap.empty): Unit = {
     val callsite = callGraph.callsites(callsiteMethod)(call)
     try {
       assert(callsite.callsiteInstruction == call)

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlineSourceMatcherTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlineSourceMatcherTest.scala
@@ -12,6 +12,7 @@ import scala.tools.testkit.BytecodeTesting
 import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
+@annotation.nowarn("msg=Boolean literals should be passed using named argument syntax for parameter (negated|terminal)")
 class InlineSourceMatcherTest extends BytecodeTesting {
   import compiler._
 
@@ -29,7 +30,7 @@ class InlineSourceMatcherTest extends BytecodeTesting {
     try body finally global.settings.optChoices.inlineFrom.selections = saved
   }
 
-  case class E(regex: String, @deprecatedName negated: Boolean = false, @deprecatedName terminal: Boolean = true)
+  case class E(regex: String, negated: Boolean = false, terminal: Boolean = true)
 
   def check(pat: String, expect: E*): InlineSourceMatcher = {
     val m = new InlineSourceMatcher(pat.split(':').toList)


### PR DESCRIPTION
Follow-up to https://github.com/scala/scala/pull/10612

In particular, ensure compilation without bootstrap. So @retronym can get some work done.