### PR TITLE
Add `-Wtostring-interpolated` to warn if interpolator uses `toString`

### DIFF
--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -572,6 +572,7 @@ object Reporting {
         WFlagNumericWiden,
         WFlagSelfImplicit,
         WFlagUnnamedBooleanLiteral,
+        WFlagTostringInterpolated,
         WFlagValueDiscard
       = wflag()
 

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -123,6 +123,7 @@ trait Warnings {
   val warnOctalLiteral     = BooleanSetting("-Woctal-literal", "Warn on obsolete octal syntax.") withAbbreviation "-Ywarn-octal-literal"
   val warnUnnamedBoolean   = BooleanSetting("-Wunnamed-boolean-literal", "Warn about unnamed boolean literals if there is more than one or defaults are used, unless parameter has @deprecatedName.")
   val warnUnnamedStrict    = BooleanSetting("-Wunnamed-boolean-literal-strict", "Warn about all unnamed boolean literals, unless parameter has @deprecatedName or the method has a single leading boolean parameter.").enabling(warnUnnamedBoolean :: Nil)
+  val warnToString         = BooleanSetting("-Wtostring-interpolated", "Warn when a standard interpolator uses toString.")
 
   object PerformanceWarnings extends MultiChoiceEnumeration {
     val Captured       = Choice("captured",        "Modification of var in closure causes boxing.")

--- a/test/files/neg/stringinterpolation_macro-neg.check
+++ b/test/files/neg/stringinterpolation_macro-neg.check
@@ -10,11 +10,6 @@ stringinterpolation_macro-neg.scala:15: error: too many arguments for interpolat
 stringinterpolation_macro-neg.scala:16: error: too few arguments for interpolated string
   new StringContext("", "").f()
                              ^
-stringinterpolation_macro-neg.scala:19: error: type mismatch;
- found   : String
- required: Boolean, Null
-  f"$s%b"
-     ^
 stringinterpolation_macro-neg.scala:20: error: type mismatch;
  found   : String
  required: Char, Byte, Short, Int
@@ -162,6 +157,9 @@ stringinterpolation_macro-neg.scala:77: error: Missing conversion operator in '%
 stringinterpolation_macro-neg.scala:80: error: conversions must follow a splice; use %% for literal %, %n for newline
   f"${d}random-leading-junk%d"
                            ^
+stringinterpolation_macro-neg.scala:19: warning: Boolean format is null test for non-Boolean
+  f"$s%b"
+       ^
 stringinterpolation_macro-neg.scala:63: warning: Index is not this arg
   f"${8}%d ${9}%1$$d"
                 ^
@@ -171,5 +169,5 @@ stringinterpolation_macro-neg.scala:64: warning: Argument index ignored if '<' f
 stringinterpolation_macro-neg.scala:65: warning: Index is not this arg
   f"$s%s $s%1$$s"
             ^
-3 warnings
-46 errors
+4 warnings
+45 errors

--- a/test/files/neg/tostring-interpolated.check
+++ b/test/files/neg/tostring-interpolated.check
@@ -1,0 +1,41 @@
+tostring-interpolated.scala:7: error: interpolation uses toString
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=w-flag-tostring-interpolated, site=T.f
+  def f = f"$c" // warn
+             ^
+tostring-interpolated.scala:8: error: interpolation uses toString
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=w-flag-tostring-interpolated, site=T.s
+  def s = s"$c" // warn
+             ^
+tostring-interpolated.scala:9: error: interpolation uses toString
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=w-flag-tostring-interpolated, site=T.r
+  def r = raw"$c" // warn
+               ^
+tostring-interpolated.scala:11: error: interpolation uses toString
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=w-flag-tostring-interpolated, site=T.format
+  def format = f"${c.x}%d in $c or $c%s" // warn using c.toString // warn
+                              ^
+tostring-interpolated.scala:11: error: interpolation uses toString
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=w-flag-tostring-interpolated, site=T.format
+  def format = f"${c.x}%d in $c or $c%s" // warn using c.toString // warn
+                                      ^
+tostring-interpolated.scala:13: warning: Boolean format is null test for non-Boolean
+  def bool = f"$c%b" // warn just a null check
+                  ^
+tostring-interpolated.scala:15: error: interpolation uses toString
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=w-flag-tostring-interpolated, site=T.oops
+  def oops = s"${null} slipped thru my fingers" // warn
+                 ^
+tostring-interpolated.scala:20: error: interpolation uses toString
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=w-flag-tostring-interpolated, site=T.greeting
+  def greeting = s"$sb, world" // warn
+                    ^
+tostring-interpolated.scala:31: error: interpolated Unit value
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=w-flag-tostring-interpolated, site=Mitigations.unitized
+  def unitized = s"unfortunately $shown" // warn accidental unit value
+                                  ^
+tostring-interpolated.scala:32: error: interpolated Unit value
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=w-flag-tostring-interpolated, site=Mitigations.funitized
+  def funitized = f"unfortunately $shown" // warn accidental unit value
+                                       ^
+1 warning
+9 errors

--- a/test/files/neg/tostring-interpolated.scala
+++ b/test/files/neg/tostring-interpolated.scala
@@ -1,0 +1,36 @@
+//> using options -Wconf:cat=w-flag-tostring-interpolated:e -Wtostring-interpolated
+
+case class C(x: Int)
+
+trait T {
+  def c = C(42)
+  def f = f"$c" // warn
+  def s = s"$c" // warn
+  def r = raw"$c" // warn
+
+  def format = f"${c.x}%d in $c or $c%s" // warn using c.toString // warn
+
+  def bool = f"$c%b" // warn just a null check
+
+  def oops = s"${null} slipped thru my fingers" // warn
+
+  def ok = s"${c.toString}"
+
+  def sb = new StringBuilder().append("hello")
+  def greeting = s"$sb, world" // warn
+}
+
+class Mitigations {
+
+  val s = "hello, world"
+  val i = 42
+  def shown() = println("shown")
+
+  def ok = s"$s is ok"
+  def jersey = s"number $i"
+  def unitized = s"unfortunately $shown" // warn accidental unit value
+  def funitized = f"unfortunately $shown" // warn accidental unit value
+
+  def nopct = f"$s is ok"
+  def nofmt = f"number $i"
+}

--- a/test/files/run/f-interpolator-unit.scala
+++ b/test/files/run/f-interpolator-unit.scala
@@ -33,7 +33,7 @@ object Test extends App {
   final val tester = "hello"
   final val number = "42"  // strings only, alas
 
-  def assertEquals(s0: String, s1: String) = assert(s0 == s1, s"$s0 == $s1")
+  def assertEquals(s0: String, s1: String, i: Int = -1) = assert(s0 == s1, s"$s0 == $s1${if (i >= 0) " at " + i.toString else ""}")
 
   def noEscape() = {
     val s = "string"
@@ -134,7 +134,7 @@ object Test extends App {
       f"${null}%b"  -> "false",
       f"${false}%b" -> "false",
       f"${true}%b"  -> "true",
-      f"${true && false}%b"                 -> "false",
+      f"${true && false}%b"                     -> "false",
       f"${java.lang.Boolean.valueOf(false)}%b"  -> "false",
       f"${java.lang.Boolean.valueOf(true)}%b"   -> "true",
 
@@ -255,7 +255,7 @@ object Test extends App {
       f"z" -> "z"
     )
 
-    for ((f, s) <- ss) assertEquals(s, f)
+    for (((f, s), i) <- ss.zipWithIndex) assertEquals(s, f, i)
   }
 
   noEscape()


### PR DESCRIPTION
Adds `-Wtostring-interpolated` which warns if a standard interpolator uses `toString` to convert a value which is not string or primitive type.

`-Wconf:cat=w-flag-tostring-interpolated:e` to boost.

Also restores edge case `f"${ "hello" }%b"` which is `"true"` for non-boolean arg. That became an error in previous refactor, possibly intentionally. (It is arguably an obscure feature of format.) (Edit: the C.I. error reminds me that the change was to make the expected type Boolean, so that conversions work normally. That is also edge casey. Maybe it can try boolean, null, and any? Edit: yes, try non-any first, then any if allowed.)

The "default" `%s` is improved so that the warning position is at the interpolated element in `s"$x"`.

Follow-up to https://github.com/scala/scala/pull/8654
