### PR TITLE
Align tasty file lookup with dotty, add test case

### DIFF
--- a/src/compiler/scala/tools/nsc/classpath/DirectoryClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/DirectoryClassPath.scala
@@ -334,7 +334,7 @@ case class DirectoryClassPath(dir: File) extends JFileDirectoryLookup[ClassFileE
 
   protected def createFileEntry(file: AbstractFile): ClassFileEntryImpl = ClassFileEntryImpl(file)
   protected def isMatchingFile(f: File, siblingExists: String => Boolean): Boolean =
-    f.isClass && !(f.getName.endsWith(".class") && siblingExists(f.getName.dropRight(6) + ".tasty"))
+    f.isClass && !(f.getName.endsWith(".class") && siblingExists(classNameToTasty(f.getName)))
 
   private[nsc] def classes(inPackage: PackageName): Seq[ClassFileEntry] = files(inPackage)
 }

--- a/src/compiler/scala/tools/nsc/classpath/FileUtils.scala
+++ b/src/compiler/scala/tools/nsc/classpath/FileUtils.scala
@@ -77,9 +77,9 @@ object FileUtils {
     )
     val className =
       if (isStandaloneObjectHeuristic)
-        fileName.dropRight(7)
+        fileName.stripSuffix("$.class")
       else
-        fileName.dropRight(6)
+        fileName.stripSuffix(".class")
     className + SUFFIX_TASTY
   }
 

--- a/src/compiler/scala/tools/nsc/classpath/FileUtils.scala
+++ b/src/compiler/scala/tools/nsc/classpath/FileUtils.scala
@@ -58,6 +58,31 @@ object FileUtils {
 
   @inline private def ends (filename:String, suffix:String) = filename.endsWith(suffix) && filename.length > suffix.length
 
+  def classNameToTasty(fileName: String): String = {
+    // TODO [tasty]: Dotty really wants to special-case standalone objects
+    // i.e. their classfile will end with `$`, but the tasty file will not.
+    //   however then it needs to escape `Null$`, `Nothing$`, and `$`
+    //   because these are "legitimate" classes with `$` in their name.
+    // It seems its not actually necessary to drop these files,
+    //   as the classfile parser will not complain about them,
+    //   however, it could increase efficiency to follow dotty
+    //   and drop them anyway.
+    // Scala 3 also prevents compilation of `object Foo` and `class Foo$` in the same package
+    // See test/tasty/run/src-2/tastytest/TestRuntimeSpecialClasses.scala for a test case
+    val isStandaloneObjectHeuristic = (
+      fileName.lastIndexOf('$') == fileName.length - 7
+        && fileName != "Null$.class"
+        && fileName != "Nothing$.class"
+        && fileName != "$.class"
+    )
+    val className =
+      if (isStandaloneObjectHeuristic)
+        fileName.dropRight(7)
+      else
+        fileName.dropRight(6)
+    className + SUFFIX_TASTY
+  }
+
   def endsClass(fileName: String): Boolean =
     ends (fileName, SUFFIX_CLASS) || fileName.endsWith(SUFFIX_SIG) || fileName.endsWith(SUFFIX_TASTY)
 

--- a/src/compiler/scala/tools/nsc/classpath/VirtualDirectoryClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/VirtualDirectoryClassPath.scala
@@ -50,5 +50,5 @@ case class VirtualDirectoryClassPath(dir: VirtualDirectory) extends ClassPath wi
 
   protected def createFileEntry(file: AbstractFile): ClassFileEntryImpl = ClassFileEntryImpl(file)
   protected def isMatchingFile(f: AbstractFile, siblingExists: String => Boolean): Boolean =
-    f.isClass && !(f.hasExtension("class") && siblingExists(f.name.dropRight(6) + ".tasty"))
+    f.isClass && !(f.hasExtension("class") && siblingExists(classNameToTasty(f.name)))
 }

--- a/src/compiler/scala/tools/nsc/classpath/ZipAndJarFileLookupFactory.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ZipAndJarFileLookupFactory.scala
@@ -74,7 +74,7 @@ object ZipAndJarClassPathFactory extends ZipAndJarFileLookupFactory {
 
     override protected def createFileEntry(file: FileZipArchive#Entry): ClassFileEntryImpl = ClassFileEntryImpl(file)
     override protected def isRequiredFileType(file: AbstractFile, siblingExists: String => Boolean): Boolean = {
-      file.isClass && !(file.hasExtension("class") && siblingExists(file.name.dropRight(6) + ".tasty"))
+      file.isClass && !(file.hasExtension("class") && siblingExists(classNameToTasty(file.name)))
     }
   }
 

--- a/test/tasty/run/src-2/tastytest/TestRuntimeSpecialClasses.scala
+++ b/test/tasty/run/src-2/tastytest/TestRuntimeSpecialClasses.scala
@@ -4,7 +4,7 @@ object TestRuntimeSpecialClasses extends Suite("TestRuntimeSpecialClasses") {
   test("consume standalone top-level object") {
     assert(new tastytest.Null$().res.head === 23)
     assert(new tastytest.Nothing$().res.head === 23)
-    assert(new tastytest.$().res.head === 23)
+    assert($.res.head === 23)
     assert(StandaloneObject.res.head === 23)
   }
 }

--- a/test/tasty/run/src-2/tastytest/TestRuntimeSpecialClasses.scala
+++ b/test/tasty/run/src-2/tastytest/TestRuntimeSpecialClasses.scala
@@ -1,0 +1,10 @@
+package tastytest
+
+object TestRuntimeSpecialClasses extends Suite("TestRuntimeSpecialClasses") {
+  test("consume standalone top-level object") {
+    assert(new tastytest.Null$().res.head === 23)
+    assert(new tastytest.Nothing$().res.head === 23)
+    assert(new tastytest.$().res.head === 23)
+    assert(StandaloneObject.res.head === 23)
+  }
+}

--- a/test/tasty/run/src-3/tastytest/RuntimeSpecialClasses.scala
+++ b/test/tasty/run/src-3/tastytest/RuntimeSpecialClasses.scala
@@ -1,17 +1,22 @@
 package tastytest
 
+// makes Null$.class, and Null$.tasty
 class Null$ {
   def res: List[Int] = List(23)
 }
 
+// makes Nothing$.class, and Nothing$.tasty
 class Nothing$ {
   def res: List[Int] = List(23)
+
 }
 
-class $ {
+// makes $$.class, $.class, and $.tasty
+object $ {
   def res: List[Int] = List(23)
 }
 
+// makes StandaloneObject$.class, StandaloneObject.class, and StandaloneObject.tasty
 object StandaloneObject {
   def res: List[Int] = List(23)
 }

--- a/test/tasty/run/src-3/tastytest/RuntimeSpecialClasses.scala
+++ b/test/tasty/run/src-3/tastytest/RuntimeSpecialClasses.scala
@@ -1,0 +1,17 @@
+package tastytest
+
+class Null$ {
+  def res: List[Int] = List(23)
+}
+
+class Nothing$ {
+  def res: List[Int] = List(23)
+}
+
+class $ {
+  def res: List[Int] = List(23)
+}
+
+object StandaloneObject {
+  def res: List[Int] = List(23)
+}


### PR DESCRIPTION
it seems this is not strictly necessary to prevent errors, it just aligns with what dotty does and I guess prunes more files