### PR TITLE
Use pos.unit.source instead of currentUnit.source in quick fixes

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Adaptations.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Adaptations.scala
@@ -102,7 +102,7 @@ trait Adaptations {
             s"adapted the argument list to the expected ${args.size}-tuple: add additional parens instead")
           val pos = wrappingPos(args)
           context.warning(t.pos, msg, WarningCategory.LintAdaptedArgs,
-            runReporting.codeAction("add wrapping parentheses", pos, s"(${currentUnit.source.sourceAt(pos)})", msg))
+            runReporting.codeAction("add wrapping parentheses", pos, s"(${pos.source.sourceAt(pos)})", msg))
         }
         true // keep adaptation
       }

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -467,7 +467,7 @@ abstract class RefChecks extends Transform {
                 val msg = s"$mbr without a parameter list overrides ${other.fullLocationString} defined with a single empty parameter list"
                 val namePos = member.pos
                 val action =
-                  if (namePos.isDefined && currentUnit.source.sourceAt(namePos) == member.decodedName)
+                  if (namePos.isDefined && namePos.source.sourceAt(namePos) == member.decodedName)
                     runReporting.codeAction("add empty parameter list", namePos.focusEnd, "()", msg)
                   else Nil
                 overrideErrorOrNullaryWarning(msg, action)
@@ -477,7 +477,7 @@ abstract class RefChecks extends Transform {
                 val msg = s"$mbr with a single empty parameter list overrides ${other.fullLocationString} defined without a parameter list"
                 val namePos = member.pos
                 val action =
-                  if (namePos.isDefined && currentUnit.source.sourceAt(namePos) == member.decodedName)
+                  if (namePos.isDefined && namePos.source.sourceAt(namePos) == member.decodedName)
                     runReporting.codeAction("remove empty parameter list", namePos.focusEnd.withEnd(namePos.end + 2), "", msg, expected = Some(("()", currentUnit)))
                   else Nil
                 overrideErrorOrNullaryWarning(msg, action)
@@ -1811,7 +1811,7 @@ abstract class RefChecks extends Transform {
           val msg = s"side-effecting nullary methods are discouraged: suggest defining as `def ${sym.name.decode}()` instead"
           val namePos = sym.pos.focus.withEnd(sym.pos.point + sym.decodedName.length)
           val action =
-            if (currentUnit.source.sourceAt(namePos) == sym.decodedName)
+            if (namePos.source.sourceAt(namePos) == sym.decodedName)
               runReporting.codeAction("add empty parameter list", namePos.focusEnd, "()", msg)
             else Nil
           refchecksWarning(sym.pos, msg, WarningCategory.LintNullaryUnit, action)

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1181,7 +1181,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             if (isInharmonic) {
               // not `context.deprecationWarning` because they are not buffered in silent mode
               val msg = s"Widening conversion from ${tpSym.name} to ${ptSym.name} is deprecated because it loses precision. Write `.to${ptSym.name}` instead."
-              val orig = currentUnit.source.sourceAt(tree.pos)
+              val orig = tree.pos.source.sourceAt(tree.pos)
               context.warning(tree.pos, msg, WarningCategory.Deprecation,
                 runReporting.codeAction("add conversion", tree.pos, s"${CodeAction.maybeWrapInParens(orig)}.to${ptSym.name}", msg))
             } else {
@@ -1191,7 +1191,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                   case Apply(Select(q, nme.DIV), _) if isInt(q) =>
                     val msg = s"integral division is implicitly converted (widened) to floating point. Add an explicit `.to${ptSym.name}`."
                     context.warning(tree.pos, msg, WarningCategory.LintIntDivToFloat,
-                      runReporting.codeAction("add conversion", tree.pos, s"(${currentUnit.source.sourceAt(tree.pos)}).to${ptSym.name}", msg))
+                      runReporting.codeAction("add conversion", tree.pos, s"(${tree.pos.source.sourceAt(tree.pos)}).to${ptSym.name}", msg))
                   case Apply(Select(a1, _), List(a2)) if isInt(tree) && isInt(a1) && isInt(a2) => traverse(a1); traverse(a2)
                   case Select(q, _) if isInt(tree) && isInt(q) => traverse(q)
                   case _ =>
@@ -5040,8 +5040,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
           val action = {
             val etaPos = pos.withEnd(pos.end + 2)
-            if (currentUnit.source.sourceAt(etaPos).endsWith(" _"))
-              runReporting.codeAction("replace by function literal", etaPos, s"() => ${currentUnit.source.sourceAt(pos)}", msg)
+            if (pos.source.sourceAt(etaPos).endsWith(" _"))
+              runReporting.codeAction("replace by function literal", etaPos, s"() => ${pos.source.sourceAt(pos)}", msg)
             else Nil
           }
 


### PR DESCRIPTION
Type completion can lead to currentUnit being different from tree.pos.unit.

Test case for https://github.com/scala/bug/issues/12941, fix was in https://github.com/scala/scala/pull/10681.