### PR TITLE
SeqMap.keys guarantees only key iteration order

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -58,6 +58,11 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[MissingClassProblem]("scala.annotation.meta.defaultArg"),
     ProblemFilters.exclude[MissingClassProblem]("scala.annotation.meta.superArg"),
     ProblemFilters.exclude[MissingClassProblem]("scala.annotation.meta.superFwdArg"),
+
+    // scala/scala#10766
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.SeqMap#EmptySeqMap.keys"),
+
+    // IMPROVE YOUR KARMA use trailing comma
   )
 
   override val buildSettings = Seq(

--- a/src/library/scala/collection/Map.scala
+++ b/src/library/scala/collection/Map.scala
@@ -181,7 +181,12 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
 
   /** A set representing the keys contained by this map.
    *
-   *  For efficiency the resulting set may be a view (maintaining a reference to the map and reflecting modifications
+   *  By default, the set uses `keysIterator` for iteration and delegates `contains` to the `Map`.
+   *
+   *  For `Map` implementations with ordered but not sorted keys, such as a `SeqMap`,
+   *  `keys` may efficiently build a representation that preserves order.
+   *
+   *  For efficiency, the resulting set may be a view (maintaining a reference to the map and reflecting modifications
    *  to the map), but it may also be a strict collection without reference to the map.
    *
    *   - To ensure an independent strict collection, use `m.keysIterator.toSet`
@@ -191,8 +196,7 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
    */
   def keySet: Set[K] = new KeySet
 
-  /** The implementation class of the set returned by `keySet`.
-    */
+  /** The implementation class of the set returned by `keySet`. */
   protected class KeySet extends AbstractSet[K] with GenKeySet with DefaultSerializable {
     def diff(that: Set[K]): Set[K] = fromSpecific(this.view.filterNot(that))
   }
@@ -208,6 +212,16 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
 
   /** An [[Iterable]] collection of the keys contained by this map.
    *
+   *  The default implementation returns `keySet`.
+   *
+   *  For `Map` implementations with ordered but not sorted keys, such as a `SeqMap`,
+   *  `keys` may efficiently build a representation that preserves order.
+   *
+   *  Its iterator respects the iteration order of `keysIterator`, such that
+   *  ```
+   *  keys.iterator.sameElements(keySet.iterator)
+   *  ```
+   *
    *  For efficiency the resulting collection may be a view (maintaining a reference to the map and reflecting
    *  modifications to the map), but it may also be a strict collection without reference to the map.
    *
@@ -216,7 +230,6 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
    *
    *  @return an [[Iterable]] collection of the keys contained by this map
    */
-  @deprecatedOverriding("This method should be an alias for keySet", since="2.13.13")
   def keys: Iterable[K] = keySet
 
   /** Collects all values of this map in an iterable collection.
@@ -230,6 +243,11 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
 
   /** An [[Iterator]] of the keys contained by this map.
    *
+   *  If the collection maintains ordered keys, then `keysIterator` respects that order.
+   *
+   *  The default implementation uses the iterator of this `Map`,
+   *  but may be overridden for efficiency.
+   *
    *  @return an [[Iterator]] of the keys contained by this map
    */
   def keysIterator: Iterator[K] = new AbstractIterator[K] {
@@ -239,9 +257,12 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
   }
 
   /** Creates an iterator for all values in this map.
-    *
-    *  @return an iterator over all values that are associated with some key in this map.
-    */
+   *
+   *  The default implementation uses the iterator of this `Map`,
+   *  but may be overridden for efficiency.
+   *
+   *  @return an iterator over all values that are associated with some key in this map.
+   */
   def valuesIterator: Iterator[V] = new AbstractIterator[V] {
     val iter = MapOps.this.iterator
     def hasNext = iter.hasNext

--- a/src/library/scala/collection/MapView.scala
+++ b/src/library/scala/collection/MapView.scala
@@ -27,7 +27,6 @@ trait MapView[K, +V]
    *
    *  @return the keys of this map as a view.
    */
-  @nowarn("msg=overriding method keys")
   override def keys: Iterable[K] = new MapView.Keys(this)
 
   // Ideally this returns a `View`, but bincompat

--- a/src/library/scala/collection/immutable/ListMap.scala
+++ b/src/library/scala/collection/immutable/ListMap.scala
@@ -14,7 +14,7 @@ package scala
 package collection
 package immutable
 
-import scala.annotation.{nowarn, tailrec}
+import scala.annotation.tailrec
 import scala.collection.mutable.ReusableBuilder
 import scala.collection.generic.DefaultSerializable
 import scala.runtime.Statics.releaseFence
@@ -70,7 +70,6 @@ sealed class ListMap[K, +V]
     res.iterator
   }
 
-  @nowarn("msg=overriding method keys")
   override def keys: Iterable[K] = {
     var curr: ListMap[K, V] = this
     var res: List[K] = Nil

--- a/src/library/scala/collection/immutable/SeqMap.scala
+++ b/src/library/scala/collection/immutable/SeqMap.scala
@@ -71,6 +71,7 @@ object SeqMap extends MapFactory[SeqMap] {
     def iterator: Iterator[(Any, Nothing)] = Iterator.empty
     def updated [V1] (key: Any, value: V1): SeqMap[Any, V1] = new SeqMap1(key, value)
     def removed(key: Any): SeqMap[Any, Nothing] = this
+    override def keys: Iterable[Any] = Vector.empty[Any]
   }
 
   @SerialVersionUID(3L)
@@ -95,6 +96,7 @@ object SeqMap extends MapFactory[SeqMap] {
     override def foreachEntry[U](f: (K, V) => U): Unit = {
       f(key1, value1)
     }
+    override def keys: Iterable[K] = Vector(key1)
   }
 
   @SerialVersionUID(3L)
@@ -130,6 +132,7 @@ object SeqMap extends MapFactory[SeqMap] {
       f(key1, value1)
       f(key2, value2)
     }
+    override def keys: Iterable[K] = Vector(key1, key2)
   }
 
   @SerialVersionUID(3L)
@@ -171,6 +174,7 @@ object SeqMap extends MapFactory[SeqMap] {
       f(key2, value2)
       f(key3, value3)
     }
+    override def keys: Iterable[K] = Vector(key1, key2, key3)
   }
 
   @SerialVersionUID(3L)
@@ -230,6 +234,7 @@ object SeqMap extends MapFactory[SeqMap] {
       f(key3, value3)
       f(key4, value4)
     }
+    override def keys: Iterable[K] = Vector(key1, key2, key3, key4)
 
     private[SeqMap] def buildTo[V1 >: V](builder: Builder[(K, V1), SeqMap[K, V1]]): builder.type =
       builder.addOne((key1, value1)).addOne((key2, value2)).addOne((key3, value3)).addOne((key4, value4))

--- a/src/library/scala/collection/immutable/VectorMap.scala
+++ b/src/library/scala/collection/immutable/VectorMap.scala
@@ -14,7 +14,7 @@ package scala
 package collection
 package immutable
 
-import scala.annotation.{nowarn, tailrec}
+import scala.annotation.tailrec
 
 /** This class implements immutable maps using a vector/map-based data structure, which preserves insertion order.
   *
@@ -210,7 +210,6 @@ final class VectorMap[K, +V] private (
    *
    *  @return  a [[Vector]] of the keys contained by this map.
    */
-  @nowarn("msg=overriding method keys")
   override def keys: Vector[K] = keysIterator.toVector
 
   override def values: Iterable[V] = new Iterable[V] with IterableFactoryDefaults[V, Iterable] {

--- a/test/junit/scala/collection/immutable/SeqMapTest.scala
+++ b/test/junit/scala/collection/immutable/SeqMapTest.scala
@@ -4,6 +4,7 @@ import org.junit.Test
 import org.junit.Assert.assertEquals
 
 import scala.collection.mutable
+import scala.tools.testkit.AssertUtil.assertSameElements
 
 class SeqMapTest {
   private def checkClass(map: SeqMap[_, _], simpleName: String): Unit = {
@@ -38,5 +39,22 @@ class SeqMapTest {
 
     // `addAll`
     checkClass(build(_ ++= List(1 -> 1)), "SeqMap1")
+  }
+
+  @Test def `keys are iteration order`: Unit = {
+    val pairs = List.tabulate(6)(i => s"k$i" -> i)
+    for (elems <- pairs.tails) {
+      val vm = elems.to(VectorMap)
+      val sm = elems.to(SeqMap)
+      val lm = elems.to(ListMap)
+      val keys = elems.map(_._1)
+      assertSameElements(keys, vm.keys)
+      assertSameElements(keys, sm.keys)
+      assertSameElements(keys.iterator, vm.keys.iterator)
+      assertSameElements(keys.iterator, sm.keys.iterator)
+      assertSameElements(vm.keys, sm.keys)
+      assertEquals(vm.keys, sm.keys)
+      assertEquals(lm.keys, sm.keys)
+    }
   }
 }


### PR DESCRIPTION
Fixes scala/bug#12991

Ensure that `keys` of a `SeqMap` is ~a `Seq`~ in expected order.

That satisfies the unwritten expectation that `keys` is ordered ~and mutually comparable~.

The implementation of the collection returned by `keys` is not specified. As an implementation detail or convenience, it is a `Vector` for small `SeqMap`s.