### PR TITLE
Add support for `-Vphases` when incremental compilation is enabled

### DIFF
--- a/src/sbt-bridge/scala/tools/xsbt/CallbackGlobal.scala
+++ b/src/sbt-bridge/scala/tools/xsbt/CallbackGlobal.scala
@@ -106,6 +106,7 @@ sealed class ZincCompiler(settings: Settings, dreporter: DelegatingReporter, out
     val analyzer = new Analyzer(global)
     def newPhase(prev: Phase) = analyzer.newPhase(prev)
     def name = phaseName
+    def description = "analyze the generated class files and map them to sources"
   }
 
   /** Phase that extracts dependency information */
@@ -120,6 +121,7 @@ sealed class ZincCompiler(settings: Settings, dreporter: DelegatingReporter, out
     val dependency = new Dependency(global)
     def newPhase(prev: Phase) = dependency.newPhase(prev)
     def name = phaseName
+    def description = "extract dependency information"
   }
 
   /**
@@ -140,13 +142,17 @@ sealed class ZincCompiler(settings: Settings, dreporter: DelegatingReporter, out
     val api = new API(global)
     def newPhase(prev: Phase) = api.newPhase(prev)
     def name = phaseName
+    def description = "construct a representation of the public API"
   }
 
   override lazy val phaseDescriptors = {
     phasesSet += sbtAnalyzer
+    phasesDescMap(sbtAnalyzer) = sbtAnalyzer.description
     if (callback.enabled()) {
       phasesSet += sbtDependency
+      phasesDescMap(sbtDependency) = sbtDependency.description
       phasesSet += apiExtractor
+      phasesDescMap(apiExtractor) = apiExtractor.description
     }
     this.computePhaseDescriptors
   }

--- a/src/sbt-bridge/scala/tools/xsbt/CompilerBridge.scala
+++ b/src/sbt-bridge/scala/tools/xsbt/CompilerBridge.scala
@@ -163,6 +163,7 @@ private final class CachedCompiler0(
       if (callback2 != null) callback2.problem2(p.category, p.position, p.message, p.severity, true, p.rendered, p.diagnosticCode, p.diagnosticRelatedInformation, p.actions)
       else callback.problem(p.category, p.position, p.message, p.severity, true)
 
+    compiler.set(callback, underlyingReporter)
     if (command.shouldStopWithInfo) {
       underlyingReporter.echo(command.getInfoMessage(compiler))
       throw new InterfaceCompileFailed(args, Array(), StopInfoError)
@@ -170,7 +171,6 @@ private final class CachedCompiler0(
 
     if (noErrors(underlyingReporter)) {
       debug(log, prettyPrintCompilationArguments(args))
-      compiler.set(callback, underlyingReporter)
       val run = new compiler.ZincRun(compileProgress)
 
       run.compileFiles(sources)

--- a/test/junit/scala/tools/xsbt/BasicBridgeTest.scala
+++ b/test/junit/scala/tools/xsbt/BasicBridgeTest.scala
@@ -1,6 +1,9 @@
 package scala.tools.xsbt
 
 import org.junit.Test
+import xsbti.CompileFailed
+
+import scala.tools.testkit.AssertUtil.assertThrown
 
 class BasicBridgeTest extends BridgeTesting {
   @Test
@@ -19,5 +22,21 @@ class BasicBridgeTest extends BridgeTesting {
       val t = tempDir / "target" / "index.html"
       assert(t.exists)
     }
+  }
+
+  @Test
+  def noNPEonVphases(): Unit = withTemporaryDirectory { tempDir =>
+    val compiler = mkCompiler
+    assertThrown[CompileFailed](
+      _.toString.contains("Compiler option supplied that disabled Zinc compilation"))(
+      compiler.run(
+        sources = Array.empty,
+        changes = emptyChanges,
+        options = Array("-usejavacp", "-Vphases"),
+        output = new TestOutput(tempDir),
+        callback = new TestCallback,
+        delegate = mkReporter,
+        progress = ignoreProgress,
+        log = TestLogger))
   }
 }

--- a/test/junit/scala/tools/xsbt/BridgeTesting.scala
+++ b/test/junit/scala/tools/xsbt/BridgeTesting.scala
@@ -30,14 +30,14 @@ class BridgeTesting {
 
   def mkScaladoc: ScaladocBridge = new ScaladocBridge()
 
-  private val emptyChanges: DependencyChanges = new DependencyChanges {
+  val emptyChanges: DependencyChanges = new DependencyChanges {
     override val modifiedLibraries = new Array[VirtualFileRef](0)
     override val modifiedBinaries = new Array[File](0)
     override val modifiedClasses = new Array[String](0)
     override def isEmpty = true
   }
 
-  private val ignoreProgress = new CompileProgress { }
+  val ignoreProgress = new CompileProgress { }
 
   def compileSrcs(baseDir: Path, srcs: String*): (Seq[VirtualFile], TestCallback) =
     compileSrcs(baseDir, mkReporter, srcs: _*)


### PR DESCRIPTION
When incremental compilation is enabled, previously `-Vphases` throws `NullPointerException`. This PR fixes the `NullPointerException` and adds description for each of zinc phases. 

Ports https://github.com/sbt/zinc/pull/1314