### PR TITLE
Track import selector of implicit info in search

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/PostProcessor.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/PostProcessor.scala
@@ -16,7 +16,7 @@ package backend.jvm
 import java.util.concurrent.ConcurrentHashMap
 
 import scala.collection.mutable
-import scala.reflect.internal.util.{NoPosition, Position, StringContextStripMarginOps}
+import scala.reflect.internal.util.{NoPosition, Position}
 import scala.reflect.io.AbstractFile
 import scala.tools.asm.ClassWriter
 import scala.tools.asm.tree.ClassNode

--- a/src/compiler/scala/tools/nsc/plugins/PluginDescription.scala
+++ b/src/compiler/scala/tools/nsc/plugins/PluginDescription.scala
@@ -13,8 +13,6 @@
 package scala.tools.nsc
 package plugins
 
-import scala.reflect.internal.util.StringContextStripMarginOps
-
 /** A description of a compiler plugin, suitable for serialization
  *  to XML for inclusion in the plugin's .jar file.
  *

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -22,7 +22,7 @@ import java.util.zip.Deflater
 import scala.annotation.{elidable, nowarn}
 import scala.collection.mutable
 import scala.language.existentials
-import scala.reflect.internal.util.{ StatisticsStatics, StringContextStripMarginOps }
+import scala.reflect.internal.util.StatisticsStatics
 import scala.tools.nsc.util.DefaultJarFactory
 import scala.tools.util.PathResolver.Defaults
 import scala.util.chaining._

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1341,7 +1341,6 @@ trait Contexts { self: Analyzer =>
       }
     }
 
-
     private def isReplImportWrapperImport(tree: Tree): Boolean = {
       tree match {
         case Import(expr, selector :: Nil) =>
@@ -1685,10 +1684,13 @@ trait Contexts { self: Analyzer =>
         }
 
         // the choice has been made
-        imp1.recordUsage(impSel, impSym)
+        if (lookupError == null) {
+          imp1.recordUsage(impSel, impSym)
 
-        // optimization: don't write out package prefixes
-        finish(duplicateAndResetPos.transform(imp1.qual), impSym)
+          // optimization: don't write out package prefixes
+          finish(duplicateAndResetPos.transform(imp1.qual), impSym)
+        }
+        else finish(EmptyTree, NoSymbol)
       }
       else finish(EmptyTree, NoSymbol)
     }
@@ -1899,7 +1901,7 @@ trait Contexts { self: Analyzer =>
     def qual: Tree = tree.symbol.info match {
       case ImportType(expr) => expr
       case ErrorType        => tree setType NoType // fix for #2870
-      case _                => throw new FatalError("symbol " + tree.symbol + " has bad type: " + tree.symbol.info) //debug
+      case bad              => throw new FatalError(s"symbol ${tree.symbol} has bad type: ${bad}")
     }
 
     /** Is name imported explicitly, not via wildcard? */

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -18,7 +18,7 @@ import scala.annotation.{tailrec, unused}
 import scala.collection.mutable
 import mutable.ListBuffer
 import scala.reflect.internal.{Chars, TypesStats}
-import scala.reflect.internal.util.{CodeAction, FreshNameCreator, ListOfNil, Statistics, StringContextStripMarginOps}
+import scala.reflect.internal.util.{CodeAction, FreshNameCreator, ListOfNil, Statistics}
 import scala.tools.nsc.Reporting.{MessageFilter, Suppression, WConf, WarningCategory}, WarningCategory.Scala3Migration
 import scala.util.chaining._
 import symtab.Flags._

--- a/test/files/neg/t12690.check
+++ b/test/files/neg/t12690.check
@@ -1,0 +1,6 @@
+t12690.scala:10: warning: Unused import
+  import A._ // missing unused warning (order of imports is significant)
+           ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/t12690.scala
+++ b/test/files/neg/t12690.scala
@@ -1,0 +1,12 @@
+
+//> using options -Werror -Wunused:imports
+
+class X
+class Y extends X
+object A { implicit val x: X = new X }
+object B { implicit val y: Y = new Y }
+class C {
+  import B._
+  import A._ // missing unused warning (order of imports is significant)
+  def t = implicitly[X]
+}

--- a/test/files/neg/t12690b.check
+++ b/test/files/neg/t12690b.check
@@ -1,0 +1,14 @@
+t12690b.scala:15: error: reference to v is ambiguous;
+it is imported twice in the same scope by
+import Y.v
+and import X.v
+    v
+    ^
+t12690b.scala:11: warning: Unused import
+  import X.v
+           ^
+t12690b.scala:12: warning: Unused import
+  import Y.v
+           ^
+2 warnings
+1 error

--- a/test/files/neg/t12690b.scala
+++ b/test/files/neg/t12690b.scala
@@ -1,0 +1,17 @@
+
+// scalac: -Wunused:imports -Werror
+
+object X {
+  val v = 27
+}
+object Y {
+  val v = 42
+}
+object Main {
+  import X.v
+  import Y.v
+  def main(args: Array[String]) = println {
+    //"hello, world"
+    v
+  }
+}

--- a/test/files/neg/warn-unused-imports/sample_1.scala
+++ b/test/files/neg/warn-unused-imports/sample_1.scala
@@ -1,3 +1,4 @@
+// scalac: -Werror -Wunused:imports
 
 import language._
 


### PR DESCRIPTION
For recording when import selectors have been "used", record selector only after successful implicit search; for other look-ups, avoid recording during implicit search.

Fixes scala/bug#12690