### PR TITLE
Remove no-longer-needed JDK 21 workaround in build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,9 @@ jobs:
         name: "JDK 8 pr validation"
         if: type = pull_request
         script:
-          - sbt -Dsbt.io.jdktimestamps=true -Dsbt.scala.version=2.12.18 -warn setupPublishCore generateBuildCharacterPropertiesFile headerCheck publishLocal
+          - sbt -Dsbt.io.jdktimestamps=true -warn setupPublishCore generateBuildCharacterPropertiesFile headerCheck publishLocal
           - STARR=`cat buildcharacter.properties | grep ^maven.version.number | cut -d= -f2` && echo $STARR
-          - sbt -Dsbt.io.jdktimestamps=true -Dsbt.scala.version=2.12.18 -Dstarr.version=$STARR -warn setupValidateTest test:compile info testAll
+          - sbt -Dsbt.io.jdktimestamps=true -Dstarr.version=$STARR -warn setupValidateTest test:compile info testAll
 
       # build the spec using jekyll
       - stage: build

--- a/scripts/common
+++ b/scripts/common
@@ -19,7 +19,7 @@ SBT_VERSION=`grep sbt.version $WORKSPACE/project/build.properties | sed -n 's/sb
 SBT_CMD=${SBT_CMD-sbt}
 # the jdktimestamps thing is to work around https://github.com/sbt/sbt/issues/7463 --
 # it can be removed again once we're on an sbt version with a fix
-SBT_CMD="$SBT_CMD -Dsbt.io.jdktimestamps=true -Dsbt.scala.version=2.12.18 -sbt-version $SBT_VERSION"
+SBT_CMD="$SBT_CMD -Dsbt.io.jdktimestamps=true -sbt-version $SBT_VERSION"
 
 # repo to publish builds
 integrationRepoUrl=${integrationRepoUrl-"https://scala-ci.typesafe.com/artifactory/scala-integration/"}


### PR DESCRIPTION
We'd added this to work around https://github.com/scala/bug/issues/12783 , but sbt has taken the 2.12.18 upgrade now
