### PR TITLE
Fix `LazyList.range` [ci: last-only]

### DIFF
--- a/src/library/scala/collection/immutable/LazyList.scala
+++ b/src/library/scala/collection/immutable/LazyList.scala
@@ -1234,7 +1234,10 @@ object LazyList extends SeqFactory[LazyList] {
     newLL(rangeImpl(start, end, step = Integral[A].one))
 
   override def range[A](start: A, end: A, step: A)(implicit ev: Integral[A]): LazyList[A] =
-    newLL(rangeImpl(start, end, step))
+    newLL {
+      if (ev.equiv(step, ev.zero)) throw new IllegalArgumentException("step cannot be 0.")
+      else rangeImpl(start, end, step)
+    }
 
   private[this] def rangeImpl[A](start: A, end: A, step: A)(implicit ev: Integral[A]): State[A] =
     if (ev.lt(start, end)) sCons(start, newLL(rangeImpl(ev.plus(start, step), end, step)))

--- a/src/library/scala/collection/immutable/LazyList.scala
+++ b/src/library/scala/collection/immutable/LazyList.scala
@@ -1231,7 +1231,7 @@ object LazyList extends SeqFactory[LazyList] {
   }
 
   override def range[A: Integral](start: A, end: A): LazyList[A] =
-    range(start, end, step = Integral[A].one)
+    newLL(rangeImpl(start, end, step = Integral[A].one))
 
   override def range[A](start: A, end: A, step: A)(implicit ev: Integral[A]): LazyList[A] =
     newLL(rangeImpl(start, end, step))

--- a/src/library/scala/collection/immutable/LazyList.scala
+++ b/src/library/scala/collection/immutable/LazyList.scala
@@ -968,6 +968,13 @@ final class LazyList[+A] private(private[this] var lazyState: () => LazyList.Sta
   */
 @SerialVersionUID(3L)
 object LazyList extends SeqFactory[LazyList] {
+  // Override SeqFactory methods.
+  override def range[A: Integral](start: A, end: A): LazyList[A] =
+    range(start, end, step = Integral[A].one)
+
+  override def range[A](start: A, end: A, step: A)(implicit ev: Integral[A]): LazyList[A] =
+    LazyList.iterate(start)(ev.plus(_, step)).takeWhile(ev.lt(_, end))
+
   // Eagerly evaluate cached empty instance
   private[this] val _empty = newLL(State.Empty).force
 

--- a/src/library/scala/collection/immutable/LazyList.scala
+++ b/src/library/scala/collection/immutable/LazyList.scala
@@ -973,7 +973,11 @@ object LazyList extends SeqFactory[LazyList] {
     range(start, end, step = Integral[A].one)
 
   override def range[A](start: A, end: A, step: A)(implicit ev: Integral[A]): LazyList[A] =
-    LazyList.iterate(start)(ev.plus(_, step)).takeWhile(ev.lt(_, end))
+    newLL(rangeImpl(start, end, step))
+
+  private[this] def rangeImpl[A](start: A, end: A, step: A)(implicit ev: Integral[A]): State[A] =
+    if (ev.lt(start, end)) sCons(start, newLL(rangeImpl(ev.plus(start, step), end, step)))
+    else State.Empty
 
   // Eagerly evaluate cached empty instance
   private[this] val _empty = newLL(State.Empty).force

--- a/src/library/scala/collection/immutable/LazyList.scala
+++ b/src/library/scala/collection/immutable/LazyList.scala
@@ -968,17 +968,6 @@ final class LazyList[+A] private(private[this] var lazyState: () => LazyList.Sta
   */
 @SerialVersionUID(3L)
 object LazyList extends SeqFactory[LazyList] {
-  // Override SeqFactory methods.
-  override def range[A: Integral](start: A, end: A): LazyList[A] =
-    range(start, end, step = Integral[A].one)
-
-  override def range[A](start: A, end: A, step: A)(implicit ev: Integral[A]): LazyList[A] =
-    newLL(rangeImpl(start, end, step))
-
-  private[this] def rangeImpl[A](start: A, end: A, step: A)(implicit ev: Integral[A]): State[A] =
-    if (ev.lt(start, end)) sCons(start, newLL(rangeImpl(ev.plus(start, step), end, step)))
-    else State.Empty
-
   // Eagerly evaluate cached empty instance
   private[this] val _empty = newLL(State.Empty).force
 
@@ -1240,6 +1229,16 @@ object LazyList extends SeqFactory[LazyList] {
 
     at(0)
   }
+
+  override def range[A: Integral](start: A, end: A): LazyList[A] =
+    range(start, end, step = Integral[A].one)
+
+  override def range[A](start: A, end: A, step: A)(implicit ev: Integral[A]): LazyList[A] =
+    newLL(rangeImpl(start, end, step))
+
+  private[this] def rangeImpl[A](start: A, end: A, step: A)(implicit ev: Integral[A]): State[A] =
+    if (ev.lt(start, end)) sCons(start, newLL(rangeImpl(ev.plus(start, step), end, step)))
+    else State.Empty
 
   // significantly simpler than the iterator returned by Iterator.unfold
   override def unfold[A, S](init: S)(f: S => Option[(A, S)]): LazyList[A] =

--- a/test/junit/scala/collection/immutable/LazyListTest.scala
+++ b/test/junit/scala/collection/immutable/LazyListTest.scala
@@ -444,6 +444,18 @@ class LazyListTest {
     LazyList(1).lazyAppendedAll({ count += 1; Seq(2)}).toList
     assertEquals(1, count)
   }
+
+  @Test
+  def lazyRangeAllowsMoreThanIntMaxValue(): Unit = {
+    val totalElements: Long = Int.MaxValue.toLong + 2L
+    val count: Long =
+      LazyList
+        .range(start = 0L, end = totalElements)
+        .foldLeft(0L) { case (acc, _) =>
+          acc + 1L
+        }
+    assertEquals(totalElements, count)
+  }
 }
 
 object LazyListTest {

--- a/test/junit/scala/collection/immutable/LazyListTest.scala
+++ b/test/junit/scala/collection/immutable/LazyListTest.scala
@@ -447,14 +447,15 @@ class LazyListTest {
 
   @Test
   def lazyRangeAllowsMoreThanIntMaxValue(): Unit = {
-    val totalElements: Long = Int.MaxValue.toLong + 2L
-    val count: Long =
-      LazyList
-        .range(start = 0L, end = totalElements)
-        .foldLeft(0L) { case (acc, _) =>
-          acc + 1L
-        }
-    assertEquals(totalElements, count)
+    // We use a reverse range to avoid computing a lot of elements.
+    val maxValue = Int.MaxValue.toLong
+    val lazyList = LazyList.range(
+      start = maxValue * 2L,
+      end = 0,
+      step = -1L
+    )
+    val nums = lazyList.take(10)
+    assert(nums.forall(_ > maxValue))
   }
 }
 


### PR DESCRIPTION
Since `LazyList` is not strict, there is not reason to make `range` delegate through `from(NumericRange)` which doesn't allow more than `Int.MaxValue` elements.