### PR TITLE
[backport] desugar switchable matches with guards in async methods

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/async/AsyncPhase.scala
+++ b/src/compiler/scala/tools/nsc/transform/async/AsyncPhase.scala
@@ -31,6 +31,8 @@ abstract class AsyncPhase extends Transform with TypingTransformers with AnfTran
                                            stateDiagram: ((Symbol, Tree) => Option[String => Unit]),
                                            allowExceptionsToPropagate: Boolean) extends PlainAttachment
 
+  def hasAsyncAttachment(dd: DefDef) = dd.hasAttachment[AsyncAttachment]
+
   // Optimization: avoid the transform altogether if there are no async blocks in a unit.
   private val sourceFilesToTransform = perRunCaches.newSet[SourceFile]()
   private val awaits: mutable.Set[Symbol] = perRunCaches.newSet[Symbol]()

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
@@ -218,6 +218,8 @@ trait MatchOptimization extends MatchTreeMaking with MatchAnalysis {
   trait SwitchEmission extends TreeMakers with MatchMonadInterface {
     import treeInfo.isGuardedCase
 
+    def inAsync: Boolean
+
     abstract class SwitchMaker {
       abstract class SwitchableTreeMakerExtractor { def unapply(x: TreeMaker): Option[Tree] }
       val SwitchableTreeMaker: SwitchableTreeMakerExtractor
@@ -501,7 +503,7 @@ trait MatchOptimization extends MatchTreeMaking with MatchAnalysis {
     class RegularSwitchMaker(scrutSym: Symbol, matchFailGenOverride: Option[Tree => Tree], val unchecked: Boolean) extends SwitchMaker {
       val switchableTpe = Set(ByteTpe, ShortTpe, IntTpe, CharTpe)
       val alternativesSupported = true
-      val canJump = true
+      val canJump = !inAsync
 
       // Constant folding sets the type of a constant tree to `ConstantType(Constant(folded))`
       // The tree itself can be a literal, an ident, a selection, ...

--- a/test/async/run/switch-await-in-guard.scala
+++ b/test/async/run/switch-await-in-guard.scala
@@ -1,0 +1,50 @@
+// scalac: -Xasync
+
+import scala.tools.partest.async.OptionAwait._
+import org.junit.Assert._
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    assertEquals(Some(22), sw1(11))
+    assertEquals(Some(3), sw1(3))
+
+    assertEquals(Some(22), sw2(11))
+    assertEquals(Some(3), sw2(3))
+
+    assertEquals(Some(22), sw3(11))
+    assertEquals(Some(44), sw3(22))
+    assertEquals(Some(3), sw3(3))
+
+    assertEquals(Some("22"), swS("11"))
+    assertEquals(Some("3"), swS("3"))
+  }
+
+  private def sw1(i: Int) = optionally {
+    i match {
+      case 11 if value(Some(430)) > 42 => 22
+      case p => p
+    }
+  }
+
+  private def sw2(i: Int) = optionally {
+    i match {
+      case 11 => if (value(Some(430)) > 42) 22 else i
+      case p => p
+    }
+  }
+
+  private def sw3(i: Int) = optionally {
+    i match {
+      case 11 => if (value(Some(430)) > 42) 22 else i
+      case 22 | 33 => 44
+      case p => p
+    }
+  }
+
+  private def swS(s: String) = optionally {
+    s match {
+      case "11" if value(Some(430)) > 42 => "22"
+      case p => p
+    }
+  }
+}

--- a/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
+++ b/test/junit/scala/tools/nsc/backend/jvm/BytecodeTest.scala
@@ -871,4 +871,45 @@ class BytecodeTest extends BytecodeTesting {
       Op(RETURN),
     ))
   }
+
+  @Test
+  def t12990(): Unit = {
+    val komp = BytecodeTesting.newCompiler(extraArgs = "-Xasync")
+    val code =
+      """import scala.tools.nsc.OptionAwait._
+        |
+        |class C {
+        |  def sw1(i: Int) = optionally {
+        |    i match {
+        |      case 11 if value(Some(430)) > 42 => 22
+        |      case p => p
+        |    }
+        |  }
+        |  def sw2(i: Int) = optionally {
+        |    i match {
+        |      case 11 => if (value(Some(430)) > 42) 22 else i
+        |      case p => p
+        |    }
+        |  }
+        |  def sw3(i: Int) = optionally {
+        |    i match {
+        |      case 11 => if (value(Some(430)) > 42) 22 else i
+        |      case 22 | 33 => 44
+        |      case p => p
+        |    }
+        |  }
+        |}
+        |""".stripMargin
+    val cs = komp.compileClasses(code)
+
+    val sm1 = getMethod(cs.find(_.name == "C$stateMachine$async$1").get, "apply")
+    assertSame(1, sm1.instructions.count(_.opcode == TABLESWITCH))
+
+    val sm2 = getMethod(cs.find(_.name == "C$stateMachine$async$2").get, "apply")
+    assertSame(2, sm2.instructions.count(_.opcode == TABLESWITCH))
+
+    val sm3 = getMethod(cs.find(_.name == "C$stateMachine$async$3").get, "apply")
+    assertSame(1, sm3.instructions.count(_.opcode == TABLESWITCH))
+    assertSame(1, sm3.instructions.count(_.opcode == LOOKUPSWITCH))
+  }
 }


### PR DESCRIPTION
Backport of https://github.com/scala/scala/pull/10775

The async transformation supports `Match` trees that are left in place for the backend to emit a switch in bytecode.

Guards are desugared into a jump to the default case

    case 22 if p => 5
    case _       => 6

becomes

    case 22 => if (p) 5 else default()
    case _  => default: { 6 }

This pattern is unexpected for the async transform and leads to invalid bytecode if the guard `p` has an await call.

The fix is to desugar switchable matches with guards in patmat if the enclosing method has the `AsyncAttachment`.