### PR TITLE
Support certain Java libraries compiled on JDK 21

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -212,7 +212,7 @@ abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
           case CONSTANT_METHODHANDLE                                           => in skip 3
           case CONSTANT_FIELDREF | CONSTANT_METHODREF | CONSTANT_INTFMETHODREF => in skip 4
           case CONSTANT_NAMEANDTYPE | CONSTANT_INTEGER | CONSTANT_FLOAT        => in skip 4
-          case CONSTANT_INVOKEDYNAMIC                                          => in skip 4
+          case CONSTANT_DYNAMIC | CONSTANT_INVOKEDYNAMIC                       => in skip 4
           case CONSTANT_LONG | CONSTANT_DOUBLE                                 => in skip 8 ; i += 1
           case _                                                               => errorBadTag(in.bp - 1)
         }

--- a/src/reflect/scala/reflect/internal/ClassfileConstants.scala
+++ b/src/reflect/scala/reflect/internal/ClassfileConstants.scala
@@ -81,6 +81,7 @@ object ClassfileConstants {
   final val CONSTANT_NAMEANDTYPE   = 12
   final val CONSTANT_METHODHANDLE  = 15
   final val CONSTANT_METHODTYPE    = 16
+  final val CONSTANT_DYNAMIC       = 17
   final val CONSTANT_INVOKEDYNAMIC = 18
   final val CONSTANT_MODULE        = 19
   final val CONSTANT_PACKAGE       = 20

--- a/test/files/pos/t12396/A_1.java
+++ b/test/files/pos/t12396/A_1.java
@@ -1,0 +1,17 @@
+// javaVersion: 21+
+
+public class A_1 {
+  public int f(Object s) {
+    switch(s) {
+      case Res.R -> {
+        return 1;
+      }
+      default -> {
+        return 3;
+      }
+    }
+  }
+  static enum Res {
+    R
+  }
+}

--- a/test/files/pos/t12396/B_2.scala
+++ b/test/files/pos/t12396/B_2.scala
@@ -1,0 +1,5 @@
+// javaVersion: 21+
+
+class B {
+  def bar = (new A_1).f(null)
+}

--- a/test/junit/scala/tools/nsc/backend/jvm/ClassfileParserTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/ClassfileParserTest.scala
@@ -1,0 +1,31 @@
+package scala.tools.nsc.backend.jvm
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+import java.lang.reflect.Member
+
+class ClassfileParserTest {
+  @Test
+  def noConstantPoolLag(): Unit = {
+    def constNames(ms: List[Member]) = ms.collect {
+      case f if f.getName.startsWith("CONSTANT_") => f.getName
+    }.sorted
+
+    val toScalac = Map(
+      "CONSTANT_INTERFACE_METHODREF" -> "CONSTANT_INTFMETHODREF",
+      "CONSTANT_INVOKE_DYNAMIC" -> "CONSTANT_INVOKEDYNAMIC",
+      "CONSTANT_METHOD_HANDLE" -> "CONSTANT_METHODHANDLE",
+      "CONSTANT_METHOD_TYPE" -> "CONSTANT_METHODTYPE",
+      "CONSTANT_NAME_AND_TYPE" -> "CONSTANT_NAMEANDTYPE",
+    ).withDefault(x => x)
+
+    val asmConsts = constNames(Class.forName("scala.tools.asm.Symbol").getDeclaredFields.toList)
+      .map(_.stripSuffix("_TAG"))
+      .map(toScalac)
+      .::("CONSTANT_UNICODE")
+      .sorted
+    val scalacConsts = constNames(scala.reflect.internal.ClassfileConstants.getClass.getDeclaredMethods.toList)
+    assertEquals(scalacConsts, asmConsts)
+  }
+}


### PR DESCRIPTION
This makes certain Java libraries compiled using Java 21 usable from Scala — libraries that use `switch` in a certain way.

The fix is to our classfile reader, to recognize `CONSTANT_Dynamic` when it appears in the constant pool.

Fixes scala/bug#12936

### Implementation notes

Previous PR in this vein, for comparison: #8289

I verified that `partest test/files/pos/t12396` was failing locally on JDK 21 but now passes.

PR validation runs on Java 8, so it will not run the test, but it will run at https://github.com/scala/scala/actions after the PR is merged; our GitHub Actions config has `java: [8, 11, 17, 21]`