### PR TITLE
Invalidate sources that depends on `@inline` methods

### DIFF
--- a/src/sbt-bridge/scala/tools/xsbt/ExtractAPI.scala
+++ b/src/sbt-bridge/scala/tools/xsbt/ExtractAPI.scala
@@ -526,6 +526,7 @@ class ExtractAPI[GlobalType <: Global](
     val absOver = s.hasFlag(ABSOVERRIDE)
     val abs = s.hasFlag(ABSTRACT) || s.hasFlag(DEFERRED) || absOver
     val over = s.hasFlag(OVERRIDE) || absOver
+    val hasInline = s.annotations.exists(_.symbol.tpe == typeOf[scala.inline])
     new xsbti.api.Modifiers(
       abs,
       over,
@@ -533,7 +534,7 @@ class ExtractAPI[GlobalType <: Global](
       s.hasFlag(SEALED),
       isImplicit(s),
       s.hasFlag(LAZY),
-      s.hasFlag(MACRO),
+      s.hasFlag(MACRO) || hasInline,
       s.hasFlag(SUPERACCESSOR)
     )
   }

--- a/src/sbt-bridge/scala/tools/xsbt/ExtractAPI.scala
+++ b/src/sbt-bridge/scala/tools/xsbt/ExtractAPI.scala
@@ -526,7 +526,7 @@ class ExtractAPI[GlobalType <: Global](
     val absOver = s.hasFlag(ABSOVERRIDE)
     val abs = s.hasFlag(ABSTRACT) || s.hasFlag(DEFERRED) || absOver
     val over = s.hasFlag(OVERRIDE) || absOver
-    val hasInline = s.annotations.exists(_.symbol.tpe == typeOf[scala.inline])
+    val hasInline = global.settings.optInlinerEnabled || s.annotations.exists(_.symbol.tpe == typeOf[scala.inline])
     new xsbti.api.Modifiers(
       abs,
       over,

--- a/src/sbt-bridge/scala/tools/xsbt/ExtractAPI.scala
+++ b/src/sbt-bridge/scala/tools/xsbt/ExtractAPI.scala
@@ -526,7 +526,7 @@ class ExtractAPI[GlobalType <: Global](
     val absOver = s.hasFlag(ABSOVERRIDE)
     val abs = s.hasFlag(ABSTRACT) || s.hasFlag(DEFERRED) || absOver
     val over = s.hasFlag(OVERRIDE) || absOver
-    val hasInline = global.settings.optInlinerEnabled || s.annotations.exists(_.symbol.tpe == typeOf[scala.inline])
+    val hasInline = global.settings.optInlinerEnabled && s.annotations.exists(_.symbol.tpe == typeOf[scala.inline])
     new xsbti.api.Modifiers(
       abs,
       over,


### PR DESCRIPTION
This PR fixes https://github.com/sbt/sbt/issues/4125, https://github.com/sbt/zinc/issues/537.

### Issue

When `@inline` method implementation changes, the public API of `@inline` method does not change, hence Zinc does not invalidate sources that depends on `@inline` method.

### Solution

The behaviour of `@inline` method is similar to macro methods. Hence, we can mark `@inline` method as macro and reuse existing Zinc invalidation logic for macro invalidation.

### Validating the fix

Scripted test is added to Zinc side (https://github.com/sbt/zinc/pull/1310). The test passed.

### TODOs

- This PR does not handle call-site `@inline`. To handle that case, we need to follow https://github.com/sbt/zinc/issues/537#issuecomment-421753875 and drop call-site `@inline` at compiler side.
- Even without `@inline` annotation, compiler may still sometimes inline a method. The compiler keep a log of inlined methods, so in a follow up PR, we can utilize that information instead of directly checking `@inline` annotation.