### PR TITLE
Check pos before using point

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -643,9 +643,13 @@ trait TypeDiagnostics extends splain.SplainDiagnostics {
         ))
       )
     def sympos(s: Symbol): Int =
-      if (s.pos.isDefined) s.pos.point else if (s.isTerm) s.asTerm.referenced.pos.point else -1
+      if (s.pos.isDefined) s.pos.point
+      else if (s.isTerm && s.asTerm.referenced.pos.isDefined) s.asTerm.referenced.pos.point
+      else -1
     def treepos(t: Tree): Int =
-      if (t.pos.isDefined) t.pos.point else sympos(t.symbol)
+      if (t.pos.isDefined) t.pos.point
+      else if (t.symbol != null) sympos(t.symbol)
+      else -1
 
     def unusedTypes = defnTrees.toList.filter(t => isUnusedType(t.symbol)).sortBy(treepos)
     def unusedTerms = {


### PR DESCRIPTION
Check that the position is defined before taking its point.

There are a few issues: position should be safer to use; and it should be trivial to sort by position (even if undefined).

No test yet, just tested the example as an sbt project against local build.

Fixes scala/bug#12895