### PR TITLE
Fix recent regression in implicit search (don't include `inPackagePrefix` in ImplicitInfo equality)

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -300,8 +300,7 @@ trait Implicits extends splain.SplainData {
       case that: ImplicitInfo =>
           this.name == that.name &&
           this.pre =:= that.pre &&
-          this.sym == that.sym &&
-          this.inPackagePrefix == that.inPackagePrefix
+          this.sym == that.sym
       case _ => false
     }
     override def hashCode = {


### PR DESCRIPTION
This lead to some implicit inference failures in the community build.

https://github.com/scala/community-build/pull/1710#issuecomment-1931076681

Follow-up for https://github.com/scala/scala/pull/10621