### PR TITLE
Fix `-Wconf` and `-nowarn` to be more consistent

### DIFF
--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -28,7 +28,7 @@ import scala.tools.nsc.Reporting._
 import scala.util.matching.Regex
 
 /** Provides delegates to the reporter doing the actual work.
- * PerRunReporting implements per-Run stateful info tracking and reporting
+ *  PerRunReporting implements per-Run stateful info tracking and reporting
  */
 trait Reporting extends internal.Reporting { self: ast.Positions with CompilationUnits with internal.Symbols =>
   def settings: Settings
@@ -53,9 +53,12 @@ trait Reporting extends internal.Reporting { self: ast.Positions with Compilatio
         globalError(s"Failed to parse `-Wconf` configuration: ${settings.Wconf.value}\n${msgs.mkString("\n")}$multiHelp")
         WConf(Nil)
       case Right(conf) =>
-        // configure cat=scala3-migration:e and if -deprecation cat=deprecation:w or s (instead of default ws)
+        // default is "cat=deprecation:ws,cat=feature:ws,cat=optimizer:ws"
+        // under -deprecation, "cat=deprecation:w", but under -deprecation:false or -nowarn, "cat=deprecation:s"
+        // similarly for -feature, -Wopt (?)
+        val needsDefaultAdjustment = settings.deprecation.isSetByUser
         val adjusted =
-          if (settings.deprecation.isSetByUser) {
+          if (needsDefaultAdjustment || settings.nowarn.value) {
             val (user, defaults) = conf.filters.splitAt(conf.filters.length - settings.WconfDefault.length)
             val Deprecation = MessageFilter.Category(WarningCategory.Deprecation)
             val action = if (settings.deprecation.value) Action.Warning else Action.Silent
@@ -66,9 +69,13 @@ trait Reporting extends internal.Reporting { self: ast.Positions with Compilatio
             conf.copy(filters = user ::: fixed)
           }
           else conf
-        val Migration = MessageFilter.Category(WarningCategory.Scala3Migration)
-        val boost = (settings.isScala3: @nowarn) && !conf.filters.exists(_._1.exists(_ == Migration))
-        if (boost) adjusted.copy(filters = adjusted.filters :+ (Migration :: Nil, Action.Error)) else adjusted
+        // configure any:s for -nowarn or cat=scala3-migration:e for -Xsource:3
+        def Migration = MessageFilter.Category(WarningCategory.Scala3Migration)
+        if (settings.nowarn.value)
+          adjusted.copy(filters = adjusted.filters :+ (MessageFilter.Any :: Nil, Action.Silent))
+        else if (settings.isScala3: @nowarn)
+          adjusted.copy(filters = adjusted.filters :+ (Migration :: Nil, Action.Error))
+        else adjusted
     }
 
     private lazy val quickfixFilters = {
@@ -397,19 +404,20 @@ trait Reporting extends internal.Reporting { self: ast.Positions with Compilatio
     var seenMacroExpansionsFallingBack = false
 
     // i.e., summarize warnings
-    def summarizeErrors(): Unit = if (!reporter.hasErrors && !settings.nowarn.value) {
-      for (c <- summarizedWarnings.keys.toList.sortBy(_.name))
+    def summarizeErrors(): Unit = if (!reporter.hasErrors) {
+      val warnOK = !settings.nowarn.value
+      if (warnOK) for (c <- summarizedWarnings.keys.toList.sortBy(_.name))
         summarize(Action.WarningSummary, c)
       for (c <- summarizedInfos.keys.toList.sortBy(_.name))
         summarize(Action.InfoSummary, c)
 
-      if (seenMacroExpansionsFallingBack)
+      if (warnOK && seenMacroExpansionsFallingBack)
         warning(NoPosition, "some macros could not be expanded and code fell back to overridden methods;"+
                 "\nrecompiling with generated classfiles on the classpath might help.", WarningCategory.Other, site = "")
 
       // todo: migrationWarnings
 
-      if (settings.fatalWarnings.value && reporter.hasWarnings)
+      if (warnOK && settings.fatalWarnings.value && reporter.hasWarnings)
         reporter.error(NoPosition, "No warnings can be incurred under -Werror.")
     }
 

--- a/src/compiler/scala/tools/nsc/reporters/ConsoleReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/ConsoleReporter.scala
@@ -26,7 +26,7 @@ class ConsoleReporter(val settings: Settings, val reader: BufferedReader, val wr
 
   override def finish(): Unit = {
     import reflect.internal.util.StringOps.countElementsAsString
-    if (!settings.nowarn.value && hasWarnings)
+    if (hasWarnings && !settings.nowarn.value)
       writer.println(countElementsAsString(warningCount, WARNING.toString.toLowerCase))
     if (hasErrors)
       writer.println(countElementsAsString(errorCount, ERROR.toString.toLowerCase))

--- a/src/compiler/scala/tools/nsc/reporters/Reporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/Reporter.scala
@@ -60,7 +60,6 @@ object Reporter {
 /** The reporter used in a Global instance.
   *
   * It filters messages based on
-  *   - settings.nowarn
   *   - settings.maxerrs / settings.maxwarns
   *   - positions (only one error at a position, no duplicate messages on a position)
   */

--- a/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
@@ -36,10 +36,7 @@ trait StandardScalaSettings { _: MutableSettings =>
   /** Other settings.
    */
   val dependencyfile =  StringSetting ("-dependencyfile", "file", "Set dependency tracking file.", ".scala_dependencies") withAbbreviation "--dependency-file"
-  val deprecation =    BooleanSetting ("-deprecation", "Emit warning and location for usages of deprecated APIs. See also -Wconf.") withAbbreviation "--deprecation" withPostSetHook { s =>
-    if (s.value) Wconf.tryToSet(List(s"cat=deprecation:w"))
-    else Wconf.tryToSet(List(s"cat=deprecation:s"))
-  }
+  val deprecation =    BooleanSetting ("-deprecation", "Emit warning and location for usages of deprecated APIs. See also -Wconf.").withAbbreviation("--deprecation")
   val encoding =        StringSetting ("-encoding", "encoding", "Specify character encoding used by source files.", Properties.sourceEncoding) withAbbreviation "--encoding"
   val explaintypes =   BooleanSetting ("-explaintypes", "Explain type errors in more detail.") withAbbreviation "--explain-types"
   val feature =        BooleanSetting ("-feature", "Emit warning and location for usages of features that should be imported explicitly. See also -Wconf.") withAbbreviation "--feature" withPostSetHook { s =>

--- a/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
@@ -45,7 +45,9 @@ trait StandardScalaSettings { _: MutableSettings =>
   }
   val g =               ChoiceSetting ("-g", "level", "Set level of generated debugging info.", List("none", "source", "line", "vars", "notailcalls"), "vars")
   val help =           BooleanSetting ("-help", "Print a synopsis of standard options") withAbbreviation "--help" withAbbreviation("-h")
-  val nowarn =         BooleanSetting ("-nowarn", "Generate no warnings.") withAbbreviation "--no-warnings" withPostSetHook { s => if (s.value) maxwarns.value = 0 }
+  val nowarn =         BooleanSetting("-nowarn", "Silence warnings. (-Wconf:any:s)")
+                        .withAbbreviation("--no-warnings")
+                        .withPostSetHook(s => if (s.value) maxwarns.value = 0)
   val optimise:        BooleanSetting // depends on post hook which mutates other settings
   val print =          BooleanSetting ("-print", "Print program with Scala-specific features removed.") withAbbreviation "--print"
   val quickfix =       MultiStringSetting(

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -27,7 +27,7 @@ trait Warnings {
   // Warning semantics.
   val fatalWarnings = BooleanSetting("-Werror", "Fail the compilation if there are any warnings.") withAbbreviation "-Xfatal-warnings"
 
-  private val WconfDefault = List("cat=deprecation:ws", "cat=feature:ws", "cat=optimizer:ws")
+  val WconfDefault = List("cat=deprecation:ws", "cat=feature:ws", "cat=optimizer:ws")
   // Note: user-defined settings are added on the right, but the value is reversed before
   // it's parsed, so that later defined settings take precedence.
   val Wconf = MultiStringSetting(

--- a/src/reflect/scala/reflect/internal/Reporting.scala
+++ b/src/reflect/scala/reflect/internal/Reporting.scala
@@ -122,8 +122,8 @@ abstract class Reporter {
 
   private def filteredInfo(pos: Position, msg: String, severity: Severity, actions: List[CodeAction]): Unit = {
     val f = filter(pos, msg, severity)
-    if (f <= 1) increment(severity)
-    if (f == 0) doReport(pos, msg, severity, actions)
+    if (f < Reporter.Suppress) increment(severity)
+    if (f == Reporter.Display) doReport(pos, msg, severity, actions)
   }
 
   def increment(severity: Severity): Unit = severity match {

--- a/test/files/neg/t12664.check
+++ b/test/files/neg/t12664.check
@@ -1,0 +1,11 @@
+t12664.scala:4: warning: side-effecting nullary methods are discouraged: suggest defining as `def f()` instead [quickfixable]
+  def f: Unit = 42
+      ^
+t12664.scala:4: warning: a pure expression does nothing in statement position
+  def f: Unit = 42
+                ^
+warning: 1 deprecation (since 1.0); re-run enabling -deprecation for details, or try -help
+warning: 1 lint warning; change -Wconf for cat=lint to display individual messages
+error: No warnings can be incurred under -Werror.
+4 warnings
+1 error

--- a/test/files/neg/t12664.scala
+++ b/test/files/neg/t12664.scala
@@ -1,0 +1,12 @@
+//> using options -Wconf:cat=lint-missing-interpolator:ws,cat=deprecation:ws -Werror -Xlint
+
+class C {
+  def f: Unit = 42
+
+  def oops = "$f"
+
+  @deprecated("old stuff", since="1.0")
+  def old = 17
+
+  def stale = old
+}

--- a/test/files/neg/t12984.check
+++ b/test/files/neg/t12984.check
@@ -1,0 +1,6 @@
+t12984.scala:12: warning: class D is deprecated (since 2.0): Will be phased out eventually someday.
+  def d = new D
+              ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/t12984.scala
+++ b/test/files/neg/t12984.scala
@@ -1,0 +1,13 @@
+
+//> using options -deprecation -Wconf:cat=deprecation&origin=C:s -Werror -Xlint
+
+@deprecated("Just say no.", since="1.0")
+class C
+
+@deprecated("Will be phased out eventually someday.", since="2.0")
+class D
+
+trait Test {
+  def c = new C
+  def d = new D
+}

--- a/test/files/pos/t12664.scala
+++ b/test/files/pos/t12664.scala
@@ -1,0 +1,38 @@
+//> using options -nowarn -Wconf:cat=lint-missing-interpolator:ws -Werror -Xlint -Xsource:3
+
+/*
+-nowarn and -Xlint are in contradiction. Which wins?
+-nowarn is recognized by per-run reporting and by sink reporter (e.g., ConsoleReporter).
+For per-run reporting, -nowarn means default wconf for deprecation must not be ws (summary, which would warn).
+Instead, it is w or s depending on whether -deprecation is requested.
+So from the perspective of per-run reporting, -deprecation means issue a diagnostic even if -nowarn.
+
+For the sink reporter, too, -nowarn means "don't summarize with warning count".
+In addition, -nowarn means -maxwarns:0, so any warning is filtered by FilteringReporter.
+(Normally, displayed warnings is capped by -maxwarns and then summarized as a count when done.)
+So from the perspective of the sink reporter, -nowarn means filter out warnings and don't print count of warnings.
+It doesn't consider -deprecation at all.
+In addition, -nowarn subverts -Werror.
+
+In the test example, there are 2 lints, a non-lint, and a migration warning.
+The wconf boosts a lint to ws summary, but -nowarn tells the sink not to print either a warning or a count.
+Migration is boosted to e by default, but -nowarn says don't boost migration warnings.
+A user-supplied wconf could boost migration despite -nowarn.
+Other warnings are silenced by any:s installed by -nowarn.
+*/
+trait T {
+  def g[A]: Option[A]
+}
+
+class C extends T {
+  def f: Unit = 42 // suppressed other warning for expr, lint for parens
+
+  override def g[A] = None // suppressed migration warning, not boosted to error under --no-warnings
+
+  def oops = "$f" // summarized lint
+
+  @deprecated("old stuff", since="1.0")
+  def old = 17
+
+  def stale = old
+}

--- a/test/files/pos/t8410.scala
+++ b/test/files/pos/t8410.scala
@@ -1,5 +1,4 @@
 //> using options -opt:inline:** -Wopt:none -Werror -deprecation:false
-//
 
 object Test extends App {
   @deprecated("","") def f = 42

--- a/test/files/run/nowarn.scala
+++ b/test/files/run/nowarn.scala
@@ -10,7 +10,7 @@ class Driven extends Driver {
     true
   }
   protected def newCompiler(): Global = Global(settings, reporter)
-  override protected def doCompile(compiler: Global): Unit = reporter.warning(NoPosition, "I don't do anything.")
+  override protected def doCompile(compiler: Global): Unit = reporter.warning(NoPosition, s"I can't do anything for ${reporter.getClass}.")
   def run(): Unit = process(Array("file.scala"))
 }
 object Test {

--- a/test/files/run/settings-parse.check
+++ b/test/files/run/settings-parse.check
@@ -12,55 +12,46 @@
 
 3) List(-cp, , -deprecation) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 4) List(-cp, , , -deprecation) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 5) List(-cp, , -deprecation, ) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 6) List(, -cp, , -deprecation) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 7) List(-cp, , -deprecation, foo.scala) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 8) List(-cp, , , -deprecation, foo.scala) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 9) List(-cp, , -deprecation, , foo.scala) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 10) List(-cp, , -deprecation, foo.scala, ) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 11) List(, -cp, , -deprecation, foo.scala) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
@@ -82,115 +73,96 @@
 
 16) List(-cp, , foo.scala, -deprecation) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 17) List(-cp, , , foo.scala, -deprecation) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 18) List(-cp, , foo.scala, , -deprecation) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 19) List(-cp, , foo.scala, -deprecation, ) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 20) List(, -cp, , foo.scala, -deprecation) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 21) List(-deprecation, -cp, ) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 22) List(, -deprecation, -cp, ) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 23) List(-deprecation, -cp, , ) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 24) List(-deprecation, , -cp, ) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 25) List(-deprecation, -cp, , foo.scala) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 26) List(, -deprecation, -cp, , foo.scala) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 27) List(-deprecation, -cp, , , foo.scala) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 28) List(-deprecation, -cp, , foo.scala, ) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 29) List(-deprecation, , -cp, , foo.scala) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 30) List(-deprecation, foo.scala, -cp, ) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 31) List(, -deprecation, foo.scala, -cp, ) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 32) List(-deprecation, , foo.scala, -cp, ) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 33) List(-deprecation, foo.scala, -cp, , ) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 34) List(-deprecation, foo.scala, , -cp, ) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
@@ -212,61 +184,51 @@
 
 39) List(foo.scala, -cp, , -deprecation) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 40) List(, foo.scala, -cp, , -deprecation) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 41) List(foo.scala, -cp, , , -deprecation) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 42) List(foo.scala, -cp, , -deprecation, ) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 43) List(foo.scala, , -cp, , -deprecation) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 44) List(foo.scala, -deprecation, -cp, ) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 45) List(, foo.scala, -deprecation, -cp, ) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 46) List(foo.scala, , -deprecation, -cp, ) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 47) List(foo.scala, -deprecation, -cp, , ) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
 48) List(foo.scala, -deprecation, , -cp, ) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = ""
 }
 
@@ -284,55 +246,46 @@
 
 3) List(-cp, /tmp:/bippy, -deprecation) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 4) List(-cp, /tmp:/bippy, , -deprecation) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 5) List(-cp, /tmp:/bippy, -deprecation, ) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 6) List(, -cp, /tmp:/bippy, -deprecation) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 7) List(-cp, /tmp:/bippy, -deprecation, foo.scala) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 8) List(-cp, /tmp:/bippy, , -deprecation, foo.scala) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 9) List(-cp, /tmp:/bippy, -deprecation, , foo.scala) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 10) List(-cp, /tmp:/bippy, -deprecation, foo.scala, ) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 11) List(, -cp, /tmp:/bippy, -deprecation, foo.scala) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
@@ -354,115 +307,96 @@
 
 16) List(-cp, /tmp:/bippy, foo.scala, -deprecation) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 17) List(-cp, /tmp:/bippy, , foo.scala, -deprecation) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 18) List(-cp, /tmp:/bippy, foo.scala, , -deprecation) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 19) List(-cp, /tmp:/bippy, foo.scala, -deprecation, ) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 20) List(, -cp, /tmp:/bippy, foo.scala, -deprecation) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 21) List(-deprecation, -cp, /tmp:/bippy) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 22) List(, -deprecation, -cp, /tmp:/bippy) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 23) List(-deprecation, -cp, /tmp:/bippy, ) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 24) List(-deprecation, , -cp, /tmp:/bippy) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 25) List(-deprecation, -cp, /tmp:/bippy, foo.scala) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 26) List(, -deprecation, -cp, /tmp:/bippy, foo.scala) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 27) List(-deprecation, -cp, /tmp:/bippy, , foo.scala) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 28) List(-deprecation, -cp, /tmp:/bippy, foo.scala, ) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 29) List(-deprecation, , -cp, /tmp:/bippy, foo.scala) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 30) List(-deprecation, foo.scala, -cp, /tmp:/bippy) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 31) List(, -deprecation, foo.scala, -cp, /tmp:/bippy) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 32) List(-deprecation, , foo.scala, -cp, /tmp:/bippy) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 33) List(-deprecation, foo.scala, -cp, /tmp:/bippy, ) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 34) List(-deprecation, foo.scala, , -cp, /tmp:/bippy) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
@@ -484,61 +418,51 @@
 
 39) List(foo.scala, -cp, /tmp:/bippy, -deprecation) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 40) List(, foo.scala, -cp, /tmp:/bippy, -deprecation) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 41) List(foo.scala, -cp, /tmp:/bippy, , -deprecation) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 42) List(foo.scala, -cp, /tmp:/bippy, -deprecation, ) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 43) List(foo.scala, , -cp, /tmp:/bippy, -deprecation) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 44) List(foo.scala, -deprecation, -cp, /tmp:/bippy) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 45) List(, foo.scala, -deprecation, -cp, /tmp:/bippy) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 46) List(foo.scala, , -deprecation, -cp, /tmp:/bippy) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 47) List(foo.scala, -deprecation, -cp, /tmp:/bippy, ) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 
 48) List(foo.scala, -deprecation, , -cp, /tmp:/bippy) ==> Settings {
   -deprecation = true
-  -Wconf = List(cat=deprecation:w, cat=deprecation:ws, cat=feature:ws, cat=optimizer:ws)
   -classpath = /tmp:/bippy
 }
 

--- a/test/junit/scala/tools/nsc/reporters/WConfTest.scala
+++ b/test/junit/scala/tools/nsc/reporters/WConfTest.scala
@@ -43,8 +43,7 @@ class WConfTest extends BytecodeTesting {
     reports(code, extraWconf, lint).filter(_.severity == InternalReporter.INFO)
 
   def reports(code: String, extraWconf: String = "", lint: Boolean = false): List[Info] = {
-    // lint has a postSetHook to enable `deprecated`, which in turn adds to `Wconf`,
-    // but since we clear and initialize Wconf after enabling lint, that effect is cancelled.
+    global.settings.deprecation.reset()
     if (lint) {
       global.settings.warnUnused.clear()
       global.settings.lint.tryToSet(List("_"))


### PR DESCRIPTION
Always respect user `-Wconf` settings, including `-nowarn`. Previously, some defaults were incorrectly enforced.

For example,
`-Wconf:cat=deprecation:e -deprecation -nowarn`
would fail to issue an error on deprecation, but now correctly works the same as
`-deprecation -nowarn -Wconf:cat=deprecation:e`

`-nowarn` sets `-Xmaxwarns:0` (which limits how many warnings are displayed) and also suppresses the "summary" messages that report a summary count, as well as suppressing the error under `-Werror` ("No warnings can be incurred"). It adds `any:s` to suppress any other warnings, and turns off `cat=scala3-migration:e` that boosts migration errors under `-Xsource:3`.

Fixes scala/bug#12984
Fixes https://github.com/scala/bug/issues/12664

Instead of adding wconf for deprecation when setting is selected, adjust the default filter when processing the configuration. This ensures that user config is respected in this respect.

Otherwise, subtle order dependency is not friendly.

Besides setting `maxwarns`, `nowarn` is a trailing `-Wconf:any:s`. That is, any unconfigured warnings are silenced. Configured warnings are counted and reported in the usual way, but summaries are silenced under `-nowarn`.