### PR TITLE
Paramaccessors are private local in specialize

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -1997,7 +1997,7 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
             // param accessors for private members (the others are inherited from the generic class)
             if (m.isPrimaryConstructor) {
               for (param <- vparams ; if sClass.info.nonPrivateMember(param.name) == NoSymbol) {
-                val acc = param.cloneSymbol(sClass, param.flags | PARAMACCESSOR | PRIVATE)
+                val acc = param.cloneSymbol(sClass, param.flags | PARAMACCESSOR | PrivateLocal)
                 sClass.info.decls.enter(acc)
                 mbrs += ValDef(acc, EmptyTree).setType(NoType).setPos(m.pos)
               }

--- a/test/files/specialized/t12929.scala
+++ b/test/files/specialized/t12929.scala
@@ -1,0 +1,7 @@
+
+class C[@specialized(Int) A](i: Int)
+
+object Test extends App {
+  val c = new C[Int](42)
+  assert(c.getClass.getDeclaredFields.isEmpty)
+}


### PR DESCRIPTION
Allow Constructors to elide the field.

Fixes scala/bug#12929