### PR TITLE
IterableOnce#copyToArray uses helper for count [ci: last-only]

### DIFF
--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -21,6 +21,8 @@ import scala.math.{Numeric, Ordering}
 import scala.reflect.ClassTag
 import scala.runtime.{AbstractFunction1, AbstractFunction2}
 
+import IterableOnce.elemsToCopyToArray
+
 /**
   * A template trait for collections which can be traversed either once only
   * or one or more times.
@@ -264,18 +266,25 @@ object IterableOnce {
   @inline implicit def iterableOnceExtensionMethods[A](it: IterableOnce[A]): IterableOnceExtensionMethods[A] =
     new IterableOnceExtensionMethods[A](it)
 
-  /** Computes the number of elements to copy to an array from a source IterableOnce
-    *
-    * @param srcLen the length of the source collection
-    * @param destLen the length of the destination array
-    * @param start the index in the destination array at which to start copying elements to
-    * @param len the requested number of elements to copy (we may only be able to copy less than this)
-    * @return the number of elements that will be copied to the destination array
-    */
-  @inline private[collection] def elemsToCopyToArray(srcLen: Int, destLen: Int, start: Int, len: Int): Int =
-    math.max(0,
-      math.min(if (start < 0) destLen else destLen - start,
-        math.min(len, srcLen)))
+  /** Computes the number of elements to copy to an array from a source IterableOnce.
+   *
+   *  If `start` is less than zero, it is taken as zero.
+   *  If any of the length inputs is less than zero, the computed result is zero.
+   *
+   *  The result is the smaller of the remaining capacity in the destination and the requested count.
+   *
+   *  @param srcLen the length of the source collection
+   *  @param destLen the length of the destination array
+   *  @param start the index in the destination array at which to start copying elements
+   *  @param len the requested number of elements to copy (we may only be able to copy less than this)
+   *  @return the number of elements that will be copied to the destination array
+   */
+  @inline private[collection] def elemsToCopyToArray(srcLen: Int, destLen: Int, start: Int, len: Int): Int = {
+    val limit = math.min(len, srcLen)
+    val capacity = if (start < 0) destLen else destLen - start
+    val total = math.min(capacity, limit)
+    math.max(0, total)
+  }
 
   /** Calls `copyToArray` on the given collection, regardless of whether or not it is an `Iterable`. */
   @inline private[collection] def copyElemsToArray[A, B >: A](elems: IterableOnce[A],
@@ -988,28 +997,29 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
 
   /** Copies elements to an array, returning the number of elements written.
    *
-   *  Fills the given array `xs` starting at index `start` with values of this $coll.
+   *  Fills the given array `dest` starting at index `start` with values of this $coll.
    *
    *  Copying will stop once either all the elements of this $coll have been copied,
    *  or the end of the array is reached.
    *
-   *  @param  xs     the array to fill.
+   *  @param  dest   the array to fill.
    *  @tparam B      the type of the elements of the array.
    *  @return        the number of elements written to the array
    *
    *  @note    Reuse: $consumesIterator
    */
   @deprecatedOverriding("This should always forward to the 3-arg version of this method", since = "2.13.4")
-  def copyToArray[B >: A](xs: Array[B]): Int = copyToArray(xs, 0, Int.MaxValue)
+  def copyToArray[B >: A](@deprecatedName("xs", since="2.13.17") dest: Array[B]): Int =
+    copyToArray(dest, start = 0, n = Int.MaxValue)
 
   /** Copies elements to an array, returning the number of elements written.
    *
-   *  Fills the given array `xs` starting at index `start` with values of this $coll.
+   *  Fills the given array `dest` starting at index `start` with values of this $coll.
    *
    *  Copying will stop once either all the elements of this $coll have been copied,
    *  or the end of the array is reached.
    *
-   *  @param  xs     the array to fill.
+   *  @param  dest   the array to fill.
    *  @param  start  the starting index of xs.
    *  @tparam B      the type of the elements of the array.
    *  @return        the number of elements written to the array
@@ -1017,33 +1027,40 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
    *  @note    Reuse: $consumesIterator
    */
   @deprecatedOverriding("This should always forward to the 3-arg version of this method", since = "2.13.4")
-  def copyToArray[B >: A](xs: Array[B], start: Int): Int = copyToArray(xs, start, Int.MaxValue)
+  def copyToArray[B >: A](@deprecatedName("xs", since="2.13.17") dest: Array[B], start: Int): Int =
+    copyToArray(dest, start = start, n = Int.MaxValue)
 
-  /** Copy elements to an array, returning the number of elements written.
+  /** Copies elements to an array and returns the number of elements written.
    *
-   *  Fills the given array `xs` starting at index `start` with at most `len` elements of this $coll.
+   *  Fills the given array `dest` starting at index `start` with at most `n` elements of this $coll.
    *
    *  Copying will stop once either all the elements of this $coll have been copied,
-   *  or the end of the array is reached, or `len` elements have been copied.
+   *  or the end of the array is reached, or `n` elements have been copied.
    *
-   *  @param  xs     the array to fill.
+   *  If `start` is less than zero, it is taken as zero.
+   *
+   *  @param  dest   the array to fill.
    *  @param  start  the starting index of xs.
-   *  @param  len    the maximal number of elements to copy.
+   *  @param  n      the maximal number of elements to copy.
    *  @tparam B      the type of the elements of the array.
    *  @return        the number of elements written to the array
    *
    *  @note    Reuse: $consumesIterator
    */
-  def copyToArray[B >: A](xs: Array[B], start: Int, len: Int): Int = {
+  def copyToArray[B >: A](
+    @deprecatedName("xs", since="2.13.17") dest: Array[B],
+    start: Int,
+    @deprecatedName("len", since="2.13.17") n: Int
+  ): Int = {
     val it = iterator
     var i = start
     val srclen = knownSize match {
-      case -1 => xs.length
+      case -1 => dest.length
       case  k => k
     }
-    val end = start + IterableOnce.elemsToCopyToArray(srclen, xs.length, start, len)
+    val end = start + elemsToCopyToArray(srclen, dest.length, start, n)
     while (i < end && it.hasNext) {
-      xs(i) = it.next()
+      dest(i) = it.next()
       i += 1
     }
     i - start

--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -273,7 +273,9 @@ object IterableOnce {
     * @return the number of elements that will be copied to the destination array
     */
   @inline private[collection] def elemsToCopyToArray(srcLen: Int, destLen: Int, start: Int, len: Int): Int =
-    math.max(math.min(math.min(len, srcLen), destLen - start), 0)
+    math.max(0,
+      math.min(if (start < 0) destLen else destLen - start,
+        math.min(len, srcLen)))
 
   /** Calls `copyToArray` on the given collection, regardless of whether or not it is an `Iterable`. */
   @inline private[collection] def copyElemsToArray[A, B >: A](elems: IterableOnce[A],
@@ -1035,7 +1037,11 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
   def copyToArray[B >: A](xs: Array[B], start: Int, len: Int): Int = {
     val it = iterator
     var i = start
-    val end = start + math.min(len, xs.length - start)
+    val srclen = knownSize match {
+      case -1 => xs.length
+      case  k => k
+    }
+    val end = start + IterableOnce.elemsToCopyToArray(srclen, xs.length, start, len)
     while (i < end && it.hasNext) {
       xs(i) = it.next()
       i += 1

--- a/test/junit/scala/collection/IterableTest.scala
+++ b/test/junit/scala/collection/IterableTest.scala
@@ -114,27 +114,42 @@ class IterableTest {
       }
     }
 
-    val far = 100000
-    val l = Iterable.from(Range(0, 100))
-    check(new Array(100), l.copyToArray(_), 100, 0, far)
-    check(new Array(10), l.copyToArray(_), 10, 0, far)
-    check(new Array(100), l.copyToArray(_), 100, 0, 100)
+    def checkUp(basis: IterableOnce[Int]): Unit = {
+      val it = Iterable.from(basis)
+      val far = 100000
 
-    check(new Array(100), l.copyToArray(_, 5), 95, 5, 105)
-    check(new Array(10), l.copyToArray(_, 5), 5, 5, 10)
-    check(new Array(1000), l.copyToArray(_, 5), 100, 5, 105)
+      check(new Array(100), it.copyToArray(_), 100, 0, far)
+      check(new Array(10), it.copyToArray(_), 10, 0, far)
+      check(new Array(100), it.copyToArray(_), 100, 0, 100)
 
-    check(new Array(100), l.copyToArray(_, 5, 50), 50, 5, 55)
-    check(new Array(10), l.copyToArray(_, 5, 50), 5, 5, 10)
-    check(new Array(1000), l.copyToArray(_, 5, 50), 50, 5, 55)
+      check(new Array(100), it.copyToArray(_, 5), 95, 5, 105)
+      check(new Array(10), it.copyToArray(_, 5), 5, 5, 10)
+      check(new Array(1000), it.copyToArray(_, 5), 100, 5, 105)
 
-    assertThrows[ArrayIndexOutOfBoundsException](l.copyToArray(new Array(10), -1))
-    assertThrows[ArrayIndexOutOfBoundsException](l.copyToArray(new Array(10), -1, 10))
-    assertEquals(0, l.copyToArray(new Array(10), 1, -1))
+      check(new Array(100), it.copyToArray(_, 5, 50), 50, 5, 55)
+      check(new Array(10), it.copyToArray(_, 5, 50), 5, 5, 10)
+      check(new Array(1000), it.copyToArray(_, 5, 50), 50, 5, 55)
 
-    check(new Array(10), l.copyToArray(_, 10), 0, 0, 0)
-    check(new Array(10), l.copyToArray(_, 10, 10), 0, 0, 0)
-    check(new Array(10), l.copyToArray(_, 0, -1), 0, 0, 0)
+      // bad start index throws if n >= 0
+      assertThrows[ArrayIndexOutOfBoundsException](it.copyToArray(new Array(10), -1))
+      assertThrows[ArrayIndexOutOfBoundsException](it.copyToArray(new Array(10), -1, 10))
+      assertEquals(0, it.copyToArray(new Array(10), 1, -1))
+
+      check(new Array(10), it.copyToArray(_, 10), 0, 0, 0)
+      check(new Array(10), it.copyToArray(_, 10, 10), 0, 0, 0)
+      check(new Array(10), it.copyToArray(_, 0, -1), 0, 0, 0)
+
+      // bad start index is ignored if n < 0
+      check(new Array(10), it.copyToArray(_, -1, -1), 0, 0, 0)
+      check(new Array(10), it.copyToArray(_, Int.MinValue, -1), 0, 0, 0)
+
+      // also if destination is empty
+      check(new Array(0), it.copyToArray(_, 10, 10), 0, 0, 0)
+      check(new Array(0), it.copyToArray(_, Int.MinValue, -1), 0, 0, 0)
+    }
+    checkUp(Range(0, 100))
+    checkUp(List.range(0, 100))
+    checkUp(Vector.range(0, 100))
   }
 
   @Test @nowarn("cat=deprecation")

--- a/test/junit/scala/collection/IterableTest.scala
+++ b/test/junit/scala/collection/IterableTest.scala
@@ -95,9 +95,9 @@ class IterableTest {
   }
 
   @Test def copyToArray(): Unit = {
-    def check(a: Array[Int], copyToArray: Array[Int] => Int, elemsWritten: Int, start: Int, end: Int) = {
+    def check(a: Array[Int], copyToArray: Array[Int] => Int)(n: Int)(start: Int, end: Int) = {
 
-      assertEquals(elemsWritten, copyToArray(a))
+      assertEquals(n, copyToArray(a))
 
       var i = 0
       while (i < start) {
@@ -118,34 +118,35 @@ class IterableTest {
       val it = Iterable.from(basis)
       val far = 100000
 
-      check(new Array(100), it.copyToArray(_), 100, 0, far)
-      check(new Array(10), it.copyToArray(_), 10, 0, far)
-      check(new Array(100), it.copyToArray(_), 100, 0, 100)
+      check(new Array(100), it.copyToArray(_))(100)(0, far)
+      check(new Array(10), it.copyToArray(_))(10)(0, far)
+      check(new Array(100), it.copyToArray(_))(100)(0, 100)
 
-      check(new Array(100), it.copyToArray(_, 5), 95, 5, 105)
-      check(new Array(10), it.copyToArray(_, 5), 5, 5, 10)
-      check(new Array(1000), it.copyToArray(_, 5), 100, 5, 105)
+      check(new Array(100), it.copyToArray(_, 5))(95)(5, 105)
+      check(new Array(10), it.copyToArray(_, 5))(5)(5, 10)
+      check(new Array(1000), it.copyToArray(_, 5))(100)(5, 105)
 
-      check(new Array(100), it.copyToArray(_, 5, 50), 50, 5, 55)
-      check(new Array(10), it.copyToArray(_, 5, 50), 5, 5, 10)
-      check(new Array(1000), it.copyToArray(_, 5, 50), 50, 5, 55)
+      check(new Array(100), it.copyToArray(_, 5, 50))(50)(5, 55)
+      check(new Array(10), it.copyToArray(_, 5, 50))(5)(5, 10)
+      check(new Array(1000), it.copyToArray(_, 5, 50))(50)(5, 55)
 
-      // bad start index throws if n >= 0
-      assertThrows[ArrayIndexOutOfBoundsException](it.copyToArray(new Array(10), -1))
-      assertThrows[ArrayIndexOutOfBoundsException](it.copyToArray(new Array(10), -1, 10))
-      assertEquals(0, it.copyToArray(new Array(10), 1, -1))
+      // bad start index throws if n > 0
+      assertThrows[ArrayIndexOutOfBoundsException](it.copyToArray(new Array(10), start = -1))
+      assertThrows[ArrayIndexOutOfBoundsException](it.copyToArray(new Array(10), start = -1, n = 10))
+      check(new Array(10), it.copyToArray(_, start = -1, n = 0))(0)(0, 0)
+      check(new Array(10), it.copyToArray(_, start = 1, n = -1))(0)(0, 0)
 
-      check(new Array(10), it.copyToArray(_, 10), 0, 0, 0)
-      check(new Array(10), it.copyToArray(_, 10, 10), 0, 0, 0)
-      check(new Array(10), it.copyToArray(_, 0, -1), 0, 0, 0)
+      check(new Array(10), it.copyToArray(_, 10))(0)(0, 0)
+      check(new Array(10), it.copyToArray(_, 10, 10))(0)(0, 0)
+      check(new Array(10), it.copyToArray(_, 0, -1))(0)(0, 0)
 
       // bad start index is ignored if n < 0
-      check(new Array(10), it.copyToArray(_, -1, -1), 0, 0, 0)
-      check(new Array(10), it.copyToArray(_, Int.MinValue, -1), 0, 0, 0)
+      check(new Array(10), it.copyToArray(_, -1, -1))(0)(0, 0)
+      check(new Array(10), it.copyToArray(_, Int.MinValue, -1))(0)(0, 0)
 
       // also if destination is empty
-      check(new Array(0), it.copyToArray(_, 10, 10), 0, 0, 0)
-      check(new Array(0), it.copyToArray(_, Int.MinValue, -1), 0, 0, 0)
+      check(new Array(0), it.copyToArray(_, 10, 10))(0)(0, 0)
+      check(new Array(0), it.copyToArray(_, Int.MinValue, -1))(0)(0, 0)
     }
     checkUp(Range(0, 100))
     checkUp(List.range(0, 100))

--- a/test/junit/scala/collection/IterableTest.scala
+++ b/test/junit/scala/collection/IterableTest.scala
@@ -97,19 +97,19 @@ class IterableTest {
   @Test def copyToArray(): Unit = {
     def check(a: Array[Int], copyToArray: Array[Int] => Int, elemsWritten: Int, start: Int, end: Int) = {
 
-      assertEquals(copyToArray(a), elemsWritten)
+      assertEquals(elemsWritten, copyToArray(a))
 
       var i = 0
       while (i < start) {
-        assertEquals(a(i),0)
+        assertEquals(0, a(i))
         i += 1
       }
       while (i < a.length && i < end) {
-        assertEquals(a(i), i - start)
+        assertEquals(i - start, a(i))
         i += 1
       }
       while (i < a.length) {
-        assertEquals(a(i), 0)
+        assertEquals(0, a(i))
         i += 1
       }
     }
@@ -128,9 +128,9 @@ class IterableTest {
     check(new Array(10), l.copyToArray(_, 5, 50), 5, 5, 10)
     check(new Array(1000), l.copyToArray(_, 5, 50), 50, 5, 55)
 
-    assertThrows[ArrayIndexOutOfBoundsException]( l.copyToArray(new Array(10), -1))
-    assertThrows[ArrayIndexOutOfBoundsException]( l.copyToArray(new Array(10), -1, 10))
-    assertEquals(l.copyToArray(new Array(10), 1, -1), 0)
+    assertThrows[ArrayIndexOutOfBoundsException](l.copyToArray(new Array(10), -1))
+    assertThrows[ArrayIndexOutOfBoundsException](l.copyToArray(new Array(10), -1, 10))
+    assertEquals(0, l.copyToArray(new Array(10), 1, -1))
 
     check(new Array(10), l.copyToArray(_, 10), 0, 0, 0)
     check(new Array(10), l.copyToArray(_, 10, 10), 0, 0, 0)

--- a/test/junit/scala/collection/immutable/ArraySeqTest.scala
+++ b/test/junit/scala/collection/immutable/ArraySeqTest.scala
@@ -64,12 +64,12 @@ class ArraySeqTest {
   def safeToArray(): Unit = {
     val a = ArraySeq(1,2,3)
     a.toArray.update(0, 100)
-    assertEquals(a, List(1,2,3))
+    assertEquals(List(1,2,3), a)
   }
   @Test
   def copyToArrayReturnsNonNegative(): Unit = {
     val a = ArraySeq(1,2,3)
-    assertEquals(a.copyToArray(Array(1,1,2), 0, -1), 0)
+    assertEquals(0, a.copyToArray(Array(1,1,2), 0, -1))
   }
 
   private def check[T : ClassTag](array: ArraySeq[T], expectedSliceResult1: ArraySeq[T], expectedSliceResult2: ArraySeq[T]): Unit = {
@@ -98,8 +98,8 @@ class ArraySeqTest {
   }
 
   private def assertArraySeqAndType[A](actual: ArraySeq[A], expect: ArraySeq[A], expectedArrayType: Class[_]): Unit = {
-    assertEquals(actual, expect)
-    assertEquals(actual.unsafeArray.getClass(), expectedArrayType)
+    assertEquals(expect, actual)
+    assertEquals(expectedArrayType, actual.unsafeArray.getClass())
   }
 
   @Test


### PR DESCRIPTION
Don't throw (index out of bounds) when there is no runtime work (destination is zero length or count <= 0).

Audited implementations but did not boost the test coverage much.

Fixes scala/bug#12948