### PR TITLE
GitHub Actions config: add JDK 22 to matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: [8, 11, 17, 21]
+        java: [8, 11, 17, 21, 22]
     runs-on: ${{matrix.os}}
     steps:
       - run: git config --global core.autocrlf false


### PR DESCRIPTION
And I should merge this forward to 2.13.x promptly, since 2.13.14 is imminent.