### PR TITLE
Use C[T] as lub(C[T], C[Nothing]) for invariant T

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -5118,7 +5118,7 @@ trait Types
                   else {
                     val l = lub(asKinded, depth.decr)
                     val g = glb(asKinded, depth.decr)
-                    if (l <:< g) l
+                    if (l <:< g || g.isNothing) l
                     else {
                       // @M this has issues with f-bounds, see #2251
                       // Martin: Not sure there is a good way to fix it. For the moment we

--- a/test/files/pos/lubs.scala
+++ b/test/files/pos/lubs.scala
@@ -1,3 +1,10 @@
 object Test {
   List(new { def f = 1; def g = 1}, new { def f = 2}).map(_.f)
 }
+
+object inv {
+  val m1 = if (this.hashCode == 0) Map("" -> "") else Map.empty
+  val m2: Map[String, String] = m1
+  val m3 = m2 ++ Map("a" -> "a")
+  val m4: Map[String, String] = m3
+}

--- a/test/junit/scala/tools/nsc/symtab/SymbolTableTest.scala
+++ b/test/junit/scala/tools/nsc/symtab/SymbolTableTest.scala
@@ -64,9 +64,20 @@ class SymbolTableTest {
     // Ends up in `throw GlbFailure` in glb => Null
     assertTrue(definitions.NullTpe =:= glb(t1 :: t2 :: Nil))
   }
+
+  @Test def invariantLub(): Unit = {
+    import SymbolTableTest.invariantLub._
+    import symbolTable._
+    val l = lub(typeOf[C[String]] :: typeOf[C[Nothing]] :: Nil)
+    assertTrue(s"$l", l =:= typeOf[C[String]])
+  }
 }
 
 object SymbolTableTest {
+  object invariantLub {
+    class C[T]
+  }
+
   object t12702 {
     import scala.language.existentials
     trait MFSS[X <: MFSS[_]]


### PR DESCRIPTION
This is very ad hoc but maybe worth a try, behind a flag? Is it unsound?

Here's the issue it addresses:

```scala
scala> def m: Set[String] = {
     |   val s = if (true) Set("") else Set.empty
     |   s
     | }
         s
         ^
On line 3: error: type mismatch;
        found   : scala.collection.immutable.Set[_1] where type _1 <: String
        required: Set[String]
       Note: _1 <: String, but trait Set is invariant in type A.
```

In 2.13 this existential then comes in the way when combining maps with `++`. That method no longer LUBs the key type in 2.13, that was previously possible with `CanBuildFrom`:

```scala
scala> val m: Map[Object, String] = Map("" -> "") ++ Map(new Object() -> "")
                                                  ^
       error: type mismatch;
        found   : scala.collection.immutable.Iterable[(Object, String)]
        required: Map[Object,String]


// or with the existential
scala> val m: Map[String, String] = (if (true) Map("" -> "") else Map.empty) ++ Map("" -> "")
                                                                             ^
       error: type mismatch;
        found   : scala.collection.immutable.Iterable[(String, String)]
        required: Map[String,String]
```

Of course *[Fixed in Scala 3]*.