### PR TITLE
sbt 1.9.9 (was .8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
-# `-Dsbt.io.jdktimestamps=true` is used to work around
-# this bug in sbt 1.9.8: https://github.com/sbt/sbt/issues/7463
-# we can remove it once we're on an sbt version with a fix.
-
 version: ~> 1.0 # needed for imports
 
 import: scala/scala-dev:travis/default.yml
@@ -44,9 +40,9 @@ jobs:
         name: "JDK 8 pr validation"
         if: type = pull_request
         script:
-          - sbt -Dsbt.io.jdktimestamps=true -warn setupPublishCore generateBuildCharacterPropertiesFile headerCheck publishLocal
+          - sbt -warn setupPublishCore generateBuildCharacterPropertiesFile headerCheck publishLocal
           - STARR=`cat buildcharacter.properties | grep ^maven.version.number | cut -d= -f2` && echo $STARR
-          - sbt -Dsbt.io.jdktimestamps=true -Dstarr.version=$STARR -warn setupValidateTest test:compile info testAll
+          - sbt -Dstarr.version=$STARR -warn setupValidateTest test:compile info testAll
 
       # build the spec using jekyll
       - stage: build

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.8
+sbt.version=1.9.9

--- a/scripts/common
+++ b/scripts/common
@@ -17,9 +17,7 @@ mkdir -p "$WORKSPACE/resolutionScratch_"
 SBT_VERSION=`grep sbt.version $WORKSPACE/project/build.properties | sed -n 's/sbt.version=\(.*\)/\1/p'`
 
 SBT_CMD=${SBT_CMD-sbt}
-# the jdktimestamps thing is to work around https://github.com/sbt/sbt/issues/7463 --
-# it can be removed again once we're on an sbt version with a fix
-SBT_CMD="$SBT_CMD -Dsbt.io.jdktimestamps=true -sbt-version $SBT_VERSION"
+SBT_CMD="$SBT_CMD -sbt-version $SBT_VERSION"
 
 # repo to publish builds
 integrationRepoUrl=${integrationRepoUrl-"https://scala-ci.typesafe.com/artifactory/scala-integration/"}


### PR DESCRIPTION
and remove now-unnecessary workaround from build

I should merge this forward onto 2.13.x promptly.