### PR TITLE
[nomerge] Tweak help for -target for 2.12 restriction only

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
@@ -65,14 +65,15 @@ trait StandardScalaSettings { _: MutableSettings =>
     }
   def releaseValue: Option[String] = release.valueSetByUser
   val target =
-    ChoiceSetting("-target", "target", "Target platform for object files. All JVM 1.5 - 1.7 targets are deprecated.", AllTargetVersions, DefaultTargetVersion)
+    ChoiceSetting("-target", "target", "Target platform for class files. Target < 8 is deprecated; target > 8 uses 8.",
+      AllTargetVersions, DefaultTargetVersion, AllTargetVersions.map(v => if (v.toInt <= 8) s"uses $v" else "unsupported, uses default 8"))
     .withPreSetHook(normalizeTarget)
     .withPostSetHook { setting =>
       if (releaseValue.map(_.toInt < setting.value.toInt).getOrElse(false))
         errorFn("-release cannot be less than -target")
       if (!setting.deprecationMessage.isDefined)
         if (setting.value.toInt > MaxSupportedTargetVersion) {
-          setting.withDeprecationMessage(s"Scala 2.12 cannot emit valid class files for targets newer than $MaxSupportedTargetVersion (this is possible with Scala 2.13). Use -release to compile against a specific platform API version.")
+          setting.withDeprecationMessage(s"Scala 2.12 cannot emit valid class files for targets newer than $MaxSupportedTargetVersion; this is possible with Scala 2.13. Use -release to compile against a specific version of the platform API.")
           setting.value = DefaultTargetVersion
         } else if (setting.value.toInt < MinSupportedTargetVersion) {
           setting.withDeprecationMessage(s"${setting.name}:${setting.value} is deprecated, forcing use of $DefaultTargetVersion")


### PR DESCRIPTION
Follow-up https://github.com/scala/scala/pull/10109 to make the explanatory message even more exoplanetary.

```
  -target:<target>                     Target platform for class files. Target < 8 is deprecated; target > 8 uses 8. Default: `8`, `help` to list choices.

// and

Usage: -target:<target> where <target> choices are 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21 (default: 8).
  5   uses 5
  6   uses 6
  7   uses 7
  8   uses 8
  9   unsupported, uses default 8
  10  unsupported, uses default 8
  11  unsupported, uses default 8
  12  unsupported, uses default 8
  13  unsupported, uses default 8
  14  unsupported, uses default 8
  15  unsupported, uses default 8
  16  unsupported, uses default 8
  17  unsupported, uses default 8
  18  unsupported, uses default 8
  19  unsupported, uses default 8
  20  unsupported, uses default 8
  21  unsupported, uses default 8
```

Fixes scala/bug#12923