### PR TITLE
[backport] Amend `Console.isTerminal` fix (backports #10758 to 2.12)

### DIFF
--- a/src/library/scala/util/Properties.scala
+++ b/src/library/scala/util/Properties.scala
@@ -164,9 +164,10 @@ private[scala] trait PropertiesTrait {
 
   /** System.console.isTerminal, or just check for null console on JDK < 22 */
   private[scala] lazy val consoleIsTerminal: Boolean = {
+    import language.reflectiveCalls
     val console = System.console
     def isTerminal: Boolean =
-      try classOf[java.io.Console].getMethod("isTerminal", null).invoke(console).asInstanceOf[Boolean]
+      try console.asInstanceOf[{ def isTerminal(): Boolean }].isTerminal()
       catch { case _: NoSuchMethodException => false }
     console != null && (!isJavaAtLeast("22") || isTerminal)
   }

--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -29,7 +29,6 @@ import io.AbstractFile
 import scala.concurrent.{Await, Future}
 import java.io.BufferedReader
 
-import scala.util.Properties.consoleIsTerminal
 import scala.util.{Try, Success, Failure}
 
 import Completion._
@@ -906,7 +905,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter) extend
    *  supplied as a `() => Completion`; the Completion object provides a concrete Completer.
    */
   def chooseReader(settings: Settings): InteractiveReader = {
-    if (settings.Xnojline || !consoleIsTerminal) SimpleReader()
+    if (settings.Xnojline) SimpleReader()
     else {
       type Completer = () => Completion
       type ReaderMaker = Completer => InteractiveReader


### PR DESCRIPTION
Don't check `isTerminal` for using JLine or not, only use it in `Properties.coloredOutputEnabled`.