### PR TITLE
[backport] New `-Yrelease` option supplements `--release`, allows access to additional JVM packages

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -244,6 +244,7 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
   val Yvirtpatmat     = BooleanSetting    ("-Yvirtpatmat", "Enable pattern matcher virtualization")
   val Youtline        = BooleanSetting    ("-Youtline", "Don't compile method bodies. Use together with `-Ystop-afer:pickler to generate the pickled signatures for all source files.").internalOnly()
 
+  val unsafe = MultiStringSetting("-Yrelease", "packages", "Expose platform packages hidden under --release")
   val exposeEmptyPackage = BooleanSetting ("-Yexpose-empty-package", "Internal only: expose the empty package.").internalOnly()
   val Ydelambdafy        = ChoiceSetting  ("-Ydelambdafy", "strategy", "Strategy used for translating lambdas into JVM code.", List("inline", "method", "method-ref"), "method")
   val YmacroClasspath = PathSetting       ("-Ymacro-classpath", "The classpath used to reflectively load macro implementations, default is the compilation classpath.", "")

--- a/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
@@ -63,6 +63,8 @@ trait StandardScalaSettings { _: MutableSettings =>
       if (!isJavaAtLeast("9") && current > 8) errorFn.apply("-release is only supported on JVM 9 and higher")
       if (target.valueSetByUser.map(_.toInt > current).getOrElse(false)) errorFn("-release cannot be less than -target")
     }
+    .withAbbreviation("--release")
+    .withAbbreviation("-java-output-version")
   def releaseValue: Option[String] = release.valueSetByUser
   val target =
     ChoiceSetting("-target", "target", "Target platform for class files. Target < 8 is deprecated; target > 8 uses 8.",

--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -260,7 +260,9 @@ final class PathResolver(settings: Settings, closeableRegistry: CloseableRegistr
 
     // Assemble the elements!
     def basis = List[Traversable[ClassPath]](
-      jrt,                                          // 0. The Java 9+ classpath (backed by the ct.sym or jrt:/ virtual system, if available)
+      if (settings.javabootclasspath.isSetByUser)   // respect explicit `-javabootclasspath rt.jar`
+        Nil
+      else jrt,                                     // 0. The Java 9+ classpath (backed by the ct.sym or jrt:/ virtual system, if available)
       classesInPath(javaBootClassPath),             // 1. The Java bootstrap class path.
       contentsOfDirsInPath(javaExtDirs),            // 2. The Java extension class path.
       classesInExpandedPath(javaUserClassPath),     // 3. The Java application class path.
@@ -271,7 +273,7 @@ final class PathResolver(settings: Settings, closeableRegistry: CloseableRegistr
       sourcesInPath(sourcePath)                     // 7. The Scala source path.
     )
 
-    private def jrt: Option[ClassPath] = JrtClassPath.apply(settings.releaseValue, closeableRegistry)
+    private def jrt: List[ClassPath] = JrtClassPath.apply(settings.releaseValue, settings.unsafe.valueSetByUser, closeableRegistry)
 
     lazy val containers = basis.flatten.distinct
 

--- a/src/repl/scala/tools/nsc/interpreter/ReplGlobal.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplGlobal.scala
@@ -89,12 +89,15 @@ trait ReplGlobal extends Global {
   }
 
   override def optimizerClassPath(base: ClassPath): ClassPath = {
-    settings.outputDirs.getSingleOutput match {
-      case None => base
-      case Some(out) =>
-        // Make bytecode of previous lines available to the inliner
-        val replOutClasspath = ClassPathFactory.newClassPath(settings.outputDirs.getSingleOutput.get, settings, closeableRegistry)
-        AggregateClassPath.createAggregate(platform.classPath, replOutClasspath)
+    def withBase(base: ClassPath): ClassPath = {
+      settings.outputDirs.getSingleOutput match {
+        case None => base
+        case Some(out) =>
+          // Make bytecode of previous lines available to the inliner
+          val replOutClasspath = ClassPathFactory.newClassPath(settings.outputDirs.getSingleOutput.get, settings, closeableRegistry)
+          AggregateClassPath.createAggregate(base, replOutClasspath)
+      }
     }
+    withBase(super.optimizerClassPath(base))
   }
 }

--- a/test/files/neg/unsafe.check
+++ b/test/files/neg/unsafe.check
@@ -1,0 +1,4 @@
+unsafe.scala:9: error: value threadId is not a member of Thread
+  def f(t: Thread) = t.threadId
+                       ^
+one error found

--- a/test/files/neg/unsafe.scala
+++ b/test/files/neg/unsafe.scala
@@ -1,0 +1,10 @@
+
+// scalac: --release:8 -Yrelease:java.lang
+// javaVersion: 19+
+
+// -Yrelease opens packages but does not override class definitions
+// because ct.sym comes first
+
+class C {
+  def f(t: Thread) = t.threadId
+}

--- a/test/files/pos/unsafe.scala
+++ b/test/files/pos/unsafe.scala
@@ -1,0 +1,21 @@
+
+// scalac: --release:8 -Yrelease:sun.misc
+
+import sun.misc.Unsafe
+
+class C {
+  val f = classOf[Unsafe].getDeclaredField("theUnsafe")
+  f.setAccessible(true)
+  val unsafe = f.get(null).asInstanceOf[Unsafe]
+
+  val k = unsafe.allocateInstance(classOf[K]).asInstanceOf[K]
+  assert(k.value == 0)
+}
+
+class K {
+  val value = 42
+}
+
+object Test extends App {
+  new C
+}

--- a/test/junit/scala/tools/nsc/classpath/JrtClassPathTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/JrtClassPathTest.scala
@@ -27,7 +27,7 @@ class JrtClassPathTest {
         val elements = new ClassPathFactory(settings, closeableRegistry).classesInPath(resolver.Calculated.javaBootClassPath)
         AggregateClassPath(elements)
       }
-      else JrtClassPath(None, closeableRegistry).get
+      else JrtClassPath(release = None, unsafe = None, closeableRegistry).head
 
     assertEquals(Nil, cp.classes(""))
     assertTrue(cp.packages("java").toString, cp.packages("java").exists(_.name == "java.lang"))


### PR DESCRIPTION
backport https://github.com/scala/scala/pull/10543 to fix scala/bug#12643

Gah, too late for 2.12.19!*

*unless @SethTisue says otherwise of course