### PR TITLE
Add `-Vcyclic` to improve reporting of "cyclic reference" errors

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -90,6 +90,8 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
 
   override def settings = currentSettings
 
+  override def isSymbolLockTracingEnabled = settings.cyclic.value
+
   private[this] var currentReporter: FilteringReporter = null
   locally { reporter = reporter0 }
 

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -563,6 +563,7 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
    */
   val Vhelp              = BooleanSetting("-V", "Print a synopsis of verbose options.")
   val browse          = PhasesSetting("-Vbrowse", "Browse the abstract syntax tree after") withAbbreviation "-Ybrowse"
+  val cyclic          = BooleanSetting("-Vcyclic", "Debug cyclic reference error.")
   val debug           = BooleanSetting("-Vdebug", "Increase the quantity of debugging output.") withAbbreviation "-Ydebug" withPostSetHook (s => if (s.value) StatisticsStatics.enableDebugAndDeoptimize())
   val YdebugTasty     = BooleanSetting("-Vdebug-tasty", "Increase the quantity of debugging output when unpickling tasty.") withAbbreviation "-Ydebug-tasty"
   val VdebugTypeError = BooleanSetting("-Vdebug-type-error", "Print the stack trace when any error is caught.") withAbbreviation "-Ydebug-type-error"

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -1340,7 +1340,7 @@ trait ContextErrors extends splain.SplainErrors {
 
       def TypeSigError(tree: Tree, ex: TypeError) = {
         ex match {
-          case CyclicReference(_, _) if tree.symbol.isTermMacro =>
+          case CyclicReference(_, _, _) if tree.symbol.isTermMacro =>
             // say, we have a macro def `foo` and its macro impl `impl`
             // if impl: 1) omits return type, 2) has anything implicit in its body, 3) sees foo
             //
@@ -1353,8 +1353,8 @@ trait ContextErrors extends splain.SplainErrors {
             // hence we (together with reportTypeError in TypeDiagnostics) make sure that this CyclicReference
             // evades all the handlers on its way and successfully reaches `isCyclicOrErroneous` in Implicits
             throw ex
-          case CyclicReference(sym, info: TypeCompleter) =>
-            issueNormalTypeError(tree, typer.cyclicReferenceMessage(sym, info.tree) getOrElse ex.getMessage)
+          case CyclicReference(sym, info: TypeCompleter, trace) =>
+            issueNormalTypeError(tree, typer.cyclicReferenceMessage(sym, info.tree, trace, tree.pos).getOrElse(ex.getMessage))
           case _ =>
             contextNamerErrorGen.issue(TypeErrorWithUnderlyingTree(tree, ex))
         }

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -6306,7 +6306,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         case ex: TypeError =>
           tree.clearType()
           // The only problematic case are (recoverable) cyclic reference errors which can pop up almost anywhere.
-          typingStack.printTyping(tree, "caught %s: while typing %s".format(ex, tree)) //DEBUG
+          typingStack.printTyping(tree, s"caught $ex: while typing $tree")
           reportTypeError(context, tree.pos, ex)
           setError(tree)
         case ex: Exception =>

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -95,6 +95,8 @@ abstract class SymbolTable extends macros.Universe
 
   def settings: MutableSettings
 
+  def isSymbolLockTracingEnabled: Boolean = isDeveloper
+
   /** Override with final implementation for inlining. */
   def debuglog(msg:  => String): Unit = if (settings.isDebug) log(msg)
 

--- a/test/files/neg/t7808.check
+++ b/test/files/neg/t7808.check
@@ -1,0 +1,4 @@
+t7808.scala:5: error: recursive value ls needs type
+    val (ls, rs) = z match {
+         ^
+1 error

--- a/test/files/neg/t7808.scala
+++ b/test/files/neg/t7808.scala
@@ -1,0 +1,18 @@
+//> using options -Vcyclic
+class C {
+  type OI = Option[Int]
+  def f(z: OI, ls: List[OI], rs: List[OI]): (List[OI], List[OI]) = {
+    val (ls, rs) = z match {
+      case Some(_) => (z::ls, rs)
+      case _       => (ls, z::rs)
+    }
+    (ls, rs)
+  }
+}
+
+/*
+t7808.scala:5: error: recursive value x$1 needs type
+    val (ls, rs) = z match {
+         ^
+1 error
+*/

--- a/test/files/neg/t7808b.check
+++ b/test/files/neg/t7808b.check
@@ -1,0 +1,4 @@
+t7808b.scala:5: error: recursive value x$1 needs type; value x$1 is synthetic; use -Vcyclic to find which definition needs an explicit type
+    val (ls, rs) = z match {
+         ^
+1 error

--- a/test/files/neg/t7808b.scala
+++ b/test/files/neg/t7808b.scala
@@ -1,0 +1,18 @@
+
+class C {
+  type OI = Option[Int]
+  def f(z: OI, ls: List[OI], rs: List[OI]): (List[OI], List[OI]) = {
+    val (ls, rs) = z match {
+      case Some(_) => (z::ls, rs)
+      case _       => (ls, z::rs)
+    }
+    (ls, rs)
+  }
+}
+
+/*
+t7808.scala:5: error: recursive value x$1 needs type
+    val (ls, rs) = z match {
+         ^
+1 error
+*/


### PR DESCRIPTION
`-Vcyclic` improves reporting of "cyclic reference" errors.

It enables "tracing" of symbol locking to show which symbols were involved in the cycle.

This is also helpful when a synthetic symbol name is reported, since that name is not meaningful.

Look for a non-synthetic symbol to blame.

Fixes scala/bug#7808
