### PR TITLE
Avoid NoPosition.start in Scaladoc warning

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/DocComments.scala
+++ b/src/compiler/scala/tools/nsc/ast/DocComments.scala
@@ -363,7 +363,7 @@ trait DocComments { self: Global =>
                 case Some(replacement) => replaceWith(replacement)
                 case None              =>
                   val pos = docCommentPos(sym)
-                  val loc = pos withPoint (pos.start + vstart + 1)
+                  val loc = if (pos.isDefined) pos.withPoint(pos.start + vstart + 1) else NoPosition
                   runReporting.warning(loc, s"Variable $vname undefined in comment for $sym in $site", WarningCategory.Scaladoc, sym)
               }
             }


### PR DESCRIPTION
Some docs for synthetic symbols derived from `library-aux` sources have no position (for some reason).

Also for some reason, operations on position are brittle instead of safe. I'd expect to map a position such that the degenerate position remains safely degenerate instead of throwing (which helps no one). After solving `NoSymbol has no owner`, they ought to have tackled `NoPosition has no start`.

This commit just patches the warning not to do position arithmetic on NoPosition.

It requires restarr to work for the OP.

Edit: this commit also doesn't address "doc variable resolution in code block".

Edit: Fixes scala/bug#12964
