### PR TITLE
Mention if missing symbol is on the class path

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/Platform.scala
+++ b/src/compiler/scala/tools/nsc/backend/Platform.scala
@@ -41,7 +41,7 @@ trait Platform {
    * Tells whether a class with both a binary and a source representation
    * (found in classpath and in sourcepath) should be re-compiled. Behaves
    * on the JVM similar to javac, i.e. if the source file is newer than the classfile,
-   * a re-compile is triggered. On .NET by contrast classfiles always take precedence.
+   * a re-compile is triggered.
    */
   def needCompile(bin: AbstractFile, src: AbstractFile): Boolean
 }

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -224,7 +224,7 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
   val XmixinForceForwarders = ChoiceSetting(
     name    = "-Xmixin-force-forwarders",
     helpArg = "mode",
-    descr   = "Generate forwarder methods in classes inhering concrete methods from traits.",
+    descr   = "Generate forwarder methods in classes inheriting concrete methods from traits.",
     choices = List("true", "junit", "false"),
     default = "true",
     choicesHelp = List(

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -330,9 +330,10 @@ trait ContextErrors extends splain.SplainErrors {
       def AmbiguousIdentError(tree: Tree, name: Name, msg: String) =
         NormalTypeError(tree, "reference to " + name + " is ambiguous;\n" + msg)
 
-      def SymbolNotFoundError(tree: Tree, name: Name, owner: Symbol, startingIdentCx: Context, inPattern: Boolean) = {
-        def help = if (inPattern && name.isTermName) s"\nIdentifiers ${if (name.charAt(0).isUpper) "that begin with uppercase" else "enclosed in backticks"} are not pattern variables but match the value in scope." else ""
-        NormalTypeError(tree, s"not found: ${decodeWithKind(name, owner)}$help")
+      def SymbolNotFoundError(tree: Tree, name: Name, owner: Symbol, inPattern: Boolean, hidden: Boolean) = {
+        val help = if (inPattern && name.isTermName) s"\nIdentifiers ${if (name.charAt(0).isUpper) "that begin with uppercase" else "enclosed in backticks"} are not pattern variables but match the value in scope." else ""
+        val path = if (hidden) s"\nA ${if (name.isTermName) "value" else "class"} on the class path is shadowed by a companion artifact currently compiled; companions must be compiled together." else ""
+        NormalTypeError(tree, s"not found: ${decodeWithKind(name, owner)}$help$path")
       }
 
       // typedAppliedTypeTree

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -467,7 +467,7 @@ trait Namers extends MethodSynthesis {
       if (existingModule.isModule && !existingModule.hasPackageFlag && inCurrentScope(existingModule) && (currentRun.canRedefine(existingModule) || existingModule.isSynthetic)) {
         updatePosFlags(existingModule, tree.pos, moduleFlags)
         setPrivateWithin(tree, existingModule)
-        existingModule.moduleClass andAlso (setPrivateWithin(tree, _))
+        existingModule.moduleClass.andAlso(setPrivateWithin(tree, _))
         context.unit.synthetics -= existingModule
         tree.symbol = existingModule
       }

--- a/src/partest/scala/tools/partest/nest/DirectCompiler.scala
+++ b/src/partest/scala/tools/partest/nest/DirectCompiler.scala
@@ -111,7 +111,9 @@ class DirectCompiler(val runner: Runner) {
     val global       = newGlobal(testSettings, reporter)
     def errorCount   = reporter.errorCount
 
-    testSettings.outputDirs.setSingleOutput(outDir.getPath)
+    // usually, -d outDir, but don't override setting by the test
+    if (!testSettings.outdir.isSetByUser)
+      testSettings.outputDirs.setSingleOutput(outDir.getPath)
 
     def reportError(s: String): Unit = reporter.error(NoPosition, s)
 

--- a/src/reflect/scala/reflect/io/Path.scala
+++ b/src/reflect/scala/reflect/io/Path.scala
@@ -233,13 +233,13 @@ class Path private[io] (val jfile: JFile) {
   // creations
   def createDirectory(force: Boolean = true, failIfExists: Boolean = false): Directory = {
     val res = if (force) jfile.mkdirs() else jfile.mkdir()
-    if (!res && failIfExists && exists) fail("Directory '%s' already exists." format name)
+    if (!res && failIfExists && exists) fail(s"Directory '$name' already exists.")
     else if (isDirectory) toDirectory
     else new Directory(jfile)
   }
   def createFile(failIfExists: Boolean = false): File = {
     val res = jfile.createNewFile()
-    if (!res && failIfExists && exists) fail("File '%s' already exists." format name)
+    if (!res && failIfExists && exists) fail(s"File '$name' already exists.")
     else if (isFile) toFile
     else new File(jfile)
   }

--- a/test/files/neg/t12289.check
+++ b/test/files/neg/t12289.check
@@ -1,0 +1,5 @@
+c_2.scala:6: error: not found: type T
+A class on the class path is shadowed by a companion artifact currently compiled; companions must be compiled together.
+  class C extends T
+                  ^
+1 error

--- a/test/files/neg/t12289/c_2.scala
+++ b/test/files/neg/t12289/c_2.scala
@@ -1,0 +1,7 @@
+//> using options -d /tmp -Yskip:jvm
+// -d is required to permit helpful output.
+// compilation will fail but ensure no output files for this round.
+package p {
+  object T
+  class C extends T
+}

--- a/test/files/neg/t12289/t_1.scala
+++ b/test/files/neg/t12289/t_1.scala
@@ -1,0 +1,3 @@
+package p {
+  trait T
+}

--- a/test/files/neg/t12289b.check
+++ b/test/files/neg/t12289b.check
@@ -1,0 +1,5 @@
+c_2.scala:7: error: not found: value T
+A value on the class path is shadowed by a companion artifact currently compiled; companions must be compiled together.
+    def companion: AnyRef = T
+                            ^
+1 error

--- a/test/files/neg/t12289b/c_2.scala
+++ b/test/files/neg/t12289b/c_2.scala
@@ -1,0 +1,9 @@
+//> using options -d /tmp -Yskip:jvm
+// -d is required to permit helpful output.
+// compilation will fail but ensure no output files for this round.
+package p {
+  trait T
+  class C extends T {
+    def companion: AnyRef = T
+  }
+}

--- a/test/files/neg/t12289b/t_1.scala
+++ b/test/files/neg/t12289b/t_1.scala
@@ -1,0 +1,3 @@
+package p {
+  object T
+}

--- a/test/files/run/t12289c.check
+++ b/test/files/run/t12289c.check
@@ -1,0 +1,2 @@
+pos: source-newSource1.scala,line-3,offset=41 not found: type T
+A class on the class path is shadowed by a companion artifact currently compiled; companions must be compiled together. ERROR

--- a/test/files/run/t12289c.scala
+++ b/test/files/run/t12289c.scala
@@ -1,0 +1,40 @@
+
+import scala.tools.partest.StoreReporterDirectTest
+import scala.tools.nsc._
+import scala.util.chaining._
+
+object Test extends StoreReporterDirectTest {
+  var round = 0
+  def code1 = "package p { trait T }"
+  def code2 =
+    sm"""|package p {
+         |  object T
+         |  class C extends T
+         |}"""
+  def code =
+    if (round > 0) code2
+    else code1.tap(_ => round += 1)
+  // intercept the settings created for compile()
+  override def newSettings(args: List[String]) = {
+    val outDir = testOutput.parent / testOutput / s"test-output-$round"
+    def prevOutDir = testOutput.parent / testOutput / s"test-output-${round - 1}"
+    outDir.createDirectory()
+    // put the previous round on the class path
+    val ss =
+      if (round > 0) super.newSettings("-cp" :: prevOutDir.path :: args)
+      else super.newSettings(args)
+    ss.outputDirs.add(srcDir = testPath.parent.path, outDir = outDir.path)
+    ss
+  }
+  // avoid setting -d
+  override def newCompiler(args: String*): Global = {
+    val settings = newSettings(tokenize(extraSettings) ++ args.toList)
+    newCompiler(settings)
+  }
+  // report helpful message when output dir is programmatically set
+  def show() = {
+    assert(compile())
+    assert(!compile())
+    filteredInfos.foreach(println)
+  }
+}


### PR DESCRIPTION
Hint if there is an object in scope, in a package, which has a class, and the class path finds it.

Fixes scala/bug#12289