### PR TITLE
Revert maladapted ArrayBuffer builder [ci: last-only]

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/Logic.scala
@@ -529,7 +529,7 @@ object Logic {
     with IterableFactoryDefaults[A, LogicLinkedHashSet] {
     override def iterableFactory: IterableFactory[LogicLinkedHashSet] = LogicLinkedHashSet
     override def addAll(xs: IterableOnce[A]): this.type = {
-      sizeHint(xs.knownSize)
+      sizeHint(xs)
       super.addAll(xs)
     }
   }

--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -1174,8 +1174,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   /** A copy of this array with all elements of a collection appended. */
   def appendedAll[B >: A : ClassTag](suffix: IterableOnce[B]): Array[B] = {
     val b = ArrayBuilder.make[B]
-    val k = suffix.knownSize
-    if(k >= 0) b.sizeHint(k + xs.length)
+    b.sizeHint(suffix, delta = xs.length)
     b.addAll(xs)
     b.addAll(suffix)
     b.result()

--- a/src/library/scala/collection/Factory.scala
+++ b/src/library/scala/collection/Factory.scala
@@ -61,7 +61,7 @@ object Factory {
   private class ArrayFactory[A: ClassTag] extends Factory[A, Array[A]] with Serializable {
     def fromSpecific(it: IterableOnce[A]): Array[A] = {
       val b = newBuilder
-      b.sizeHint(scala.math.max(0, it.knownSize))
+      b.sizeHint(it, delta = 0)
       b ++= it
       b.result()
     }

--- a/src/library/scala/collection/StrictOptimizedSeqOps.scala
+++ b/src/library/scala/collection/StrictOptimizedSeqOps.scala
@@ -34,9 +34,7 @@ trait StrictOptimizedSeqOps [+A, +CC[_], +C]
 
   override def prepended[B >: A](elem: B): CC[B] = {
     val b = iterableFactory.newBuilder[B]
-    if (knownSize >= 0) {
-      b.sizeHint(size + 1)
-    }
+    b.sizeHint(this, delta = 1)
     b += elem
     b ++= this
     b.result()
@@ -44,9 +42,7 @@ trait StrictOptimizedSeqOps [+A, +CC[_], +C]
 
   override def appended[B >: A](elem: B): CC[B] = {
     val b = iterableFactory.newBuilder[B]
-    if (knownSize >= 0) {
-      b.sizeHint(size + 1)
-    }
+    b.sizeHint(this, delta = 1)
     b ++= this
     b += elem
     b.result()

--- a/src/library/scala/collection/immutable/StrictOptimizedSeqOps.scala
+++ b/src/library/scala/collection/immutable/StrictOptimizedSeqOps.scala
@@ -14,9 +14,8 @@ package scala
 package collection
 package immutable
 
-/**
-  * Trait that overrides operations to take advantage of strict builders.
-  */
+/** Trait that overrides operations to take advantage of strict builders.
+ */
 trait StrictOptimizedSeqOps[+A, +CC[_], +C]
   extends Any
     with SeqOps[A, CC, C]
@@ -41,9 +40,7 @@ trait StrictOptimizedSeqOps[+A, +CC[_], +C]
   override def updated[B >: A](index: Int, elem: B): CC[B] = {
     if (index < 0) throw new IndexOutOfBoundsException(s"$index is out of bounds (min 0, max ${if (knownSize>=0) knownSize else "unknown"})")
     val b = iterableFactory.newBuilder[B]
-    if (knownSize >= 0) {
-      b.sizeHint(size)
-    }
+    b.sizeHint(this)
     var i = 0
     val it = iterator
     while (i < index && it.hasNext) {

--- a/src/library/scala/collection/immutable/WrappedString.scala
+++ b/src/library/scala/collection/immutable/WrappedString.scala
@@ -125,8 +125,7 @@ final class WrappedString(private val self: String) extends AbstractSeq[Char] wi
 object WrappedString extends SpecificIterableFactory[Char, WrappedString] {
   def fromSpecific(it: IterableOnce[Char]): WrappedString = {
     val b = newBuilder
-    val s = it.knownSize
-    if(s >= 0) b.sizeHint(s)
+    b.sizeHint(it)
     b ++= it
     b.result()
   }

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -299,10 +299,7 @@ object ArrayBuffer extends StrictOptimizedSeqFactory[ArrayBuffer] {
     else new ArrayBuffer[B] ++= coll
   }
 
-  def newBuilder[A]: Builder[A, ArrayBuffer[A]] =
-    new GrowableBuilder[A, ArrayBuffer[A]](empty) {
-      override def sizeHint(size: Int): Unit = elems.ensureSize(size)
-    }
+  def newBuilder[A]: Builder[A, ArrayBuffer[A]] = new GrowableBuilder[A, ArrayBuffer[A]](empty[A])
 
   def empty[A]: ArrayBuffer[A] = new ArrayBuffer[A]()
 

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -299,15 +299,11 @@ object ArrayBuffer extends StrictOptimizedSeqFactory[ArrayBuffer] {
     else new ArrayBuffer[B] ++= coll
   }
 
-  def newBuilder[A]: Builder[A, ArrayBuffer[A]] = new GrowableBuilder[A, ArrayBuffer[A]](empty[A])
+  def newBuilder[A]: Builder[A, ArrayBuffer[A]] = new GrowableBuilder[A, ArrayBuffer[A]](empty[A]) {
+    override def sizeHint(size: Int): Unit = elems.sizeHint(size)
+  }
 
   def empty[A]: ArrayBuffer[A] = new ArrayBuffer[A]()
-
-  @inline private def checkArrayLengthLimit(length: Int, currentLength: Int): Unit =
-    if (length > VM_MaxArraySize)
-      throw new Exception(s"Array of array-backed collection exceeds VM length limit of $VM_MaxArraySize. Requested length: $length; current length: $currentLength")
-    else if (length < 0)
-      throw new Exception(s"Overflow while resizing array of array-backed collection. Requested length: $length; current length: $currentLength; increase: ${length - currentLength}")
 
   /**
    * The increased size for an array-backed collection.
@@ -317,13 +313,19 @@ object ArrayBuffer extends StrictOptimizedSeqFactory[ArrayBuffer] {
    * @return
    *   - `-1` if no resizing is needed, else
    *   - `VM_MaxArraySize` if `arrayLen` is too large to be doubled, else
-   *   - `max(targetLen, arrayLen * 2, , DefaultInitialSize)`.
+   *   - `max(targetLen, arrayLen * 2, DefaultInitialSize)`.
    *   - Throws an exception if `targetLen` exceeds `VM_MaxArraySize` or is negative (overflow).
    */
   private[mutable] def resizeUp(arrayLen: Int, targetLen: Int): Int = {
+    def checkArrayLengthLimit(): Unit =
+      if (targetLen > VM_MaxArraySize)
+        throw new Exception(s"Array of array-backed collection exceeds VM length limit of $VM_MaxArraySize. Requested length: $targetLen; current length: $arrayLen")
+      else if (targetLen < 0)
+        throw new Exception(s"Overflow while resizing array of array-backed collection. Requested length: $targetLen; current length: $arrayLen; increase: ${targetLen - arrayLen}")
+
     if (targetLen > 0 && targetLen <= arrayLen) -1
     else {
-      checkArrayLengthLimit(targetLen, arrayLen)
+      checkArrayLengthLimit()
       if (arrayLen > VM_MaxArraySize / 2) VM_MaxArraySize
       else math.max(targetLen, math.max(arrayLen * 2, DefaultInitialSize))
     }

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -43,8 +43,7 @@ sealed abstract class ArraySeq[T]
 
   override protected def fromSpecific(coll: scala.collection.IterableOnce[T]): ArraySeq[T] = {
     val b = ArrayBuilder.make(elemTag).asInstanceOf[ArrayBuilder[T]]
-    val s = coll.knownSize
-    if(s > 0) b.sizeHint(s)
+    b.sizeHint(coll, delta = 0)
     b ++= coll
     ArraySeq.make(b.result())
   }

--- a/src/library/scala/collection/mutable/CollisionProofHashMap.scala
+++ b/src/library/scala/collection/mutable/CollisionProofHashMap.scala
@@ -174,8 +174,7 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
   }
 
   override def addAll(xs: IterableOnce[(K, V)]): this.type = {
-    val k = xs.knownSize
-    if(k > 0) sizeHint(contentSize + k)
+    sizeHint(xs, delta = contentSize)
     super.addAll(xs)
   }
 

--- a/src/library/scala/collection/mutable/HashMap.scala
+++ b/src/library/scala/collection/mutable/HashMap.scala
@@ -95,7 +95,7 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
   }
 
   override def addAll(xs: IterableOnce[(K, V)]): this.type = {
-    sizeHint(xs.knownSize)
+    sizeHint(xs)
 
     xs match {
       case hm: immutable.HashMap[K, V] =>

--- a/src/library/scala/collection/mutable/HashSet.scala
+++ b/src/library/scala/collection/mutable/HashSet.scala
@@ -91,7 +91,7 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
   }
 
   override def addAll(xs: IterableOnce[A]): this.type = {
-    sizeHint(xs.knownSize)
+    sizeHint(xs, delta = 0)
     xs match {
       case hs: immutable.HashSet[A] =>
         hs.foreachWithHash((k, h) => addElem(k, improveHash(h)))

--- a/src/library/scala/collection/mutable/LinkedHashMap.scala
+++ b/src/library/scala/collection/mutable/LinkedHashMap.scala
@@ -480,7 +480,7 @@ object LinkedHashMap extends MapFactory[LinkedHashMap] {
 
   def from[K, V](it: collection.IterableOnce[(K, V)]) = {
     val newlhm = empty[K, V]
-    newlhm.sizeHint(it.knownSize)
+    newlhm.sizeHint(it, delta = 0)
     newlhm.addAll(it)
     newlhm
   }

--- a/src/library/scala/collection/mutable/LinkedHashSet.scala
+++ b/src/library/scala/collection/mutable/LinkedHashSet.scala
@@ -318,7 +318,7 @@ object LinkedHashSet extends IterableFactory[LinkedHashSet] {
 
   def from[E](it: collection.IterableOnce[E]) = {
     val newlhs = empty[E]
-    newlhs.sizeHint(it.knownSize)
+    newlhs.sizeHint(it, delta = 0)
     newlhs.addAll(it)
     newlhs
   }

--- a/src/library/scala/runtime/Tuple2Zipped.scala
+++ b/src/library/scala/runtime/Tuple2Zipped.scala
@@ -47,7 +47,7 @@ final class Tuple2Zipped[El1, It1 <: Iterable[El1], El2, It2 <: Iterable[El2]](p
 
   def map[B, To](f: (El1, El2) => B)(implicit bf: BuildFrom[It1, B, To]): To = {
     val b = bf.newBuilder(coll1)
-    b.sizeHint(coll1, 0)
+    b.sizeHint(coll1, delta = 0)
     val elems1 = coll1.iterator
     val elems2 = coll2.iterator
 

--- a/test/junit/scala/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBufferTest.scala
@@ -512,4 +512,11 @@ class ArrayBufferTest {
   @Test def `drop right when empty is empty`: Unit = {
     assertTrue(ArrayBuffer().dropRight(1).isEmpty)
   }
+
+  @Test def `refuse to build from an overly huge thing`: Unit = {
+    val bld = ArrayBuffer.newBuilder[String]
+    assertThrows[Exception](bld.sizeHint(Int.MaxValue), _.contains("exceeds VM length limit"))
+    bld.addOne("hello, world")
+    assertTrue(bld.result().contains("hello, world"))
+  }
 }

--- a/test/junit/scala/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBufferTest.scala
@@ -508,4 +508,8 @@ class ArrayBufferTest {
     check(_ ++= (1 to 100))
     check(_.insertAll(1, 1 to 100))
   }
+
+  @Test def `drop right when empty is empty`: Unit = {
+    assertTrue(ArrayBuffer().dropRight(1).isEmpty)
+  }
 }


### PR DESCRIPTION
Follow-up to https://github.com/scala/scala/pull/10448

The old builder was for older code.

```
Untested methods in Mut_ArrayBuffer:
  clearAndShrink elementWise    findLast       lazyZip        repr
  sizeHint       stepper        tapEach        trimToSize     unapply

All laws successfully used (19755 times)
[info] Passed: Total 98, Failed 0, Errors 0, Passed 98
[success] Total time: 307 s (05:07), completed Dec 21, 2023, 11:38:14 PM
All laws succeeded to the expected extent.
```
