### PR TITLE
Fix 2.13.13 regression in Scaladoc compilation when using Scala 3 definitions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -712,7 +712,7 @@ lazy val partest = configureAsSubproject(project)
   )
 
 lazy val tastytest = configureAsSubproject(project)
-  .dependsOn(library, reflect, compiler)
+  .dependsOn(library, reflect, compiler, scaladoc)
   .settings(disableDocs)
   .settings(fatalWarningsSettings)
   .settings(publish / skip := true)

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -173,7 +173,7 @@ abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
           AnyRefClass
 
           val bytes = in.buf.take(file.sizeOption.get)
-          TastyUnpickler.unpickle(TastyUniverse)(bytes, clazz, staticModule, file.path.stripSuffix(".class") + ".tasty")
+          TastyUnpickler.unpickle(TastyUniverse)(bytes, clazz, staticModule, file.path)
         } else {
           parseHeader()
           this.pool = new ConstantPool

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -2635,7 +2635,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       if (
         (file eq NoAbstractFile) || {
           val path = file.path
-          path.endsWith(".class") || path.endsWith(".sig")
+          path.endsWith(".class") || path.endsWith(".sig") || path.endsWith(".tasty")
         }) null else file
     }
 

--- a/src/tastytest/scala/tools/tastytest/Scaladoc.scala
+++ b/src/tastytest/scala/tools/tastytest/Scaladoc.scala
@@ -1,0 +1,76 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.tools.tastytest
+
+import scala.collection.immutable.ArraySeq
+import scala.util.{ Try, Success, chaining }, chaining._
+import scala.tools.nsc.{ reporters}, reporters.{Reporter, ConsoleReporter}
+import java.io.OutputStream
+import java.io.PrintWriter
+
+import scala.tools.nsc.{ScalaDoc => RealScaladoc, doc}
+import scala.reflect.internal.util.NoPosition
+
+object Scaladoc extends Script.Command {
+
+  def scaladoc(out: String, additionalSettings: Seq[String], sources: String*): Try[Boolean] =
+    scaladoc(Console.out, out, additionalSettings, sources:_*)
+
+  def scaladoc(writer: OutputStream, out: String, additionalSettings: Seq[String], sources: String*) = {
+
+    def setup(args: Seq[String]): (Reporter, doc.Settings, RealScaladoc.Command) = {
+      lazy val (reporter: Reporter, docSettings) = {
+        val docSettings = new doc.Settings(msg => reporter.error(NoPosition, msg), msg => reporter.echo(msg))
+        val pwriter = new PrintWriter(writer, true)
+        (new ConsoleReporter(docSettings, Console.in, pwriter).tap(_.shortname = true), docSettings)
+      }
+      (reporter, docSettings, new RealScaladoc.Command(args.toList, docSettings))
+    }
+
+    def compile(args: String*): Try[Boolean] = {
+      val (reporter, docSettings, command) = setup(args)
+      Try {
+        assert(command.files.nonEmpty, "no files to compile")
+        try { new doc.DocFactory(reporter, docSettings).document(command.files) }
+        finally reporter.finish()
+      }.map(_ => !reporter.hasErrors)
+    }
+
+    if (sources.isEmpty) {
+      Success(true)
+    }
+    else {
+      val settings = Array(
+        "-d", out,
+        "-classpath", out,
+        "-deprecation",
+        "-Xfatal-warnings",
+        "-usejavacp"
+      ) ++ additionalSettings ++ sources
+      compile(ArraySeq.unsafeWrapArray(settings):_*)
+    }
+  }
+
+  val commandName: String = "scaladoc"
+  val describe: String = s"$commandName <out: Directory> <src: File> <args: String*>"
+
+  def process(args: String*): Int = {
+    if (args.length < 2) {
+      println(red(s"please provide at least 2 arguments in sub-command: $describe"))
+      return 1
+    }
+    val Seq(out, src, additionalArgs @ _*) = args: @unchecked
+    val success = scaladoc(out, additionalArgs, src).get
+    if (success) 0 else 1
+  }
+}

--- a/test/tasty/pos-doctool/src-2/app/Main.scala
+++ b/test/tasty/pos-doctool/src-2/app/Main.scala
@@ -1,0 +1,8 @@
+package app
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    println(testlib.ADT.SingletonCase)
+    println(testlib.ADT.ClassCase("foo"))
+  }
+}

--- a/test/tasty/pos-doctool/src-3/testlib/ADT.scala
+++ b/test/tasty/pos-doctool/src-3/testlib/ADT.scala
@@ -1,0 +1,5 @@
+package testlib
+
+enum ADT:
+  case SingletonCase
+  case ClassCase(x: String)

--- a/test/tasty/test/scala/tools/tastytest/TastyTestJUnit.scala
+++ b/test/tasty/test/scala/tools/tastytest/TastyTestJUnit.scala
@@ -51,6 +51,15 @@ class TastyTestJUnit {
     additionalDottySettings = Nil
   ).eval
 
+  @test def posDoctool(): Unit = TastyTest.posDocSuite(
+    src                     = "pos-doctool",
+    srcRoot                 = assertPropIsSet(propSrc),
+    pkgName                 = assertPropIsSet(propPkgName),
+    outDir                  = None,
+    additionalSettings      = Nil,
+    additionalDottySettings = Nil
+  ).eval
+
   @test def neg(): Unit = TastyTest.negSuite(
     src                     = "neg",
     srcRoot                 = assertPropIsSet(propSrc),


### PR DESCRIPTION
`.tasty` files are no longer considered source files of a symbol.

Specifically the behavior observed in https://github.com/scala/bug/issues/12955 is caused by the top level class `scala.deriving.Mirror` not being filtered out from generating a doc page, because the `sourceFile` property on the Symbol wasn't null (i.e. it returned a ".tasty" file)

fixes https://github.com/scala/bug/issues/12955