### PR TITLE
[SUPERSEDED] No warn unused implicit of marker trait

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -769,7 +769,7 @@ trait TypeDiagnostics extends splain.SplainDiagnostics {
         )
         def warningIsOnFor(s: Symbol) =
           if (!s.isImplicit) settings.warnUnusedExplicits
-          else if (!s.isSynthetic) settings.warnUnusedImplicits
+          else if (!s.isSynthetic) settings.warnUnusedImplicits && s.info.members.reverseIterator.exists(m => !m.isPrivate && !m.isConstructor && !isUniversalMember(m))
           else settings.warnUnusedSynthetics
         def warnable(s: Symbol) = (
           warningIsOnFor(s)

--- a/test/files/neg/warn-unused-implicits.check
+++ b/test/files/neg/warn-unused-implicits.check
@@ -4,6 +4,9 @@ warn-unused-implicits.scala:13: warning: parameter s in method f is never used
 warn-unused-implicits.scala:33: warning: parameter s in method i is never used
   def i(implicit s: String, t: Int) = t           // yes, warn
                  ^
+warn-unused-implicits.scala:52: warning: parameter ev in method ==> is never used
+    def ==>[B](b: B)(implicit ev: BadCanEqual[A, B]): Boolean = a == b // warn, ev.run
+                              ^
 error: No warnings can be incurred under -Werror.
-2 warnings
+3 warnings
 1 error

--- a/test/files/neg/warn-unused-implicits.scala
+++ b/test/files/neg/warn-unused-implicits.scala
@@ -40,3 +40,15 @@ trait U { _: T =>
   override def f()(implicit i: Int): Int = g()  // no warn, required by baseclass, scala/bug#12876
   def g(): Int
 }
+
+trait CanEqual[A, B]
+trait BadCanEqual[A, B] extends Runnable
+
+class EqTest {
+  implicit class ArrowAssert[A](a: A) {
+    def ==>[B](b: B)(implicit ev: CanEqual[A, B]): Boolean = a == b // no warn, no non-trivial members
+  }
+  implicit class BadArrowAssert[A](a: A) {
+    def ==>[B](b: B)(implicit ev: BadCanEqual[A, B]): Boolean = a == b // warn, ev.run
+  }
+}

--- a/test/files/neg/warn-unused-params.scala
+++ b/test/files/neg/warn-unused-params.scala
@@ -96,7 +96,7 @@ trait Anonymous {
 
   def g = for (i <- List(1)) yield answer    // warn map.(i => 42)
 }
-trait Context[A]
+trait Context[A] { def answer = 27 /* contextually */ }
 trait Implicits {
   def f[A](implicit ctx: Context[A]) = answer
   def g[A: Context] = answer


### PR DESCRIPTION
If an implicit parameter is a type which contributes no member services, don't warn if it is unused; take it as a marker trait only, evidence of something.

First swipe at https://github.com/scala/bug/issues/12935