### PR TITLE
No warn in unused elements

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -544,11 +544,12 @@ trait TypeDiagnostics extends splain.SplainDiagnostics {
             case ValDef(mods@_, name@_, tpt@_, rhs@_) if wasPatVarDef(t) =>
               if (settings.warnUnusedPatVars && !atBounded(t)) patvars += sym
             case DefDef(mods@_, name@_, tparams@_, vparamss, tpt@_, rhs@_) if !sym.isAbstract && !sym.isDeprecated && !sym.isMacro =>
+              if (isSuppressed(sym)) return
               if (sym.isPrimaryConstructor)
                 for (cpa <- sym.owner.constrParamAccessors if cpa.isPrivateLocal) params += cpa
               else if (sym.isSynthetic && sym.isImplicit) return
               else if (!sym.isConstructor && !sym.isVar && !isTrivial(rhs))
-                for (vs <- vparamss) params ++= vs.map(_.symbol)
+                for (vs <- vparamss; v <- vs) if (!isSingleType(v.symbol.tpe)) params += v.symbol
               defnTrees += m
             case TypeDef(mods@_, name@_, tparams@_, rhs@_) =>
               if (!sym.isAbstract && !sym.isDeprecated)

--- a/src/repl-frontend/scala/tools/nsc/Interpreter.scala
+++ b/src/repl-frontend/scala/tools/nsc/Interpreter.scala
@@ -115,6 +115,7 @@ class InterpreterLoop {
         }
 
         // for 2.8 compatibility
+        @annotation.unused
         final class Compat {
           def bindValue(id: String, value: Any) =
             interpreter.bind(id, value.asInstanceOf[AnyRef].getClass.getName, value)

--- a/test/files/neg/warn-unused-params.scala
+++ b/test/files/neg/warn-unused-params.scala
@@ -141,3 +141,13 @@ class Unequal {
 class Seriously {
   def f(s: Serializable) = toString.nonEmpty  // warn explicit param of marker trait
 }
+
+class TryStart(start: String) {
+  def FINALLY(end: END.type) = start
+}
+
+object END
+
+class Nested {
+  @annotation.unused private def actuallyNotUsed(fresh: Int, stale: Int) = fresh
+}

--- a/test/files/neg/warn-unused-privates.check
+++ b/test/files/neg/warn-unused-privates.check
@@ -61,6 +61,9 @@ warn-unused-privates.scala:154: warning: private method x in class OtherNames is
 warn-unused-privates.scala:155: warning: private method y_= in class OtherNames is never used
   private def y_=(i: Int): Unit = ()
               ^
+warn-unused-privates.scala:269: warning: private val n in class t12992 enclosing def is unused is never used
+  private val n = 42
+              ^
 warn-unused-privates.scala:121: warning: private class Bar1 in object Types is never used
   private class Bar1 // warn
                 ^
@@ -80,5 +83,5 @@ warn-unused-privates.scala:114: warning: local var x in method f2 is never updat
     var x = 100 // warn about it being a var
         ^
 error: No warnings can be incurred under -Werror.
-27 warnings
+28 warnings
 1 error

--- a/test/files/neg/warn-unused-privates.scala
+++ b/test/files/neg/warn-unused-privates.scala
@@ -264,3 +264,8 @@ trait `short comings` {
 class `issue 12600 ignore abstract types` {
   type Abs
 }
+
+class `t12992 enclosing def is unused` {
+  private val n = 42
+  @annotation.unused def f() = n + 2 // unused code uses n
+}

--- a/test/junit/scala/collection/BuildFromTest.scala
+++ b/test/junit/scala/collection/BuildFromTest.scala
@@ -1,10 +1,11 @@
 package scala.collection
 
 import org.junit.Test
+import org.junit.Assert.{assertEquals, assertTrue}
 
-import scala.annotation.unused
-import scala.collection.mutable.Builder
 import scala.math.Ordering
+
+import mutable.{ArrayBuffer, Builder}
 
 class BuildFromTest {
 
@@ -43,57 +44,68 @@ class BuildFromTest {
 
   @Test
   def optionSequence1Test(): Unit = {
-    val xs1 = immutable.List(Some(1), None, Some(2))
+    val xs1 = List(Some(1), None, Some(2))
     val o1 = optionSequence1(xs1)
-    @unused val o1t: Option[immutable.List[Int]] = o1
+    val o1t: Option[List[Int]] = o1
+    assertTrue(o1t.isEmpty)
 
     val xs2: immutable.TreeSet[Option[String]] = immutable.TreeSet(Some("foo"), Some("bar"), None)
     val o2 = optionSequence1(xs2)
-    @unused val o2t: Option[immutable.Set[String]] = o2
+    val o2t: Option[immutable.Set[String]] = o2
+    assertTrue(o2t.isEmpty)
 
-    val xs4 = immutable.List[Option[(Int, String)]](Some((1 -> "a")), Some((2 -> "b")))
+    val xs4 = List[Option[(Int, String)]](Some((1 -> "a")), Some((2 -> "b")))
     val o4 = optionSequence1(xs4)
-    @unused val o4t: Option[immutable.List[(Int, String)]] = o4
-    @unused val o5: Option[immutable.TreeMap[Int, String]] = o4.map(_.to(immutable.TreeMap))
+    val o4t: Option[List[(Int, String)]] = o4
+    assertEquals(Some(List(1 -> "a", 2 -> "b")), o4t)
+    val o5: Option[immutable.TreeMap[Int, String]] = o4.map(_.to(immutable.TreeMap))
+    assertEquals(Some(immutable.TreeMap(1 -> "a", 2 -> "b")), o5)
   }
 
   @Test
   def optionSequence2Test(): Unit = {
-    val xs1 = immutable.List(Some(1), None, Some(2))
+    val xs1 = List(Some(1), None, Some(2))
     val o1 = optionSequence2(xs1)
-    @unused val o1t: Option[immutable.List[Int]] = o1
+    val o1t: Option[immutable.List[Int]] = o1
+    assertTrue(o1t.isEmpty)
 
     val xs2 = immutable.TreeSet(Some("foo"), Some("bar"), None)
     val o2 = optionSequence2(xs2)
-    @unused val o2t: Option[immutable.TreeSet[String]] = o2
+    val o2t: Option[immutable.TreeSet[String]] = o2
+    assertTrue(o2t.isEmpty)
 
     // Breakout-like use case from https://github.com/scala/scala/pull/5233:
-    val xs4 = immutable.List[Option[(Int, String)]](Some((1 -> "a")), Some((2 -> "b")))
+    val xs4 = List[Option[(Int, String)]](Some((1 -> "a")), Some((2 -> "b")))
     val o4 = optionSequence2(xs4)(immutable.TreeMap) // same syntax as in `.to`
-    @unused val o4t: Option[immutable.TreeMap[Int, String]] = o4
+    val o4t: Option[immutable.TreeMap[Int, String]] = o4
+    assertEquals(Some(immutable.TreeMap(1 -> "a", 2 -> "b")), o4t)
   }
 
   @Test
   def optionSequence3Test(): Unit = {
     val xs1 = immutable.List(Some(1), None, Some(2))
     val o1 = optionSequence3(xs1)
-    @unused val o1t: Option[immutable.List[Int]] = o1
+    val o1t: Option[immutable.List[Int]] = o1
+    assertTrue(o1t.isEmpty)
 
     val xs2 = immutable.TreeSet(Some("foo"), Some("bar"), None)
     val o2 = optionSequence3(xs2)
-    @unused val o2t: Option[immutable.TreeSet[String]] = o2
+    val o2t: Option[immutable.TreeSet[String]] = o2
+    assertTrue(o2t.isEmpty)
 
     // Breakout-like use case from https://github.com/scala/scala/pull/5233:
     val xs4 = immutable.List[Option[(Int, String)]](Some((1 -> "a")), Some((2 -> "b")))
     val o4 = optionSequence3(xs4)(immutable.TreeMap) // same syntax as in `.to`
-    @unused val o4t: Option[immutable.TreeMap[Int, String]] = o4
+    val o4t: Option[immutable.TreeMap[Int, String]] = o4
+    assertEquals(Some(immutable.TreeMap(1 -> "a", 2 -> "b")), o4t)
   }
 
   @Test
   def eitherSequenceTest(): Unit = {
     val xs3 = mutable.ListBuffer(Right("foo"), Left(0), Right("bar"))
     val e1 = eitherSequence(xs3)
-    @unused val e1t: Either[Int, mutable.ListBuffer[String]] = e1
+    val e1t: Either[Int, mutable.ListBuffer[String]] = e1
+    assertTrue(e1t.isLeft)
   }
 
   // From https://github.com/scala/collection-strawman/issues/44
@@ -118,34 +130,42 @@ class BuildFromTest {
 
   @Test
   def flatCollectTest(): Unit = {
-    val xs1 = immutable.List(1, 2, 3)
-    val xs2 = flatCollect(xs1) { case 2 => mutable.ArrayBuffer("foo", "bar") }
-    @unused val xs3: immutable.List[String] = xs2
+    val xs1 = List(1, 2, 3)
+    val xs2 = flatCollect(xs1) { case 2 => ArrayBuffer("foo", "bar") }
+    val xs3: List[String] = xs2
+    assertEquals(List("foo", "bar"), xs3)
 
     val xs4 = immutable.TreeMap((1, "1"), (2, "2"))
     val xs5 = flatCollect(xs4) { case (2, v) => immutable.List((v, v)) }
-    @unused val xs6: immutable.TreeMap[String, String] = xs5
+    val xs6: immutable.TreeMap[String, String] = xs5
+    assertEquals(immutable.TreeMap("2" -> "2"), xs6)
 
     val xs7 = immutable.HashMap((1, "1"), (2, "2"))
     val xs8 = flatCollect(xs7) { case (2, v) => immutable.List((v, v)) }
-    @unused val xs9: immutable.HashMap[String, String] = xs8
+    val xs9: immutable.HashMap[String, String] = xs8
+    assertEquals(immutable.HashMap("2" -> "2"), xs9)
 
     val xs10 = immutable.TreeSet(1, 2, 3)
     val xs11 = flatCollect(xs10) { case 2 => immutable.List("foo", "bar") }
-    @unused val xs12: immutable.TreeSet[String] = xs11
+    val xs12: immutable.TreeSet[String] = xs11
+    assertEquals(immutable.TreeSet("foo", "bar"), xs12)
   }
 
   @Test
   def partitionMapTest(): Unit = {
-    val xs1 = immutable.List(1, 2, 3)
+    val xs1 = List(1, 2, 3)
     val (xs2, xs3) = partitionMap(xs1)(x => if (x % 2 == 0) Left(x) else Right(x.toString))
-    @unused val xs4: immutable.List[Int] = xs2
-    @unused val xs5: immutable.List[String] = xs3
+    val xs4: List[Int] = xs2
+    assertEquals(List(2), xs4)
+    val xs5: List[String] = xs3
+    assertEquals(List("1", "3"), xs5)
 
     val xs6 = immutable.TreeMap((1, "1"), (2, "2"))
     val (xs7, xs8) = partitionMap(xs6) { case (k, v) => Left[(String, Int), (Int, Boolean)]((v, k)) }
-    @unused val xs9: immutable.TreeMap[String, Int] = xs7
-    @unused val xs10: immutable.TreeMap[Int, Boolean] = xs8
+    val xs9: immutable.TreeMap[String, Int] = xs7
+    assertEquals(immutable.TreeMap(("1", 1), ("2", 2)), xs9)
+    val xs10: immutable.TreeMap[Int, Boolean] = xs8
+    assertTrue(xs10.isEmpty)
   }
 
   @Test
@@ -190,8 +210,8 @@ class BuildFromTest {
     implicitly[collection.BuildFrom[Seq[Any], (Int, HCons[ExtendsOrdered, HNil]), Seq[(Int, HCons[ExtendsOrdered, HNil])]]]
 
     //
-    // In Scala 2.12, buildFromSortedSetOps is not a candidate because if it is in the companion object of
-    // the SortedSet heirarchy, which is not part of the implicit scope for this search.
+    // In Scala 2.12, buildFromSortedSetOps is not a candidate because it is in the companion object of
+    // the SortedSet hierarchy, which is not part of the implicit scope for this search.
     // In 2.13, the implicit was moved to `object BuildFrom`, so _is_ considered
     //
     // The dependent implicit search:

--- a/test/junit/scala/collection/MinByMaxByTest.scala
+++ b/test/junit/scala/collection/MinByMaxByTest.scala
@@ -3,7 +3,6 @@ package scala.collection
 import org.junit.Assert._
 import org.junit.Test
 
-import scala.annotation.unused
 import scala.tools.testkit.AssertUtil.assertThrows
 import scala.util.Random
 
@@ -35,8 +34,10 @@ class MinByMaxByTest {
   def testReturnTheFirstMatch() = {
     val d = List(1, 2, 3, 4, 5, 6, 7, 8)
     def f(x: Int) = x % 3;
-    assert(d.maxBy(f) == 2, "If multiple elements evaluated to the largest value, maxBy should return the first one.")
-    assert(d.minBy(f) == 3, "If multiple elements evaluated to the largest value, minBy should return the first one.")
+    assertEquals("If multiple elements evaluated to the largest value, maxBy should return the first one.",
+      2, d.maxBy(f))
+    assertEquals("If multiple elements evaluated to the largest value, minBy should return the first one.",
+      3, d.minBy(f))
   }
 
   // Make sure it evaluates f no more than list.length times.
@@ -44,43 +45,49 @@ class MinByMaxByTest {
   def testOnlyEvaluateOnce() = {
     var evaluatedCountOfMaxBy = 0
 
-    @unused val max = list.maxBy(x => {
+    val max = list.maxBy { x =>
       evaluatedCountOfMaxBy += 1
       x * 10
-    })
-    assert(evaluatedCountOfMaxBy == list.length, s"maxBy: should evaluate f only ${list.length} times, but it evaluated $evaluatedCountOfMaxBy times.")
+    }
+    assertTrue(!list.exists(_ > max))
+    assertEquals(s"maxBy: should evaluate f only ${list.length} times, but it evaluated $evaluatedCountOfMaxBy times.",
+      list.length,
+      evaluatedCountOfMaxBy)
 
     var evaluatedCountOfMinBy = 0
 
-    @unused val min = list.minBy(x => {
+    val min = list.minBy { x =>
       evaluatedCountOfMinBy += 1
       x * 10
-    })
-    assert(evaluatedCountOfMinBy == list.length, s"minBy: should evaluate f only ${list.length} times, but it evaluated $evaluatedCountOfMinBy times.")
+    }
+    assertTrue(!list.exists(_ < min))
+    assertEquals(s"minBy: should evaluate f only ${list.length} times, but it evaluated $evaluatedCountOfMinBy times.",
+      list.length,
+      evaluatedCountOfMinBy)
   }
 
   @Test
   def checkEmptyOption(): Unit = {
-    assert(Seq.empty[Int].maxOption == None, "maxOption on a Empty Iterable is None")
-    assert(Seq.empty[Int].minOption == None, "minOption on a Empty Iterable is None")
-    assert(Seq.empty[Int].maxByOption(identity) == None, "maxByOption on a Empty Iterable is None")
-    assert(Seq.empty[Int].minByOption(identity) == None, "minByOption on a Empty Iterable is None")
+    assertTrue("maxOption on a Empty Iterable is None", Seq.empty[Int].maxOption.isEmpty)
+    assertTrue("minOption on a Empty Iterable is None", Seq.empty[Int].minOption.isEmpty)
+    assertTrue("maxByOption on a Empty Iterable is None", Seq.empty[Int].maxByOption(identity).isEmpty)
+    assertTrue("minByOption on a Empty Iterable is None", Seq.empty[Int].minByOption(identity).isEmpty)
   }
 
   @Test
   def checkNonEmptyOption(): Unit = {
-    assert(Seq(1).maxOption == Some(1), "maxOption on a Non Empty Iterable has value")
-    assert(Seq(1).minOption == Some(1), "minOption on a Non Empty Iterable has value")
-    assert(Seq(1).maxByOption(identity) == Some(1), "maxByOption on a Non Empty Iterable has value")
-    assert(Seq(1).minByOption(identity) == Some(1), "minByOption on a Non Empty Iterable has value")
+    assertEquals("maxOption on a Non Empty Iterable has value", Some(1), Seq(1).maxOption)
+    assertEquals("minOption on a Non Empty Iterable has value", Some(1), Seq(1).minOption)
+    assertEquals("maxByOption on a Non Empty Iterable has value", Some(1), Seq(1).maxByOption(identity))
+    assertEquals("minByOption on a Non Empty Iterable has value", Some(1), Seq(1).minByOption(identity))
   }
 
   @Test
   def testMinMaxCorrectness(): Unit = {
     import Ordering.Double.IeeeOrdering
     val seq = Seq(5.0, 3.0, Double.NaN, 4.0)
-    assert(seq.min.isNaN)
-    assert(seq.max.isNaN)
+    assertTrue(seq.min.isNaN)
+    assertTrue(seq.max.isNaN)
   }
 
 }

--- a/test/junit/scala/collection/generic/DecoratorsTest.scala
+++ b/test/junit/scala/collection/generic/DecoratorsTest.scala
@@ -1,12 +1,13 @@
 package scala.collection.generic
 
 import org.junit.Test
+import org.junit.Assert.{assertEquals, assertTrue}
 
 import scala.AdaptedArrowAssocWorkaround.Tx
-import scala.annotation.unused
 import scala.collection.immutable.{BitSet, IntMap, LongMap, TreeMap, TreeSet}
 import scala.collection.{BuildFrom, View, mutable}
 import scala.language.implicitConversions
+import scala.tools.testkit.AssertUtil.assertSameElements
 
 class DecoratorsTest {
 
@@ -26,11 +27,13 @@ class DecoratorsTest {
 
     val xs1 = Iterator(1, 2, 3, 4, 5)
     val xs2 = xs1.filterMap(f)
-    @unused val xs2T: Iterator[Int] = xs2
+    val xs2T: Iterator[Int] = xs2
+    assertSameElements(List(2, 4), xs2T)
 
     val xs3 = Array(1, 2, 3, 4, 5)
     val xs4 = xs3.filterMap(f)
-    @unused val xs4T: Array[Int] = xs4
+    val xs4T: Array[Int] = xs4
+    assertSameElements(List(2, 4), xs4T)
   }
 
   @Test
@@ -50,47 +53,68 @@ class DecoratorsTest {
     val i: Int => Option[Int] = x => if (x % 2 == 0) Some(2 * x) else None
 
     val xs1 = List(1, 2, 3).filterMap(f)
-    @unused val xs1T: List[String] = xs1
+    val xs1T: List[String] = xs1
+    assertSameElements(List("2"), xs1T)
     val xs2 = List(1, 2, 3).view.filterMap(f)
-    @unused val xs2T: View[String] = xs2
+    val xs2T: View[String] = xs2
+    assertSameElements(List("2"), xs2T)
     val xs3 = Vector(1, 2, 3).filterMap(f)
-    @unused val xs3T: Vector[String] = xs3
+    val xs3T: Vector[String] = xs3
+    assertSameElements(List("2"), xs3T)
     val xs4 = Vector(1, 2, 3).view.filterMap(f)
-    @unused val xs4T: View[String] = xs4
+    val xs4T: View[String] = xs4
+    assertSameElements(List("2"), xs4T)
     val xs5 = (1 to 10).filterMap(f)
-    @unused val xs5T: IndexedSeq[String] = xs5
+    val xs5T: IndexedSeq[String] = xs5
+    assertSameElements(List(2,4,6,8,10).map(_.toString), xs5T)
     val xs6 = (1 to 10).view.filterMap(f)
-    @unused val xs6T: View[String] = xs6
+    val xs6T: View[String] = xs6
+    assertSameElements(List(2,4,6,8,10).map(_.toString), xs6T)
     val xs7 = Array(1, 2, 3).filterMap(f)
-    @unused val xs7T: Array[String] = xs7
+    val xs7T: Array[String] = xs7
+    assertSameElements(List("2"), xs7T)
     val xs8 = Array(1, 2, 3).view.filterMap(f)
-    @unused val xs8T: View[String] = xs8
+    val xs8T: View[String] = xs8
+    assertSameElements(List("2"), xs8T)
     val xs9 = "foo".filterMap(g)
-    @unused val xs9T: IndexedSeq[Int] = xs9
+    val xs9T: IndexedSeq[Int] = xs9
+    assertTrue(xs9T.isEmpty)
     val xs10 = "foo".view.filterMap(g)
-    @unused val xs10T: View[Int] = xs10
+    val xs10T: View[Int] = xs10
+    assertTrue(xs10T.isEmpty)
     val xs11 = Map(1 -> "foo").filterMap(h)
-    @unused val xs11T: Map[String, Int] = xs11
+    val xs11T: Map[String, Int] = xs11
+    assertTrue(xs11T.isEmpty)
     val xs12 = Map(1 -> "foo").view.filterMap(h)
-    @unused val xs12T: View[(String, Int)] = xs12
+    val xs12T: View[(String, Int)] = xs12
+    assertTrue(xs12T.isEmpty)
     val xs13 = TreeMap(1 -> "foo").filterMap(h)
-    @unused val xs13T: TreeMap[String, Int] = xs13
+    val xs13T: TreeMap[String, Int] = xs13
+    assertTrue(xs13T.isEmpty)
     val xs14 = TreeMap(1 -> "foo").view.filterMap(h)
-    @unused val xs14T: View[(String, Int)] = xs14
+    val xs14T: View[(String, Int)] = xs14
+    assertTrue(xs14T.isEmpty)
     val xs15 = BitSet(1, 2, 3).filterMap(i)
-    @unused val xs15T: BitSet = xs15
+    val xs15T: BitSet = xs15
+    assertSameElements(List(4), xs15T)
     val xs16 = BitSet(1, 2, 3).view.filterMap(i)
-    @unused val xs16T: View[Int] = xs16
+    val xs16T: View[Int] = xs16
+    assertSameElements(List(4), xs16T)
     val xs17 = Set(1, 2, 3).filterMap(f)
-    @unused val xs17T: Set[String] = xs17
+    val xs17T: Set[String] = xs17
+    assertSameElements(List("2"), xs17T)
     val xs18 = Set(1, 2, 3).view.filterMap(f)
-    @unused val xs18T: View[String] = xs18
+    val xs18T: View[String] = xs18
+    assertSameElements(List("2"), xs18T)
     val xs19 = TreeSet(1, 2, 3).filterMap(f)
-    @unused val xs19T: TreeSet[String] = xs19
+    val xs19T: TreeSet[String] = xs19
+    assertSameElements(List("2"), xs19T)
     val xs20 = TreeSet(1, 2, 3).view.filterMap(f)
-    @unused val xs20T: View[String] = xs20
+    val xs20T: View[String] = xs20
+    assertSameElements(List("2"), xs20T)
     val xs21 = TreeSet(1, 2, 3).filterMap(f)
-    @unused val xs21T: TreeSet[String] = xs21
+    val xs21T: TreeSet[String] = xs21
+    assertSameElements(List("2"), xs21T)
   }
 
   @Test
@@ -118,7 +142,7 @@ class DecoratorsTest {
           lastTestResult match {
             case None =>
               currentGroup.addOne(elem)
-            case Some(lastTest) if currentTest == lastTest =>
+            case Some(`currentTest`) =>
               currentGroup.addOne(elem)
             case Some(_) =>
               groups.addOne(currentGroup.result())
@@ -134,25 +158,35 @@ class DecoratorsTest {
 
     val p: Int => Boolean = _ % 2 == 0
     val xs = List(1, 2, 3).groupedWith(p)
-    @unused val xsT: List[List[Int]] = xs
+    val xsT: List[List[Int]] = xs
+    assertEquals(List(1, 2, 3).map(List(_)), xsT)
     val xs2 = List(1, 2, 3).view.groupedWith(p)
-    @unused val xs2T: View[View[Int]] = xs2
+    val xs2T: View[View[Int]] = xs2
+    assertSameElements(List(1, 2, 3).map(List(_)), xs2T.map(_.toList))
     val xs3 = Vector(1, 2, 3).groupedWith(p)
-    @unused val xs3T: Vector[Vector[Int]] = xs3
+    val xs3T: Vector[Vector[Int]] = xs3
+    assertEquals(Vector(1, 2, 3).map(Vector(_)), xs3T)
     val xs4 = Vector(1, 2, 3).view.groupedWith(p)
-    @unused val xs4T: View[View[Int]] = xs4
+    val xs4T: View[View[Int]] = xs4
+    assertSameElements(Vector(1, 2, 3).map(Vector(_)), xs4T.map(_.toVector))
     val xs5 = (1 to 10).groupedWith(p)
-    @unused val xs5T: IndexedSeq[IndexedSeq[Int]] = xs5
+    val xs5T: IndexedSeq[IndexedSeq[Int]] = xs5
+    assertSameElements((1 to 10).toVector.map(Vector(_)), xs5T.map(_.toVector))
     val xs6 = (1 to 10).view.groupedWith(p)
-    @unused val xs6T: View[View[Int]] = xs6
+    val xs6T: View[View[Int]] = xs6
+    assertSameElements((1 to 10).toVector.map(Vector(_)), xs6T.map(_.toVector))
     val xs7 = Array(1, 2, 3).groupedWith(p)
-    @unused val xs7T: Array[Array[Int]] = xs7
+    val xs7T: Array[Array[Int]] = xs7
+    assertSameElements(Vector(1, 2, 3).map(Vector(_)), xs7T.map(_.toVector))
     val xs8 = Array(1, 2, 3).view.groupedWith(p)
-    @unused val xs8T: View[View[Int]] = xs8
+    val xs8T: View[View[Int]] = xs8
+    assertSameElements(Vector(1, 2, 3).map(Vector(_)), xs8T.map(_.toVector))
     val xs9 = "foo".groupedWith(_.isLower)
-    @unused val xs9T: IndexedSeq[String] = xs9
+    val xs9T: IndexedSeq[String] = xs9
+    assertEquals(List("foo"), xs9T)
     val xs10 = "foo".view.groupedWith(_.isLower)
-    @unused val xs10T: View[View[Char]] = xs10
+    val xs10T: View[View[Char]] = xs10
+    assertEquals(Vector("foo".toVector), xs10T.toVector.map(_.toVector))
   }
 
   @Test
@@ -180,63 +214,83 @@ class DecoratorsTest {
 
     val map = Map(1 -> "foo")
     val mapLJoin = map.leftOuterJoin(Map(1 -> "bar"))
-    @unused val mapLJoinT: Map[Int, (String, Option[String])] = mapLJoin
+    val mapLJoinT: Map[Int, (String, Option[String])] = mapLJoin
+    assertEquals(Map(1 -> ("foo" -> Some("bar"))), mapLJoinT)
     val mapRJoin = map.rightOuterJoin(Map(1 -> "bar"))
-    @unused val mapRJoinT: Map[Int, (Option[String], String)] = mapRJoin
+    val mapRJoinT: Map[Int, (Option[String], String)] = mapRJoin
+    assertEquals(Map(1 -> (Some("foo") -> "bar")), mapRJoinT)
 
     val mapView = Map(1 -> "foo").view
     val mapViewLJoin = mapView.leftOuterJoin(Map(1 -> "bar"))
-    @unused val mapViewLJoinT: View[(Int, (String, Option[String]))] = mapViewLJoin
+    val mapViewLJoinT: View[(Int, (String, Option[String]))] = mapViewLJoin
+    assertSameElements(List(1 -> ("foo" -> Some("bar"))), mapViewLJoinT)
     val mapViewRJoin = mapView.rightOuterJoin(Map(1 -> "bar"))
-    @unused val mapViewRJoinT: View[(Int, (Option[String], String))] = mapViewRJoin
+    val mapViewRJoinT: View[(Int, (Option[String], String))] = mapViewRJoin
+    assertSameElements(List(1 -> (Some("foo") -> "bar")), mapViewRJoinT)
 
     val treemap = TreeMap(1 -> "foo")
     val treemapLJoin = treemap.leftOuterJoin(Map(1 -> "bar"))
-    @unused val treemapLJoinT: TreeMap[Int, (String, Option[String])] = treemapLJoin
+    val treemapLJoinT: TreeMap[Int, (String, Option[String])] = treemapLJoin
+    assertEquals(Map(1 -> ("foo" -> Some("bar"))), treemapLJoinT)
     val treemapRJoin = treemap.rightOuterJoin(Map(1 -> "bar"))
-    @unused val treemapRJoinT: TreeMap[Int, (Option[String], String)] = treemapRJoin
+    val treemapRJoinT: TreeMap[Int, (Option[String], String)] = treemapRJoin
+    assertEquals(Map(1 -> (Some("foo") -> "bar")), treemapRJoinT)
 
     val treemapView = TreeMap(1 -> "foo").view
     val treemapViewLJoin = treemapView.leftOuterJoin(Map(1 -> "bar"))
-    @unused val treemapViewLJoinT: View[(Int, (String, Option[String]))] = treemapViewLJoin
+    val treemapViewLJoinT: View[(Int, (String, Option[String]))] = treemapViewLJoin
+    assertSameElements(List(1 -> ("foo" -> Some("bar"))), treemapViewLJoinT)
     val treemapViewRJoin = treemapView.rightOuterJoin(Map(1 -> "bar"))
-    @unused val treemapViewRJoinT: View[(Int, (Option[String], String))] = treemapViewRJoin
+    val treemapViewRJoinT: View[(Int, (Option[String], String))] = treemapViewRJoin
+    assertSameElements(List(1 -> (Some("foo") -> "bar")), treemapViewRJoinT)
 
     val mmap = mutable.Map(1 -> "foo")
     val mmapLJoin = mmap.leftOuterJoin(Map(1 -> "bar"))
-    @unused val mmapLJoinT: mutable.Map[Int, (String, Option[String])] = mmapLJoin
+    val mmapLJoinT: mutable.Map[Int, (String, Option[String])] = mmapLJoin
+    assertEquals(Map(1 -> ("foo" -> Some("bar"))), mmapLJoinT)
     val mmapRJoin = mmap.rightOuterJoin(Map(1 -> "bar"))
-    @unused val mmapRJoinT: mutable.Map[Int, (Option[String], String)] = mmapRJoin
+    val mmapRJoinT: mutable.Map[Int, (Option[String], String)] = mmapRJoin
+    assertEquals(Map(1 -> (Some("foo") -> "bar")), mmapRJoinT)
 
     val mmapView = mutable.Map(1 -> "foo").view
     val mmapViewLJoin = mmapView.leftOuterJoin(Map(1 -> "bar"))
-    @unused val mmapViewLJoinT: View[(Int, (String, Option[String]))] = mmapViewLJoin
+    val mmapViewLJoinT: View[(Int, (String, Option[String]))] = mmapViewLJoin
+    assertSameElements(List(1 -> ("foo" -> Some("bar"))), mmapViewLJoinT)
     val mmapViewRJoin = mmapView.rightOuterJoin(Map(1 -> "bar"))
-    @unused val mmapViewRJoinT: View[(Int, (Option[String], String))] = mmapViewRJoin
+    val mmapViewRJoinT: View[(Int, (Option[String], String))] = mmapViewRJoin
+    assertSameElements(List(1 -> (Some("foo") -> "bar")), mmapViewRJoinT)
 
     val anyrefmap = mutable.AnyRefMap("foo" -> 1)
     val anyrefmapLJoin = anyrefmap.leftOuterJoin(Map("bar" -> true))
-    @unused val anyrefmapLJoinT: mutable.AnyRefMap[String, (Int, Option[Boolean])] = anyrefmapLJoin
+    val anyrefmapLJoinT: mutable.AnyRefMap[String, (Int, Option[Boolean])] = anyrefmapLJoin
+    assertEquals(Map("foo" -> (1 -> None)), anyrefmapLJoinT)
     val anyrefmapRJoin = anyrefmap.rightOuterJoin(Map("bar" -> true))
-    @unused val anyrefmapRJoinT: mutable.AnyRefMap[String, (Option[Int], Boolean)] = anyrefmapRJoin
+    val anyrefmapRJoinT: mutable.AnyRefMap[String, (Option[Int], Boolean)] = anyrefmapRJoin
+    assertEquals(Map("bar" -> (None -> true)), anyrefmapRJoinT)
 
     val intmap = IntMap(1 -> "foo")
     val intmapLJoin = intmap.leftOuterJoin(Map(1 -> "bar"))
-    @unused val intmapLJoinT: IntMap[(String, Option[String])] = intmapLJoin
+    val intmapLJoinT: IntMap[(String, Option[String])] = intmapLJoin
+    assertEquals(Map(1 -> ("foo" -> Some("bar"))), intmapLJoinT)
     val intmapRJoin = intmap.rightOuterJoin(Map(1 -> "bar"))
-    @unused val intmapRJoinT: IntMap[(Option[String], String)] = intmapRJoin
+    val intmapRJoinT: IntMap[(Option[String], String)] = intmapRJoin
+    assertEquals(Map(1 -> (Some("foo") -> "bar")), intmapRJoinT)
 
     val longmap = LongMap(1L -> "foo")
     val longmapLJoin = longmap.leftOuterJoin(Map(1L -> "bar"))
-    @unused val longmapLJoinT: LongMap[(String, Option[String])] = longmapLJoin
+    val longmapLJoinT: LongMap[(String, Option[String])] = longmapLJoin
+    assertEquals(Map(1L -> ("foo" -> Some("bar"))), longmapLJoinT)
     val longmapRJoin = longmap.rightOuterJoin(Map(1L -> "bar"))
-    @unused val longmapRJoinT: LongMap[(Option[String], String)] = longmapRJoin
+    val longmapRJoinT: LongMap[(Option[String], String)] = longmapRJoin
+    assertEquals(Map(1L -> (Some("foo") -> "bar")), longmapRJoinT)
 
     val mlongmap = mutable.LongMap(1L -> "foo")
     val mlongmapLJoin = mlongmap.leftOuterJoin(Map(1L -> "bar"))
-    @unused val mlongmapLJoinT: mutable.LongMap[(String, Option[String])] = mlongmapLJoin
+    val mlongmapLJoinT: mutable.LongMap[(String, Option[String])] = mlongmapLJoin
+    assertEquals(Map(1L -> ("foo" -> Some("bar"))), mlongmapLJoinT)
     val mlongmapRJoin = mlongmap.rightOuterJoin(Map(1L -> "bar"))
-    @unused val mlongmapRJoinT: mutable.LongMap[(Option[String], String)] = mlongmapRJoin
+    val mlongmapRJoinT: mutable.LongMap[(Option[String], String)] = mlongmapRJoin
+    assertEquals(Map(1L -> (Some("foo") -> "bar")), mlongmapRJoinT)
   }
 
 }

--- a/test/junit/scala/collection/immutable/VectorTest.scala
+++ b/test/junit/scala/collection/immutable/VectorTest.scala
@@ -391,7 +391,7 @@ class VectorTest {
     assertEquals(Vector(1,2,3), v)
 
 
-    val f: Any => Unit = println
+    val f: Any => Unit = _ => ()
 
     // test that type info is not lost
     @unused val x: Vector[Char] = Vector[Char]().tapEach(f)

--- a/test/junit/scala/lang/stringinterpol/StringContextTest.scala
+++ b/test/junit/scala/lang/stringinterpol/StringContextTest.scala
@@ -114,13 +114,9 @@ class StringContextTest {
 
   @Test def `f interpolator baseline`(): Unit = {
 
-    // ignore spurious warning scala/bug#11946
-    type ignore = annotation.unused
-    @ignore def ignore: ignore = ???  // ignore that ignore looks unused
-
-    @ignore implicit def stringToBoolean(s: String): Boolean = java.lang.Boolean.parseBoolean(s)
-    @ignore implicit def stringToChar(s: String): Char = s(0)
-    @ignore implicit def str2fmt(s: String): java.util.Formattable = new java.util.Formattable {
+    implicit def stringToBoolean(s: String): Boolean = java.lang.Boolean.parseBoolean(s)
+    implicit def stringToChar(s: String): Char = s(0)
+    implicit def str2fmt(s: String): java.util.Formattable = new java.util.Formattable {
       def formatTo(f: java.util.Formatter, g: Int, w: Int, p: Int) = f.format("%s", s)
     }
 
@@ -140,7 +136,7 @@ class StringContextTest {
     import java.util.{Calendar, Locale}
     val c = Calendar.getInstance(Locale.US)
     c.set(2012, Calendar.MAY, 26)
-    @ignore implicit def strToDate(x: String): Calendar = c
+    implicit def strToDate(x: String): Calendar = c
 
     val ss = List[(String, String)] (
       // 'b' / 'B' (category: general)
@@ -225,8 +221,8 @@ class StringContextTest {
 
       f"Just want to say ${"hello, world"}%#s..." -> "Just want to say hello, world...",
 
-      { @ignore implicit val strToShort = (s: String) => java.lang.Short.parseShort(s) ; f"${"120"}%d" } -> "120",
-      { @ignore implicit val strToInt = (s: String) => 42 ; f"${"120"}%d" } -> "42",
+      { implicit val strToShort = (s: String) => java.lang.Short.parseShort(s) ; f"${"120"}%d" } -> "120",
+      { implicit val strToInt = (s: String) => 42 ; f"${"120"}%d" } -> "42",
 
       // 'e' | 'E' | 'g' | 'G' | 'f' | 'a' | 'A' (category: floating point)
       // ------------------------------------------------------------------


### PR DESCRIPTION
Don't warn about unused parameters of a method that is marked unused.

Don't warn about unused parameters that are singleton-typed (which is useful for DSLs).

A method that is marked unused does not consume other elements. For instance, a val that is referenced only by an unused method is warnable as unused. (Deleting an unused method should not cascade in further unused warnings.)

Fixes scala/bug#12992