### PR TITLE
Allow `-java-output-version` flag, matching Scala 3

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
@@ -78,7 +78,7 @@ trait StandardScalaSettings { _: MutableSettings =>
         //target.value = setting.value  // this would trigger deprecation
       }
       .withAbbreviation("--release")
-      // .withAbbreviation("-java-output-version")
+      .withAbbreviation("-java-output-version")
   def releaseValue: Option[String] = release.valueSetByUser
   val target =
     ChoiceSetting("-target", "target", "Target platform for object files.", AllTargetVersions, "8")
@@ -89,7 +89,7 @@ trait StandardScalaSettings { _: MutableSettings =>
       .withAbbreviation("--target")
       // .withAbbreviation("--Xtarget")
       // .withAbbreviation("-Xtarget")
-      // .withAbbreviation("-Xunchecked-java-output-version")
+      .withAbbreviation("-Xunchecked-java-output-version")
       .withDeprecationMessage("Use -release instead to compile against the correct platform API.")
   def targetValue: String = target.valueSetByUser.orElse(releaseValue).getOrElse(target.value)
   val unchecked =      BooleanSetting ("-unchecked", "Enable additional warnings where generated code depends on assumptions. See also -Wconf.") withAbbreviation "--unchecked" withPostSetHook { s =>


### PR DESCRIPTION
Following on from https://github.com/scala/scala/pull/9982 and [discussion there](https://github.com/scala/scala/pull/9982/files#r1434172490), this change enables `-java-output-version` as an alternative name for the `-release` flag in Scala 2, as in Scala 3 `-java-output-version` is the preferred flag name (see https://github.com/lampepfl/dotty/pull/14606), with the alias of `-release` still permitted.

`-Xunchecked-java-output-version` is also included as an alternative for `-target`, though note use of this flag is discouraged in favour of `-java-output-version`/`-release` for Java 9 and above.