### PR TITLE
In mixed compilation, allow Java sources to reference `MODULE$`

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5356,9 +5356,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       // For Java, instance and static members are in the same scope, but we put the static ones in the companion object
       // so, when we can't find a member in the class scope, check the companion
       def inCompanionForJavaStatic(cls: Symbol, name: Name): Symbol =
-        if (!(context.unit.isJava && cls.isClass)) NoSymbol else {
-          context.javaFindMember(cls.typeOfThis, name, _.isStaticMember)._2
-        }
+        if (!(context.unit.isJava && cls.isClass)) NoSymbol
+        else context.javaFindMember(cls.typeOfThis, name, s => s.isStaticMember || s.isStaticModule)._2
 
       /* Attribute a selection where `tree` is `qual.name`.
        * `qual` is already attributed.
@@ -5379,7 +5378,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             if (!isPastTyper && isUniversalMember(result.symbol))
               context.warning(tree.pos, s"dubious usage of ${result.symbol} with unit value", WarningCategory.LintUniversalMethods)
 
-          val sym = tree.symbol orElse member(qual.tpe, name) orElse inCompanionForJavaStatic(qual.tpe.typeSymbol, name)
+          val sym = tree.symbol orElse member(qualTp, name) orElse inCompanionForJavaStatic(qualTp.typeSymbol, name)
           if ((sym eq NoSymbol) && name != nme.CONSTRUCTOR && mode.inAny(EXPRmode | PATTERNmode)) {
             // symbol not found? --> try to convert implicitly to a type that does have the required
             // member.  Added `| PATTERNmode` to allow enrichment in patterns (so we can add e.g., an

--- a/src/reflect/scala/reflect/internal/Names.scala
+++ b/src/reflect/scala/reflect/internal/Names.scala
@@ -519,7 +519,7 @@ trait Names extends api.Names {
 
     def dropLocal: TermName      = toTermName stripSuffix NameTransformer.LOCAL_SUFFIX_STRING
     def dropSetter: TermName     = toTermName stripSuffix NameTransformer.SETTER_SUFFIX_STRING
-    def dropModule: ThisNameType = this stripSuffix NameTransformer.MODULE_SUFFIX_STRING
+    def dropModule: ThisNameType = stripSuffix(NameTransformer.MODULE_SUFFIX_STRING)
     def localName: TermName      = getterName append NameTransformer.LOCAL_SUFFIX_STRING
     def setterName: TermName     = getterName append NameTransformer.SETTER_SUFFIX_STRING
     def getterName: TermName     = dropTraitSetterSeparator.dropSetter.dropLocal

--- a/test/files/run/t9714/J.java
+++ b/test/files/run/t9714/J.java
@@ -1,0 +1,14 @@
+
+package p;
+
+public class J {
+	public static J j = new J();
+	public static p.J f() {
+		return p.J.j;
+	}
+	public static p.Module$ module() {
+		return p.Module$.MODULE$;
+	}
+
+	public String toString() { return "J"; }
+}

--- a/test/files/run/t9714/Module.scala
+++ b/test/files/run/t9714/Module.scala
@@ -1,0 +1,10 @@
+package p {
+  object Module {
+    override def toString = "Module"
+  }
+}
+
+object Test extends App {
+  assert(p.J.f().toString == "J")
+  assert(p.J.module().toString == "Module")
+}


### PR DESCRIPTION
Java can refer to a Scala object `Module` as `Module$.MODULE$`, which is of runtime type `Module$`.

However, in mixed compilation, Scalac does not understand `Module$` as a type written in Java, which is `Module.type` in Scala. This commit allows Scala to accept the notation in Java sources.

Fixes scala/bug#9714