### PR TITLE
Rename `-Xlint:named-booleans` to `-Wunnamed-boolean-literal` (and no longer include it in `-Xlint`)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -169,6 +169,7 @@ lazy val commonSettings = instanceSettings ++ clearSourceAndResourceDirectories 
     "-Wconf:cat=optimizer:is",
     // we use @nowarn for methods that are deprecated in JDK > 8, but CI/release is under JDK 8
     "-Wconf:cat=unused-nowarn:s",
+    //"-Wunnamed-boolean-literal-strict",
     ),
   Compile / doc / scalacOptions ++= Seq(
     "-doc-footer", "epfl",

--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -571,6 +571,7 @@ object Reporting {
         WFlagExtraImplicit,
         WFlagNumericWiden,
         WFlagSelfImplicit,
+        WFlagNamedLiteral,
         WFlagValueDiscard
       = wflag()
 
@@ -623,8 +624,7 @@ object Reporting {
         LintPerformance,
         LintIntDivToFloat,
         LintUniversalMethods,
-        LintNumericMethods,
-        LintNamedBooleans
+        LintNumericMethods
       = lint()
 
     sealed class Feature extends WarningCategory {

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -121,6 +121,8 @@ trait Warnings {
   val warnValueDiscard     = BooleanSetting("-Wvalue-discard", "Warn when non-Unit expression results are unused.") withAbbreviation "-Ywarn-value-discard"
   val warnNumericWiden     = BooleanSetting("-Wnumeric-widen", "Warn when numerics are widened.") withAbbreviation "-Ywarn-numeric-widen"
   val warnOctalLiteral     = BooleanSetting("-Woctal-literal", "Warn on obsolete octal syntax.") withAbbreviation "-Ywarn-octal-literal"
+  val warnNamedLiteral     = BooleanSetting("-Wunnamed-boolean-literal", "Warn about unnamed boolean literals if there is more than one or defaults are used, unless parameter has @deprecatedName.")
+  val warnNamedBoolean     = BooleanSetting("-Wunnamed-boolean-literal-strict", "Warn about all unnamed boolean literals, unless parameter has @deprecatedName or the method has a single leading boolean parameter.").enabling(warnNamedLiteral :: Nil)
 
   object PerformanceWarnings extends MultiChoiceEnumeration {
     val Captured       = Choice("captured",        "Modification of var in closure causes boxing.")
@@ -217,7 +219,6 @@ trait Warnings {
     val NumericMethods         = LintWarning("numeric-methods",           "Dubious usages, such as `42.isNaN`.")
     val ArgDiscard             = LintWarning("arg-discard",               "-Wvalue-discard for adapted arguments.")
     val IntDivToFloat          = LintWarning("int-div-to-float",          "Warn when an integer division is converted (widened) to floating point: `(someInt / 2): Double`.")
-    val NamedBooleans          = LintWarning("named-booleans",            "Boolean literals should be named args unless param is @deprecatedName.")
     val PatternShadow          = LintWarning("pattern-shadow",            "Pattern variable id is also a term in scope.")
     val CloneableObject        = LintWarning("cloneable",                 "Modules (objects) should not be Cloneable.")
 
@@ -256,7 +257,6 @@ trait Warnings {
   def lintNumericMethods         = lint.contains(NumericMethods)
   def lintArgDiscard             = lint.contains(ArgDiscard)
   def lintIntDivToFloat          = lint.contains(IntDivToFloat)
-  def lintNamedBooleans          = lint.contains(NamedBooleans)
   def warnPatternShadow          = lint.contains(PatternShadow)
   def warnCloneableObject        = lint.contains(CloneableObject)
 

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -121,8 +121,8 @@ trait Warnings {
   val warnValueDiscard     = BooleanSetting("-Wvalue-discard", "Warn when non-Unit expression results are unused.") withAbbreviation "-Ywarn-value-discard"
   val warnNumericWiden     = BooleanSetting("-Wnumeric-widen", "Warn when numerics are widened.") withAbbreviation "-Ywarn-numeric-widen"
   val warnOctalLiteral     = BooleanSetting("-Woctal-literal", "Warn on obsolete octal syntax.") withAbbreviation "-Ywarn-octal-literal"
-  val warnNamedLiteral     = BooleanSetting("-Wunnamed-boolean-literal", "Warn about unnamed boolean literals if there is more than one or defaults are used, unless parameter has @deprecatedName.")
-  val warnNamedBoolean     = BooleanSetting("-Wunnamed-boolean-literal-strict", "Warn about all unnamed boolean literals, unless parameter has @deprecatedName or the method has a single leading boolean parameter.").enabling(warnNamedLiteral :: Nil)
+  val warnUnnamedBoolean   = BooleanSetting("-Wunnamed-boolean-literal", "Warn about unnamed boolean literals if there is more than one or defaults are used, unless parameter has @deprecatedName.")
+  val warnUnnamedStrict    = BooleanSetting("-Wunnamed-boolean-literal-strict", "Warn about all unnamed boolean literals, unless parameter has @deprecatedName or the method has a single leading boolean parameter.").enabling(warnUnnamedBoolean :: Nil)
 
   object PerformanceWarnings extends MultiChoiceEnumeration {
     val Captured       = Choice("captured",        "Modification of var in closure causes boxing.")

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1703,6 +1703,7 @@ abstract class RefChecks extends Transform {
 
           transform(qual)
       case Apply(fn, args) =>
+        currentApplication = tree
         // sensicality should be subsumed by the unreachability/exhaustivity/irrefutability
         // analyses in the pattern matcher
         if (!inPattern) {
@@ -1710,13 +1711,14 @@ abstract class RefChecks extends Transform {
           checkSensible(tree.pos, fn, args) // TODO: this should move to preEraseApply, as reasoning about runtime semantics makes more sense in the JVM type system
           checkNamedBooleanArgs(fn, args)
         }
-        currentApplication = tree
         tree
     }
 
     /** Check that boolean literals are passed as named args.
-     *  The rule is enforced when the type of the parameter is `Boolean`.
-     *  The rule is relaxed when the method has exactly one boolean parameter
+     *  The rule is enforced when the type of the parameter is `Boolean`,
+     *  and there is more than one parameter with an unnamed argument.
+     *  The stricter internal lint warns for any unnamed argument,
+     *  except that the rule is relaxed when the method has exactly one boolean parameter
      *  and it is the first parameter, such as `assert(false, msg)`.
      */
     private def checkNamedBooleanArgs(fn: Tree, args: List[Tree]): Unit = {
@@ -1724,26 +1726,52 @@ abstract class RefChecks extends Transform {
       def applyDepth: Int = {
         def loop(t: Tree, d: Int): Int =
           t match {
-            case Apply(f, _) => loop(f, d+1)
+            case Apply(t, _) => loop(t, d+1)
             case _ => d
           }
         loop(fn, 0)
       }
-      def isAssertParadigm(params: List[Symbol]): Boolean = !sym.isConstructor && !sym.isCaseApplyOrUnapply && {
-        params match {
-          case h :: t => h.tpe == BooleanTpe && !t.exists(_.tpe == BooleanTpe)
-          case _ => false
-        }
-      }
-      if (settings.lintNamedBooleans && !sym.isJavaDefined && !args.isEmpty) {
+      if (settings.warnNamedLiteral.value && !sym.isJavaDefined && !args.isEmpty) {
+        def isUnnamedArg(t: Tree) = t.hasAttachment[UnnamedArg.type]
+        def isDefaultArg(t: Tree) = t.symbol != null && (
+          t.symbol.isDefaultGetter || t.symbol.name.startsWith(nme.NAMEDARG_PREFIX) && {
+            analyzer.NamedApplyBlock.namedApplyInfo(currentApplication) match {
+              case Some(analyzer.NamedApplyInfo(_, _, _, _, original)) =>
+                val treeInfo.Applied(_, _, argss) = original
+                val orig = argss.head(t.symbol.name.decoded.stripPrefix(nme.NAMEDARG_PREFIX).toInt - 1)
+                orig.symbol != null && orig.symbol.isDefaultGetter
+              case _ => false
+            }
+          }
+        )
         val params = sym.paramLists(applyDepth)
-        if (!isAssertParadigm(params))
-          foreach2(args, params)((arg, param) => arg match {
-            case Literal(Constant(_: Boolean))
-            if arg.hasAttachment[UnnamedArg.type] && param.tpe.typeSymbol == BooleanClass && !param.deprecatedParamName.contains(nme.NO_NAME) =>
-              runReporting.warning(arg.pos, s"Boolean literals should be passed using named argument syntax for parameter ${param.name}.", WarningCategory.LintNamedBooleans, sym)
-            case _ =>
-          })
+        val numBools = params.count(_.tpe == BooleanTpe)
+        def onlyLeadingBool = numBools == 1 && params.head.tpe == BooleanTpe
+        val checkable = if (settings.warnNamedBoolean.value) numBools > 0 && !onlyLeadingBool else numBools >= 2
+        if (checkable) {
+          val (unnamed, numSuspicious) = args.lazyZip(params).iterator
+            .foldLeft((List.empty[(Tree, Symbol)], 0)) { (acc, ap) =>
+              ap match {
+                case (arg, param) if param.tpe.typeSymbol == BooleanClass && !param.deprecatedParamName.contains(nme.NO_NAME) =>
+                  arg match {
+                    case Literal(Constant(_: Boolean)) =>
+                      if (isUnnamedArg(arg)) (ap :: acc._1, acc._2 + 1) else acc
+                    case _ =>
+                      if (isDefaultArg(arg)) (acc._1, acc._2 + 1) else acc
+                  }
+                case _ => acc
+              }
+            }
+          val warn = !unnamed.isEmpty && (settings.warnNamedBoolean.value || numSuspicious >= 2)
+          if (warn)
+            unnamed.reverse.foreach {
+              case (arg, param) =>
+                val msg = s"Boolean literals should be passed using named argument syntax for parameter ${param.name}."
+                val action = runReporting.codeAction("name boolean literal", arg.pos.focusStart, s"${param.name} = ", msg)
+                runReporting.warning(arg.pos, msg, WarningCategory.WFlagNamedLiteral, sym, action)
+              case _ =>
+            }
+        }
       }
     }
 

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1754,7 +1754,7 @@ abstract class RefChecks extends Transform {
                     h.count {
                       case treeInfo.Applied(getter, _, _) if getter.symbol != null && getter.symbol.isDefaultGetter =>
                         val (_, i) = nme.splitDefaultGetterName(getter.symbol.name)
-                        isNameableBoolean(allParams(i-1))
+                        i > 0 && isNameableBoolean(allParams(i-1))
                       case _ => false
                     }
                   case _ => 0

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3829,7 +3829,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               val fun1 = transformNamedApplication(Typer.this, mode, pt)(fun, x => x)
               if (fun1.isErroneous) duplErrTree
               else {
-                val NamedApplyBlock(NamedApplyInfo(qual, targs, previousArgss, _)) = fun1: @unchecked
+                val NamedApplyBlock(NamedApplyInfo(qual, targs, previousArgss, _, _)) = fun1: @unchecked
                 val blockIsEmpty = fun1 match {
                   case Block(Nil, _) =>
                     // if the block does not have any ValDef we can remove it. Note that the call to

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -551,7 +551,12 @@ trait StdNames {
           case -1  => (name.toTermName, -1)
           case idx => (name.toTermName.take(idx), idx + DEFAULT_GETTER_STRING.length)
         }
-      if (i >= 0) (n, name.encoded.substring(i).toInt) else (n, -1)
+      if (i < 0) (n, -1)
+      else {
+        val j = name.indexOf('$', i) // f$default$7$extension
+        val idx = name.subSequence(i, if (j < 0) name.length else j)
+        (n, idx.toString.toInt)
+      }
     }
 
     def localDummyName(clazz: Symbol): TermName = newTermName(LOCALDUMMY_PREFIX + clazz.name + ">")

--- a/test/files/neg/named-booleans-relaxed.check
+++ b/test/files/neg/named-booleans-relaxed.check
@@ -40,6 +40,12 @@ named-booleans-relaxed.scala:80: warning: Boolean literals should be passed usin
 named-booleans-relaxed.scala:81: warning: Boolean literals should be passed using named argument syntax for parameter reverse. [quickfixable]
   def rev5 = rev(42, true, down=true) // warn, out of order so it's a named block, otherwise same as rev3
                      ^
+named-booleans-relaxed.scala:92: warning: Boolean literals should be passed using named argument syntax for parameter insideIf. [quickfixable]
+  def sus(s: String) = p.needsParentheses(s)(false) // warn
+                                             ^
+named-booleans-relaxed.scala:95: warning: Boolean literals should be passed using named argument syntax for parameter x. [quickfixable]
+  def f = p.f(true, z=42) // warn
+              ^
 error: No warnings can be incurred under -Werror.
-14 warnings
+16 warnings
 1 error

--- a/test/files/neg/named-booleans-relaxed.check
+++ b/test/files/neg/named-booleans-relaxed.check
@@ -46,6 +46,9 @@ named-booleans-relaxed.scala:92: warning: Boolean literals should be passed usin
 named-booleans-relaxed.scala:95: warning: Boolean literals should be passed using named argument syntax for parameter x. [quickfixable]
   def f = p.f(true, z=42) // warn
               ^
+named-booleans-relaxed.scala:106: warning: Boolean literals should be passed using named argument syntax for parameter y. [quickfixable]
+  def w = new V(true).combo(false)
+                            ^
 error: No warnings can be incurred under -Werror.
-16 warnings
+17 warnings
 1 error

--- a/test/files/neg/named-booleans-relaxed.check
+++ b/test/files/neg/named-booleans-relaxed.check
@@ -1,0 +1,45 @@
+named-booleans-relaxed.scala:22: warning: Boolean literals should be passed using named argument syntax for parameter x. [quickfixable]
+  val x0 = c.f(17, true, false) // warn
+                   ^
+named-booleans-relaxed.scala:22: warning: Boolean literals should be passed using named argument syntax for parameter y. [quickfixable]
+  val x0 = c.f(17, true, false) // warn
+                         ^
+named-booleans-relaxed.scala:44: warning: Boolean literals should be passed using named argument syntax for parameter cond. [quickfixable]
+  c.uncheck(false, "OK", true)
+            ^
+named-booleans-relaxed.scala:44: warning: Boolean literals should be passed using named argument syntax for parameter flag. [quickfixable]
+  c.uncheck(false, "OK", true)
+                         ^
+named-booleans-relaxed.scala:63: warning: Boolean literals should be passed using named argument syntax for parameter isKlazz. [quickfixable]
+  def test = Klazz(true, false) // warn case class apply as for ctor
+                   ^
+named-booleans-relaxed.scala:63: warning: Boolean literals should be passed using named argument syntax for parameter isWarnable. [quickfixable]
+  def test = Klazz(true, false) // warn case class apply as for ctor
+                         ^
+named-booleans-relaxed.scala:71: warning: Boolean literals should be passed using named argument syntax for parameter up. [quickfixable]
+  def g3 = f(42, false) // warn, unnamed could mean either param with default
+                 ^
+named-booleans-relaxed.scala:72: warning: Boolean literals should be passed using named argument syntax for parameter up. [quickfixable]
+  def g4 = f(42, false, true) // warn, swappable
+                 ^
+named-booleans-relaxed.scala:72: warning: Boolean literals should be passed using named argument syntax for parameter down. [quickfixable]
+  def g4 = f(42, false, true) // warn, swappable
+                        ^
+named-booleans-relaxed.scala:79: warning: Boolean literals should be passed using named argument syntax for parameter up. [quickfixable]
+  def rev3 = rev(42, reverse=true, false) // warn, unnamed could mean either param with default
+                                   ^
+named-booleans-relaxed.scala:80: warning: Boolean literals should be passed using named argument syntax for parameter reverse. [quickfixable]
+  def rev4 = rev(42, false, true, false) // warn, swappable
+                     ^
+named-booleans-relaxed.scala:80: warning: Boolean literals should be passed using named argument syntax for parameter up. [quickfixable]
+  def rev4 = rev(42, false, true, false) // warn, swappable
+                            ^
+named-booleans-relaxed.scala:80: warning: Boolean literals should be passed using named argument syntax for parameter down. [quickfixable]
+  def rev4 = rev(42, false, true, false) // warn, swappable
+                                  ^
+named-booleans-relaxed.scala:81: warning: Boolean literals should be passed using named argument syntax for parameter reverse. [quickfixable]
+  def rev5 = rev(42, true, down=true) // warn, out of order so it's a named block, otherwise same as rev3
+                     ^
+error: No warnings can be incurred under -Werror.
+14 warnings
+1 error

--- a/test/files/neg/named-booleans-relaxed.scala
+++ b/test/files/neg/named-booleans-relaxed.scala
@@ -80,3 +80,19 @@ class Defaulting {
   def rev4 = rev(42, false, true, false) // warn, swappable
   def rev5 = rev(42, true, down=true) // warn, out of order so it's a named block, otherwise same as rev3
 }
+
+class Printers {
+  def needsParentheses(parent: String)(insideIf: Boolean = true, insideMatch: Boolean = true, insideTry: Boolean = true, insideAnnotated: Boolean = true, insideBlock: Boolean = true, insideLabelDef: Boolean = true, insideAssign: Boolean = true): Boolean = true
+
+  def f(x: Boolean, y: String = "hi", z: Int = 2, b: Boolean = false) = if (x && b) y+z else y*z
+}
+object TestPrinters {
+  val p = new Printers
+  def ok(s: String) = p.needsParentheses(s)(insideLabelDef = false)
+  def sus(s: String) = p.needsParentheses(s)(false) // warn
+  def pick(s: String) = p.needsParentheses(s)(true, insideAssign=false, insideLabelDef=false, insideBlock=false, insideAnnotated=false, insideTry=false, insideMatch=false)
+
+  def f = p.f(true, z=42) // warn
+  def g = p.f(x=true, b=true) // nowarn, no unnamed
+  def h = p.f(true, b=true) // nowarn, one unnamed but other boolean is named; defaults are non-boolean
+}

--- a/test/files/neg/named-booleans-relaxed.scala
+++ b/test/files/neg/named-booleans-relaxed.scala
@@ -96,3 +96,12 @@ object TestPrinters {
   def g = p.f(x=true, b=true) // nowarn, no unnamed
   def h = p.f(true, b=true) // nowarn, one unnamed but other boolean is named; defaults are non-boolean
 }
+
+object Testy {
+  class V(val x: Boolean) extends AnyVal {
+    def combo(y: Boolean = true, z: Boolean = false) = x&&y&&z
+  }
+
+  def v = new V(true)
+  def w = new V(true).combo(false)
+}

--- a/test/files/neg/named-booleans.check
+++ b/test/files/neg/named-booleans.check
@@ -1,21 +1,30 @@
-named-booleans.scala:22: warning: Boolean literals should be passed using named argument syntax for parameter x.
+named-booleans.scala:22: warning: Boolean literals should be passed using named argument syntax for parameter x. [quickfixable]
   val x0 = c.f(17, true, b) // warn
                    ^
-named-booleans.scala:38: warning: Boolean literals should be passed using named argument syntax for parameter b.
+named-booleans.scala:38: warning: Boolean literals should be passed using named argument syntax for parameter b. [quickfixable]
   val ss = c.fs(42)("hello", true)
                              ^
-named-booleans.scala:39: warning: Boolean literals should be passed using named argument syntax for parameter b.
+named-booleans.scala:39: warning: Boolean literals should be passed using named argument syntax for parameter b. [quickfixable]
   val tt = c.gs(42)("hello", true)
                              ^
-named-booleans.scala:44: warning: Boolean literals should be passed using named argument syntax for parameter cond.
+named-booleans.scala:44: warning: Boolean literals should be passed using named argument syntax for parameter cond. [quickfixable]
   c.uncheck(false, "OK", true)
             ^
-named-booleans.scala:44: warning: Boolean literals should be passed using named argument syntax for parameter flag.
+named-booleans.scala:44: warning: Boolean literals should be passed using named argument syntax for parameter flag. [quickfixable]
   c.uncheck(false, "OK", true)
                          ^
-named-booleans.scala:63: warning: Boolean literals should be passed using named argument syntax for parameter isKlazz.
-  def test = Klazz(true) // warn case class apply as for ctor
-                   ^
+named-booleans.scala:70: warning: Boolean literals should be passed using named argument syntax for parameter down. [quickfixable]
+  def g2 = f(42, up=false, true)
+                           ^
+named-booleans.scala:71: warning: Boolean literals should be passed using named argument syntax for parameter up. [quickfixable]
+  def g3 = f(42, false)
+                 ^
+named-booleans.scala:72: warning: Boolean literals should be passed using named argument syntax for parameter up. [quickfixable]
+  def g4 = f(42, false, true)
+                 ^
+named-booleans.scala:72: warning: Boolean literals should be passed using named argument syntax for parameter down. [quickfixable]
+  def g4 = f(42, false, true)
+                        ^
 error: No warnings can be incurred under -Werror.
-6 warnings
+9 warnings
 1 error

--- a/test/files/neg/warn-unused-locals.scala
+++ b/test/files/neg/warn-unused-locals.scala
@@ -36,3 +36,8 @@ object Types {
     (new Bippy): Something
   }
 }
+
+// breakage: local val x$1 in method skolemize is never used
+case class SymbolKind(accurate: String, sanitized: String, abbreviation: String) {
+  def skolemize: SymbolKind = copy(accurate = s"$accurate skolem", abbreviation = s"$abbreviation#SKO")
+}

--- a/test/junit/scala/tools/nsc/QuickfixTest.scala
+++ b/test/junit/scala/tools/nsc/QuickfixTest.scala
@@ -149,4 +149,20 @@ class QuickfixTest extends BytecodeTesting {
         |""".stripMargin
     testQuickfixs(a2s, b2, "-Xsource:3 -quickfix:any")
   }
+
+  @Test def `named boolean literal lint has a fix`: Unit = {
+    val a =
+      sm"""|class C {
+           |  def f(hasState: Boolean, isMutable: Boolean): Boolean = hasState && isMutable
+           |  def test = f(true, false)
+           |}
+           |"""
+    val b =
+      sm"""|class C {
+           |  def f(hasState: Boolean, isMutable: Boolean): Boolean = hasState && isMutable
+           |  def test = f(hasState = true, isMutable = false)
+           |}
+           |"""
+    testQuickfix(a, b, "-Wunnamed-boolean-literal -quickfix:any")
+  }
 }


### PR DESCRIPTION
The existing lint to check that boolean literal arguments in method calls use named arg syntax (`f(flag = true)`) is moved to a warning option `-Wunnamed-boolean-literal`.

The warning is issued if the unnamed arg may be inadvertently swapped with another: there is another unnamed boolean arg or another boolean parameter that is supplied using a default argument.

A stricter warning is available under `-Wunnamed-boolean-literal-strict`, which warns about any unnamed boolean arg, except for the pattern of an `assert` method that takes exactly one boolean parameter in first position.

The exclusion for `assert` assumes that such a method will have a name that conveys how the boolean arg is used, so that naming the arg is superfluous.

This warning is on a par with `-Wvalue-discard`, which is also an ordinary language feature, but may be deemed warnable for some projects.

Follow-up to https://github.com/scala/scala/pull/10612

Removes the exclusion Lukas doubted at https://github.com/scala/scala/pull/10612#discussion_r1420102963
