### PR TITLE
[backport] Lambda is serializable when SAM defined in nonserializable parent

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
+++ b/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
@@ -110,7 +110,7 @@ abstract class Delambdafy extends Transform with TypingTransformers with ast.Tre
 
       // no need for adaptation when the implemented sam is of a specialized built-in function type
       val lambdaTarget = if (isSpecialized) target else createBoxingBridgeMethodIfNeeded(fun, target, functionalInterface, sam)
-      val isSerializable = samUserDefined == NoSymbol || samUserDefined.owner.isNonBottomSubClass(definitions.JavaSerializableClass)
+      val isSerializable = samUserDefined == NoSymbol || functionalInterface.isNonBottomSubClass(definitions.JavaSerializableClass)
       val addScalaSerializableMarker = samUserDefined == NoSymbol
 
       val samBridges = logResultIf[List[Symbol]](s"will add SAM bridges for $fun", _.nonEmpty) {

--- a/test/files/run/t12774.scala
+++ b/test/files/run/t12774.scala
@@ -1,0 +1,16 @@
+trait SerializableBiFunction[T, U, R] extends java.util.function.BiFunction[T, U, R] with Serializable {
+  // def apply(t: T, u: U): R
+}
+object Test {
+  def main(args: Array[String]): Unit = {
+    import java.io._
+    val fn: SerializableBiFunction[String, Int, Boolean] = (str, expected) => str.length == expected
+
+    val buffer = new ByteArrayOutputStream
+    val out = new ObjectOutputStream(buffer)
+    out.writeObject(fn)
+    val in = new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray))
+    val res = in.readObject.asInstanceOf[SerializableBiFunction[String, Int, Boolean]]
+    assert(res("success", 7))
+  }
+}


### PR DESCRIPTION
This trivial backport (of https://github.com/scala/scala/pull/10399) was below the author's paygrade.

It turns the test green.