### PR TITLE
Fix rare `NullPointerException` in some tree-based collections (by fixing `RedBlackTree.doFrom`)

### DIFF
--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -26,6 +26,21 @@ import scala.runtime.Statics.releaseFence
   *  optimizations behind a reasonably clean API.
   */
 private[collection] object RedBlackTree {
+  def validate[A](tree: Tree[A, _])(implicit ordering: Ordering[A]): tree.type = {
+    def impl(tree: Tree[A, _], keyProp: A => Boolean): Int = {
+      assert(keyProp(tree.key), s"key check failed: $tree")
+      if (tree.isRed) {
+        assert(tree.left == null || tree.left.isBlack, s"red-red left $tree")
+        assert(tree.right == null || tree.right.isBlack, s"red-red right $tree")
+      }
+      val leftBlacks = if (tree.left == null) 0 else impl(tree.left, k => keyProp(k) && ordering.compare(k, tree.key) < 0)
+      val rightBlacks = if (tree.right == null) 0 else impl(tree.right, k => keyProp(k) && ordering.compare(k, tree.key) > 0)
+      assert(leftBlacks == rightBlacks, s"not balanced: $tree")
+      leftBlacks + (if (tree.isBlack) 1 else 0)
+    }
+    if (tree != null) impl(tree, _ => true)
+    tree
+  }
 
   def isEmpty(tree: Tree[_, _]): Boolean = tree eq null
 
@@ -437,7 +452,7 @@ private[collection] object RedBlackTree {
     if (ordering.lt(tree.key, from)) return doFrom(tree.right, from)
     val newLeft = doFrom(tree.left, from)
     if (newLeft eq tree.left) tree
-    else if (newLeft eq null) upd(tree.right, tree.key, tree.value, overwrite = false)
+    else if (newLeft eq null) maybeBlacken(upd(tree.right, tree.key, tree.value, overwrite = false))
     else join(newLeft, tree.key, tree.value, tree.right)
   }
   private[this] def doTo[A, B](tree: Tree[A, B], to: A)(implicit ordering: Ordering[A]): Tree[A, B] = {
@@ -445,15 +460,15 @@ private[collection] object RedBlackTree {
     if (ordering.lt(to, tree.key)) return doTo(tree.left, to)
     val newRight = doTo(tree.right, to)
     if (newRight eq tree.right) tree
-    else if (newRight eq null) upd(tree.left, tree.key, tree.value, overwrite = false)
-    else join (tree.left, tree.key, tree.value, newRight)
+    else if (newRight eq null) maybeBlacken(upd(tree.left, tree.key, tree.value, overwrite = false))
+    else join(tree.left, tree.key, tree.value, newRight)
   }
   private[this] def doUntil[A, B](tree: Tree[A, B], until: A)(implicit ordering: Ordering[A]): Tree[A, B] = {
     if (tree eq null) return null
     if (ordering.lteq(until, tree.key)) return doUntil(tree.left, until)
     val newRight = doUntil(tree.right, until)
     if (newRight eq tree.right) tree
-    else if (newRight eq null) upd(tree.left, tree.key, tree.value, overwrite = false)
+    else if (newRight eq null) maybeBlacken(upd(tree.left, tree.key, tree.value, overwrite = false))
     else join(tree.left, tree.key, tree.value, newRight)
   }
 

--- a/test/junit/scala/collection/immutable/SortedSetTest.scala
+++ b/test/junit/scala/collection/immutable/SortedSetTest.scala
@@ -1,8 +1,10 @@
 package scala.collection.immutable
 
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 import scala.tools.testkit.AllocationTest
+import scala.tools.testkit.AssertUtil.assertThrows
 
 
 class SortedSetTest extends AllocationTest{
@@ -22,5 +24,87 @@ class SortedSetTest extends AllocationTest{
   @Test def apply2(): Unit ={
     val ord = Ordering[String]
     exactAllocates(216)(SortedSet("a", "b")(ord))
+  }
+
+  @Test def redBlackValidate(): Unit = {
+    import RedBlackTree._
+    def redLeaf(x: Int) = RedTree(x, null, null, null)
+    def blackLeaf(x: Int) = BlackTree(x, null, null, null)
+
+    validate(redLeaf(1))
+    validate(blackLeaf(1))
+    assertThrows[AssertionError](validate(RedTree(2, null, redLeaf(1), null)), _.contains("red-red"))
+    assertThrows[AssertionError](validate(RedTree(2, null, blackLeaf(1), null)), _.contains("not balanced"))
+    validate(RedTree(2, null, blackLeaf(1), blackLeaf(3)))
+    validate(BlackTree(2, null, blackLeaf(1), blackLeaf(3)))
+    assertThrows[AssertionError](validate(RedTree(4, null, blackLeaf(1), blackLeaf(3))), _.contains("key check"))
+  }
+
+  @Test def t12921(): Unit = {
+    val s1 = TreeSet(6, 1, 11, 9, 10, 8)
+    RedBlackTree.validate(s1.tree)
+
+    val s2 = s1.rangeFrom(2)
+    RedBlackTree.validate(s2.tree)
+    assertEquals(Set(6, 8, 9, 10, 11), s2)
+
+    val s3 = s2 ++ Seq(7,3,5)
+    RedBlackTree.validate(s3.tree)
+    assertEquals(Set(3, 5, 6, 7, 8, 9, 10, 11), s3)
+
+    val s4 = s3.rangeFrom(4)
+    RedBlackTree.validate(s4.tree)
+    assertEquals(Set(5, 6, 7, 8, 9, 10, 11), s4)
+  }
+
+  @Test def t12921b(): Unit = {
+    import RedBlackTree._
+    val t = BlackTree(
+      5,
+      null,
+      BlackTree(
+        3,
+        null,
+        RedTree(1, null, null, null),
+        RedTree(4, null, null, null)
+      ),
+      BlackTree(7, null, RedTree(6, null, null, null), null)
+    )
+    validate(t)
+    validate(from(t, 2))
+  }
+
+  @Test def t12921c(): Unit = {
+    import RedBlackTree._
+    val t = BlackTree(
+      8,
+      null,
+      BlackTree(4, null, null, RedTree(6, null, null, null)),
+      BlackTree(
+        12,
+        null,
+        RedTree(10, null, null, null),
+        RedTree(14, null, null, null)
+      )
+    )
+    validate(t)
+    validate(to(t, 13))
+  }
+
+  @Test def t12921d(): Unit = {
+    import RedBlackTree._
+    val t = BlackTree(
+      8,
+      null,
+      BlackTree(4, null, null, RedTree(6, null, null, null)),
+      BlackTree(
+        12,
+        null,
+        RedTree(10, null, null, null),
+        RedTree(14, null, null, null)
+      )
+    )
+    validate(t)
+    validate(until(t, 13))
   }
 }

--- a/test/scalacheck/redblacktree.scala
+++ b/test/scalacheck/redblacktree.scala
@@ -63,7 +63,7 @@ abstract class RedBlackTreeTest(tname: String) extends Properties(tname) with Re
   def genInput: Gen[(Tree[String, Int], ModifyParm, Tree[String, Int])] = for {
     tree <- genTree
     parm <- genParm(tree)
-  } yield (tree, parm, modify(tree, parm))
+  } yield (tree, parm, validate(modify(tree, parm)))
 
   def setup(invariant: Tree[String, Int] => Boolean): Prop = forAll(genInput) { case (tree, parm, newTree) =>
     invariant(newTree)
@@ -348,7 +348,7 @@ abstract class BulkTest(pName: String) extends RedBlackTreeTest(pName) {
     l1.foreach { case i => t1 = update(t1, ""+i, i, false) }
     var t2: Tree[String, Int] = null
     l2.foreach { case i => t2 = update(t2, ""+i, i, false) }
-    val t3 = modify(t1, t2)
+    val t3 = validate(modify(t1, t2))
     (t1, t2, t3)
   }
 


### PR DESCRIPTION
`upd` may return a red tree with a red child. Need to use `maybeBlacken` when such a tree is not expected.

Fixes https://github.com/scala/bug/issues/12921