### PR TITLE
`-Wconf:x,y` now (incompatibly!) means `-Wconf:x -Wconf:y` (y overrules x), rather than the reverse (to align with Scala 3.4+ and with user intuition)

### DIFF
--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -522,6 +522,7 @@ object Reporting {
     def includes(o: WarningCategory): Boolean = this eq o
     def summaryCategory: WarningCategory = this
     lazy val name: String = WarningCategory.nameOf(this)
+    override def toString = name
   }
 
   object WarningCategory {
@@ -722,7 +723,7 @@ object Reporting {
   }
 
   object MessageFilter {
-    object Any extends MessageFilter {
+    case object Any extends MessageFilter {
       def matches(message: Message): Boolean = true
     }
 
@@ -768,7 +769,9 @@ object Reporting {
     }
   }
 
-  sealed trait Action
+  sealed trait Action {
+    override def toString = s"Action[${getClass.getSimpleName.stripSuffix("$")}]"
+  }
 
   object Action {
     object Error extends Action

--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -700,7 +700,7 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
     }
 
     def tryToSet(args: List[String])                  = tryToSetArgs(args, halting = true)
-    def tryToSetColon(args: List[String])    = tryToSetArgs(args, halting = false)
+    def tryToSetColon(args: List[String])             = tryToSetArgs(args, halting = false)
     override def tryToSetFromPropertyValue(s: String) = tryToSet(s.trim.split(',').toList) // used from ide
 
     /** Try to set args, handling "help" and default.
@@ -822,12 +822,12 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
         case Nil                                  => (seen, Nil)
       }
       val (seen, rest) = loop(Nil, args)
-      if (prepend) value = value.prependedAll(seen.reverse)
+      if (prepend) value = value.prependedAll(seen)
       else value = value.appendedAll(seen.reverse)
       Some(rest)
     }
     def tryToSet(args: List[String])                  = tryToSetArgs(args, halting = true)
-    def tryToSetColon(args: List[String])    = tryToSetArgs(args, halting = false)
+    def tryToSetColon(args: List[String])             = tryToSetArgs(args, halting = false)
     override def tryToSetFromPropertyValue(s: String) = tryToSet(s.trim.split(',').toList) // used from ide
 
     def clear(): Unit         = (v = Nil)

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -82,8 +82,13 @@ trait Warnings {
          |The default configuration is:
          |  -Wconf:${WconfDefault.mkString(",")}
          |
-         |User-defined configurations are added to the left. The leftmost rule matching
-         |a warning message defines the action.
+         |Under -Xsource:3-cross, the category of scala3-migration warnings are errors by default:
+         |  -Wconf:cat=scala3-migration:e
+         |Under -Xsource:3-migration, they are warnings:
+         |  -Wconf:cat=scala3-migration:w
+         |
+         |User-defined configurations override previous settings, such that the last matching
+         |configuration defines the action for a given diagnostic message.
          |
          |Examples:
          |  - change every warning into an error: -Wconf:any:error

--- a/test/junit/scala/tools/nsc/reporters/WConfTest.scala
+++ b/test/junit/scala/tools/nsc/reporters/WConfTest.scala
@@ -215,8 +215,8 @@ class WConfTest extends BytecodeTesting {
   def lint(): Unit = {
     check(infos(code, "cat=lint:i"), Nil)
     check(infos(code, "cat=lint:i", lint = true), List(l2, l23))
-    check(reports(code, "any:s,cat=lint:ws", lint = true), Nil)
-    check(reports(code, "cat=lint:ws,any:s", lint = true), List((-1, "2 lint warnings")))
+    check(reports(code, "any:s,cat=lint:ws", lint = true), List((-1, "2 lint warnings")))
+    check(reports(code, "cat=lint:ws,any:s", lint = true), Nil)
     check(infos(code, "cat=lint-deprecation:i", lint = true), List(l2))
     check(infos(code, "cat=lint-adapted-args:i", lint = true), List(l23))
   }


### PR DESCRIPTION
`-Wconf` applies the "last matching" configuration, or equivalently, the "first matching" in reverse order. User config has precedence over default config.

However, previously, two configs in a "comma-separated" setting were taken such that the "first matching" in order as written had precedence. This is different from Scala 3.4+ and possibly unintuitive or awkward to document.

This behavior is corrected so that a config always overrides or has precedence over previous configs, including a comma-separated setting as read from left to right.

## Example

`-Wconf:A,B -Wconf:C`
is now the same as
`-Wconf:A -Wconf:B -Wconf:C`
where "the last applicable configuration wins".
Previously, it was taken as
`-Wconf:B -Wconf:A -Wconf:C`

If configs `A` and `B` are "overlapping" filters, then swapping the order will change the resulting behavior.

## Advice on cross-building

The Scala 3.3.x series will retain the old behavior, as per https://github.com/scala/scala3/issues/21818 . Therefore, if you are cross-building for both Scala 2.13.15+ and Scala 3.3, you should avoid the comma-separated form (`-Wconf:x,y`) and instead prefer separate flags (`-Wconf:x -Wconf:y`), which behave the same on all Scala versions (as far as we know!).

## Implementation notes

Don't reverse before prependedAll.

Noticed at https://github.com/scala/scala3/issues/19885#issuecomment-1982949423
