### PR TITLE
Fix false-positive by-name implicit warnings with `-Wmacros`

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3698,12 +3698,12 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                     argss.find {
                       case (aiv: ApplyImplicitView) :: Nil =>
                         aiv.args match {
-                          case Block(_, _) :: Nil => true
+                          case Block(_ :: _, _) :: Nil => true
                           case _ => false
                         }
                       case _ => false
                     }
-                  needsAdjust.foreach(ts => context.warning(ts.head.pos, "Implicits applied to block expressions after overload resolution may have unexpected semantics", WarningCategory.LintBynameImplicit))
+                  needsAdjust.foreach(ts => context.warning(ts.head.pos, "Overloaded implicit conversions that take a by-name parameter are applied to the entire block, not just the result expression.", WarningCategory.LintBynameImplicit))
                 }
               inferMethodAlternative(fun, undetparams, argTpes.toList, pt)
               doTypedApply(tree, adaptAfterOverloadResolution(fun, mode.forFunMode, WildcardType), args1, mode, pt).tap(checkConversionsToBlockArgs)

--- a/test/files/neg/byname-implicit.check
+++ b/test/files/neg/byname-implicit.check
@@ -1,13 +1,13 @@
-byname-implicit.scala:84: warning: Implicits applied to block expressions after overload resolution may have unexpected semantics
+byname-implicit.scala:84: warning: Overloaded implicit conversions that take a by-name parameter are applied to the entire block, not just the result expression.
   Foo.bar { println("barring"); 0 }  // warn
           ^
-byname-implicit.scala:14: warning: Block result was adapted via implicit conversion (method ints are strs) taking a by-name parameter
+byname-implicit.scala:14: warning: Block result expression was adapted via implicit conversion (method ints are strs) taking a by-name parameter; only the result was passed, not the entire block.
       42                      // warn
       ^
-byname-implicit.scala:25: warning: Block result was adapted via implicit conversion (method bools are strs) taking a by-name parameter
+byname-implicit.scala:25: warning: Block result expression was adapted via implicit conversion (method bools are strs) taking a by-name parameter; only the result was passed, not the entire block.
       true                    // warn
       ^
-byname-implicit.scala:68: warning: Block result was adapted via implicit conversion (method fromBooleanCheck) taking a by-name parameter
+byname-implicit.scala:68: warning: Block result expression was adapted via implicit conversion (method fromBooleanCheck) taking a by-name parameter; only the result was passed, not the entire block.
     false                  // warn
     ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/byname-implicit.scala
+++ b/test/files/neg/byname-implicit.scala
@@ -1,4 +1,4 @@
-// scalac: -Werror -Xlint:byname-implicit
+//> using options -Werror -Xlint:byname-implicit
 
 import language._
 
@@ -84,3 +84,11 @@ object FooTest extends App {
   Foo.bar { println("barring"); 0 }  // warn
 }
 
+class Nowarn {
+  implicit def cv(n: => Int): String = n.toString
+
+  def show(s: String) = println(s"[$s]")
+
+  def f(): Unit = show(cv(42))  // nowarn because it only warns if statements
+  def g(): Unit = show { println(); cv(42) }  // nowarn anymore because explicit call by user
+}


### PR DESCRIPTION
Only warn about a block arg passed into the by-name param of an implicit method if it was an implicit view.

Fixes scala/bug#12072

This implements lrytz's suggestion on the ticket.
https://github.com/scala/bug/issues/12072#issuecomment-738812622

Confirmed that the Shapeless 2 solutions to the guide exercises now compile cleanly.

Since Shapeless is not relying on conversions, this PR ignores the ticket title as a red herring.
