### PR TITLE
Introduce `-Xsource-features`, for customizing the behavior of `-Xsource:3` and `-Xsource:3-cross`

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1180,12 +1180,22 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
     val profiler: Profiler = Profiler(settings)
     keepPhaseStack = settings.log.isSetByUser
 
-    // We hit these checks regularly. They shouldn't change inside the same run, so cache the comparisons here.
-    @nowarn("cat=deprecation")
-    val isScala3: Boolean = settings.isScala3.value // reporting.isScala3
-    @nowarn("cat=deprecation")
-    val isScala3Cross: Boolean = settings.isScala3Cross.value // reporting.isScala3Cross
-    val isScala3ImplicitResolution: Boolean = settings.Yscala3ImplicitResolution.value
+    val isScala3: Boolean = settings.isScala3: @nowarn
+
+    object sourceFeatures {
+      private val s = settings
+      private val o = s.sourceFeatures
+      import s.XsourceFeatures.contains
+      def caseApplyCopyAccess    = isScala3 && contains(o.caseApplyCopyAccess)
+      def caseCompanionFunction  = isScala3 && contains(o.caseCompanionFunction)
+      def inferOverride          = isScala3 && contains(o.inferOverride)
+      def any2StringAdd          = isScala3 && contains(o.any2StringAdd)
+      def unicodeEscapesRaw      = isScala3 && contains(o.unicodeEscapesRaw)
+      def stringContextScope     = isScala3 && contains(o.stringContextScope)
+      def leadingInfix           = isScala3 && contains(o.leadingInfix)
+      def packagePrefixImplicits = isScala3 && contains(o.packagePrefixImplicits)
+      def implicitResolution     = isScala3 && contains(o.implicitResolution) || settings.Yscala3ImplicitResolution.value
+    }
 
     // used in sbt
     def uncheckedWarnings: List[(Position, String)]   = reporting.uncheckedWarnings

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1556,7 +1556,7 @@ self =>
 
       // Scala 2 allowed uprooted Ident for purposes of virtualization
       val t1 =
-        if (currentRun.isScala3Cross) atPos(o2p(start)) { Select(Select(Ident(nme.ROOTPKG), nme.scala_), nme.StringContextName) }
+        if (currentRun.sourceFeatures.stringContextScope) atPos(o2p(start)) { Select(Select(Ident(nme.ROOTPKG), nme.scala_), nme.StringContextName) }
         else atPos(o2p(start)) { Ident(nme.StringContextName).updateAttachment(VirtualStringContext) }
       val t2 = atPos(start) { Apply(t1, partsBuf.toList) } updateAttachment InterpolatedString
       t2 setPos t2.pos.makeTransparent

--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -212,8 +212,8 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
     add(new IntSetting(name, descr, default, range, parser))
   def MultiStringSetting(name: String, arg: String, descr: String, default: List[String] = Nil, helpText: Option[String] = None, prepend: Boolean = false) =
     add(new MultiStringSetting(name, arg, descr, default, helpText, prepend))
-  def MultiChoiceSetting[E <: MultiChoiceEnumeration](name: String, helpArg: String, descr: String, domain: E, default: Option[List[String]] = None) =
-    add(new MultiChoiceSetting[E](name, helpArg, descr, domain, default))
+  def MultiChoiceSetting[E <: MultiChoiceEnumeration](name: String, helpArg: String, descr: String, domain: E, default: Option[List[String]] = None, helpText: Option[String] = None) =
+    add(new MultiChoiceSetting[E](name, helpArg, descr, domain, default, helpText))
   def OutputSetting(default: String) = add(new OutputSetting(default))
   def PhasesSetting(name: String, descr: String, default: String = "") = add(new PhasesSetting(name, descr, default))
   def StringSetting(name: String, arg: String, descr: String, default: String = "", helpText: Option[String] = None) = add(new StringSetting(name, arg, descr, default, helpText))
@@ -609,7 +609,8 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
     val helpArg: String,
     descr: String,
     val domain: E,
-    val default: Option[List[String]]
+    val default: Option[List[String]],
+    val helpText: Option[String]
   ) extends Setting(name, descr) with Clearable {
 
     withHelpSyntax(s"$name:<${helpArg}s>")
@@ -780,7 +781,7 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
         case _ => default
       }
       val orelse = verboseDefault.map(_.mkString(f"%nDefault: ", ", ", f"%n")).getOrElse("")
-      choices.zipAll(descriptions, "", "").map(describe).mkString(f"${descr}%n", f"%n", orelse)
+      choices.zipAll(descriptions, "", "").map(describe).mkString(f"${helpText.getOrElse(descr)}%n", f"%n", orelse)
     }
 
     def clear(): Unit = {

--- a/src/compiler/scala/tools/nsc/typechecker/AnalyzerPlugins.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/AnalyzerPlugins.scala
@@ -55,7 +55,7 @@ trait AnalyzerPlugins { self: Analyzer with splain.SplainData =>
      * Let analyzer plugins change the types assigned to definitions. For definitions that have
      * an annotated type, the assigned type is obtained by typing that type tree. Otherwise, the
      * type is inferred by typing the definition's righthand side, or from the overridden
-     * member under `-Xsource:3-cross`.
+     * member under `-Xsource-features`.
      *
      * In order to know if the type was inferred, you can query the `wasEmpty` field in the `tpt`
      * TypeTree of the definition (for DefDef and ValDef).

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1072,11 +1072,6 @@ trait Contexts { self: Analyzer =>
     private def isQualifyingImplicit(name: Name, sym: Symbol, pre: Type, imported: Boolean) =
       sym.isImplicit &&
       isAccessible(sym, pre) &&
-      !(
-        // [eed3si9n] ideally I'd like to do this: val fd = currentRun.isScala3 && sym.isDeprecated
-        // but implicit caching currently does not report sym.isDeprecated correctly.
-        currentRun.isScala3Cross && (sym == currentRun.runDefinitions.Predef_any2stringaddMethod)
-      ) &&
       !(imported && {
         val e = scope.lookupEntry(name)
         (e ne null) && (e.owner == scope) && e.sym.exists

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -141,7 +141,7 @@ trait Implicits extends splain.SplainData {
       }
       if (result.inPackagePrefix && currentRun.isScala3) {
         val msg =
-          s"""Implicit $rts was found in a package prefix of the required type, which is not part of the implicit scope in Scala 3.
+          s"""Implicit $rts was found in a package prefix of the required type, which is not part of the implicit scope in Scala 3 (or with -Xsource-features:package-prefix-implicits).
              |For migration, add `import ${rts.fullNameString}`.""".stripMargin
         context.warning(result.tree.pos, msg, WarningCategory.Scala3Migration)
       }
@@ -1346,7 +1346,7 @@ trait Implicits extends splain.SplainData {
                 if (sym.isPackageClass) (sym.packageObject.typeOfThis, true)
                 else (singleType(pre, companionSymbolOf(sym, context)), false)
               val preInfos = {
-                if (currentRun.isScala3Cross && inPackagePrefix) Iterator.empty
+                if (currentRun.sourceFeatures.packagePrefixImplicits && inPackagePrefix) Iterator.empty
                 else pre1.implicitMembers.iterator.map(mem => new ImplicitInfo(mem.name, pre1, mem, inPackagePrefix = inPackagePrefix))
               }
               val mergedInfos = if (symInfos.isEmpty) preInfos else {

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -903,7 +903,8 @@ trait Infer extends Checkable {
       case _                         =>
         tpe2 match {
           case PolyType(tparams2, rtpe2) => isAsSpecificValueType(tpe1, rtpe2, undef1, undef2 ::: tparams2)
-          case _ if !currentRun.isScala3ImplicitResolution => existentialAbstraction(undef1, tpe1) <:< existentialAbstraction(undef2, tpe2)
+          case _ if !currentRun.sourceFeatures.implicitResolution =>
+            existentialAbstraction(undef1, tpe1) <:< existentialAbstraction(undef2, tpe2)
           case _ =>
             // Backport of fix for https://github.com/scala/bug/issues/2509
             // from Dotty https://github.com/scala/scala3/commit/89540268e6c49fb92b9ca61249e46bb59981bf5a

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1117,7 +1117,8 @@ trait Namers extends MethodSynthesis {
             }
           }
         val legacy = dropIllegalStarTypes(widenIfNecessary(tree.symbol, rhsTpe, pt))
-        if (inferOverridden && currentRun.isScala3 && !currentRun.isScala3Cross && !(legacy =:= pt)) {
+        // <:< check as a workaround for scala/bug#12968
+        def warnIfInferenceChanged(): Unit = if (!(legacy =:= pt || legacy <:< pt && pt <:< legacy)) {
           val pts = pt.toString
           val leg = legacy.toString
           val help = if (pts != leg) s" instead of $leg" else ""

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1416,7 +1416,14 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             if (settings.logImplicitConv.value)
               context.echo(qual.pos, s"applied implicit conversion from ${qual.tpe} to ${searchTemplate} = ${coercion.symbol.defString}")
 
-            typedQualifier(atPos(qual.pos)(new ApplyImplicitView(coercion, List(qual))))
+            if (currentRun.isScala3 && coercion.symbol == currentRun.runDefinitions.Predef_any2stringaddMethod) {
+              if (currentRun.sourceFeatures.any2StringAdd) qual
+              else {
+                runReporting.warning(qual.pos, s"Converting to String for concatenation is not supported in Scala 3 (or with -Xsource-features:any2stringadd).", Scala3Migration, coercion.symbol)
+                typedQualifier(atPos(qual.pos)(new ApplyImplicitView(coercion, List(qual))))
+              }
+            }
+            else typedQualifier(atPos(qual.pos)(new ApplyImplicitView(coercion, List(qual))))
         }
       }
       else qual

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1128,7 +1128,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       def adaptApplyInsertion(): Tree = doAdaptApplyInsertion(retry = false)
 
       def doAdaptApplyInsertion(retry: Boolean): Tree =
-        if (currentRun.isScala3Cross && !isPastTyper && tree.symbol != null && tree.symbol.isModule && tree.symbol.companion.isCase && isFunctionType(pt))
+        if (!isPastTyper && tree.symbol != null && tree.symbol.isModule && tree.symbol.companion.isCase && isFunctionType(pt))
           silent(_.typed(atPos(tree.pos)(Select(tree, nme.apply)), mode, if (retry) WildcardType else pt)) match {
             case SilentResultValue(applicator) =>
               val arity = definitions.functionArityFromType(applicator.tpe)
@@ -5401,7 +5401,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
       // If they try C.tupled, make it (C.apply _).tupled
       def fixUpCaseTupled(tree: Tree, qual: Tree, name: Name, mode: Mode): Tree =
-        if (currentRun.isScala3Cross && !isPastTyper && qual.symbol != null && qual.symbol.isModule && qual.symbol.companion.isCase &&
+        if (!isPastTyper && qual.symbol != null && qual.symbol.isModule && qual.symbol.companion.isCase &&
             context.undetparams.isEmpty && fixableFunctionMembers.contains(name)) {
           val t2 = {
             val t = atPos(tree.pos)(Select(qual, nme.apply))

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3487,7 +3487,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               if (!sym.initialize.hasFlag(IS_ERROR)) {
                 newStats += typedStat(tree) // might add even more synthetics to the scope
                 tree.getAndRemoveAttachment[CaseApplyInheritAccess.type].foreach(_ =>
-                  runReporting.warning(tree.pos, "access modifiers for `apply` method are copied from the case class constructor", Scala3Migration, sym))
+                  runReporting.warning(tree.pos, "access modifiers for `apply` method are copied from the case class constructor under Scala 3 (or with -Xsource-features:case-apply-copy-access)", Scala3Migration, sym))
               }
               context.unit.synthetics -= sym
             case _ => ()
@@ -5683,7 +5683,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                 if (symbol != definitions.StringContextModule)
                   runReporting.warning(
                     tree.pos,
-                    s"String interpolations always use scala.StringContext in Scala 3 (${symbol.fullNameString} is used here)",
+                    s"In Scala 3 (or with -Xsource-features:string-context-scope), String interpolations always use scala.StringContext (${symbol.fullNameString} is used here)",
                     Scala3Migration,
                     context.owner)
               )

--- a/src/compiler/scala/tools/reflect/FastStringInterpolator.scala
+++ b/src/compiler/scala/tools/reflect/FastStringInterpolator.scala
@@ -46,10 +46,10 @@ trait FastStringInterpolator extends FormatInterpolator {
                     lit.pos.withShift(diffindex)
                   }
                   def msg(fate: String) = s"Unicode escapes in raw interpolations are $fate; use literal characters instead"
-                  if (currentRun.isScala3Cross)
+                  if (currentRun.sourceFeatures.unicodeEscapesRaw)
                     stringVal
                   else if (currentRun.isScala3) {
-                    runReporting.warning(pos, msg("ignored in Scala 3"), Scala3Migration, c.internal.enclosingOwner)
+                    runReporting.warning(pos, msg("ignored in Scala 3 (or with -Xsource-features:unicode-escapes-raw)"), Scala3Migration, c.internal.enclosingOwner)
                     processed
                   }
                   else {

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/ShellConfig.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/ShellConfig.scala
@@ -40,7 +40,7 @@ object ShellConfig {
       val doCompletion: Boolean = !(settings.noCompletion.value || batchMode)
       val haveInteractiveConsole: Boolean = settings.Xjline.value != "off"
       override val viMode = super.viMode || settings.Xjline.value == "vi"
-      @nowarn def xsource: String = if (settings.isScala3.value) settings.source.value.versionString else ""
+      def xsource: String = if (settings.isScala3: @nowarn) settings.source.value.versionString else ""
     }
     case _ => new ShellConfig {
       val filesToPaste: List[String] = Nil
@@ -50,7 +50,7 @@ object ShellConfig {
       val doCompletion: Boolean = !settings.noCompletion.value
       val haveInteractiveConsole: Boolean = settings.Xjline.value != "off"
       override val viMode = super.viMode || settings.Xjline.value == "vi"
-      @nowarn def xsource: String = if (settings.isScala3.value) settings.source.value.versionString else ""
+      def xsource: String = if (settings.isScala3: @nowarn) settings.source.value.versionString else ""
     }
   }
 }

--- a/test/files/neg/case-cross.check
+++ b/test/files/neg/case-cross.check
@@ -1,4 +1,4 @@
-t12883.scala:3: error: access modifiers for `apply` method are copied from the case class constructor under Scala 3 (or with -Xsource-features:case-apply-copy-access)
+case-cross.scala:5: error: access modifiers for `apply` method are copied from the case class constructor under Scala 3 (or with -Xsource-features:case-apply-copy-access)
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=C.apply
 case class C private (c: Int) {

--- a/test/files/neg/case-cross.scala
+++ b/test/files/neg/case-cross.scala
@@ -1,0 +1,7 @@
+//> using options -Xsource:3
+
+// warn about case class synthetic method getting access modifier from constructor
+
+case class C private (c: Int) {
+  def copy(c: Int) = this // warn about apply instead
+}

--- a/test/files/neg/case-warn.check
+++ b/test/files/neg/case-warn.check
@@ -1,0 +1,9 @@
+case-warn.scala:6: warning: access modifiers for `copy` method are copied from the case class constructor under Scala 3 (or with -Xsource-features:case-apply-copy-access)
+case class C private (c: Int)
+           ^
+case-warn.scala:6: warning: access modifiers for `apply` method are copied from the case class constructor under Scala 3 (or with -Xsource-features:case-apply-copy-access)
+case class C private (c: Int)
+           ^
+error: No warnings can be incurred under -Werror.
+2 warnings
+1 error

--- a/test/files/neg/case-warn.scala
+++ b/test/files/neg/case-warn.scala
@@ -1,0 +1,6 @@
+//> using options -Werror -Xsource:3 -Wconf:cat=scala3-migration:w
+
+// warn about case class synthetic method getting access modifier from constructor.
+// if erroring, the error message for apply is hidden by previous error for copy.
+
+case class C private (c: Int)

--- a/test/files/neg/caseclass_private_constructor.scala
+++ b/test/files/neg/caseclass_private_constructor.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:3-cross -Wconf:cat=scala3-migration:s
+//> using options -Xsource:3 -Wconf:cat=scala3-migration:s -Xsource-features:case-apply-copy-access
 
 case class A private (i: Int)
 object A

--- a/test/files/neg/deprecated-options.check
+++ b/test/files/neg/deprecated-options.check
@@ -1,4 +1,4 @@
-warning: -Xsource is deprecated: instead of -Xsource:2.14, use -Xsource:3 or -Xsource:3-cross
+warning: -Xsource is deprecated: instead of -Xsource:2.14, use -Xsource:3 and optionally -Xsource-features
 warning: -Xfuture is deprecated: Not used since 2.13.
 warning: -optimize is deprecated: Since 2.12, enables -opt:inline:**. This can be dangerous.
 warning: -Xexperimental is deprecated: Not used since 2.13.

--- a/test/files/neg/deprecationsFor3.check
+++ b/test/files/neg/deprecationsFor3.check
@@ -1,10 +1,8 @@
 deprecationsFor3.scala:4: warning: Unicode escapes in triple quoted strings are deprecated; use the literal character instead
   def inTripleQuoted = """\u0041""" // deprecation
                           ^
-deprecationsFor3.scala:16: warning: Line starts with an operator that in future
-will be taken as an infix expression continued from the previous line.
-To force the previous interpretation as a separate statement,
-add an explicit `;`, add an empty line, or remove spaces after the operator.
+deprecationsFor3.scala:16: warning: Lines starting with an operator are taken as an infix expression continued from the previous line in Scala 3 (or with -Xsource-features:leading-infix).
+To force the current interpretation as a separate statement, add an explicit `;`, add an empty line, or remove spaces after the operator.
     `x` (42) // migration
     ^
 deprecationsFor3.scala:5: warning: Unicode escapes in raw interpolations are deprecated; use literal characters instead

--- a/test/files/neg/deprecationsFor3.scala
+++ b/test/files/neg/deprecationsFor3.scala
@@ -1,4 +1,4 @@
-//> using options -deprecation -Xmigration -Werror
+//> using options -deprecation -Werror -Xmigration
 
 object UnicodeEscapes {
   def inTripleQuoted = """\u0041""" // deprecation

--- a/test/files/neg/dotless-targs-ranged-a.scala
+++ b/test/files/neg/dotless-targs-ranged-a.scala
@@ -1,4 +1,4 @@
-// scalac: -Werror -Xlint -Xmigration -Xsource:3 -Yrangepos:true
+//> using options -Wconf:cat=scala3-migration:w -Werror -Xlint -Xsource:3 -Yrangepos:true
 class A {
   def fn1 = List apply 1
   def fn2 = List apply[Int] 2

--- a/test/files/neg/equiv-migration.scala
+++ b/test/files/neg/equiv-migration.scala
@@ -1,4 +1,4 @@
-// scalac: -Xmigration -Werror
+//> using options -Werror -Xmigration
 object Test {
   val f = Equiv[Float]
   val d = Equiv[Double]

--- a/test/files/neg/implicit-any2stringadd-migration.check
+++ b/test/files/neg/implicit-any2stringadd-migration.check
@@ -1,0 +1,6 @@
+implicit-any2stringadd-migration.scala:4: error: Converting to String for concatenation is not supported in Scala 3 (or with -Xsource-features:any2stringadd).
+Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=scala.Predef.any2stringadd
+  true + "what"
+  ^
+1 error

--- a/test/files/neg/implicit-any2stringadd-migration.scala
+++ b/test/files/neg/implicit-any2stringadd-migration.scala
@@ -1,0 +1,5 @@
+//> using options -Xsource:3
+
+object Test {
+  true + "what"
+}

--- a/test/files/neg/implicit-any2stringadd-warning.scala
+++ b/test/files/neg/implicit-any2stringadd-warning.scala
@@ -1,5 +1,5 @@
-// scalac: -Xfatal-warnings -deprecation
-//
+//> using options -Werror -deprecation
+
 object Test {
   true + "what"
 }

--- a/test/files/neg/implicit-any2stringadd.scala
+++ b/test/files/neg/implicit-any2stringadd.scala
@@ -1,5 +1,5 @@
-// scalac: -Xsource:3-cross -Vimplicits
-//
+//> using options -Xsource:3 -Xsource-features:any2stringadd
+
 object Test {
   true + "what"
 }

--- a/test/files/neg/multiLineOps-b.scala
+++ b/test/files/neg/multiLineOps-b.scala
@@ -1,4 +1,4 @@
-//> using options -Werror -Xsource:3-cross
+//> using options -Werror -Xsource:3 -Xsource-features:leading-infix
 
 class Test {
   val b1 = {

--- a/test/files/neg/multiLineOps-c.scala
+++ b/test/files/neg/multiLineOps-c.scala
@@ -1,4 +1,4 @@
-//> using options -Werror -Xsource:3-cross
+//> using options -Werror -Xsource:3 -Xsource-features:leading-infix
 
 class Test {
   val x = 42

--- a/test/files/neg/multiLineOps.scala
+++ b/test/files/neg/multiLineOps.scala
@@ -1,4 +1,4 @@
-//> using options -Werror -Xlint -Xsource:3-cross
+//> using options -Werror -Xlint -Xsource:3 -Xsource-features:leading-infix
 
 class Test {
   val x = 1

--- a/test/files/neg/ordering-migration.scala
+++ b/test/files/neg/ordering-migration.scala
@@ -1,4 +1,4 @@
-// scalac: -Xmigration -Werror
+//> using options -Xmigration -Werror
 object Test {
   val f = Ordering[Float]
   val d = Ordering[Double]

--- a/test/files/neg/source3Xneg.scala
+++ b/test/files/neg/source3Xneg.scala
@@ -1,4 +1,4 @@
-//> using options -deprecation -Xsource:3-cross -Wconf:cat=scala3-migration:w -Werror
+//> using options -deprecation -Xsource:3 -Xsource-features:_ -Wconf:cat=scala3-migration:w -Werror
 
 // StringContext hygiene
 class SC1 {

--- a/test/files/neg/source3XnegRefchecks.scala
+++ b/test/files/neg/source3XnegRefchecks.scala
@@ -1,4 +1,4 @@
-//> using options -deprecation -Xsource:3-cross -Wconf:cat=scala3-migration:w -Werror
+//> using options -deprecation -Xsource:3 -Xsource-features:_ -Wconf:cat=scala3-migration:w -Werror
 
 object NameShadowing {
   class A { class X }

--- a/test/files/neg/source3cross.check
+++ b/test/files/neg/source3cross.check
@@ -1,0 +1,4 @@
+source3cross.scala:4: error: value + is not a member of Any
+  def f(a: Any) = a + ""
+                    ^
+1 error

--- a/test/files/neg/source3cross.scala
+++ b/test/files/neg/source3cross.scala
@@ -1,0 +1,5 @@
+//> using options -Xsource:3-cross
+
+object T {
+  def f(a: Any) = a + ""
+}

--- a/test/files/neg/source3neg.check
+++ b/test/files/neg/source3neg.check
@@ -34,6 +34,9 @@ source3neg.scala:44: warning: Implicit definition must have explicit type (infer
 source3neg.scala:43: warning: Implicit definition must have explicit type (inferred Int) [quickfixable]
   implicit val i = 0 // error
                ^
+source3neg.scala:47: warning: Converting to String for concatenation is not supported in Scala 3 (or with -Xsource-features:any2stringadd).
+object AnyPlus { def f(xs: List[Int]) = xs + ";" }
+                                        ^
 source3neg.scala:47: warning: method any2stringadd in object Predef is deprecated (since 2.13.0): Implicit injection of + is deprecated. Convert to String to call +
 object AnyPlus { def f(xs: List[Int]) = xs + ";" }
                                         ^

--- a/test/files/neg/source3neg.check
+++ b/test/files/neg/source3neg.check
@@ -1,28 +1,26 @@
-source3neg.scala:16: warning: Unicode escapes in triple quoted strings are ignored in Scala 3; use the literal character instead
+source3neg.scala:16: warning: Unicode escapes in triple quoted strings are ignored in Scala 3 (or with -Xsource-features:unicode-escapes-raw); use the literal character instead
   def inTripleQuoted = """\u0041""" // error
                           ^
-source3neg.scala:28: warning: Line starts with an operator that in future
-will be taken as an infix expression continued from the previous line.
-To force the previous interpretation as a separate statement,
-add an explicit `;`, add an empty line, or remove spaces after the operator.
+source3neg.scala:28: warning: Lines starting with an operator are taken as an infix expression continued from the previous line in Scala 3 (or with -Xsource-features:leading-infix).
+To force the current interpretation as a separate statement, add an explicit `;`, add an empty line, or remove spaces after the operator.
     `x` (42) // error
     ^
-source3neg.scala:12: warning: String interpolations always use scala.StringContext in Scala 3 (SC1.StringContext is used here)
+source3neg.scala:12: warning: In Scala 3 (or with -Xsource-features:string-context-scope), String interpolations always use scala.StringContext (SC1.StringContext is used here)
   def test = s"hello, $name" // error
              ^
-source3neg.scala:17: warning: Unicode escapes in raw interpolations are ignored in Scala 3; use literal characters instead
+source3neg.scala:17: warning: Unicode escapes in raw interpolations are ignored in Scala 3 (or with -Xsource-features:unicode-escapes-raw); use literal characters instead
   def inRawInterpolation = raw"\u0041" // error
                                ^
-source3neg.scala:18: warning: Unicode escapes in raw interpolations are ignored in Scala 3; use literal characters instead
+source3neg.scala:18: warning: Unicode escapes in raw interpolations are ignored in Scala 3 (or with -Xsource-features:unicode-escapes-raw); use literal characters instead
   def inRawTripleQuoted = raw"""\u0041""" // error
                                 ^
-source3neg.scala:32: warning: access modifiers for `copy` method are copied from the case class constructor
+source3neg.scala:32: warning: access modifiers for `copy` method are copied from the case class constructor under Scala 3 (or with -Xsource-features:case-apply-copy-access)
 case class CaseCompanionMods private (x: Int) // 2 errors
            ^
-source3neg.scala:32: warning: access modifiers for `apply` method are copied from the case class constructor
+source3neg.scala:32: warning: access modifiers for `apply` method are copied from the case class constructor under Scala 3 (or with -Xsource-features:case-apply-copy-access)
 case class CaseCompanionMods private (x: Int) // 2 errors
            ^
-source3neg.scala:36: warning: under -Xsource:3-cross, the inferred type changes to Object instead of String [quickfixable]
+source3neg.scala:36: warning: in Scala 3 (or with -Xsource-features:infer-override), the inferred type changes to Object instead of String [quickfixable]
 object InferredSub extends InferredBase { def f = "a" } // error
                                               ^
 source3neg.scala:42: warning: Implicit definition must have explicit type (inferred String => Option[Int]) [quickfixable]
@@ -44,5 +42,5 @@ source3neg.scala:51: warning: shadowing a nested class of a parent is deprecated
   class B extends A { class X; def f = new X }
                             ^
 error: No warnings can be incurred under -Werror.
-13 warnings
+14 warnings
 1 error

--- a/test/files/neg/t12071.check
+++ b/test/files/neg/t12071.check
@@ -7,34 +7,24 @@ This can be achieved by adding the import clause 'import scala.language.postfixO
 or by setting the compiler option -language:postfixOps.
 See the Scaladoc for value scala.language.postfixOps for a discussion
 why the feature needs to be explicitly enabled.
-Line starts with an operator that in future
-will be taken as an infix expression continued from the previous line.
-To force the previous interpretation as a separate statement,
-add an explicit `;`, add an empty line, or remove spaces after the operator.
+Lines starting with an operator are taken as an infix expression continued from the previous line in Scala 3 (or with -Xsource-features:leading-infix).
+To force the current interpretation as a separate statement, add an explicit `;`, add an empty line, or remove spaces after the operator.
     `c c` i
           ^
-t12071.scala:20: warning: Line starts with an operator that in future
-will be taken as an infix expression continued from the previous line.
-To force the previous interpretation as a separate statement,
-add an explicit `;`, add an empty line, or remove spaces after the operator.
+t12071.scala:20: warning: Lines starting with an operator are taken as an infix expression continued from the previous line in Scala 3 (or with -Xsource-features:leading-infix).
+To force the current interpretation as a separate statement, add an explicit `;`, add an empty line, or remove spaces after the operator.
     + 2
     ^
-t12071.scala:25: warning: Line starts with an operator that in future
-will be taken as an infix expression continued from the previous line.
-To force the previous interpretation as a separate statement,
-add an explicit `;`, add an empty line, or remove spaces after the operator.
+t12071.scala:25: warning: Lines starting with an operator are taken as an infix expression continued from the previous line in Scala 3 (or with -Xsource-features:leading-infix).
+To force the current interpretation as a separate statement, add an explicit `;`, add an empty line, or remove spaces after the operator.
     + 1
     ^
-t12071.scala:28: warning: Line starts with an operator that in future
-will be taken as an infix expression continued from the previous line.
-To force the previous interpretation as a separate statement,
-add an explicit `;`, add an empty line, or remove spaces after the operator.
+t12071.scala:28: warning: Lines starting with an operator are taken as an infix expression continued from the previous line in Scala 3 (or with -Xsource-features:leading-infix).
+To force the current interpretation as a separate statement, add an explicit `;`, add an empty line, or remove spaces after the operator.
     `test-1` + `test-2`
     ^
-t12071.scala:31: warning: Line starts with an operator that in future
-will be taken as an infix expression continued from the previous line.
-To force the previous interpretation as a separate statement,
-add an explicit `;`, add an empty line, or remove spaces after the operator.
+t12071.scala:31: warning: Lines starting with an operator are taken as an infix expression continued from the previous line in Scala 3 (or with -Xsource-features:leading-infix).
+To force the current interpretation as a separate statement, add an explicit `;`, add an empty line, or remove spaces after the operator.
     `compareTo` (2 - 1)
     ^
 4 warnings

--- a/test/files/neg/t12798-migration.check
+++ b/test/files/neg/t12798-migration.check
@@ -3,48 +3,70 @@ Note that assignments in argument position are no longer allowed since Scala 2.1
 To express the assignment expression, wrap it in brackets, e.g., `{ z = ... }`.
     f(42, z = 27)
             ^
-t12798-migration.scala:25: warning: unary prefix operator definition with empty parameter list is unsupported: instead, remove () to declare as `def unary_- = -42` [quickfixable]
+t12798-migration.scala:25: error: unary prefix operator definition with empty parameter list is unsupported: instead, remove () to declare as `def unary_- = -42` [quickfixable]
+Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def unary_-() = -42
       ^
-t12798-migration.scala:33: warning: procedure syntax is deprecated for constructors: add `=`, as in method definition [quickfixable]
+t12798-migration.scala:33: error: procedure syntax is deprecated for constructors: add `=`, as in method definition [quickfixable]
+Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def this(s: String) { this() }
                      ^
-t12798-migration.scala:34: warning: procedure syntax is unsupported: instead, add `: Unit =` to explicitly declare `f`'s return type [quickfixable]
+t12798-migration.scala:34: error: procedure syntax is unsupported: instead, add `: Unit =` to explicitly declare `f`'s return type [quickfixable]
+Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def f() { println() }
           ^
-t12798-migration.scala:35: warning: procedure syntax is unsupported: instead, add `: Unit` to explicitly declare `g`'s return type [quickfixable]
+t12798-migration.scala:35: error: procedure syntax is unsupported: instead, add `: Unit` to explicitly declare `g`'s return type [quickfixable]
+Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def g()
          ^
-t12798-migration.scala:39: warning: parentheses are required around the parameter of a lambda
+t12798-migration.scala:39: error: parentheses are required around the parameter of a lambda
 Use '-Wconf:msg=lambda-parens:s' to silence this warning. [quickfixable]
+Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def f = List(42).map { x: Int => x + 1 }
                           ^
-t12798-migration.scala:43: warning: type application is not allowed for infix operators [quickfixable]
+t12798-migration.scala:43: error: type application is not allowed for infix operators [quickfixable]
+Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def f = List(42) map [Int] (_ + 1)
                    ^
-t12798-migration.scala:46: warning: Top-level wildcard is not allowed
+t12798-migration.scala:46: error: Top-level wildcard is not allowed
+Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
 class `misuse of underscore`[_]
                              ^
-t12798-migration.scala:48: warning: early initializers are deprecated; use trait parameters instead.
+t12798-migration.scala:48: error: early initializers are deprecated; use trait parameters instead.
+Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
 class `early bird` extends { val x = "hello, world" } with Runnable { def run() = println(x) }
                            ^
-t12798-migration.scala:17: warning: Unicode escapes in raw interpolations are ignored in Scala 3; use literal characters instead
+t12798-migration.scala:17: error: Unicode escapes in raw interpolations are ignored in Scala 3 (or with -Xsource-features:unicode-escapes-raw); use literal characters instead
+Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=interpolated unicode such as C.f
   def f = raw"\u0043 is for $entry"
               ^
-t12798-migration.scala:18: warning: Unicode escapes in raw interpolations are ignored in Scala 3; use literal characters instead
+t12798-migration.scala:18: error: Unicode escapes in raw interpolations are ignored in Scala 3 (or with -Xsource-features:unicode-escapes-raw); use literal characters instead
+Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=interpolated unicode such as C.g
   def g = raw"""\u0043 is for Cat"""
                 ^
-t12798-migration.scala:50: warning: access modifiers for `copy` method are copied from the case class constructor
+t12798-migration.scala:50: error: access modifiers for `copy` method are copied from the case class constructor under Scala 3 (or with -Xsource-features:case-apply-copy-access)
+Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=case mods propagate
 case class `case mods propagate` private (s: String)
            ^
-t12798-migration.scala:60: warning: under -Xsource:3-cross, the inferred type changes to Option[Int] instead of Some[Int] [quickfixable]
+t12798-migration.scala:60: error: in Scala 3 (or with -Xsource-features:infer-override), the inferred type changes to Option[Int] instead of Some[Int] [quickfixable]
+Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=Child.f
   override def f = Some(27)
                ^
-t12798-migration.scala:50: warning: access modifiers for `apply` method are copied from the case class constructor
-case class `case mods propagate` private (s: String)
-           ^
-t12798-migration.scala:52: warning: access modifiers for `apply` method are copied from the case class constructor
+t12798-migration.scala:52: error: access modifiers for `apply` method are copied from the case class constructor under Scala 3 (or with -Xsource-features:case-apply-copy-access)
+Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=copyless case mods propagate.apply
 case class `copyless case mods propagate` private (s: String) {
            ^
-14 warnings
-1 error
+14 errors

--- a/test/files/neg/t12798-migration.scala
+++ b/test/files/neg/t12798-migration.scala
@@ -1,4 +1,4 @@
-// scalac: -Xmigration -Xsource:3
+//> using options -Xsource:3
 
 // Demonstrate migration warnings at typer for -Xsource:3
 

--- a/test/files/neg/t12798.check
+++ b/test/files/neg/t12798.check
@@ -44,27 +44,27 @@ Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
 class `early bird` extends { val x = "hello, world" } with Runnable { def run() = println(x) }
                            ^
-t12798.scala:17: error: Unicode escapes in raw interpolations are ignored in Scala 3; use literal characters instead
+t12798.scala:17: error: Unicode escapes in raw interpolations are ignored in Scala 3 (or with -Xsource-features:unicode-escapes-raw); use literal characters instead
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=interpolated unicode such as C.f
   def f = raw"\u0043 is for $entry"
               ^
-t12798.scala:18: error: Unicode escapes in raw interpolations are ignored in Scala 3; use literal characters instead
+t12798.scala:18: error: Unicode escapes in raw interpolations are ignored in Scala 3 (or with -Xsource-features:unicode-escapes-raw); use literal characters instead
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=interpolated unicode such as C.g
   def g = raw"""\u0043 is for Cat"""
                 ^
-t12798.scala:50: error: access modifiers for `copy` method are copied from the case class constructor
+t12798.scala:50: error: access modifiers for `copy` method are copied from the case class constructor under Scala 3 (or with -Xsource-features:case-apply-copy-access)
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=case mods propagate
 case class `case mods propagate` private (s: String)
            ^
-t12798.scala:60: error: under -Xsource:3-cross, the inferred type changes to Option[Int] instead of Some[Int] [quickfixable]
+t12798.scala:60: error: in Scala 3 (or with -Xsource-features:infer-override), the inferred type changes to Option[Int] instead of Some[Int] [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=Child.f
   override def f = Some(27)
                ^
-t12798.scala:52: error: access modifiers for `apply` method are copied from the case class constructor
+t12798.scala:52: error: access modifiers for `apply` method are copied from the case class constructor under Scala 3 (or with -Xsource-features:case-apply-copy-access)
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=copyless case mods propagate.apply
 case class `copyless case mods propagate` private (s: String) {

--- a/test/files/neg/t12798.scala
+++ b/test/files/neg/t12798.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:3
+//> using options -Xsource:3
 
 // Demonstrate migration warnings at typer for -Xsource:3
 

--- a/test/files/neg/t12798b.scala
+++ b/test/files/neg/t12798b.scala
@@ -1,4 +1,4 @@
-// scalac: -Wconf:cat=scala3-migration:e -Xmigration -Xsource:3
+//> using options -Xsource:3
 
 // Demonstrate migration warnings at refchecks for -Xsource:3
 

--- a/test/files/neg/t12919-3cross.scala
+++ b/test/files/neg/t12919-3cross.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:3-cross
+//> using options -Xsource:3 -Xsource-features:package-prefix-implicits
 
 package object a {
   implicit val aOrd: Ordering[A] = null

--- a/test/files/neg/t12919.check
+++ b/test/files/neg/t12919.check
@@ -1,10 +1,10 @@
-t12919.scala:24: error: Implicit value aOrd was found in a package prefix of the required type, which is not part of the implicit scope in Scala 3.
+t12919.scala:24: error: Implicit value aOrd was found in a package prefix of the required type, which is not part of the implicit scope in Scala 3 (or with -Xsource-features:package-prefix-implicits).
 For migration, add `import a.aOrd`.
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=b.V.f
     def f(xs: List[a.A]) = xs.sorted // warn
                               ^
-t12919.scala:48: error: Implicit method myClassToSeq was found in a package prefix of the required type, which is not part of the implicit scope in Scala 3.
+t12919.scala:48: error: Implicit method myClassToSeq was found in a package prefix of the required type, which is not part of the implicit scope in Scala 3 (or with -Xsource-features:package-prefix-implicits).
 For migration, add `import a1.a2.myClassToSeq`.
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=a1.Main.f

--- a/test/files/neg/t2509-2.scala
+++ b/test/files/neg/t2509-2.scala
@@ -1,4 +1,4 @@
-// scalac: -Yscala3-implicit-resolution
+//> using options -Xsource:3 -Xsource-features:implicit-resolution
 class A
 class B extends A
 class C extends B

--- a/test/files/neg/t2509-3.scala
+++ b/test/files/neg/t2509-3.scala
@@ -1,4 +1,4 @@
-// scalac: -Yscala3-implicit-resolution
+//> using options -Xsource:3 -Xsource-features:implicit-resolution
 class A
 class B extends A
 

--- a/test/files/neg/t2509-7b.scala
+++ b/test/files/neg/t2509-7b.scala
@@ -1,4 +1,4 @@
-// scalac: -Yscala3-implicit-resolution
+//> using options -Xsource:3 -Xsource-features:implicit-resolution
 class Both[-A, +B]
 
 trait Factory[A] {

--- a/test/files/neg/t3664.check
+++ b/test/files/neg/t3664.check
@@ -1,6 +1,11 @@
-t3664.scala:9: warning: Synthetic case companion used as a Function, use explicit object with Function parent
-  def f(xs: List[Int]): List[C] = xs.map(C)
+t3664.scala:10: error: Synthetic case companion used as a function. In Scala 3 (or with -Xsource-features:case-companion-function), case companions no longer extend FunctionN. Use C.apply instead.
+Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=Test.f
+  def f(xs: List[Int]): List[C] = xs.map(C) // ident
                                          ^
-error: No warnings can be incurred under -Werror.
-1 warning
-1 error
+t3664.scala:11: error: Synthetic case companion used as a function. In Scala 3 (or with -Xsource-features:case-companion-function), case companions no longer extend FunctionN. Use D.apply instead.
+Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=Test.g
+  def g(xs: List[Int]): List[O.D] = xs.map(O.D) // select
+                                             ^
+2 errors

--- a/test/files/neg/t3664.scala
+++ b/test/files/neg/t3664.scala
@@ -1,10 +1,12 @@
-//> using options -Werror -Xlint -Xsource:3
+//> using options -Xsource:3
 
 // use -Xsource:3 to warn that implicitly extending Function is deprecated
-// use -Xsource:3-cross for dotty behavior: no extend Function, yes adapt C.apply.tupled
+// use -Xsource-features for dotty behavior: no extend Function, yes adapt C.apply.tupled
 
 case class C(i: Int)
+object O { case class D(i: Int) }
 
 class Test {
-  def f(xs: List[Int]): List[C] = xs.map(C)
+  def f(xs: List[Int]): List[C] = xs.map(C) // ident
+  def g(xs: List[Int]): List[O.D] = xs.map(O.D) // select
 }

--- a/test/files/neg/t3664b.check
+++ b/test/files/neg/t3664b.check
@@ -1,6 +1,9 @@
-t3664b.scala:9: warning: The method `apply` is inserted. The auto insertion will be deprecated, please write `C.apply` explicitly.
-  def f(xs: List[Int]): List[C] = xs.map(C)
+t3664b.scala:10: warning: The method `apply` is inserted. The auto insertion will be deprecated, please write `C.apply` explicitly.
+  def f(xs: List[Int]): List[C] = xs.map(C) // ident
                                          ^
+t3664b.scala:11: warning: The method `apply` is inserted. The auto insertion will be deprecated, please write `D.apply` explicitly.
+  def g(xs: List[Int]): List[O.D] = xs.map(O.D) // select
+                                             ^
 error: No warnings can be incurred under -Werror.
-1 warning
+2 warnings
 1 error

--- a/test/files/neg/t3664b.scala
+++ b/test/files/neg/t3664b.scala
@@ -1,10 +1,12 @@
-//> using options -Werror -Xlint -Xsource:3-cross
+//> using options -Werror -Xsource:3 -Xsource-features:case-companion-function -deprecation
 
 // use -Xsource:3 to warn that implicitly extending Function is deprecated
-// use -Xsource:3-cross for dotty behavior: no extend Function, yes adapt C.apply.tupled
+// use -Xsource-features for dotty behavior: no extend Function, yes adapt C.apply.tupled
 
 case class C(i: Int)
+object O { case class D(i: Int) }
 
 class Test {
-  def f(xs: List[Int]): List[C] = xs.map(C)
+  def f(xs: List[Int]): List[C] = xs.map(C) // ident
+  def g(xs: List[Int]): List[O.D] = xs.map(O.D) // select
 }

--- a/test/files/neg/t3664c.check
+++ b/test/files/neg/t3664c.check
@@ -15,10 +15,10 @@ t3664c.scala:24: error: type mismatch;
                                                 ^
 t3664c.scala:26: warning: An unapplied 0-arity method was eta-expanded (due to the expected type () => E), rather than applied to `()`.
 Write E.apply() to invoke method apply, or change the expected type.
-  val e: () => E = E
+  val e: () => E = E // apply insertion warning, plus lint warning about 0-arity eta expansion
                    ^
 t3664c.scala:26: warning: The method `apply` is inserted. The auto insertion will be deprecated, please write `E.apply` explicitly.
-  val e: () => E = E
+  val e: () => E = E // apply insertion warning, plus lint warning about 0-arity eta expansion
                    ^
 t3664c.scala:28: warning: The method `apply` is inserted. The auto insertion will be deprecated, please write `F.apply` explicitly.
   def ov(xs: List[Int]): List[F] = xs.map(F)

--- a/test/files/neg/t3664c.scala
+++ b/test/files/neg/t3664c.scala
@@ -1,7 +1,7 @@
-//> using options -Werror -Xlint -Xsource:3-cross
+//> using options -Werror -Xlint -Xsource:3 -Xsource-features:case-companion-function
 
 // use -Xsource:3 to warn that implicitly extending Function is deprecated
-// use -Xsource:3-cross for dotty behavior: no extend Function, yes adapt C.apply.tupled
+// use -Xsource-features for dotty behavior: no extend Function, yes adapt C.apply.tupled
 
 case class C(i: Int, j: Int)
 
@@ -23,7 +23,7 @@ class Test {
 
   def d(xs: List[(Int, Int)]): List[D] = xs.map(D) // hard error
 
-  val e: () => E = E
+  val e: () => E = E // apply insertion warning, plus lint warning about 0-arity eta expansion
 
   def ov(xs: List[Int]): List[F] = xs.map(F)
 }

--- a/test/files/neg/t5265b.check
+++ b/test/files/neg/t5265b.check
@@ -3,9 +3,9 @@ Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=Missing.tsMissing
   implicit val tsMissing = new T[String] {}   // warn val in trait
                ^
-t5265b.scala:20: error: under -Xsource:3-cross, the inferred type changes to T[String] [quickfixable]
+t5265b.scala:20: error: Implicit definition must have explicit type (inferred T[String]) [quickfixable]
 Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=Child.tsChild
-  implicit val tsChild = new T[String] {}     // nowarn because inferred from overridden
+  implicit val tsChild = new T[String] {}     // warn (no warn with -Xsource-features:infer-override)
                ^
 2 errors

--- a/test/files/neg/t5265b.scala
+++ b/test/files/neg/t5265b.scala
@@ -17,6 +17,6 @@ trait Parent {
   def tsChild: T[String]
 }
 trait Child extends Parent {
-  implicit val tsChild = new T[String] {}     // nowarn because inferred from overridden
+  implicit val tsChild = new T[String] {}     // warn (no warn with -Xsource-features:infer-override)
   def f = new C[String]
 }

--- a/test/files/neg/t6120.scala
+++ b/test/files/neg/t6120.scala
@@ -1,4 +1,4 @@
-// scalac: -deprecation -Xmigration:2.10 -Xfatal-warnings
+//> using options -deprecation -Werror -Xmigration:2.10
 //
 // showing that multiple warnings at same location are reported
 //

--- a/test/files/neg/t7212.check
+++ b/test/files/neg/t7212.check
@@ -1,12 +1,16 @@
-t7212.scala:5: warning: under -Xsource:3-cross, the inferred type changes to Object instead of String [quickfixable]
+t7212.scala:5: error: in Scala 3 (or with -Xsource-features:infer-override), the inferred type changes to Object instead of String [quickfixable]
+Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=K.f
 class K extends T { def f = "" }
                         ^
-t7212.scala:11: warning: under -Xsource:3-cross, the inferred type changes to Object instead of String [quickfixable]
+t7212.scala:11: error: in Scala 3 (or with -Xsource-features:infer-override), the inferred type changes to Object instead of String [quickfixable]
+Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=F.f
 class F extends T { val f = "" }
                         ^
-t7212.scala:17: warning: under -Xsource:3-cross, the inferred type changes to Object instead of String [quickfixable]
+t7212.scala:17: error: in Scala 3 (or with -Xsource-features:infer-override), the inferred type changes to Object instead of String [quickfixable]
+Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=V.f
 trait V extends T { var f = "" }
                         ^
-error: No warnings can be incurred under -Werror.
-3 warnings
-1 error
+3 errors

--- a/test/files/neg/t7212.scala
+++ b/test/files/neg/t7212.scala
@@ -20,3 +20,12 @@ object W {
   val w = new W
   val s: String = w.f
 }
+
+object refinement {
+  trait X { def f: Int }
+  trait T { def f: X }
+  // inferred:    RefinedType(List(T, AnyRef), Nil)
+  // parent type: TypeRef(T)
+  // `=:=` is false, but `<:<` is true in both directions
+  class C extends T { def f = new X { def f = 1 } }
+}

--- a/test/files/neg/t7212.scala
+++ b/test/files/neg/t7212.scala
@@ -1,5 +1,5 @@
 
-//> using options -Werror -Xmigration -Xsource:3
+//> using options -Xsource:3
 
 trait T { def f: Object }
 class K extends T { def f = "" }

--- a/test/files/neg/t7212b.check
+++ b/test/files/neg/t7212b.check
@@ -1,14 +1,14 @@
-t7212b.scala:8: error: type mismatch;
+t7212b.scala:7: error: type mismatch;
  found   : Object
  required: String
   val s: String = k.f
                     ^
-t7212b.scala:14: error: type mismatch;
+t7212b.scala:13: error: type mismatch;
  found   : Object
  required: String
   val s: String = f.f
                     ^
-t7212b.scala:21: error: type mismatch;
+t7212b.scala:20: error: type mismatch;
  found   : Object
  required: String
   val s: String = w.f

--- a/test/files/neg/t7212b.scala
+++ b/test/files/neg/t7212b.scala
@@ -1,5 +1,4 @@
-
-//> using options -Xmigration -Xsource:3-cross
+//> using options -Xsource:3 -Xsource-features:infer-override
 
 trait T { def f: Object }
 class K extends T { def f = "" }

--- a/test/files/neg/t8035-removed.scala
+++ b/test/files/neg/t8035-removed.scala
@@ -1,5 +1,5 @@
-//> using options -Werror -Xlint -Xsource:3-cross
-//
+//> using options -Werror -Xlint -Xsource:3
+
 object Foo {
   List(1,2,3).toSet()
 

--- a/test/files/pos/caseclass_private_constructor.scala
+++ b/test/files/pos/caseclass_private_constructor.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:3 -Xmigration
+//> using options -Wconf:cat=scala3-migration:ws -Xsource:3
 
 case class A private (i: Int)
 object A {

--- a/test/files/pos/infixed.scala
+++ b/test/files/pos/infixed.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:3-cross
+//> using options -Xsource:3 -Xsource-features:leading-infix
 
 class K { def x(y: Int) = 0 }
 

--- a/test/files/pos/leading-infix-op.scala
+++ b/test/files/pos/leading-infix-op.scala
@@ -1,5 +1,4 @@
-
-// scalac: -Xsource:3-cross
+//> using options -Xsource:3 -Xsource-features:leading-infix
 
 trait T {
   def f(x: Int): Boolean =

--- a/test/files/pos/multiLineOps.scala
+++ b/test/files/pos/multiLineOps.scala
@@ -1,4 +1,4 @@
-// scalac: -Werror -Xsource:3-cross
+//> using options -Werror -Xsource:3 -Xsource-features:leading-infix
 
 class Channel {
   def ! (msg: String): Channel = this

--- a/test/files/pos/t2509-5.scala
+++ b/test/files/pos/t2509-5.scala
@@ -1,5 +1,5 @@
 // See https://github.com/scala/scala3/issues/2974
-// scalac: -Yscala3-implicit-resolution
+//> using options -Xsource:3 -Xsource-features:implicit-resolution
 
 trait Foo[-T]
 

--- a/test/files/pos/t2509-6.scala
+++ b/test/files/pos/t2509-6.scala
@@ -1,4 +1,4 @@
-// scalac: -Yscala3-implicit-resolution
+//> using options -Xsource:3 -Xsource-features:implicit-resolution
 class A
 class B extends A
 

--- a/test/files/pos/t2509-7a.scala
+++ b/test/files/pos/t2509-7a.scala
@@ -1,4 +1,4 @@
-// scalac: -Yscala3-implicit-resolution
+//> using options -Xsource:3 -Xsource-features:implicit-resolution
 
 class Both[-A, +B]
 

--- a/test/files/pos/t3664.scala
+++ b/test/files/pos/t3664.scala
@@ -1,5 +1,4 @@
-
-//> using options -Werror -Xlint -Xsource:3-cross
+//> using options -Werror -Xlint -Xsource:3
 
 import language.implicitConversions
 

--- a/test/files/pos/t6963c.scala
+++ b/test/files/pos/t6963c.scala
@@ -1,4 +1,4 @@
-// scalac: -Xmigration:2.9 -Xfatal-warnings
+//> using options -Werror -Xmigration:2.9
 //
 import collection.Seq
 object Test {

--- a/test/files/pos/t7212.scala
+++ b/test/files/pos/t7212.scala
@@ -1,5 +1,4 @@
-
-// scalac: -Xsource:3-cross -Xmigration
+//> using options -Xsource:3 -Xsource-features:infer-override
 
 class A {
   def f: Option[String] = Some("hello, world")

--- a/test/files/pos/t7212b/ScalaThing.scala
+++ b/test/files/pos/t7212b/ScalaThing.scala
@@ -1,5 +1,4 @@
-
-// scalac: -Xsource:3-cross -Xmigration
+//> using options -Xsource:3 -Xsource-features:infer-override
 
 class ScalaThing extends JavaThing {
   override def remove() = ???

--- a/test/files/run/multiLineOps.scala
+++ b/test/files/run/multiLineOps.scala
@@ -1,8 +1,8 @@
-//> using options -Xsource:3-cross
-//
+//> using options -Xsource:3 -Xsource-features:leading-infix
+
 // was: without backticks, "not found: value +" (but parsed here as +a * 6, where backticks fool the lexer)
 // now: + is taken as "solo" infix op
-//
+
 object Test extends App {
   val a = 7
   val x = 1

--- a/test/files/run/print-args.scala
+++ b/test/files/run/print-args.scala
@@ -1,9 +1,10 @@
-
 import java.nio.file.Files
 
 import scala.jdk.CollectionConverters._
 import scala.reflect.internal.util._
 import scala.tools.partest.DirectTest
+
+import org.junit.Assert._
 
 object Test extends DirectTest {
   lazy val argfile = testOutput.jfile.toPath().resolve("print-args.txt")
@@ -26,6 +27,7 @@ object Test extends DirectTest {
     """
   def show() = {
     assert(!compile())
+    //assertEquals(expected.linesIterator.toList, Files.readAllLines(argfile).asScala.toList)
     assert(expected.linesIterator.toList.tail.init.sameElements(Files.readAllLines(argfile).asScala))
   }
 }

--- a/test/files/run/productElementName.scala
+++ b/test/files/run/productElementName.scala
@@ -1,4 +1,4 @@
-//> using options -Xsource:3-cross
+//> using options -Xsource:3 -Xsource-features:leading-infix
 
 import scala.tools.testkit.AssertUtil.assertThrown
 import scala.util.chaining.*

--- a/test/files/run/source3Xrun.scala
+++ b/test/files/run/source3Xrun.scala
@@ -1,4 +1,4 @@
-//> using options -Xsource:3-cross
+//> using options -Xsource:3 -Xsource-features:_
 
 // StringContext hygiene
 class SC1 {

--- a/test/files/run/t12071.scala
+++ b/test/files/run/t12071.scala
@@ -1,4 +1,4 @@
-//> using options -Werror -Xlint -Xsource:3-cross
+//> using options -Werror -Xlint -Xsource:3 -Xsource-features:_
 
 class C {
   def `c c`(n: Int): Int = n + 1

--- a/test/files/run/t2509-1.scala
+++ b/test/files/run/t2509-1.scala
@@ -1,4 +1,4 @@
-// scalac: -Yscala3-implicit-resolution
+//> using options -Xsource:3 -Xsource-features:implicit-resolution
 import scala.language.implicitConversions
 
 class A

--- a/test/files/run/t2509-4.scala
+++ b/test/files/run/t2509-4.scala
@@ -1,4 +1,4 @@
-// scalac: -Yscala3-implicit-resolution
+//> using options -Xsource:3 -Xsource-features:implicit-resolution
 import scala.language.implicitConversions
 
 class A

--- a/test/files/run/t3220-214.scala
+++ b/test/files/run/t3220-214.scala
@@ -1,4 +1,4 @@
-//> using options -Xmigration -Xsource:3-cross
+//> using options -Xsource:3 -Xsource-features:unicode-escapes-raw
 
 object Literals214 {
   def inTripleQuoted = """\u000A"""

--- a/test/files/run/t3664.scala
+++ b/test/files/run/t3664.scala
@@ -1,7 +1,7 @@
-//> using options -Xlint -Xsource:3-cross
+//> using options -Xsource:3 -Xsource-features:case-companion-function -deprecation
 
 // use -Xsource:3 to warn that implicitly extending Function is deprecated
-// use -Xsource:3-cross for dotty behavior: no extend Function, yes adapt C.apply.tupled
+// use -Xsource-features for dotty behavior: no extend Function, yes adapt C.apply.tupled
 
 case class B(i: Int)
 case class C(i: Int, j: Int)

--- a/test/files/run/t7768.scala
+++ b/test/files/run/t7768.scala
@@ -1,4 +1,4 @@
-// scalac: -Yscala3-implicit-resolution
+//> using options -Xsource:3 -Xsource-features:implicit-resolution
 class A
 class B extends A
 class C extends B

--- a/test/junit/scala/tools/nsc/settings/ScalaVersionTest.scala
+++ b/test/junit/scala/tools/nsc/settings/ScalaVersionTest.scala
@@ -39,8 +39,6 @@ class ScalaVersionTest {
     // oh really
     assertEquals(NoScalaVersion, ScalaVersion("none"))
     assertSame(NoScalaVersion, ScalaVersion("none"))
-    assertEquals(Scala3Cross, ScalaVersion("3-cross"))
-    assertSame(Scala3Cross, ScalaVersion("3-cross"))
     assertEquals(AnyScalaVersion, ScalaVersion("any"))
     assertSame(AnyScalaVersion, ScalaVersion("any"))
 

--- a/test/junit/scala/tools/nsc/typechecker/InferencerTest.scala
+++ b/test/junit/scala/tools/nsc/typechecker/InferencerTest.scala
@@ -2,7 +2,7 @@ package scala.tools.nsc
 package typechecker
 
 import org.junit.Assert.assertTrue
-import org.junit.{After, Before, Test}
+import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
@@ -23,21 +23,14 @@ trait ZwC[-T] extends Z[T] with C
 
 @RunWith(classOf[JUnit4])
 class InferencerTests extends BytecodeTesting {
-  import compiler.global._, analyzer._
+  import compiler.global._
+  import analyzer._
 
-  var storedYscala3ImplicitResolution: Boolean = false
-  @Before
-  def storeYscala3ImplicitResolution(): Unit = {
-    storedYscala3ImplicitResolution = settings.Yscala3ImplicitResolution.value
-  }
-  @After
-  def restoreYscala3ImplicitResolution(): Unit = {
-    settings.Yscala3ImplicitResolution.value = storedYscala3ImplicitResolution
-  }
+  override def compilerArgs: String = "-Xsource:3"
 
   @Test
   def isAsSpecificScala2(): Unit = {
-    settings.Yscala3ImplicitResolution.value = false
+    settings.XsourceFeatures.clear()
     val run = new global.Run
 
     enteringPhase(run.typerPhase) {
@@ -103,7 +96,8 @@ class InferencerTests extends BytecodeTesting {
 
   @Test
   def isAsSpecificScala3(): Unit = {
-    settings.Yscala3ImplicitResolution.value = true
+    settings.XsourceFeatures.clear()
+    settings.XsourceFeatures.tryToSet(List("implicit-resolution"))
 
     val run = new global.Run
 


### PR DESCRIPTION
This feature is only recommended for projects that cross-build between Scala 2.13 and Scala 3. For migrating to Scala 3, use plain `-Xsource:3`. See also https://docs.scala-lang.org/scala3/guides/migration/tooling-scala2-xsource3.html.

This PR makes Scala 3 language features opt-in under an option "buffet" or "à la carte". To view the menu:

```
$> scalac -Xsource-features:help
Enable Scala 3 features under -Xsource:3.

Instead of `-Xsource-features:_`, it is recommended to enable specific features, for
example `-Xsource-features:v2.13.14,-case-companion-function` (-x to exclude x).
This way, new semantic changes in future Scala versions are not silently adopted;
new features can be enabled after auditing the corresponding migration warnings.

`-Xsource:3-cross` is a shorthand for `-Xsource:3 -Xsource-features:_`.

Features marked with [bin] affect the binary encoding. Enabling them in a project
with existing releases for Scala 2.13 can break binary compatibility.

Available features:

  case-apply-copy-access    Constructor modifiers are used for apply / copy methods of case classes. [bin]
  case-companion-function   Synthetic case companion objects no longer extend FunctionN. [bin]
  infer-override            Inferred type of member uses type of overridden member. [bin]
  any2stringadd             Implicit `any2stringadd` is never inferred.
  unicode-escapes-raw       Don't process unicode escapes in triple quoted strings and raw interpolations.
  string-context-scope      String interpolations always desugar to scala.StringContext.
  leading-infix             Leading infix operators continue the previous line.
  package-prefix-implicits  The package prefix p is no longer part of the implicit search scope for type p.A.
  implicit-resolution       Use Scala-3-style downwards comparisons for implicit search and overloading resolution (see github.com/scala/scala/pull/6037).
  v2.13.13                  case-apply-copy-access,case-companion-function,infer-override,any2stringadd,unicode-escapes-raw,string-context-scope,leading-infix,package-prefix-implicits.
  v2.13.14                  v2.13.13 plus implicit-resolution
```

`-Xsource:3 -Xsource-features:_` (or `-Xsource:3-cross` for convenience to start a REPL) offers all "courses" as "prix fixe". It's not recommended in a build script, use `v2.13.14` instead to get migration warnings as new features are adopted.

`-Xmigration` is no longer "overloaded" to mean `-Wconf:cat=scala3-migration:w`. That incantation must be written in full.

Fixes scala/bug#12961
