### PR TITLE
bugfix: Fix the start position of rename

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2852,7 +2852,8 @@ self =>
         if (in.token == ARROW || (currentRun.isScala3 && isRawIdent && in.name == nme.as)) {
           in.nextToken()
           if (name == nme.WILDCARD && !bbq) syntaxError(in.offset, "Wildcard import cannot be renamed")
-          (wildcardOrIdent(), in.offset)
+          val renameOffset = in.offset
+          (wildcardOrIdent(), renameOffset)
         }
         else if (name == nme.WILDCARD && !bbq) (null, -1)
         else (name, start)


### PR DESCRIPTION
Problem with testing it is that it looks it's never actually used in the compiler itself. But pretty sure this caused https://github.com/scalameta/metals/issues/5975