### PR TITLE
-d is also a scaladoc option

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -558,7 +558,7 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
   }
 
   /** Set the output directory for all sources. */
-  class OutputSetting private[nsc](default: String) extends StringSetting("-d", "directory|jar", "destination for generated classfiles.", default, None)
+  class OutputSetting private[nsc](default: String) extends StringSetting("-d", "directory|jar", "Destination for generated artifacts.", default, None)
 
   /**
    * Each [[MultiChoiceSetting]] takes a MultiChoiceEnumeration as domain. The enumeration may

--- a/src/scaladoc/scala/tools/nsc/doc/Settings.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/Settings.scala
@@ -249,8 +249,8 @@ class Settings(error: String => Unit, val printMsg: String => Unit = println(_),
   )
 
   // For improved help output.
-  def scaladocSpecific = Set[Settings#Setting](
-    docformat, doctitle, docfooter, docversion, docUncompilable, docsourceurl, docgenerator, docRootContent,
+  def scalaDocSpecific = Set[Settings#Setting](
+    outdir, docformat, doctitle, docfooter, docversion, docUncompilable, docsourceurl, docgenerator, docRootContent,
     docExternalDoc,
     docAuthor, docDiagrams, docDiagramsDebug, docDiagramsDotPath,
     docDiagramsDotTimeout, docDiagramsDotRestart,
@@ -258,8 +258,8 @@ class Settings(error: String => Unit, val printMsg: String => Unit = println(_),
     docDiagramsMaxNormalClasses, docDiagramsMaxImplicitClasses,
     docNoPrefixes, docNoLinkWarnings, docRawOutput, docSkipPackages,
     docExpandAllTypes, docGroups, docNoJavaComments
-  ).map(s => s.withAbbreviation("-" + s.name))
-  val isScaladocSpecific: String => Boolean = scaladocSpecific map (_.name)
+  ).map(s => s.withAbbreviation(s"-${s.name}"))
+  val isScaladocSpecific: String => Boolean = scalaDocSpecific.map(_.name)
 
   override def isScaladoc = true
 


### PR DESCRIPTION
Fixes scala/bug#9609

The text is hardwired, but there is a mechanism for identifying options.