### PR TITLE
Avoid unused import warnings in REPL

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -732,7 +732,7 @@ trait Contexts { self: Analyzer =>
 
     def makeImportContext(tree: Import): Context =
       make(tree).tap { ctx =>
-        if (settings.warnUnusedImport && openMacros.isEmpty && !ctx.isRootImport)
+        if (settings.warnUnusedImport && openMacros.isEmpty && !ctx.isRootImport && !ctx.outer.owner.isInterpreterWrapper)
           allImportInfos(ctx.unit) ::= ctx.importOrNull -> ctx.owner
       }
 
@@ -1355,14 +1355,14 @@ trait Contexts { self: Analyzer =>
       }
     }
 
-    private def isReplImportWrapperImport(tree: Tree): Boolean = {
+    // detect magic REPL imports (used to manage visibility)
+    private def isReplImportWrapperImport(tree: Tree): Boolean =
       tree match {
         case Import(expr, selector :: Nil) =>
           // Just a syntactic check to avoid forcing typechecking of imports
           selector.name.string_==(nme.INTERPRETER_IMPORT_LEVEL_UP) && owner.enclosingTopLevelClass.isInterpreterWrapper
         case _ => false
       }
-    }
 
   } //class Context
 

--- a/test/files/run/t7722.check
+++ b/test/files/run/t7722.check
@@ -1,0 +1,23 @@
+
+scala> import concurrent.duration._
+import concurrent.duration._
+
+scala> 60.seconds
+val res0: scala.concurrent.duration.FiniteDuration = 60 seconds
+
+scala> class C
+class C
+
+scala> implicit def cv(s: String): C = new C
+warning: 1 feature warning; for details, enable `:setting -feature` or `:replay -feature`
+def cv(s: String): C
+
+scala> "hello, world"
+val res1: String = hello, world
+
+scala> { import concurrent.duration._; "adios, amigos" }
+                                    ^
+       warning: Unused import
+val res2: String = adios, amigos
+
+scala> :quit

--- a/test/files/run/t7722.scala
+++ b/test/files/run/t7722.scala
@@ -1,0 +1,6 @@
+
+import scala.tools.partest.SessionTest
+
+object Test extends SessionTest {
+  override def extraSettings = "-usejavacp -Wunused:imports"
+}


### PR DESCRIPTION
Context avoids spurious warnings for history imports, REPL's bread and butter.

When compiling user input that is only imports, turn off the warning. (It would always warn, trivially.)

Users builds may have mitigations for this which may now be removed.

Fixes scala/bug#7722