### PR TITLE
fix `scala` task in our sbt build so REPL has JLine features again

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -597,6 +597,7 @@ lazy val replFrontend = configureAsSubproject(project, srcdir = Some("repl-front
   .settings(
     run := (Compile / run).partialInput(" -usejavacp").evaluated, // so `replFrontend/run` works
     Compile / run / javaOptions += s"-Dscala.color=${!scala.util.Properties.isWin}",
+    Compile / run / javaOptions += "-Dorg.jline.terminal.output=forced-out",
   )
   .dependsOn(repl)
 


### PR DESCRIPTION
fixes scala/scala-dev#755 (mostly, see remarks below)

references jline/jline3#884

mergeable for 2.13.13, and labeled "internal", because it doesn't affect end users, only contributors