### PR TITLE
Prefer ownersIterator

### DIFF
--- a/src/compiler/scala/reflect/reify/codegen/GenSymbols.scala
+++ b/src/compiler/scala/reflect/reify/codegen/GenSymbols.scala
@@ -83,7 +83,7 @@ trait GenSymbols {
        *    object B { object B } => selectType(staticModule("B"), "B")
        *    object B { package B } => impossible
        */
-      val hasPackagelessParent = sym.ownerChain.tail.tail exists (_.isEmptyPackageClass)
+      val hasPackagelessParent = sym.ownersIterator.drop(2).exists(_.isEmptyPackageClass)
       if (sym.isStatic && (sym.isClass || sym.isModule) && !hasPackagelessParent) {
         // scala/bug#6238: if applicable, emit references to StandardDefinitions instead of staticClass/staticModule calls
         val resolver = if (sym.isType) nme.staticClass else nme.staticModule

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1081,11 +1081,9 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
   @inline final def enteringUncurry[T](op: => T): T       = enteringPhase(currentRun.uncurryPhase)(op)
 
   // Owners which aren't package classes.
-  private def ownerChainString(sym: Symbol): String = (
+  private def ownerChainString(sym: Symbol): String =
     if (sym == null) ""
-    else sym.ownerChain takeWhile (!_.isPackageClass) mkString " -> "
-  )
-
+    else sym.ownersIterator.takeWhile(!_.isPackageClass).mkString(" -> ")
 
   /** Don't want to introduce new errors trying to report errors,
    *  so swallow exceptions.

--- a/src/compiler/scala/tools/nsc/symtab/SymbolTrackers.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolTrackers.scala
@@ -49,7 +49,7 @@ trait SymbolTrackers {
     def containsSymbol(t: Tree) = t.symbol != null && t.symbol != NoSymbol
 
     // This is noise reduction only.
-    def dropSymbol(sym: Symbol) = sym.ownerChain exists (_ hasFlag Flags.SPECIALIZED)
+    def dropSymbol(sym: Symbol) = sym.ownersIterator.exists(_.hasFlag(Flags.SPECIALIZED))
 
     def symbolSnapshot(unit: CompilationUnit): Map[Symbol, Set[Tree]] = {
       if (unit.body == null) Map.empty
@@ -84,7 +84,7 @@ trait SymbolTrackers {
         def descendents(s: Symbol) = (syms - s) filter (_ hasTransOwner s)
         def rooted(root: Symbol)   = new Node(root, nodes(descendents(root)))
 
-        val roots    = syms filterNot (_.ownerChain drop 1 exists syms)
+        val roots    = syms.filterNot(_.ownersIterator.drop(1).exists(syms))
         val deep     = roots map rooted
         val deepSyms = deep flatMap (_.flatten)
 

--- a/src/compiler/scala/tools/nsc/transform/TailCalls.scala
+++ b/src/compiler/scala/tools/nsc/transform/TailCalls.scala
@@ -119,8 +119,8 @@ abstract class TailCalls extends Transform {
 
       def newThis(pos: Position) = {
         def msg = "Creating new `this` during tailcalls\n  method: %s\n  current class: %s".format(
-          method.ownerChain.mkString(" -> "),
-          currentClass.ownerChain.mkString(" -> ")
+          method.ownersIterator.mkString(" -> "),
+          currentClass.ownersIterator.mkString(" -> ")
         )
         logResult(msg)(method.newValue(nme.THIS, pos, SYNTHETIC) setInfo currentClass.typeOfThis)
       }

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1015,8 +1015,10 @@ trait Implicits extends splain.SplainData {
           if (sym.hasAccessorFlag) {
             val symAcc = sym.accessed // #3373
             symAcc.pos.pointOrElse(0) < ownerPos &&
-            !(owner.ownerChain exists (o => (o eq sym) || (o eq symAcc))) // probably faster to iterate only once, don't feel like duplicating hasTransOwner for this case
-          } else !(owner hasTransOwner sym)) // faster than owner.ownerChain contains sym
+            !owner.ownersIterator.exists(o => (o eq sym) || (o eq symAcc)) // probably faster to iterate only once, don't feel like duplicating hasTransOwner for this case
+          }
+          else !owner.hasTransOwner(sym)
+        )
       }
 
       sym.isInitialized || {

--- a/src/compiler/scala/tools/nsc/typechecker/MacroAnnotationNamers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MacroAnnotationNamers.scala
@@ -621,8 +621,8 @@ trait MacroAnnotationNamers { self: Analyzer =>
       if (!currentRun.compiles(owner) &&
           // NOTE: the following three lines of code are added to work around #7
           !owner.enclosingTopLevelClass.isRefinementClass &&
-          !owner.ownerChain.exists(_.isLocalDummy) &&
-          owner.ownerChain.forall(!currentRun.compiles(_))) {
+          !owner.ownersIterator.exists(_.isLocalDummy) &&
+          owner.ownersIterator.forall(!currentRun.compiles(_))) {
         owner.initialize
       }
       original.companionSymbol orElse {

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -567,7 +567,7 @@ abstract class RefChecks extends Transform {
         }
 
         def checkOverrideDeprecated(): Unit = {
-          if (other.hasDeprecatedOverridingAnnotation && !(member.hasDeprecatedOverridingAnnotation || member.ownerChain.exists(_.isDeprecated))) {
+          if (other.hasDeprecatedOverridingAnnotation && !(member.hasDeprecatedOverridingAnnotation || member.ownersIterator.exists(_.isDeprecated))) {
             val version = other.deprecatedOverridingVersion.getOrElse("")
             val since   = if (version.isEmpty) version else s" (since $version)"
             val message = other.deprecatedOverridingMessage map (msg => s": $msg") getOrElse ""
@@ -1332,14 +1332,14 @@ abstract class RefChecks extends Transform {
         if (changed)
           refchecksWarning(pos, s"${sym.fullLocationString} has changed semantics in version ${sym.migrationVersion.get}:\n${sym.migrationMessage.get}", WarningCategory.OtherMigration)
       }
-      if (sym.isExperimental && !currentOwner.ownerChain.exists(x => x.isExperimental)) {
+      if (sym.isExperimental && !currentOwner.ownersIterator.exists(_.isExperimental)) {
         val msg =
           s"${sym.fullLocationString} is marked @experimental and therefore its enclosing scope must be experimental."
         reporter.error(pos, msg)
       }
       // See an explanation of compileTimeOnly in its scaladoc at scala.annotation.compileTimeOnly.
       // async/await is expanded after erasure
-      if (sym.isCompileTimeOnly && !inAnnotation && !currentOwner.ownerChain.exists(x => x.isCompileTimeOnly)) {
+      if (sym.isCompileTimeOnly && !inAnnotation && !currentOwner.ownersIterator.exists(_.isCompileTimeOnly)) {
         if (!async.deferCompileTimeOnlyError(sym)) {
           def defaultMsg =
             sm"""Reference to ${sym.fullLocationString} should not have survived past type checking,

--- a/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
@@ -71,7 +71,7 @@ abstract class TreeCheckers extends Analyzer {
     case s: Symbol => s.shortSymbolClass
     case x         => shortClassOfInstance(x.asInstanceOf[AnyRef])
   }
-  private def nonPackageOwners(s: Symbol) = s.ownerChain drop 1 takeWhile (!_.hasPackageFlag)
+  private def nonPackageOwners(s: Symbol) = s.ownerChain.drop(1).takeWhile(!_.hasPackageFlag)
   private def nonPackageOwnersPlusOne(s: Symbol) = nonPackageOwners(s) ::: (s.ownerChain dropWhile (!_.hasPackageFlag) take 1)
   private def ownersString(s: Symbol) = nonPackageOwnersPlusOne(s) match {
     case Nil => "NoSymbol"

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1908,7 +1908,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           val sameSourceFile = context.unit.source.file == psym.sourceFile
 
           if (!isPastTyper && psym.hasDeprecatedInheritanceAnnotation &&
-            !sameSourceFile && !context.owner.ownerChain.exists(_.isDeprecated)) {
+            !sameSourceFile && !context.owner.ownersIterator.exists(_.isDeprecated)) {
             val version = psym.deprecatedInheritanceVersion.getOrElse("")
             val since   = if (version.isEmpty) version else s" (since $version)"
             val message = psym.deprecatedInheritanceMessage.map(msg => s": $msg").getOrElse("")
@@ -2493,7 +2493,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                   DeprecatedParamNameError(p, alt)
             }
 
-          if (settings.multiargInfix && !meth.isConstructor && meth.owner.isClass && !meth.isDeprecated && !meth.hasAnnotation(UnusedClass) && !meth.ownerChain.exists(_.isDeprecated) && !meth.isSynthetic)
+          if (settings.multiargInfix && !meth.isConstructor && meth.owner.isClass && !meth.isDeprecated && !meth.hasAnnotation(UnusedClass) && !meth.ownersIterator.exists(_.isDeprecated) && !meth.isSynthetic)
             meth.paramss match {
               case (h :: _ :: _) :: Nil if !h.isImplicit && Chars.isOperatorPart(meth.name.decoded.head) =>
                 warnMultiargInfix(ddef)

--- a/src/reflect/scala/reflect/internal/util/TraceSymbolActivity.scala
+++ b/src/reflect/scala/reflect/internal/util/TraceSymbolActivity.scala
@@ -68,7 +68,7 @@ trait TraceSymbolActivity {
     show(dashes(s1), ss map dashes: _*)
   }
   private def showSym(sym: Symbol): Unit = {
-    def prefix = ("  " * (sym.ownerChain.length - 1)) + sym.id
+    def prefix = ("  " * (sym.ownersIterator.size - 1)) + sym.id
     try println("%s#%s %s".format(prefix, sym.accurateKindString, sym.name.decode))
     catch {
       case x: Throwable => println(prefix + " failed: " + x)
@@ -111,7 +111,7 @@ trait TraceSymbolActivity {
     println("")
 
     showHeader("descendants", "symbol")
-    showFreq(allSymbols.values flatMap (_.ownerChain drop 1))(_.id, symbolStr)
+    showFreq(allSymbols.values.flatMap(_.ownersIterator.drop(1)))(_.id, symbolStr)
 
     showHeader("children", "symbol")
     showMapFreq(allChildren)(symbolStr)

--- a/src/reflect/scala/reflect/runtime/JavaMirrors.scala
+++ b/src/reflect/scala/reflect/runtime/JavaMirrors.scala
@@ -254,7 +254,7 @@ private[scala] trait JavaMirrors extends internal.SymbolTable with api.JavaUnive
     def moduleSymbol(rtcls: RuntimeClass): ModuleSymbol = classToScala(rtcls).companionModule.asModule
 
     private def ensuringNotFree(sym: Symbol)(body: => Any): Unit = {
-      val freeType = sym.ownerChain find (_.isFreeType)
+      val freeType = sym.ownersIterator.find(_.isFreeType)
       freeType match {
         case Some(freeType) => ErrorFree(sym, freeType)
         case _ => body

--- a/src/sbt-bridge/scala/tools/xsbt/CallbackGlobal.scala
+++ b/src/sbt-bridge/scala/tools/xsbt/CallbackGlobal.scala
@@ -210,8 +210,8 @@ sealed class ZincCompiler(settings: Settings, dreporter: DelegatingReporter, out
   }
 
   private def flattenedOwner(g: Global)(sym: g.Symbol): g.Symbol = {
-    val chain = sym.owner.ownerChain.dropWhile(o => o.isClass && !o.hasPackageFlag)
-    if (chain.isEmpty) g.NoSymbol else chain.head
+    val chain = sym.owner.ownersIterator.dropWhile(o => o.isClass && !o.hasPackageFlag)
+    if (!chain.hasNext) g.NoSymbol else chain.next()
   }
 
   private def flattenedName(g: Global)(sym: g.Symbol): g.Name = {

--- a/src/scaladoc/scala/tools/nsc/doc/model/MemberLookup.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/MemberLookup.scala
@@ -76,7 +76,7 @@ trait MemberLookup extends base.MemberLookupBase {
     Option(s.associatedFile).flatMap(_.underlyingSource).map { src =>
       val path = src.canonicalPath
       if(path.endsWith(".class")) { // Individual class file -> Classpath entry is root dir
-        val nesting = s.ownerChain.count(_.hasPackageFlag)
+        val nesting = s.ownersIterator.count(_.hasPackageFlag)
         if(nesting > 0) {
           val p = 0.until(nesting).foldLeft(src) {
             case (null, _) => null

--- a/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/model/ModelFactory.scala
@@ -983,7 +983,7 @@ class ModelFactory(val global: Global, val settings: doc.Settings) {
   }
 
   def makeQualifiedName(sym: Symbol, relativeTo: Option[Symbol] = None): String = {
-    val stop = relativeTo map (_.ownerChain.toSet) getOrElse Set[Symbol]()
+    val stop = relativeTo.map(_.ownersIterator.toSet).getOrElse(Set.empty[Symbol])
     var sym1 = sym
     val path = new StringBuilder()
     // var path = List[Symbol]()


### PR DESCRIPTION
When using `ownerChain` to search, prefer `ownersIterator` to creating and discarding a list.

A `find` may not even examine all owners.
