### PR TITLE
silence some warnings in test code

### DIFF
--- a/src/partest/scala/tools/partest/nest/StreamCapture.scala
+++ b/src/partest/scala/tools/partest/nest/StreamCapture.scala
@@ -61,7 +61,8 @@ object StreamCapture {
     extra.foreach { case (k, v) => modified.setProperty(k, v) }
     // Trying to avoid other threads seeing the new properties object prior to the new entries
     // https://github.com/scala/scala/pull/6391#issuecomment-371346171
-    UnsafeAccess.U.storeFence()
+    // (JDK 22 deprecates `storeFence`; once we drop JDK 8 we can use the VarHandles one instead)
+    UnsafeAccess.U.storeFence(): @annotation.nowarn("cat=deprecation")
     System.setProperties(modified)
     try {
       action

--- a/test/scalacheck/scala/reflect/quasiquotes/TermConstructionProps.scala
+++ b/test/scalacheck/scala/reflect/quasiquotes/TermConstructionProps.scala
@@ -232,13 +232,14 @@ object TermConstructionProps extends QuasiquoteProperties("term construction") {
     object O
     implicit val liftO = Liftable[O.type] { _ => q"foo; bar" }
     assertEqAst(q"f(..$O)", "f(foo, bar)")
-  }
+  }: @annotation.nowarn("cat=unused-locals")
+
 
   property("scala/bug#7275 c2") = test {
     object O
     implicit val liftO = Liftable[O.type] { _ => q"{ foo; bar }; { baz; bax }" }
     assertEqAst(q"f(...$O)", "f(foo, bar)(baz, bax)")
-  }
+  }: @annotation.nowarn("cat=unused-locals")
 
   property("scala/bug#7275 d") = test {
     val l = q"a; b" :: q"c; d" :: Nil

--- a/test/tasty/test/scala/tools/tastytest/TastyTestJUnit.scala
+++ b/test/tasty/test/scala/tools/tastytest/TastyTestJUnit.scala
@@ -18,7 +18,7 @@ class TastyTestJUnit {
     outDir                  = None,
     additionalSettings      = Nil,
     additionalDottySettings = Nil
-  ).eval
+  ).eval()
 
   @test def runPipelined(): Unit = {
     assumeFalse("Disabled on Windows due to bug in jar format", isWindows)
@@ -29,7 +29,7 @@ class TastyTestJUnit {
       outDirs                 = None,
       additionalSettings      = Nil,
       additionalDottySettings = Nil
-    ).eval
+    ).eval()
   }
 
   @test def pos(): Unit = TastyTest.posSuite(
@@ -39,7 +39,7 @@ class TastyTestJUnit {
     outDir                  = None,
     additionalSettings      = Nil,
     additionalDottySettings = Nil
-  ).eval
+  ).eval()
 
   /** false positives that should fail, but work when annotations are not read */
   @test def posFalseNoAnnotations(): Unit = TastyTest.posSuite(
@@ -49,7 +49,7 @@ class TastyTestJUnit {
     outDir                  = None,
     additionalSettings      = Seq("-Ytasty-no-annotations"),
     additionalDottySettings = Nil
-  ).eval
+  ).eval()
 
   @test def posDoctool(): Unit = TastyTest.posDocSuite(
     src                     = "pos-doctool",
@@ -58,7 +58,7 @@ class TastyTestJUnit {
     outDir                  = None,
     additionalSettings      = Nil,
     additionalDottySettings = Nil
-  ).eval
+  ).eval()
 
   @test def neg(): Unit = TastyTest.negSuite(
     src                     = "neg",
@@ -67,7 +67,7 @@ class TastyTestJUnit {
     outDir                  = None,
     additionalSettings      = Nil,
     additionalDottySettings = Nil
-  ).eval
+  ).eval()
 
   @test def negPipelined(): Unit = {
     assumeFalse("Disabled on Windows due to bug in jar format", isWindows)
@@ -78,7 +78,7 @@ class TastyTestJUnit {
       outDirs                 = None,
       additionalSettings      = Nil,
       additionalDottySettings = Nil
-    ).eval
+    ).eval()
   }
 
   @test def negMoveMacros(): Unit = TastyTest.negChangePreSuite(
@@ -88,7 +88,7 @@ class TastyTestJUnit {
     outDirs                 = None,
     additionalSettings      = Nil,
     additionalDottySettings = Nil
-  ).eval
+  ).eval()
 
   @test def negIsolated(): Unit = TastyTest.negSuiteIsolated(
     src                     = "neg-isolated",
@@ -97,7 +97,7 @@ class TastyTestJUnit {
     outDirs                 = None,
     additionalSettings      = Nil,
     additionalDottySettings = Nil
-  ).eval
+  ).eval()
 
   @test def negFullCircle(): Unit = TastyTest.negFullCircleSuite(
     src                     = "neg-full-circle",
@@ -106,7 +106,7 @@ class TastyTestJUnit {
     outDir                  = None,
     additionalSettings      = Nil,
     additionalDottySettings = Nil
-  ).eval
+  ).eval()
 
   val propSrc     = "tastytest.src"
   val propPkgName = "tastytest.packageName"
@@ -135,7 +135,7 @@ object TastyTestJUnit {
   }
 
   final implicit class TryOps(val op: Try[Unit]) extends AnyVal {
-    def eval: Unit = op match {
+    def eval(): Unit = op match {
       case Failure(err) => fail(err.getMessage)
       case _ => ()
     }


### PR DESCRIPTION
one of them involves a JDK 22 deprecation warning, so it was failing the build now that we've added JDK 22 to the matrix