### PR TITLE
Move terminal test to properties

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -39,6 +39,9 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.concurrent.impl.FutureConvertersImpl#P.accept"),
     ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.concurrent.impl.FutureConvertersImpl#P.andThen"),
 
+    // private[scala] member used by Properties and by REPL
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.util.Properties.consoleIsTerminal"),
+
   )
 
   override val buildSettings = Seq(

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/ShellConfig.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/ShellConfig.scala
@@ -21,11 +21,10 @@ import scala.sys.Prop._
 
 import scala.tools.nsc.{GenericRunnerSettings, Settings}
 import scala.tools.nsc.Properties.{
-  coloredOutputEnabled, envOrNone, javaVersion, javaVmName,
+  coloredOutputEnabled, consoleIsTerminal, envOrNone, javaVersion, javaVmName,
   shellBannerString, shellInterruptedString, shellPromptString, shellWelcomeString,
   userHome, versionString, versionNumberString,
 }
-import scala.util.Properties.isJavaAtLeast
 
 object ShellConfig {
   val EDITOR = envOrNone("EDITOR")
@@ -60,15 +59,7 @@ trait ShellConfig {
   def batchText: String
   def batchMode: Boolean
   def doCompletion: Boolean
-  def haveInteractiveConsole: Boolean = System.console != null && consoleIsTerminal
-
-  // false if JDK 22 and the system console says !isTerminal
-  def consoleIsTerminal: Boolean = {
-    def isTerminal: Boolean =
-      try classOf[java.io.Console].getMethod("isTerminal", null).invoke(System.console).asInstanceOf[Boolean]
-      catch { case _: NoSuchMethodException => false }
-    !isJavaAtLeast(22) || isTerminal
-  }
+  def haveInteractiveConsole: Boolean = consoleIsTerminal
 
   // source compatibility, i.e., -Xsource
   def xsource: String
@@ -77,7 +68,7 @@ trait ShellConfig {
   private def int(name: String)  = Prop[Int](name)
 
   // This property is used in TypeDebugging. Let's recycle it.
-  val colorOk = coloredOutputEnabled && haveInteractiveConsole
+  val colorOk = coloredOutputEnabled
 
   val historyFile = s"$userHome/.scala_history_jline3"
 

--- a/test/files/neg/t6323a.scala
+++ b/test/files/neg/t6323a.scala
@@ -1,4 +1,4 @@
-// scalac: -Vimplicits
+//> using options -Vimplicits
 //
 import scala.reflect.runtime.universe._
 import scala.reflect.runtime.{currentMirror => m}


### PR DESCRIPTION
Follow up https://github.com/scala/scala/pull/10751 to be more like https://github.com/scala/scala/pull/10752

ShellConfig has a comment that the same property for colorization is used by TypeDebugging.

Notify the Scala Store to restock the "be more like Seth" t-shirts.
