### PR TITLE
Align WConf category for WFlagUnnamedBooleanLiteral

### DIFF
--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -571,7 +571,7 @@ object Reporting {
         WFlagExtraImplicit,
         WFlagNumericWiden,
         WFlagSelfImplicit,
-        WFlagNamedLiteral,
+        WFlagUnnamedBooleanLiteral,
         WFlagValueDiscard
       = wflag()
 

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1768,7 +1768,7 @@ abstract class RefChecks extends Transform {
               case (arg, param) =>
                 val msg = s"Boolean literals should be passed using named argument syntax for parameter ${param.name}."
                 val action = runReporting.codeAction("name boolean literal", arg.pos.focusStart, s"${param.name} = ", msg)
-                runReporting.warning(arg.pos, msg, WarningCategory.WFlagNamedLiteral, sym, action)
+                runReporting.warning(arg.pos, msg, WarningCategory.WFlagUnnamedBooleanLiteral, sym, action)
               case _ =>
             }
         }


### PR DESCRIPTION
This affects the `-Wconf` category (`w-flag-unnamed-boolean-literal`).