### PR TITLE
Normalize reference to undet param in stabilizer

### DIFF
--- a/test/files/pos/t12987.scala
+++ b/test/files/pos/t12987.scala
@@ -1,0 +1,30 @@
+object typeMember {
+  class Foo {
+    type FT
+    class I
+    def m(b: FT, o: Option[I]): Int = 0
+  }
+
+  object Test {
+    def f[T]: Foo { type FT = T } = ???
+    def t = {
+      val b: Any = ???
+      f.m(b, None)
+    }
+  }
+}
+
+object typeParam {
+  class Foo[FT] {
+    class I
+    def m(b: FT, o: Option[I]): Int = 0
+  }
+
+  object Test {
+    def f[T]: Foo[T] = ???
+    def t = {
+      val b: Any = ???
+      f.m(b, None)
+    }
+  }
+}


### PR DESCRIPTION
Details in the ticket.

Fixes https://github.com/scala/bug/issues/12987.