### PR TITLE
During constant folding, warn more often about inexactness

### DIFF
--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -775,8 +775,7 @@ private[collection] object RedBlackTree {
   //see #Tree docs "Colour, mutablity and size encoding"
   //we make these final vals because the optimiser inlines them, without reference to the enclosing module
   private[RedBlackTree] final val colourBit         = 0x80000000
-  //really its ~colourBit but that doesnt get inlined
-  private[RedBlackTree] final val colourMask        = colourBit - 1
+  private[RedBlackTree] final val colourMask        = ~colourBit
   private[RedBlackTree] final val initialBlackCount = colourBit
   private[RedBlackTree] final val initialRedCount   = 0
 

--- a/test/files/neg/constant-warning.check
+++ b/test/files/neg/constant-warning.check
@@ -1,6 +1,39 @@
-constant-warning.scala:3: warning: Evaluation of a constant expression results in an arithmetic error: / by zero
+constant-warning.scala:4: warning: Evaluation of a constant expression results in an arithmetic error: / by zero
   val fails = 1 + 2 / (3 - 2 - 1)
                     ^
+constant-warning.scala:6: warning: Evaluation of a constant expression results in an arithmetic error: integer overflow, using -2147483607
+  val addi: Int = Int.MaxValue + 42
+                               ^
+constant-warning.scala:7: warning: Evaluation of a constant expression results in an arithmetic error: integer overflow, using 2147483606
+  val subi: Int = Int.MinValue - 42
+                               ^
+constant-warning.scala:8: warning: Evaluation of a constant expression results in an arithmetic error: integer overflow, using -2
+  val muli: Int = Int.MaxValue * 2
+                               ^
+constant-warning.scala:9: warning: Evaluation of a constant expression results in an arithmetic error: integer overflow, using -2147483648
+  val divi: Int = Int.MinValue / -1
+                               ^
+constant-warning.scala:10: warning: Evaluation of a constant expression results in an arithmetic error: / by zero
+  val divz: Int = Int.MinValue / 0
+                               ^
+constant-warning.scala:12: warning: Evaluation of a constant expression results in an arithmetic error: integer overflow, using 0
+  val long: Long = 100 * 1024 * 1024 * 1024
+                                     ^
+constant-warning.scala:13: warning: Evaluation of a constant expression results in an arithmetic error: long overflow, using -9223372036854775767
+  val addl: Long = Long.MaxValue + 42
+                                 ^
+constant-warning.scala:14: warning: Evaluation of a constant expression results in an arithmetic error: long overflow, using 9223372036854775766
+  val subl: Long = Long.MinValue - 42
+                                 ^
+constant-warning.scala:15: warning: Evaluation of a constant expression results in an arithmetic error: long overflow, using -2
+  val mull: Long = Long.MaxValue * 2
+                                 ^
+constant-warning.scala:16: warning: Evaluation of a constant expression results in an arithmetic error: long overflow, using -9223372036854775808
+  val divl: Long = Long.MinValue / -1
+                                 ^
+constant-warning.scala:17: warning: Evaluation of a constant expression results in an arithmetic error: / by zero
+  val divlz: Long = Long.MinValue / 0
+                                  ^
 error: No warnings can be incurred under -Werror.
-1 warning
+12 warnings
 1 error

--- a/test/files/neg/constant-warning.scala
+++ b/test/files/neg/constant-warning.scala
@@ -1,4 +1,18 @@
-// scalac: -Xlint:constant -Xfatal-warnings
+//> using options -Werror -Xlint:constant
+//-Vprint:cleanup (bytecode test to ensure warnable constants are folded)
 object Test {
   val fails = 1 + 2 / (3 - 2 - 1)
+
+  val addi: Int = Int.MaxValue + 42
+  val subi: Int = Int.MinValue - 42
+  val muli: Int = Int.MaxValue * 2
+  val divi: Int = Int.MinValue / -1
+  val divz: Int = Int.MinValue / 0
+
+  val long: Long = 100 * 1024 * 1024 * 1024
+  val addl: Long = Long.MaxValue + 42
+  val subl: Long = Long.MinValue - 42
+  val mull: Long = Long.MaxValue * 2
+  val divl: Long = Long.MinValue / -1
+  val divlz: Long = Long.MinValue / 0
 }

--- a/test/junit/scala/collection/immutable/VectorTest.scala
+++ b/test/junit/scala/collection/immutable/VectorTest.scala
@@ -5,7 +5,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.junit.Test
 
-import scala.annotation.unused
+import scala.annotation.{nowarn, unused}
 import scala.collection.immutable.VectorInline.{WIDTH3, WIDTH4, WIDTH5}
 import scala.collection.mutable.{ListBuffer, StringBuilder}
 import scala.tools.testkit.AssertUtil.intercept
@@ -110,10 +110,11 @@ class VectorTest {
   @Test
   def testBuilderAlignTo2(): Unit = {
     val Large = 1 << 20
-    for (
-      size <- Seq(0, 1, 31, 1 << 5, 1 << 10, 1 << 15, 1 << 20, 9 << 20, 1 << 25, 9 << 25, 50 << 25, 1 << 30, (1 << 31) - (1 << 26) - 1000);
+    @nowarn val KrazyKonstant = (1 << 31) - (1 << 26) - 1000
+    for {
+      size <- Seq(0, 1, 31, 1 << 5, 1 << 10, 1 << 15, 1 << 20, 9 << 20, 1 << 25, 9 << 25, 50 << 25, 1 << 30, KrazyKonstant)
       i <- Seq(0, 1, 5, 123)
-    ) {
+    } {
 //      println((i, size))
       val v = if (size < Large) Vector.tabulate(size)(_.toString) else Vector.fillSparse(size)("v")
       val prefix = Vector.fill(i)("prefix")

--- a/test/junit/scala/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBufferTest.scala
@@ -412,7 +412,7 @@ class ArrayBufferTest {
       assertThrows[Exception](rethrow(resizeUp(0, targetLen)),
                               _ == s"Array of array-backed collection exceeds VM length limit of $VM_MaxArraySize. Requested length: $targetLen; current length: 0")
 
-    checkExceedsMaxInt(Int.MaxValue + 1)
+    checkExceedsMaxInt(Int.MaxValue + 1: @nowarn)
     checkExceedsVMArrayLimit(Int.MaxValue)
     checkExceedsVMArrayLimit(Int.MaxValue - 1)
   }


### PR DESCRIPTION
Supersedes https://github.com/scala/scala/pull/10587

Warn about more cases of overflowing constants. The overflowed result is retained.

Only divide by zero retains the original tree. (It could be reduced to a throw, but that loses any platform-specific message text.)
