### PR TITLE
[REJECTED] -Ylegacy-sym-pos to use def tree for symbol position

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -3238,7 +3238,7 @@ self =>
           val (constrMods, vparamss) =
             if (mods.isTrait) (Modifiers(Flags.TRAIT), List())
             else (accessModifierOpt(), paramClauses(name, classContextBounds, ofCaseClass = mods.isCase))
-          val template = templateOpt(mods, name, constrMods withAnnotations constrAnnots, vparamss, tstart)
+          val template = templateOpt(mods, name, constrMods.withAnnotations(constrAnnots), vparamss, tstart)
           val result = gen.mkClassDef(mods, name, tparams, template).updateAttachment(namePos)
           // Context bounds generate implicit parameters (part of the template) with types
           // from tparams: we need to ensure these don't overlap

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -279,6 +279,7 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
   val YpickleWriteApiOnly = BooleanSetting("-Ypickle-write-api-only", "Exclude private members (other than those material to subclass compilation, such as private trait vals) from generated .sig files containing type signatures.").internalOnly()
   val YtrackDependencies = BooleanSetting("-Ytrack-dependencies", "Record references to in unit.depends. Deprecated feature that supports SBT 0.13 with incOptions.withNameHashing(false) only.", default = true)
   val Yscala3ImplicitResolution = BooleanSetting("-Yscala3-implicit-resolution", "Use Scala-3-style downwards comparisons for implicit search and overloading resolution (see https://github.com/scala/bug/issues/12437).", default = false)
+  val YlegacySymbolPos = BooleanSetting("-Ylegacy-symbol-pos", "Use definition tree for symbol position.", default = false)
 
   sealed abstract class CachePolicy(val name: String, val help: String)
   object CachePolicy {

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -342,7 +342,7 @@ trait Namers extends MethodSynthesis {
      *  the flags to keep.
      */
     def createMemberSymbol(tree: MemberDef, name: Name, mask: Long): Symbol = {
-      val pos         = tree.namePos
+      val pos         = if (settings.YlegacySymbolPos.value) tree.pos else tree.namePos
       val isParameter = tree.mods.isParameter
       val flags       = tree.mods.flags & mask
 

--- a/test/files/neg/t12735a.check
+++ b/test/files/neg/t12735a.check
@@ -1,6 +1,6 @@
-[ERROR] [RangePosition(t12735a.scala, 97, 97, 98)]: class B needs to be abstract.
+[ERROR] [RangePosition(t12735a.scala, 104, 104, 105)]: class B needs to be abstract.
 Missing implementation for member of trait A:
   def x: String = ???
 
-[ERROR] [RangePosition(t12735a.scala, 123, 123, 127)]: covariant type T occurs in contravariant position in type T of value t
+[ERROR] [RangePosition(t12735a.scala, 130, 130, 134)]: covariant type T occurs in contravariant position in type T of value t
 2 errors

--- a/test/files/neg/t12735a.scala
+++ b/test/files/neg/t12735a.scala
@@ -1,4 +1,4 @@
-// scalac: -Xreporter:scala.tools.partest.nest.PlainReporter
+//> using options -Xreporter:scala.tools.partest.nest.PlainReporter
 
 trait A {
   def x: String

--- a/test/files/run/t12877/denamer_0.scala
+++ b/test/files/run/t12877/denamer_0.scala
@@ -1,0 +1,18 @@
+
+import language.experimental.macros
+import scala.reflect.macros.blackbox.Context
+
+// macro to turn a symbol into a spanning position of the definition
+
+object denamer {
+  def span[A]: Option[(Int, Int, String)] = macro spanner[A]
+
+  def spanner[A: c.WeakTypeTag](c: Context) = {
+    import c.universe._
+
+    val sym = symbolOf[A]
+    ///val sym = weakTypeTag[A].tpe.typeSymbol
+    val text = String.valueOf(sym.pos.source.content, sym.pos.start, sym.pos.end - sym.pos.start)
+    q"Option.apply((${sym.pos.start}, ${sym.pos.end}, $text))"
+  }
+}

--- a/test/files/run/t12877/test_1.scala
+++ b/test/files/run/t12877/test_1.scala
@@ -1,0 +1,14 @@
+
+//> using options -Ylegacy-symbol-pos
+
+/* some header cruft */
+
+class C {
+  def p() = println("hello, world")
+}
+
+object Test extends App {
+  val Some((start, end, text)) = denamer.span[C]
+  assert(end - start > 5)
+  assert(text.startsWith("class C "))
+}


### PR DESCRIPTION
Private option for VIP users who need the old behavior where a symbol's position is the range of its definition tree.

Fixes scala/bug#12877
