### PR TITLE
For migration to 3, accommodate case companion as function

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
@@ -113,7 +113,7 @@ trait Unapplies extends ast.TreeDSL {
    */
   def caseModuleDef(cdef: ClassDef): ModuleDef = {
     val params = constrParamss(cdef)
-    def inheritFromFun = !cdef.mods.hasAbstractFlag && cdef.tparams.isEmpty && (params match {
+    def inheritFromFun = !currentRun.isScala3Cross && !cdef.mods.hasAbstractFlag && cdef.tparams.isEmpty && (params match {
       case List(ps) if ps.length <= MaxFunctionArity => true
       case _ => false
     }) && applyAccess(constrMods(cdef)) != Inherit

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -658,7 +658,7 @@ trait Definitions extends api.StandardDefinitions {
     class VarArityClass(name: String, maxArity: Int, countFrom: Int = 0, init: Option[ClassSymbol] = None) extends VarArityClassApi {
       private[this] val offset = countFrom - init.size
       private def isDefinedAt(i: Int) = i < seq.length + offset && i >= offset
-      val seq: IndexedSeq[ClassSymbol] = (init ++: countFrom.to(maxArity).map { i => getRequiredClass("scala." + name + i) }).toVector
+      val seq: IndexedSeq[ClassSymbol] = (init ++: countFrom.to(maxArity).map(i => getRequiredClass(s"scala.$name$i"))).toVector
       private[this] val symSet = new SymbolSet(seq.toList)
       def contains(sym: Symbol): Boolean = symSet.contains(sym)
       def apply(i: Int) = if (isDefinedAt(i)) seq(i - offset) else NoSymbol

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -901,6 +901,7 @@ trait StdNames {
     val tpe : NameType                 = nameType("tpe")
     val tree : NameType                = nameType("tree")
     val true_ : NameType               = nameType("true")
+    val tupled: NameType               = nameType("tupled")
     val typedProductIterator: NameType = nameType("typedProductIterator")
     val TypeName: NameType             = nameType("TypeName")
     val typeTagToManifest: NameType    = nameType("typeTagToManifest")

--- a/test/files/neg/t3664.check
+++ b/test/files/neg/t3664.check
@@ -1,0 +1,6 @@
+t3664.scala:11: warning: Synthetic case companion used as a Function, use explicit object with Function parent
+  def f(xs: List[Int]): List[C] = xs.map(C)
+                                         ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/t3664.scala
+++ b/test/files/neg/t3664.scala
@@ -1,0 +1,12 @@
+
+//> using options -Werror -Xlint -Xsource:3
+//> abusing options -Werror -Xlint -Xsource:3migration
+
+// use 3migration to warn that implicitly extending Function is deprecated
+// use 3cross for dotty behavior: no extend Function, yes adapt C.apply.tupled
+
+case class C(i: Int)
+
+class Test {
+  def f(xs: List[Int]): List[C] = xs.map(C)
+}

--- a/test/files/neg/t3664b.check
+++ b/test/files/neg/t3664b.check
@@ -1,4 +1,4 @@
-t3664.scala:9: warning: Synthetic case companion used as a Function, use explicit object with Function parent
+t3664b.scala:9: warning: The method `apply` is inserted. The auto insertion will be deprecated, please write `C.apply` explicitly.
   def f(xs: List[Int]): List[C] = xs.map(C)
                                          ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t3664b.scala
+++ b/test/files/neg/t3664b.scala
@@ -1,4 +1,4 @@
-//> using options -Werror -Xlint -Xsource:3
+//> using options -Werror -Xlint -Xsource:3-cross
 
 // use -Xsource:3 to warn that implicitly extending Function is deprecated
 // use -Xsource:3-cross for dotty behavior: no extend Function, yes adapt C.apply.tupled

--- a/test/files/neg/t3664c.check
+++ b/test/files/neg/t3664c.check
@@ -1,11 +1,27 @@
-t3664c.scala:9: error: type mismatch;
+t3664c.scala:20: error: type mismatch;
  found   : C.type
  required: ((Int, Int, Int)) => C
   def f(xs: List[(Int, Int, Int)]): List[C] = xs.map(C) // hard error
                                                      ^
-t3664c.scala:11: error: type mismatch;
+t3664c.scala:22: error: type mismatch;
  found   : ((Int, Int)) => C
  required: ((Int, Int, Int)) => C
   def g(xs: List[(Int, Int, Int)]): List[C] = xs.map(C.tupled) // hard error
                                                        ^
-2 errors
+t3664c.scala:24: error: type mismatch;
+ found   : D.type
+ required: ((Int, Int)) => D
+  def d(xs: List[(Int, Int)]): List[D] = xs.map(D) // hard error
+                                                ^
+t3664c.scala:26: warning: An unapplied 0-arity method was eta-expanded (due to the expected type () => E), rather than applied to `()`.
+Write E.apply() to invoke method apply, or change the expected type.
+  val e: () => E = E
+                   ^
+t3664c.scala:26: warning: The method `apply` is inserted. The auto insertion will be deprecated, please write `E.apply` explicitly.
+  val e: () => E = E
+                   ^
+t3664c.scala:28: warning: The method `apply` is inserted. The auto insertion will be deprecated, please write `F.apply` explicitly.
+  def ov(xs: List[Int]): List[F] = xs.map(F)
+                                          ^
+3 warnings
+3 errors

--- a/test/files/neg/t3664c.check
+++ b/test/files/neg/t3664c.check
@@ -1,0 +1,11 @@
+t3664c.scala:9: error: type mismatch;
+ found   : C.type
+ required: ((Int, Int, Int)) => C
+  def f(xs: List[(Int, Int, Int)]): List[C] = xs.map(C) // hard error
+                                                     ^
+t3664c.scala:11: error: type mismatch;
+ found   : ((Int, Int)) => C
+ required: ((Int, Int, Int)) => C
+  def g(xs: List[(Int, Int, Int)]): List[C] = xs.map(C.tupled) // hard error
+                                                       ^
+2 errors

--- a/test/files/neg/t3664c.scala
+++ b/test/files/neg/t3664c.scala
@@ -1,0 +1,12 @@
+//> using options -Werror -Xlint -Xsource:3-cross
+
+// use -Xsource:3 to warn that implicitly extending Function is deprecated
+// use -Xsource:3-cross for dotty behavior: no extend Function, yes adapt C.apply.tupled
+
+case class C(i: Int, j: Int)
+
+class Test {
+  def f(xs: List[(Int, Int, Int)]): List[C] = xs.map(C) // hard error
+
+  def g(xs: List[(Int, Int, Int)]): List[C] = xs.map(C.tupled) // hard error
+}

--- a/test/files/neg/t3664c.scala
+++ b/test/files/neg/t3664c.scala
@@ -5,8 +5,25 @@
 
 case class C(i: Int, j: Int)
 
+abstract case class D(i: Int, j: Int)
+
+case class E()
+
+case class F(i: Int)
+object F {
+  def apply(): F = apply(42)
+  def apply(i: Int): F = new F(i)
+  def apply(i: Int, j: Int): F = new F(i+j)
+}
+
 class Test {
   def f(xs: List[(Int, Int, Int)]): List[C] = xs.map(C) // hard error
 
   def g(xs: List[(Int, Int, Int)]): List[C] = xs.map(C.tupled) // hard error
+
+  def d(xs: List[(Int, Int)]): List[D] = xs.map(D) // hard error
+
+  val e: () => E = E
+
+  def ov(xs: List[Int]): List[F] = xs.map(F)
 }

--- a/test/files/pos/t3664.scala
+++ b/test/files/pos/t3664.scala
@@ -1,0 +1,13 @@
+
+//> using options -Werror -Xlint -Xsource:3-cross
+
+import language.implicitConversions
+
+case class C(i: Int)
+object C // no function parent
+
+// use conversion, don't warn about apply insertion
+class Test {
+  implicit def cv(c: C.type): Function[Int, C] = C(_)
+  def f(xs: List[Int]): List[C] = xs.map(C)
+}

--- a/test/files/run/t3664.check
+++ b/test/files/run/t3664.check
@@ -1,0 +1,9 @@
+t3664.scala:10: warning: The method `apply` is inserted. The auto insertion will be deprecated, please write `B.apply` explicitly.
+  def mapped(xs: List[Int]): List[B] = xs.map(B)
+                                              ^
+t3664.scala:15: warning: The method `apply` is inserted. The auto insertion will be deprecated, please write `(C.apply _).tupled` explicitly.
+  def f(xs: List[(Int, Int)]): List[C] = xs.map(C.tupled)
+                                                  ^
+t3664.scala:17: warning: The method `apply` is inserted. The auto insertion will be deprecated, please write `(C.apply _).curried` explicitly.
+  def g(xs: List[Int]): List[C] = xs.map(C.curried).map(_(42))
+                                           ^

--- a/test/files/run/t3664.check
+++ b/test/files/run/t3664.check
@@ -1,6 +1,9 @@
 t3664.scala:10: warning: The method `apply` is inserted. The auto insertion will be deprecated, please write `B.apply` explicitly.
   def mapped(xs: List[Int]): List[B] = xs.map(B)
                                               ^
+t3664.scala:13: warning: The method `apply` is inserted. The auto insertion will be deprecated, please write `(C.apply _).tupled` explicitly.
+  def cross(xs: List[(Int, Int)]): List[C] = xs.map(C)
+                                                    ^
 t3664.scala:15: warning: The method `apply` is inserted. The auto insertion will be deprecated, please write `(C.apply _).tupled` explicitly.
   def f(xs: List[(Int, Int)]): List[C] = xs.map(C.tupled)
                                                   ^

--- a/test/files/run/t3664.scala
+++ b/test/files/run/t3664.scala
@@ -1,0 +1,30 @@
+//> using options -Xlint -Xsource:3-cross
+
+// use -Xsource:3 to warn that implicitly extending Function is deprecated
+// use -Xsource:3-cross for dotty behavior: no extend Function, yes adapt C.apply.tupled
+
+case class B(i: Int)
+case class C(i: Int, j: Int)
+
+class Test {
+  def mapped(xs: List[Int]): List[B] = xs.map(B)
+
+  // accept for cross because dotty has no C.tupled but has fancy untupling adaptation
+  //def cross(xs: List[(Int, Int)]): List[C] = xs.map(C)
+
+  def f(xs: List[(Int, Int)]): List[C] = xs.map(C.tupled)
+
+  def g(xs: List[Int]): List[C] = xs.map(C.curried).map(_(42))
+
+  def f2(xs: List[(Int, Int)]): List[C] = xs.map((C.apply _).tupled)
+
+  def g2(xs: List[Int]): List[C] = xs.map((C.apply _).curried).map(_(42))
+
+  def g3(xs: List[Int]): List[C] = xs.map(((i: Int, j: Int) => C.apply(i, j)).curried).map(_(42))
+}
+object Test extends Test with App {
+  assert(mapped(List(52)) == List(B(52)))
+  //assert(cross(List(27->42)) == List(C(27, 42)))
+  assert(f(List(27->42)) == List(C(27, 42)))
+  assert(g(List(27)) == List(C(27, 42)))
+}

--- a/test/files/run/t3664.scala
+++ b/test/files/run/t3664.scala
@@ -10,7 +10,7 @@ class Test {
   def mapped(xs: List[Int]): List[B] = xs.map(B)
 
   // accept for cross because dotty has no C.tupled but has fancy untupling adaptation
-  //def cross(xs: List[(Int, Int)]): List[C] = xs.map(C)
+  def cross(xs: List[(Int, Int)]): List[C] = xs.map(C)
 
   def f(xs: List[(Int, Int)]): List[C] = xs.map(C.tupled)
 
@@ -24,7 +24,7 @@ class Test {
 }
 object Test extends Test with App {
   assert(mapped(List(52)) == List(B(52)))
-  //assert(cross(List(27->42)) == List(C(27, 42)))
+  assert(cross(List(27->42)) == List(C(27, 42)))
   assert(f(List(27->42)) == List(C(27, 42)))
   assert(g(List(27)) == List(C(27, 42)))
 }


### PR DESCRIPTION
Scala 2 sometimes makes the companion object of a case class extend `Function`; Scala 3 does not, but includes other adaptations which are backported under `-Xsource:3-cross` and allow the following idioms with reduced ceremony:

```
case class B(i: Int)
case class C(i: Int, j: Int)
def mapped(xs: List[Int]): List[B] = xs.map(B)
def cross(xs: List[(Int, Int)]): List[C] = xs.map(C)
def f(xs: List[(Int, Int)]): List[C] = xs.map(C.tupled)
def g(xs: List[Int]): List[C] = xs.map(C.curried).map(_(42))
```

Under `-Xsource:3`, using the case class companion as a function will warn.

Backports Dotty migration support of case class companions by inserting `apply`. Dotty does not automatically add `Function` as a parent of the companion; for Scala 2 under `-Xsource:3-cross`, follow Dotty but also adapt where the companion is not already a `Function`.

Since Scala 2 lacks parameter untupling, also support explicit `C.tupled` and for completeness `C.curried`.

Fixes scala/bug#3664
