### PR TITLE
Restore visibility of Erasure.needsJavaSig(...)

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -92,7 +92,7 @@ abstract class Erasure extends InfoTransform
   }
 
   override protected def verifyJavaErasure = settings.Xverify || settings.isDebug
-  private def needsJavaSig(sym: Symbol, tp: Type, throwsArgs: List[Type]) = !settings.Ynogenericsig && {
+  def needsJavaSig(sym: Symbol, tp: Type, throwsArgs: List[Type]) = !settings.Ynogenericsig && {
     def needs(tp: Type) = NeedsSigCollector(sym.isClassConstructor).collect(tp)
     needs(tp) || throwsArgs.exists(needs)
   }


### PR DESCRIPTION
This method was used in Scala IDE, and now it does not compile because it was made private. I'm several versions behind, but I'd rather use the latest version. If that's not API, and there's no proper replacement, could we just restore the visibility ?