### PR TITLE
Restore dot file output in PhaseAssembly

### DIFF
--- a/src/compiler/scala/tools/nsc/PhaseAssembly.scala
+++ b/src/compiler/scala/tools/nsc/PhaseAssembly.scala
@@ -261,13 +261,16 @@ trait PhaseAssembly {
       def color(hex: String)  = s""" [color="#$hex"]"""
       def node(n: graph.Node) = s""""${n.allPhaseNames}(${n.level})""""
 
+      val buf = mutable.ListBuffer.empty[String]
+      buf += "digraph G {"
+      buf ++= edges.map(e => s"${node(e.frm)}->${node(e.to)}" + color(if (e.hard) "0000ff" else "000000"))
+      buf ++= extnodes.distinct.map(n => node(n) + color("00ff00"))
+      buf ++= fatnodes.distinct.map(n => node(n) + color("0000ff"))
+      buf += "}"
+
       import scala.reflect.io._
       val f = Path(d.file) / File(filename)
-      f.printlnAll("digraph G {")
-      f.printlnAll(edges.map(e => s"${node(e.frm)}->${node(e.to)}" + color(if (e.hard) "0000ff" else "000000")): _*)
-      f.printlnAll(extnodes.distinct.map(n => node(n) + color("00ff00")): _*)
-      f.printlnAll(fatnodes.distinct.map(n => node(n) + color("0000ff")): _*)
-      f.printlnAll("}")
+      f.printlnAll(buf.toList: _*)
     }
   }
 }

--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -216,7 +216,7 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
     add(new MultiChoiceSetting[E](name, helpArg, descr, domain, default))
   def OutputSetting(default: String) = add(new OutputSetting(default))
   def PhasesSetting(name: String, descr: String, default: String = "") = add(new PhasesSetting(name, descr, default))
-  def StringSetting(name: String, arg: String, descr: String, default: String, helpText: Option[String] = None) = add(new StringSetting(name, arg, descr, default, helpText))
+  def StringSetting(name: String, arg: String, descr: String, default: String = "", helpText: Option[String] = None) = add(new StringSetting(name, arg, descr, default, helpText))
   def ScalaVersionSetting(name: String, arg: String, descr: String, initial: ScalaVersion, default: Option[ScalaVersion] = None, helpText: Option[String] = None) =
     add(new ScalaVersionSetting(name, arg, descr, initial, default, helpText))
   def PathSetting(name: String, descr: String, default: String): PathSetting = {

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -95,7 +95,7 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
   val elidebelow         = IntSetting          ("-Xelide-below", "Calls to @elidable methods are omitted if method priority is lower than argument",
                                                 elidable.MINIMUM, None, elidable.byName get _)
   val noForwarders       = BooleanSetting      ("-Xno-forwarders", "Do not generate static forwarders in mirror classes.")
-  val genPhaseGraph      = StringSetting       ("-Xgenerate-phase-graph", "file", "Generate the phase graphs (outputs .dot files) to fileX.dot.", "")
+  val genPhaseGraph      = StringSetting       ("-Vphase-graph", arg="file", descr="Generate phase graph to <file>-*.dot.").withAbbreviation("-Xgenerate-phase-graph")
   val maxerrs            = IntSetting          ("-Xmaxerrs", "Maximum errors to print", 100, None, _ => None)
   val maxwarns           = IntSetting          ("-Xmaxwarns", "Maximum warnings to print", 100, None, _ => None)
   val Xmigration         = ScalaVersionSetting ("-Xmigration", "version", "Warn about constructs whose behavior may have changed since version.", initial = NoScalaVersion, default = Some(AnyScalaVersion))

--- a/src/manual/scala/man1/scalac.scala
+++ b/src/manual/scala/man1/scalac.scala
@@ -206,7 +206,7 @@ object scalac extends Command {
           CmdOption("Xfull-lubs"),
           "Retain pre 2.10 behavior of less aggressive truncation of least upper bounds."),
         Definition(
-          CmdOption("Xgenerate-phase-graph", Argument("file")),
+          CmdOption("Vphase-graph", Argument("file")),
           "Generate the phase graphs (outputs .dot files) to fileX.dot."),
         Definition(
           CmdOption("Xlint"),


### PR DESCRIPTION
Fixes scala/bug#12959

Conflicts with rewrite of this file, but if this gets merged then it's easier to test any changes to working functionality.

Obviously, there is no automated test.