### PR TITLE
Prefer InvokeVirtual in tests, avoid passing constants

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypes.scala
@@ -1160,9 +1160,9 @@ object BTypes {
    * @param annotatedInline                     True if the method is annotated `@inline`
    * @param annotatedNoInline                   True if the method is annotated `@noinline`
    */
-  final case class MethodInlineInfo(effectivelyFinal: Boolean,
-                                    annotatedInline: Boolean,
-                                    annotatedNoInline: Boolean)
+  final case class MethodInlineInfo(effectivelyFinal: Boolean = false,
+                                    annotatedInline: Boolean = false,
+                                    annotatedNoInline: Boolean = false)
 
   // no static way (without symbol table instance) to get to nme.ScalaATTR / ScalaSignatureATTR
   val ScalaAttributeName    = "Scala"

--- a/src/testkit/scala/tools/testkit/ASMConverters.scala
+++ b/src/testkit/scala/tools/testkit/ASMConverters.scala
@@ -13,8 +13,7 @@
 package scala.tools.testkit
 
 import scala.jdk.CollectionConverters._
-import scala.tools.asm
-import asm.{tree => t}
+import scala.tools.asm, asm.{tree => t}, asm.Opcodes._
 
 /** Makes using ASM from ByteCodeTests more convenient.
  *
@@ -268,4 +267,6 @@ object ASMConverters {
     case FrameEntry(tp, local, stack)                => method.visitFrame(tp, local.length, frameTypesToAsm(local, asmLabel).toArray, stack.length, frameTypesToAsm(stack, asmLabel).toArray)
     case LineNumber(line, start)                     => method.visitLineNumber(line, asmLabel(start))
   }
+  def InvokeInterface(owner: String, name: String, desc: String): Invoke = Invoke(opcode = INVOKEINTERFACE, owner, name, desc, itf = true)
+  def InvokeVirtual(owner: String, name: String, desc: String): Invoke = Invoke(opcode = INVOKEVIRTUAL, owner, name, desc, itf = false)
 }

--- a/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
@@ -55,18 +55,18 @@ class BytecodeTest extends BytecodeTesting {
       Jump(IFEQ, Label(20)),
 
       LineNumber(6, Label(11)),
-      Invoke(INVOKEVIRTUAL, "scala/Predef$", "println", "(Ljava/lang/Object;)V", itf = false),
+      InvokeVirtual("scala/Predef$", "println", "(Ljava/lang/Object;)V"),
       Jump(GOTO, Label(33)),
 
       LineNumber(5, Label(20)),
       Jump(GOTO, Label(24)),
 
       LineNumber(8, Label(24)),
-      Invoke(INVOKEVIRTUAL, "scala/Predef$", "println", "(Ljava/lang/Object;)V", itf = false),
+      InvokeVirtual("scala/Predef$", "println", "(Ljava/lang/Object;)V"),
       Jump(GOTO, Label(33)),
 
       LineNumber(10, Label(33)),
-      Invoke(INVOKEVIRTUAL, "scala/Predef$", "println", "(Ljava/lang/Object;)V", itf = false)
+      InvokeVirtual("scala/Predef$", "println", "(Ljava/lang/Object;)V")
     )
 
     val mainIns = getInstructions(module, "main") filter {
@@ -112,7 +112,7 @@ class BytecodeTest extends BytecodeTesting {
       // AnyRef ==
       VarOp(ALOAD, 2), VarOp(ALOAD, 1), VarOp(ASTORE, 3), Op(DUP), Jump(IFNONNULL, Label(14)),
       Op(POP), VarOp(ALOAD, 3), Jump(IFNULL, Label(19)), Jump(GOTO, Label(23)),
-      Label(14), VarOp(ALOAD, 3), Invoke(INVOKEVIRTUAL, "java/lang/Object", "equals", "(Ljava/lang/Object;)Z", itf = false), Jump(IFEQ, Label(23)),
+      Label(14), VarOp(ALOAD, 3), InvokeVirtual("java/lang/Object", "equals", "(Ljava/lang/Object;)Z"), Jump(IFEQ, Label(23)),
       Label(19), Op(ICONST_1), Jump(GOTO, Label(26)),
       Label(23), Op(ICONST_0),
       Label(26), Op(IRETURN)))
@@ -143,8 +143,8 @@ class BytecodeTest extends BytecodeTesting {
 
     // t8: no null checks invoking equals on modules and constants
     assertSameCode(getMethod(c, "t8"), List(
-      Field(GETSTATIC, "scala/collection/immutable/Nil$", "MODULE$", "Lscala/collection/immutable/Nil$;"), VarOp(ALOAD, 1), Invoke(INVOKEVIRTUAL, "java/lang/Object", "equals", "(Ljava/lang/Object;)Z", itf = false), Jump(IFNE, Label(10)),
-      Ldc(LDC, ""), VarOp(ALOAD, 1), Invoke(INVOKEVIRTUAL, "java/lang/Object", "equals", "(Ljava/lang/Object;)Z", itf = false), Jump(IFNE, Label(14)),
+      Field(GETSTATIC, "scala/collection/immutable/Nil$", "MODULE$", "Lscala/collection/immutable/Nil$;"), VarOp(ALOAD, 1), InvokeVirtual("java/lang/Object", "equals", "(Ljava/lang/Object;)Z"), Jump(IFNE, Label(10)),
+      Ldc(LDC, ""), VarOp(ALOAD, 1), InvokeVirtual("java/lang/Object", "equals", "(Ljava/lang/Object;)Z"), Jump(IFNE, Label(14)),
       Label(10), Op(ICONST_1), Jump(GOTO, Label(17)),
       Label(14), Op(ICONST_0),
       Label(17), Op(IRETURN)))
@@ -172,8 +172,8 @@ class BytecodeTest extends BytecodeTesting {
     assertSameCode(t.instructions.filterNot(isFrameLine), List(
       Label(0), Ldc(LDC, ""), VarOp(ASTORE, 1),
       Label(4), VarOp(ALOAD, 1), Jump(IFNULL, Label(20)),
-      Label(9), VarOp(ALOAD, 0), Invoke(INVOKEVIRTUAL, "C", "foo", "()V", itf = false), Label(13), Op(ACONST_NULL), VarOp(ASTORE, 1), Label(17), Jump(GOTO, Label(4)),
-      Label(20), VarOp(ALOAD, 0), Invoke(INVOKEVIRTUAL, "C", "bar", "()V", itf = false), Op(RETURN), Label(26)))
+      Label(9), VarOp(ALOAD, 0), InvokeVirtual("C", "foo", "()V"), Label(13), Op(ACONST_NULL), VarOp(ASTORE, 1), Label(17), Jump(GOTO, Label(4)),
+      Label(20), VarOp(ALOAD, 0), InvokeVirtual("C", "bar", "()V"), Op(RETURN), Label(26)))
     val labels = t.instructions collect { case l: Label => l }
     val x = t.localVars.find(_.name == "x").get
     assertEquals(x.start, labels(1))
@@ -192,7 +192,7 @@ class BytecodeTest extends BytecodeTesting {
       """.stripMargin
     val t = compileClass(code)
     val tMethod = getMethod(t, "t$")
-    @unused val invoke = Invoke(INVOKEVIRTUAL, "java/lang/Object", "toString", "()Ljava/lang/String;", itf = false)
+    @unused val invoke = InvokeVirtual("java/lang/Object", "toString", "()Ljava/lang/String;")
     // ths static accessor is positioned at the line number of the accessed method.
     assertSameCode(tMethod.instructions,
       List(Label(0), LineNumber(2, Label(0)), VarOp(ALOAD, 0), Invoke(INVOKESPECIAL, "T", "t", "()V", itf = true), Op(RETURN), Label(4))
@@ -557,7 +557,7 @@ class BytecodeTest extends BytecodeTesting {
       TypeOp(CHECKCAST, "scala/collection/immutable/$colon$colon"),
       VarOp(ASTORE, 4),
       VarOp(ALOAD, 4),
-      Invoke(INVOKEVIRTUAL, "scala/collection/immutable/$colon$colon", "head", "()Ljava/lang/Object;", itf = false),
+      InvokeVirtual("scala/collection/immutable/$colon$colon", "head", "()Ljava/lang/Object;"),
       Invoke(INVOKESTATIC, "scala/runtime/BoxesRunTime", "unboxToInt", "(Ljava/lang/Object;)I", itf = false),
       VarOp(ISTORE, 5),
       VarOp(ILOAD, 5),
@@ -567,7 +567,7 @@ class BytecodeTest extends BytecodeTesting {
       Label(22),
       Field(GETSTATIC, "scala/collection/immutable/Nil$", "MODULE$", "Lscala/collection/immutable/Nil$;"),
       VarOp(ALOAD, 3),
-      Invoke(INVOKEVIRTUAL, "java/lang/Object", "equals", "(Ljava/lang/Object;)Z", itf = false),
+      InvokeVirtual("java/lang/Object", "equals", "(Ljava/lang/Object;)Z"),
       Jump(IFEQ, Label(31)),
       IntOp(BIPUSH, 20),
       Op(IRETURN),
@@ -599,7 +599,7 @@ class BytecodeTest extends BytecodeTesting {
       TypeOp(CHECKCAST, "scala/collection/immutable/$colon$colon"),
       VarOp(ASTORE, 5),
       VarOp(ALOAD, 5),
-      Invoke(INVOKEVIRTUAL, "scala/collection/immutable/$colon$colon", "head", "()Ljava/lang/Object;", itf = false),
+      InvokeVirtual("scala/collection/immutable/$colon$colon", "head", "()Ljava/lang/Object;"),
       Invoke(INVOKESTATIC, "scala/runtime/BoxesRunTime", "unboxToInt", "(Ljava/lang/Object;)I", itf = false),
       VarOp(ISTORE, 7),
       Op(ICONST_1),
@@ -632,7 +632,7 @@ class BytecodeTest extends BytecodeTesting {
       VarOp(ILOAD, 4),
       Jump(IFEQ, Label(71)),
       VarOp(ALOAD, 5),
-      Invoke(INVOKEVIRTUAL, "scala/collection/immutable/$colon$colon", "head", "()Ljava/lang/Object;", itf = false),
+      InvokeVirtual("scala/collection/immutable/$colon$colon", "head", "()Ljava/lang/Object;"),
       Invoke(INVOKESTATIC, "scala/runtime/BoxesRunTime", "unboxToInt", "(Ljava/lang/Object;)I", itf = false),
       VarOp(ISTORE, 8),
       VarOp(ILOAD, 8),
@@ -656,13 +656,13 @@ class BytecodeTest extends BytecodeTesting {
       TypeOp(CHECKCAST, "scala/collection/immutable/$colon$colon"),
       VarOp(ASTORE, 4),
       VarOp(ALOAD, 4),
-      Invoke(INVOKEVIRTUAL, "scala/collection/immutable/$colon$colon", "head", "()Ljava/lang/Object;", itf = false),
+      InvokeVirtual("scala/collection/immutable/$colon$colon", "head", "()Ljava/lang/Object;"),
       Invoke(INVOKESTATIC, "scala/runtime/BoxesRunTime", "unboxToInt", "(Ljava/lang/Object;)I", itf = false),
       VarOp(ISTORE, 5),
       Field(GETSTATIC, "scala/Predef$", "MODULE$", "Lscala/Predef$;"),
       VarOp(ILOAD, 5),
       Invoke(INVOKESTATIC, "scala/runtime/BoxesRunTime", "boxToInteger", "(I)Ljava/lang/Integer;", itf = false),
-      Invoke(INVOKEVIRTUAL, "scala/Predef$", "println", "(Ljava/lang/Object;)V", itf = false),
+      InvokeVirtual("scala/Predef$", "println", "(Ljava/lang/Object;)V"),
       Field(GETSTATIC, "scala/runtime/BoxedUnit", "UNIT", "Lscala/runtime/BoxedUnit;"),
       Op(POP),
       Op(RETURN),
@@ -671,11 +671,11 @@ class BytecodeTest extends BytecodeTesting {
       Label(27),
       Field(GETSTATIC, "scala/collection/immutable/Nil$", "MODULE$", "Lscala/collection/immutable/Nil$;"),
       VarOp(ALOAD, 3),
-      Invoke(INVOKEVIRTUAL, "java/lang/Object", "equals", "(Ljava/lang/Object;)Z", itf = false),
+      InvokeVirtual("java/lang/Object", "equals", "(Ljava/lang/Object;)Z"),
       Jump(IFEQ, Label(40)),
       Field(GETSTATIC, "scala/Predef$", "MODULE$", "Lscala/Predef$;"),
       Ldc(LDC, "nil"),
-      Invoke(INVOKEVIRTUAL, "scala/Predef$", "println", "(Ljava/lang/Object;)V", itf = false),
+      InvokeVirtual("scala/Predef$", "println", "(Ljava/lang/Object;)V"),
       Field(GETSTATIC, "scala/runtime/BoxedUnit", "UNIT", "Lscala/runtime/BoxedUnit;"),
       Op(POP),
       Op(RETURN),
@@ -701,7 +701,7 @@ class BytecodeTest extends BytecodeTesting {
       TypeOp(CHECKCAST, "scala/collection/immutable/$colon$colon"),
       VarOp(ASTORE, 4),
       VarOp(ALOAD, 4),
-      Invoke(INVOKEVIRTUAL, "scala/collection/immutable/$colon$colon", "head", "()Ljava/lang/Object;", itf = false),
+      InvokeVirtual("scala/collection/immutable/$colon$colon", "head", "()Ljava/lang/Object;"),
       Invoke(INVOKESTATIC, "scala/runtime/BoxesRunTime", "unboxToInt", "(Ljava/lang/Object;)I", itf = false),
       VarOp(ISTORE, 5),
       VarOp(ILOAD, 5),
@@ -711,7 +711,7 @@ class BytecodeTest extends BytecodeTesting {
       Label(22),
       Field(GETSTATIC, "scala/collection/immutable/Nil$", "MODULE$", "Lscala/collection/immutable/Nil$;"),
       VarOp(ALOAD, 3),
-      Invoke(INVOKEVIRTUAL, "java/lang/Object", "equals", "(Ljava/lang/Object;)Z", itf = false),
+      InvokeVirtual("java/lang/Object", "equals", "(Ljava/lang/Object;)Z"),
       Jump(IFEQ, Label(31)),
       IntOp(BIPUSH, 20),
       Op(IRETURN),
@@ -768,7 +768,7 @@ class BytecodeTest extends BytecodeTesting {
       Label(19),
       Field(GETSTATIC, "scala/collection/immutable/Nil$", "MODULE$", "Lscala/collection/immutable/Nil$;"),
       VarOp(ALOAD, 4),
-      Invoke(INVOKEVIRTUAL, "java/lang/Object", "equals", "(Ljava/lang/Object;)Z", itf = false),
+      InvokeVirtual("java/lang/Object", "equals", "(Ljava/lang/Object;)Z"),
       Jump(IFEQ, Label(30)),
       TypeOp(NEW, "B"),
       Op(DUP),
@@ -784,7 +784,7 @@ class BytecodeTest extends BytecodeTesting {
       Op(ATHROW),
       Label(41),
       TypeOp(CHECKCAST, "Tree"),
-      Invoke(INVOKEVIRTUAL, "PatmatAdaptMatchEnd", "atPos", "(LTree;)LTree;", itf = false),
+      InvokeVirtual("PatmatAdaptMatchEnd", "atPos", "(LTree;)LTree;"),
       TypeOp(CHECKCAST, "RefTree"),
       VarOp(ASTORE, 3),
       VarOp(ALOAD, 3),
@@ -946,7 +946,7 @@ class BytecodeTest extends BytecodeTesting {
       IntOp(BIPUSH, 65),
       VarOp(ILOAD, 3),
       Op(IADD),
-      Invoke(INVOKEVIRTUAL, "java/io/Writer", "write", "(I)V", itf = false),
+      InvokeVirtual("java/io/Writer", "write", "(I)V"),
       Op(RETURN),
       Label(34),
       VarOp(ALOAD, 0),
@@ -983,8 +983,8 @@ class BytecodeTest extends BytecodeTesting {
       VarOp(ALOAD, 0),
       Invoke(INVOKESPECIAL, "SourceMapWriter", "Base64Map", "()Ljava/lang/String;", itf = false),
       VarOp(ILOAD, 3),
-      Invoke(INVOKEVIRTUAL, "java/lang/String", "charAt", "(I)C", itf = false),
-      Invoke(INVOKEVIRTUAL, "java/io/Writer", "write", "(I)V", itf = false),
+      InvokeVirtual("java/lang/String", "charAt", "(I)C"),
+      InvokeVirtual("java/io/Writer", "write", "(I)V"),
       VarOp(ILOAD, 2),
       Op(ICONST_0),
       Jump(IF_ICMPEQ, Label(47)),

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/ClosureOptimizerTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/ClosureOptimizerTest.scala
@@ -56,7 +56,7 @@ class ClosureOptimizerTest extends BytecodeTesting {
       """.stripMargin
     val c = compileClass(code)
     assertSameCode(getMethod(c, "t"),
-      List(VarOp(ALOAD, 1), Invoke(INVOKEVIRTUAL, "scala/collection/immutable/List", "head", "()Ljava/lang/Object;", itf = false),
+      List(VarOp(ALOAD, 1), InvokeVirtual("scala/collection/immutable/List", "head", "()Ljava/lang/Object;"),
         TypeOp(CHECKCAST, "java/lang/String"), Op(ARETURN)))
   }
 

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/InlineInfoTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/InlineInfoTest.scala
@@ -14,7 +14,6 @@ import scala.tools.nsc.backend.jvm.BackendReporting._
 import scala.tools.testkit.BytecodeTesting
 
 @RunWith(classOf[JUnit4])
-@annotation.nowarn("msg=Boolean literals")
 class InlineInfoTest extends BytecodeTesting {
   import compiler._
   import global.genBCode.{bTypes, postProcessor}
@@ -68,9 +67,9 @@ class InlineInfoTest extends BytecodeTesting {
     compileClasses("class C { new A }", javaCode = List((jCode, "A.java")))
     val info = global.genBCode.bTypes.cachedClassBType("A").info.get.inlineInfo
     assertEquals(info.methodInfos, Map(
-      ("bar", "()I")    -> MethodInlineInfo(true,false,false),
-      ("<init>", "()V") -> MethodInlineInfo(false,false,false),
-      ("baz", "()I")    -> MethodInlineInfo(true,false,false)))
+      ("bar", "()I")    -> MethodInlineInfo(effectivelyFinal = true),
+      ("<init>", "()V") -> MethodInlineInfo(),
+      ("baz", "()I")    -> MethodInlineInfo(effectivelyFinal = true)))
   }
 
   @Test
@@ -89,7 +88,7 @@ class InlineInfoTest extends BytecodeTesting {
     // the classpath (classfile WatchEvent$Kind.class) instead of the actual companion from the source, so the static method was missing.
     val info = global.genBCode.bTypes.cachedClassBType("java/nio/file/WatchEvent$Kind").info.get.inlineInfo
     assertEquals(info.methodInfos, Map(
-      ("HAI", "()Ljava/lang/String;") -> MethodInlineInfo(true,false,false),
-      ("<init>", "()V")               -> MethodInlineInfo(false,false,false)))
+      ("HAI", "()Ljava/lang/String;") -> MethodInlineInfo(effectivelyFinal = true),
+      ("<init>", "()V")               -> MethodInlineInfo()))
   }
 }

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/MethodLevelOptsTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/MethodLevelOptsTest.scala
@@ -16,7 +16,6 @@ import scala.tools.testkit.BytecodeTesting
 import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
-@annotation.nowarn("msg=Boolean literals should be passed using named argument syntax for parameter itf.")
 class MethodLevelOptsTest extends BytecodeTesting {
   override def compilerArgs = "-opt:l:method"
   import compiler._
@@ -100,7 +99,7 @@ class MethodLevelOptsTest extends BytecodeTesting {
       """.stripMargin
     val c = compileClass(code)
     assertSameCode(getMethod(c, "t"), List(
-      Op(ACONST_NULL), Invoke(INVOKEVIRTUAL, "java/lang/Object", "toString", "()Ljava/lang/String;", false), Op(ARETURN)))
+      Op(ACONST_NULL), InvokeVirtual("java/lang/Object", "toString", "()Ljava/lang/String;"), Op(ARETURN)))
   }
 
   @Test
@@ -140,10 +139,10 @@ class MethodLevelOptsTest extends BytecodeTesting {
 
     assertSameCode(getMethod(c, "t"), List(
       Ldc(LDC, "el"), VarOp(ASTORE, 1),
-      Field(GETSTATIC, "scala/Predef$", "MODULE$", "Lscala/Predef$;"), VarOp(ALOAD, 1), Invoke(INVOKEVIRTUAL, "scala/Predef$", "println", "(Ljava/lang/Object;)V", false),
+      Field(GETSTATIC, "scala/Predef$", "MODULE$", "Lscala/Predef$;"), VarOp(ALOAD, 1), InvokeVirtual("scala/Predef$", "println", "(Ljava/lang/Object;)V"),
       Op(ACONST_NULL), VarOp(ASTORE, 1),
       Ldc(LDC, "zit"), VarOp(ASTORE, 1),
-      Field(GETSTATIC, "scala/Predef$", "MODULE$", "Lscala/Predef$;"), Invoke(INVOKEVIRTUAL, "scala/Predef$", "println", "()V", false),
+      Field(GETSTATIC, "scala/Predef$", "MODULE$", "Lscala/Predef$;"), InvokeVirtual("scala/Predef$", "println", "()V"),
       VarOp(ALOAD, 1), Op(ARETURN)))
   }
 
@@ -179,7 +178,7 @@ class MethodLevelOptsTest extends BytecodeTesting {
       """.stripMargin
     val c = compileClass(code, allowMessage = ignoreDeprecations)
     assertSameCode(getMethod(c, "t"), List(
-      TypeOp(NEW, "java/lang/Integer"), Ldc(LDC, "nono"), Invoke(INVOKESPECIAL, "java/lang/Integer", "<init>", "(Ljava/lang/String;)V", false),
+      TypeOp(NEW, "java/lang/Integer"), Ldc(LDC, "nono"), Invoke(INVOKESPECIAL, "java/lang/Integer", "<init>", "(Ljava/lang/String;)V", itf = false),
       VarOp(ILOAD, 1), VarOp(ILOAD, 2), Op(IADD), Op(IRETURN)))
   }
 
@@ -201,7 +200,7 @@ class MethodLevelOptsTest extends BytecodeTesting {
       VarOp(ILOAD, 1),
       VarOp(ILOAD, 2),
       VarOp(ILOAD, 3),
-      Invoke(INVOKESTATIC, "C", "$anonfun$t$1", "(III)I", false), Op(IRETURN)))
+      Invoke(INVOKESTATIC, "C", "$anonfun$t$1", "(III)I", itf = false), Op(IRETURN)))
   }
 
   @Test

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/ScalaInlineInfoTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/ScalaInlineInfoTest.scala
@@ -10,12 +10,11 @@ import org.junit.runners.JUnit4
 import scala.jdk.CollectionConverters._
 import scala.collection.immutable.TreeMap
 import scala.tools.asm.tree.ClassNode
-import scala.tools.nsc.backend.jvm.BTypes.{InlineInfo, MethodInlineInfo}
+import scala.tools.nsc.backend.jvm.BTypes.{EmptyInlineInfo, InlineInfo, MethodInlineInfo}
 import scala.tools.testkit.BytecodeTesting
 import scala.tools.testkit.BytecodeTesting._
 
 @RunWith(classOf[JUnit4])
-@annotation.nowarn("msg=Boolean literals")
 class ScalaInlineInfoTest extends BytecodeTesting {
   override def compilerArgs = "-opt:none"
   import compiler._
@@ -82,64 +81,58 @@ class ScalaInlineInfoTest extends BytecodeTesting {
 
     val cs @ List(c, t, tl, to) = compileClasses(code)
     val infoT = inlineInfo(t)
-    val expectT = InlineInfo (
-      false, // final class
-      None, // not a sam
-      TreeMap(
-        (("O", "()LT$O$;"),                                                 MethodInlineInfo(false,false,false)),
-        (("T$$super$toString", "()Ljava/lang/String;"),                     MethodInlineInfo(true ,false,false)),
-        (("T$_setter_$x1_$eq", "(I)V"),                                     MethodInlineInfo(false,false,false)),
-        (("f1", "()I"),                                                     MethodInlineInfo(false,false,false)),
-        (("f1$", "(LT;)I"),                                                 MethodInlineInfo(true ,false,false)),
-        (("f2", "()I"),                                                     MethodInlineInfo(true ,false,false)), // no static impl method for private method f2
-        (("f3", "()I"),                                                     MethodInlineInfo(false,false,false)),
-        (("f3$", "(LT;)I"),                                                 MethodInlineInfo(true ,false,false)),
-        (("f4", "()Ljava/lang/String;"),                                    MethodInlineInfo(false,true, false)),
-        (("f4$", "(LT;)Ljava/lang/String;"),                                MethodInlineInfo(true ,true, false)),
-        (("f5", "()I"),                                                     MethodInlineInfo(true ,false,false)),
-        (("f5$", "(LT;)I"),                                                 MethodInlineInfo(true ,false,false)),
-        (("f6", "()I"),                                                     MethodInlineInfo(false,false,true )), // no static impl method for abstract method f6
-        (("x1", "()I"),                                                     MethodInlineInfo(false,false,false)),
-        (("y2", "()I"),                                                     MethodInlineInfo(false,false,false)),
-        (("y2_$eq", "(I)V"),                                                MethodInlineInfo(false,false,false)),
-        (("x3", "()I"),                                                     MethodInlineInfo(false,false,false)),
-        (("x3_$eq", "(I)V"),                                                MethodInlineInfo(false,false,false)),
-        (("x4", "()I"),                                                     MethodInlineInfo(false,false,false)),
-        (("x4$", "(LT;)I"),                                                 MethodInlineInfo(true ,false,false)),
-        (("x5", "()I"),                                                     MethodInlineInfo(true, false,false)),
-        (("x5$", "(LT;)I"),                                                 MethodInlineInfo(true ,false,false)),
-        (("L$2", "(Lscala/runtime/LazyRef;)LT$L$1$;"),                      MethodInlineInfo(true, false,false)),
-        (("nest$1", "()I"),                                                 MethodInlineInfo(true, false,false)),
-        (("$init$", "(LT;)V"),                                              MethodInlineInfo(true,false,false)),
-        (("L$lzycompute$1", "(Lscala/runtime/LazyRef;)LT$L$1$;"),           MethodInlineInfo(true,false,false))
-      ),
-      None // warning
-    )
+    val expectT = EmptyInlineInfo.copy(methodInfos = TreeMap(
+        (("O", "()LT$O$;"),                                                 MethodInlineInfo()),
+        (("T$$super$toString", "()Ljava/lang/String;"),                     MethodInlineInfo(effectivelyFinal = true)),
+        (("T$_setter_$x1_$eq", "(I)V"),                                     MethodInlineInfo()),
+        (("f1", "()I"),                                                     MethodInlineInfo()),
+        (("f1$", "(LT;)I"),                                                 MethodInlineInfo(effectivelyFinal = true)),
+        (("f2", "()I"),                                                     MethodInlineInfo(effectivelyFinal = true)), // no static impl method for private method f2
+        (("f3", "()I"),                                                     MethodInlineInfo()),
+        (("f3$", "(LT;)I"),                                                 MethodInlineInfo(effectivelyFinal = true)),
+        (("f4", "()Ljava/lang/String;"),                                    MethodInlineInfo(annotatedInline = true)),
+        (("f4$", "(LT;)Ljava/lang/String;"),                                MethodInlineInfo(effectivelyFinal = true, annotatedInline = true)),
+        (("f5", "()I"),                                                     MethodInlineInfo(effectivelyFinal = true)),
+        (("f5$", "(LT;)I"),                                                 MethodInlineInfo(effectivelyFinal = true)),
+        (("f6", "()I"),                                                     MethodInlineInfo(annotatedNoInline = true)), // no static impl method for abstract method f6
+        (("x1", "()I"),                                                     MethodInlineInfo()),
+        (("y2", "()I"),                                                     MethodInlineInfo()),
+        (("y2_$eq", "(I)V"),                                                MethodInlineInfo()),
+        (("x3", "()I"),                                                     MethodInlineInfo()),
+        (("x3_$eq", "(I)V"),                                                MethodInlineInfo()),
+        (("x4", "()I"),                                                     MethodInlineInfo()),
+        (("x4$", "(LT;)I"),                                                 MethodInlineInfo(effectivelyFinal = true)),
+        (("x5", "()I"),                                                     MethodInlineInfo(effectivelyFinal = true)),
+        (("x5$", "(LT;)I"),                                                 MethodInlineInfo(effectivelyFinal = true)),
+        (("L$2", "(Lscala/runtime/LazyRef;)LT$L$1$;"),                      MethodInlineInfo(effectivelyFinal = true)),
+        (("nest$1", "()I"),                                                 MethodInlineInfo(effectivelyFinal = true)),
+        (("$init$", "(LT;)V"),                                              MethodInlineInfo(effectivelyFinal = true)),
+        (("L$lzycompute$1", "(Lscala/runtime/LazyRef;)LT$L$1$;"),           MethodInlineInfo(effectivelyFinal = true))
+      ))
 
     assert(infoT == expectT, mapDiff(expectT.methodInfos, infoT.methodInfos) + infoT)
     assertSameMethods(t, expectT.methodInfos.keySet.map(x => x._1 + x._2))
 
     val infoC = inlineInfo(c)
-    val expectC = InlineInfo(false, None, TreeMap(
-      ("O", "()LT$O$;")                             -> MethodInlineInfo(true ,false,false),
-      ("f1", "()I")                                 -> MethodInlineInfo(false,false,false),
-      ("f3", "()I")                                 -> MethodInlineInfo(false,false,false),
-      ("f4", "()Ljava/lang/String;")                -> MethodInlineInfo(false,true,false),
-      ("f5", "()I")                                 -> MethodInlineInfo(true,false,false),
-      ("f6", "()I")                                 -> MethodInlineInfo(false,false,false),
-      ("x1", "()I")                                 -> MethodInlineInfo(false,false,false),
-      ("T$_setter_$x1_$eq", "(I)V")                 -> MethodInlineInfo(false,false,false),
-      ("y2", "()I")                                 -> MethodInlineInfo(false,false,false),
-      ("y2_$eq", "(I)V")                            -> MethodInlineInfo(false,false,false),
-      ("x3", "()I")                                 -> MethodInlineInfo(false,false,false),
-      ("x3_$eq", "(I)V")                            -> MethodInlineInfo(false,false,false),
-      ("x4$lzycompute", "()I")                      -> MethodInlineInfo(true ,false,false),
-      ("x4", "()I")                                 -> MethodInlineInfo(false,false,false),
-      ("T$$super$toString", "()Ljava/lang/String;") -> MethodInlineInfo(true ,false,false),
-      ("<init>", "()V")                             -> MethodInlineInfo(false,false,false),
-      ("O$lzycompute$1", "()V")                     -> MethodInlineInfo(true,false,false)
-    ),
-      None)
+    val expectC = EmptyInlineInfo.copy(methodInfos = TreeMap(
+      ("O", "()LT$O$;")                             -> MethodInlineInfo(effectivelyFinal = true),
+      ("f1", "()I")                                 -> MethodInlineInfo(),
+      ("f3", "()I")                                 -> MethodInlineInfo(),
+      ("f4", "()Ljava/lang/String;")                -> MethodInlineInfo(annotatedInline = true),
+      ("f5", "()I")                                 -> MethodInlineInfo(effectivelyFinal = true),
+      ("f6", "()I")                                 -> MethodInlineInfo(),
+      ("x1", "()I")                                 -> MethodInlineInfo(),
+      ("T$_setter_$x1_$eq", "(I)V")                 -> MethodInlineInfo(),
+      ("y2", "()I")                                 -> MethodInlineInfo(),
+      ("y2_$eq", "(I)V")                            -> MethodInlineInfo(),
+      ("x3", "()I")                                 -> MethodInlineInfo(),
+      ("x3_$eq", "(I)V")                            -> MethodInlineInfo(),
+      ("x4$lzycompute", "()I")                      -> MethodInlineInfo(effectivelyFinal = true),
+      ("x4", "()I")                                 -> MethodInlineInfo(),
+      ("T$$super$toString", "()Ljava/lang/String;") -> MethodInlineInfo(effectivelyFinal = true),
+      ("<init>", "()V")                             -> MethodInlineInfo(),
+      ("O$lzycompute$1", "()V")                     -> MethodInlineInfo(effectivelyFinal = true)
+    ))
 
     assert(infoC == expectC, mapDiff(expectC.methodInfos, infoC.methodInfos) + infoC)
     assertSameMethods(c, expectC.methodInfos.keySet.map(x => x._1 + x._2))
@@ -192,9 +185,9 @@ class ScalaInlineInfoTest extends BytecodeTesting {
     val List(c, om) = compileClasses(code)
     val infoC = inlineInfo(c)
     val expected = Map(
-      ("<init>", "()V")         -> MethodInlineInfo(false,false,false),
-      ("O$lzycompute$1", "()V") -> MethodInlineInfo(true,false,false),
-      ("O", "()LC$O$;")         -> MethodInlineInfo(true,false,false))
+      ("<init>", "()V")         -> MethodInlineInfo(),
+      ("O$lzycompute$1", "()V") -> MethodInlineInfo(effectivelyFinal = true),
+      ("O", "()LC$O$;")         -> MethodInlineInfo(effectivelyFinal = true))
     assert(infoC.methodInfos == expected, mapDiff(infoC.methodInfos, expected))
     assertSameMethods(c, expected.keySet.map(x => x._1 + x._2))
   }

--- a/test/junit/scala/tools/nsc/backend/jvm/opt/SimplifyJumpsTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/opt/SimplifyJumpsTest.scala
@@ -261,7 +261,7 @@ class SimplifyJumpsTest {
   def noSimplifyNonConst(): Unit = {
     @unused val ops = List(
       Ldc(LDC, ""),
-      Invoke(INVOKEVIRTUAL, "java/lang/String", "length", "()I", itf = false),
+      InvokeVirtual("java/lang/String", "length", "()I"),
       Jump(IFEQ, Label(1)),
       Ldc(LDC, "nonempty"),
       Jump(GOTO, Label(2)),


### PR DESCRIPTION
Revert `itf = false` and instead prefer special method.