### PR TITLE
Correctly detect double defs involving param accessors & nilary methods

### DIFF
--- a/test/files/neg/i20006.check
+++ b/test/files/neg/i20006.check
@@ -1,0 +1,47 @@
+i20006.scala:8: error: method next is defined twice;
+  the conflicting value next was defined at line 6:7
+  override def next(): T = { // error
+               ^
+i20006.scala:7: error: method hasNext is defined twice;
+  the conflicting value hasNext was defined at line 5:7
+  override def hasNext: Boolean = first || hasNext(acc) // error
+               ^
+i20006.scala:22: error: method next is defined twice;
+  the conflicting value next was defined at line 18:65
+  override def next(): T = { // error
+               ^
+i20006.scala:21: error: method hasNext is defined twice;
+  the conflicting value hasNext was defined at line 18:42
+  override def hasNext: Boolean = first || hasNext(acc) // error
+               ^
+i20006.scala:36: error: method next is defined twice;
+  the conflicting value next was defined at line 32:65
+  def next(): T = { // error
+      ^
+i20006.scala:35: error: method hasNext is defined twice;
+  the conflicting value hasNext was defined at line 32:42
+  def hasNext: Boolean = first || hasNext(acc) // error
+      ^
+i20006.scala:47: error: x is already defined as value x
+  val x: String = "member" // error
+      ^
+i20006.scala:50: error: variable x is defined twice;
+  the conflicting value x was defined at line 49:9
+  private var x: Int = 42 // error
+              ^
+i20006.scala:53: error: x is already defined as value x
+  private[this] var x: Int = 42 // error
+                    ^
+i20006.scala:56: error: method x is defined twice;
+  the conflicting value x was defined at line 55:9
+  def x(): Int = 42 // error
+      ^
+i20006.scala:63: error: method x is defined twice;
+  the conflicting value x was defined at line 62:21
+  def x(): Int = 42 // error
+      ^
+i20006.scala:67: error: method x is defined twice;
+  the conflicting method x was defined at line 66:21
+  def x(): Int = 42 // error
+      ^
+12 errors

--- a/test/files/neg/i20006.scala
+++ b/test/files/neg/i20006.scala
@@ -1,0 +1,146 @@
+
+abstract class XIterateIterator[T](seed: T) extends collection.AbstractIterator[T] {
+  private var first = true
+  private var acc = seed
+  val hasNext: T => Boolean
+  val next: T => T
+  override def hasNext: Boolean = first || hasNext(acc) // error
+  override def next(): T = { // error
+    if (first) {
+      first = false
+    } else {
+      acc = next(acc)
+    }
+    acc
+  }
+}
+
+final class YIterateIterator[T](seed: T, hasNext: T => Boolean, next: T => T) extends collection.AbstractIterator[T] {
+  private var first = true
+  private var acc = seed
+  override def hasNext: Boolean = first || hasNext(acc) // error
+  override def next(): T = { // error
+    if (first) {
+      first = false
+    } else {
+      acc = next(acc)
+    }
+    acc
+  }
+}
+
+final class ZIterateIterator[T](seed: T, hasNext: T => Boolean, next: T => T) {
+  private var first = true
+  private var acc = seed
+  def hasNext: Boolean = first || hasNext(acc) // error
+  def next(): T = { // error
+    if (first) {
+      first = false
+    } else {
+      acc = next(acc)
+    }
+    acc
+  }
+}
+
+class C(x: String) {
+  val x: String = "member" // error
+}
+class D(x: String) {
+  private var x: Int = 42 // error
+}
+class E(x: String) {
+  private[this] var x: Int = 42 // error
+}
+class F(x: String) {
+  def x(): Int = 42 // error
+}
+class G(x: String) {
+  def x(i: Int): Int = i
+}
+class H {
+  private[this] val x: String = ""
+  def x(): Int = 42 // error
+}
+class I {
+  private[this] def x: String = ""
+  def x(): Int = 42 // error
+}
+
+/*
+-- [E120] Naming Error: test/files/neg/i20006.scala:8:15 ---------------------------------------------------------------
+8 |  override def hasNext: Boolean = first || hasNext(acc)
+  |               ^
+  |               Double definition:
+  |               val hasNext: T => Boolean in class XIterateIterator at line 6 and
+  |               override def hasNext: Boolean in class XIterateIterator at line 8
+-- [E120] Naming Error: test/files/neg/i20006.scala:9:15 ---------------------------------------------------------------
+9 |  override def next(): T = {
+  |               ^
+  |               Double definition:
+  |               val next: T => T in class XIterateIterator at line 7 and
+  |               override def next(): T in class XIterateIterator at line 9
+-- [E120] Naming Error: test/files/neg/i20006.scala:22:15 --------------------------------------------------------------
+22 |  override def hasNext: Boolean = first || hasNext(acc)
+   |               ^
+   |               Double definition:
+   |               private[this] val hasNext: T => Boolean in class YIterateIterator at line 19 and
+   |               override def hasNext: Boolean in class YIterateIterator at line 22
+-- [E120] Naming Error: test/files/neg/i20006.scala:23:15 --------------------------------------------------------------
+23 |  override def next(): T = {
+   |               ^
+   |               Double definition:
+   |               private[this] val next: T => T in class YIterateIterator at line 19 and
+   |               override def next(): T in class YIterateIterator at line 23
+-- [E120] Naming Error: test/files/neg/i20006.scala:36:6 ---------------------------------------------------------------
+36 |  def hasNext: Boolean = first || hasNext(acc)
+   |      ^
+   |      Double definition:
+   |      private[this] val hasNext: T => Boolean in class ZIterateIterator at line 33 and
+   |      def hasNext: Boolean in class ZIterateIterator at line 36
+-- [E120] Naming Error: test/files/neg/i20006.scala:37:6 ---------------------------------------------------------------
+37 |  def next(): T = {
+   |      ^
+   |      Double definition:
+   |      private[this] val next: T => T in class ZIterateIterator at line 33 and
+   |      def next(): T in class ZIterateIterator at line 37
+-- [E120] Naming Error: test/files/neg/i20006.scala:48:6 ---------------------------------------------------------------
+48 |  val x: String = "member" // error
+   |      ^
+   |      Double definition:
+   |      private[this] val x: String in class C at line 47 and
+   |      val x: String in class C at line 48
+-- [E120] Naming Error: test/files/neg/i20006.scala:51:14 --------------------------------------------------------------
+51 |  private var x: Int = 42 // error
+   |              ^
+   |              Double definition:
+   |              private[this] val x: String in class D at line 50 and
+   |              private[this] var x: Int in class D at line 51
+-- [E120] Naming Error: test/files/neg/i20006.scala:54:20 --------------------------------------------------------------
+54 |  private[this] var x: Int = 42 // error
+   |                    ^
+   |                    Double definition:
+   |                    private[this] val x: String in class E at line 53 and
+   |                    private[this] var x: Int in class E at line 54
+-- [E120] Naming Error: test/files/neg/i20006.scala:57:6 ---------------------------------------------------------------
+57 |  def x(): Int = 42 // error
+   |      ^
+   |      Double definition:
+   |      private[this] val x: String in class F at line 56 and
+   |      def x(): Int in class F at line 57
+-- [E120] Naming Error: test/files/neg/i20006.scala:65:6 ---------------------------------------------------------------
+65 |  def x(): Int = 42
+   |      ^
+   |      Double definition:
+   |      val x: String in class H at line 63 and
+   |      def x(): Int in class H at line 65
+-- Warning: test/files/neg/i20006.scala:54:16 --------------------------------------------------------------------------
+54 |  private[this] var x: Int = 42 // error
+   |                ^
+   |                Ignoring [this] qualifier.
+   |                This syntax will be deprecated in the future; it should be dropped.
+   |                See: https://docs.scala-lang.org/scala3/reference/dropped-features/this-qualifier.html
+   |                This construct can be rewritten automatically under -rewrite -source 3.4-migration.
+1 warning found
+11 errors found
+*/

--- a/test/files/neg/t521b.check
+++ b/test/files/neg/t521b.check
@@ -1,0 +1,5 @@
+t521b.scala:15: error: method path is defined twice;
+  the conflicting value path was defined at line 14:30
+    override def path = "";
+                 ^
+1 error

--- a/test/files/neg/t521b.scala
+++ b/test/files/neg/t521b.scala
@@ -11,7 +11,7 @@ class PlainFile(val file : File) extends AbstractFile {}
 class VirtualFile(val name : String, val path : String) extends AbstractFile {}
 
 final class ZipArchive(val file : File, archive : ZipFile) extends PlainFile(file) {
-  class Entry(name : String, path0 : String) extends VirtualFile(name, path0) {
+  class Entry(name : String, path : String) extends VirtualFile(name, path) {
     override def path = "";
   }
 }


### PR DESCRIPTION
NOTICE: This PR was substantially revised by #10846 — users should consult that PR description rather than this one.

**Old description:**

Conflicting definitions of class parameters and methods were incorrectly permitted, and now will error in Scala 2, as in Scala 3.

For example, the double definitions of `hasNext` and `next` are disallowed:
```
class MyIterator[T](hasNext: T => Boolean, next: T => T) extends AbstractIterator[T] {
  private var s: T = _
  override def hasNext: Boolean = hasNext(s)
  override def next(): T = next(s)
}
```

Noticed at https://github.com/scala/scala3/issues/20006