### PR TITLE
merge 2.12 to 2.13 20240409 [ci: last-only]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: [8, 11, 17, 21]
+        java: [8, 11, 17, 21, 22]
     runs-on: ${{matrix.os}}
     steps:
       - run: git config --global core.autocrlf false

--- a/build.sbt
+++ b/build.sbt
@@ -413,7 +413,7 @@ lazy val compilerOptionsExporter = Project("compilerOptionsExporter", file(".") 
   .settings(disablePublishing)
   .settings(
     libraryDependencies ++= {
-      val jacksonVersion = "2.16.1"
+      val jacksonVersion = "2.16.2"
       Seq(
         "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
         "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -413,7 +413,7 @@ lazy val compilerOptionsExporter = Project("compilerOptionsExporter", file(".") 
   .settings(disablePublishing)
   .settings(
     libraryDependencies ++= {
-      val jacksonVersion = "2.16.2"
+      val jacksonVersion = "2.17.0"
       Seq(
         "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
         "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.12.0")


### PR DESCRIPTION
this is mainly about the JDK 22 addition. that part won't get tested until after we merge

PICK - **GitHub Actions config: add JDK 22 to matrix**
PICK - **Update sbt-buildinfo to 0.12.0 in 2.12.x**

SKIP - **Update jackson-module-scala to 2.16.2 in 2.12.x**
SKIP - **Update jackson-module-scala to 2.17.0 in 2.12.x**
