### PR TITLE
Restrict fix to Properties

### DIFF
--- a/src/library/scala/util/Properties.scala
+++ b/src/library/scala/util/Properties.scala
@@ -148,9 +148,10 @@ private[scala] trait PropertiesTrait {
 
   /** System.console.isTerminal, or just check for null console on JDK < 22 */
   private[scala] lazy val consoleIsTerminal: Boolean = {
+    import language.reflectiveCalls
     val console = System.console
     def isTerminal: Boolean =
-      try classOf[java.io.Console].getMethod("isTerminal", null).invoke(console).asInstanceOf[Boolean]
+      try console.asInstanceOf[{ def isTerminal(): Boolean }].isTerminal()
       catch { case _: NoSuchMethodException => false }
     console != null && (!isJavaAtLeast("22") || isTerminal)
   }

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/ILoop.scala
@@ -1009,7 +1009,7 @@ object ILoop {
     def batchText: String = delegate.batchText
     def batchMode: Boolean = delegate.batchMode
     def doCompletion: Boolean = delegate.doCompletion
-    override def haveInteractiveConsole: Boolean = delegate.haveInteractiveConsole
+    def haveInteractiveConsole: Boolean = delegate.haveInteractiveConsole
 
     def xsource: String = ""
 

--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/ShellConfig.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/ShellConfig.scala
@@ -21,7 +21,7 @@ import scala.sys.Prop._
 
 import scala.tools.nsc.{GenericRunnerSettings, Settings}
 import scala.tools.nsc.Properties.{
-  coloredOutputEnabled, consoleIsTerminal, envOrNone, javaVersion, javaVmName,
+  coloredOutputEnabled, envOrNone, javaVersion, javaVmName,
   shellBannerString, shellInterruptedString, shellPromptString, shellWelcomeString,
   userHome, versionString, versionNumberString,
 }
@@ -38,7 +38,7 @@ object ShellConfig {
       val batchText: String = if (settings.execute.isSetByUser) settings.execute.value else ""
       val batchMode: Boolean = batchText.nonEmpty
       val doCompletion: Boolean = !(settings.noCompletion.value || batchMode)
-      override val haveInteractiveConsole: Boolean = super.haveInteractiveConsole && !settings.Xnojline.value
+      val haveInteractiveConsole: Boolean = !settings.Xnojline.value
       def xsource: String = if (settings.isScala3: @nowarn) settings.source.value.versionString else ""
     }
     case _ => new ShellConfig {
@@ -47,7 +47,7 @@ object ShellConfig {
       val batchText: String = ""
       val batchMode: Boolean = false
       val doCompletion: Boolean = !settings.noCompletion.value
-      override val haveInteractiveConsole: Boolean = super.haveInteractiveConsole && !settings.Xnojline.value
+      val haveInteractiveConsole: Boolean = !settings.Xnojline.value
       def xsource: String = if (settings.isScala3: @nowarn) settings.source.value.versionString else ""
     }
   }
@@ -59,7 +59,7 @@ trait ShellConfig {
   def batchText: String
   def batchMode: Boolean
   def doCompletion: Boolean
-  def haveInteractiveConsole: Boolean = consoleIsTerminal
+  def haveInteractiveConsole: Boolean
 
   // source compatibility, i.e., -Xsource
   def xsource: String


### PR DESCRIPTION
The null arg was wrong, so use idiot-proof idiom instead.

Restore ShellConfig, where the original intervention landed.

~`haveInteractiveConsole` is used for picking jline reader, so it seems correct to check isConsole.~
