### PR TITLE
Defer infer bool param

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1624,8 +1624,8 @@ self =>
         accept(RPAREN)
         if (isWildcard(r))
           placeholderParams.head.tpt match {
-            case tpt @ TypeTree() => tpt.setType(definitions.BooleanTpe)
-            case _                =>
+            case TypeTree() => placeholderParams.head.updateAttachment(BooleanParameterType)
+            case _          =>
           }
         r
       } else {

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3161,6 +3161,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             // because I don't see how we could recurse after the `setError(vparam)` call below
             if (vparam.tpt.isEmpty) {
               if (isFullyDefined(argpt)) vparam.tpt setType argpt
+              else if (vparam.hasAttachment[BooleanParameterType.type]) vparam.tpt.setType(definitions.BooleanTpe) // `if (_)`
               else paramsMissingType += vparam
 
               if (!vparam.tpt.pos.isDefined) vparam.tpt setPos vparam.pos.focus

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -181,4 +181,6 @@ trait StdAttachments {
   case object DiscardedValue extends PlainAttachment
   /** Discarded pure expression observed at refchecks. */
   case object DiscardedExpr extends PlainAttachment
+  /** Anonymous parameter of `if (_)` may be inferred as Boolean. */
+  case object BooleanParameterType extends PlainAttachment
 }

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -90,6 +90,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.UnnamedArg
     this.DiscardedValue
     this.DiscardedExpr
+    this.BooleanParameterType
     this.noPrint
     this.typeDebug
     // inaccessible: this.posAssigner

--- a/test/files/pos/ifunc.scala
+++ b/test/files/pos/ifunc.scala
@@ -8,3 +8,23 @@ trait T {
 
   val g = (b: () => Boolean) => while (b()) println()    // less weird
 }
+
+import language.implicitConversions
+
+class Setting {
+  def tap(f: this.type => Unit): this.type = { f(this); this }
+}
+class BooleanSetting extends Setting {
+  def tap2(f: BooleanSetting => Unit): BooleanSetting = { f(this); this }
+}
+object BooleanSetting {
+  implicit def cv(s: BooleanSetting): Boolean = true
+}
+
+object Test extends App {
+  val setting = new Setting().tap(println)
+  val boolean = new BooleanSetting().tap(if (_) println("yes"))
+  val bool1   = new BooleanSetting().tap(s => if (s) println("yes"))
+  val bool2a  = new BooleanSetting().tap2(s => if (s) println("yes"))
+  val bool2b  = new BooleanSetting().tap2(if (_) println("yes"))
+}


### PR DESCRIPTION
The previous tweak to take `if (_)` as `if (_: Boolean)` is too strict.

That disallowed

BooleanSetting().("-nowarn").withPostSetHook(if(_) maxwarns.value=0)

Follow-up to https://github.com/scala/scala/pull/7707

Noticed previously

> This might be perfectly normal, but I wanted to do this, then remembered the param is a setting not a boolean, but I noticed the message is suboptimal:

```
[error] .../nsc/settings/StandardScalaSettings.scala:54:127: type mismatch;
[error]  found   : Boolean => Unit
[error]  required: stabilizer$1.type => Unit
[error]   val nowarn =         BooleanSetting ("-nowarn", "Generate no warnings.") withAbbreviation "--no-warnings" withPostSetHook { if (_) maxwarns.value = 0 }
[error]  
```