### PR TITLE
Fix `ArrayBuilder` regression in Scala 2.13.13 (`OutOfMemoryError` when adding empty arrays)

### DIFF
--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -316,20 +316,12 @@ object ArrayBuffer extends StrictOptimizedSeqFactory[ArrayBuffer] {
    *   - `max(targetLen, arrayLen * 2, DefaultInitialSize)`.
    *   - Throws an exception if `targetLen` exceeds `VM_MaxArraySize` or is negative (overflow).
    */
-  private[mutable] def resizeUp(arrayLen: Int, targetLen: Int): Int = {
-    def checkArrayLengthLimit(): Unit =
-      if (targetLen > VM_MaxArraySize)
-        throw new Exception(s"Array of array-backed collection exceeds VM length limit of $VM_MaxArraySize. Requested length: $targetLen; current length: $arrayLen")
-      else if (targetLen < 0)
-        throw new Exception(s"Overflow while resizing array of array-backed collection. Requested length: $targetLen; current length: $arrayLen; increase: ${targetLen - arrayLen}")
-
-    if (targetLen > 0 && targetLen <= arrayLen) -1
-    else {
-      checkArrayLengthLimit()
-      if (arrayLen > VM_MaxArraySize / 2) VM_MaxArraySize
-      else math.max(targetLen, math.max(arrayLen * 2, DefaultInitialSize))
-    }
-  }
+  private[mutable] def resizeUp(arrayLen: Int, targetLen: Int): Int =
+    if (targetLen < 0) throw new Exception(s"Overflow while resizing array of array-backed collection. Requested length: $targetLen; current length: $arrayLen; increase: ${targetLen - arrayLen}")
+    else if (targetLen <= arrayLen) -1
+    else if (targetLen > VM_MaxArraySize) throw new Exception(s"Array of array-backed collection exceeds VM length limit of $VM_MaxArraySize. Requested length: $targetLen; current length: $arrayLen")
+    else if (arrayLen > VM_MaxArraySize / 2) VM_MaxArraySize
+    else math.max(targetLen, math.max(arrayLen * 2, DefaultInitialSize))
 
   // if necessary, copy (curSize elements of) the array to a new array of capacity n.
   // Should use Array.copyOf(array, resizeEnsuring(array.length))?

--- a/test/junit/scala/collection/mutable/ArrayBufferTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBufferTest.scala
@@ -392,6 +392,9 @@ class ArrayBufferTest {
 
     // check termination and correctness
     assertTrue(7 < ArrayBuffer.DefaultInitialSize) // condition of test
+    assertEquals(-1, resizeUp(7, 0))
+    assertEquals(-1, resizeUp(Int.MaxValue, 0))
+    assertEquals(ArrayBuffer.DefaultInitialSize, resizeUp(-1, 0)) // no check of arrayLen
     assertEquals(ArrayBuffer.DefaultInitialSize, resizeUp(7, 10))
     assertEquals(VM_MaxArraySize, resizeUp(Int.MaxValue / 2, Int.MaxValue / 2 + 1)) // `MaxValue / 2` cannot be doubled
     assertEquals(VM_MaxArraySize / 2 * 2, resizeUp(VM_MaxArraySize / 2, VM_MaxArraySize / 2 + 1)) // `VM_MaxArraySize / 2` can be doubled
@@ -406,12 +409,13 @@ class ArrayBufferTest {
       try op catch { case e: InvocationTargetException => throw e.getCause }
     def checkExceedsMaxInt(targetLen: Int): Unit = {
       assertThrows[Exception](rethrow(resizeUp(0, targetLen)),
-                              _ == s"Overflow while resizing array of array-backed collection. Requested length: $targetLen; current length: 0; increase: $targetLen")
+        _ == s"Overflow while resizing array of array-backed collection. Requested length: $targetLen; current length: 0; increase: $targetLen")
     }
     def checkExceedsVMArrayLimit(targetLen: Int): Unit =
       assertThrows[Exception](rethrow(resizeUp(0, targetLen)),
-                              _ == s"Array of array-backed collection exceeds VM length limit of $VM_MaxArraySize. Requested length: $targetLen; current length: 0")
+        _ == s"Array of array-backed collection exceeds VM length limit of $VM_MaxArraySize. Requested length: $targetLen; current length: 0")
 
+    checkExceedsMaxInt(-1)
     checkExceedsMaxInt(Int.MaxValue + 1: @nowarn)
     checkExceedsVMArrayLimit(Int.MaxValue)
     checkExceedsVMArrayLimit(Int.MaxValue - 1)

--- a/test/junit/scala/collection/mutable/ArrayBuilderTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBuilderTest.scala
@@ -32,4 +32,11 @@ class ArrayBuilderTest {
     // expect an exception when trying to grow larger than maximum size by addAll(array)
     assertThrows[Exception](ab.addAll(arr))
   }
+
+  // avoid allocating "default size" for empty, and especially avoid doubling capacity for empty
+  @Test def `addAll allocates elems more lazily`: Unit = {
+    val builder = ArrayBuilder.make[String]
+    (1 to 100).foreach(_ => builder.addAll(Array.empty[String]))
+    assertEquals(0, builder.knownSize)
+  }
 }


### PR DESCRIPTION
Defer array resize on empty; `resizeUp` no longer resizes at target length zero.

`addAll` no longer assumes `elems` is allocated (non-null).

`ArrayBuffer` allocates eagerly anyway, so it is unaffected by not resizing at "default".

Fixes scala/bug#12971