### PR TITLE
[REJECTED SCALA 2] tap returns self type

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -22,7 +22,7 @@ import scala.tools.nsc.Reporting.WarningCategory
 import scala.tools.nsc.backend.jvm.BCodeHelpers.ScalaSigBytes
 import scala.tools.nsc.backend.jvm.BackendReporting._
 import scala.tools.nsc.reporters.NoReporter
-import scala.util.chaining.scalaUtilChainingOps
+import scala.util.chaining._
 
 /*
  *  Traits encapsulating functionality to convert Scala AST Trees into ASM ClassNodes.

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -21,7 +21,6 @@ import java.util.zip.Deflater
 
 import scala.annotation.{elidable, nowarn}
 import scala.collection.mutable
-import scala.language.existentials
 import scala.reflect.internal.util.{ StatisticsStatics, StringContextStripMarginOps }
 import scala.tools.nsc.util.DefaultJarFactory
 import scala.tools.util.PathResolver.Defaults

--- a/src/library/scala/util/ChainingOps.scala
+++ b/src/library/scala/util/ChainingOps.scala
@@ -21,7 +21,7 @@ trait ChainingSyntax {
 
 /** Adds chaining methods `tap` and `pipe` to every type.
  */
-final class ChainingOps[A](private val self: A) extends AnyVal {
+final class ChainingOps[A](val self: A) extends AnyVal {
   /** Applies `f` to the value for its side effects, and returns the original value.
     *
     * {{{
@@ -36,7 +36,7 @@ final class ChainingOps[A](private val self: A) extends AnyVal {
     *  @tparam U     the result type of the function `f`.
     *  @return       the original value `self`.
     */
-  def tap[U](f: A => U): A = {
+  def tap[U](f: A => U): self.type = {
     f(self)
     self
   }

--- a/src/library/scala/util/package.scala
+++ b/src/library/scala/util/package.scala
@@ -16,5 +16,7 @@ package object util {
   /**
    * Adds chaining methods `tap` and `pipe` to every type. See [[ChainingOps]].
    */
-  object chaining extends ChainingSyntax
+  object chaining extends ChainingSyntax {
+    implicit val `accommodate existential for tap`: languageFeature.existentials = language.existentials
+  }
 }


### PR DESCRIPTION
It's obvious that `tap` should preserve the type of the tapped thing. The other tweaks follow.