### PR TITLE
Nullify unused result in async transform

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/async/ExprBuilder.scala
+++ b/src/compiler/scala/tools/nsc/transform/async/ExprBuilder.scala
@@ -12,8 +12,7 @@
 
 package scala.tools.nsc.transform.async
 
-import scala.collection.mutable
-import scala.collection.mutable.ListBuffer
+import scala.collection.mutable, mutable.ListBuffer
 
 trait ExprBuilder extends TransformUtils with AsyncAnalysis {
   import global._
@@ -57,7 +56,7 @@ trait ExprBuilder extends TransformUtils with AsyncAnalysis {
     override def toString: String = mkToString //+ " (was: " + initToString + ")"
     // private val initToString = mkToString
     def insertNullAssignments(preNulls: Iterator[Symbol], postNulls: Iterator[Symbol]): Unit = {
-      val stats1 = mutable.ListBuffer[Tree]()
+      val stats1 = ListBuffer.empty[Tree]
       def addNullAssigments(syms: Iterator[Symbol]): Unit = {
         for (fieldSym <- syms) {
           stats1 += typedCurrentPos(Assign(currentTransformState.memberRef(fieldSym), gen.mkZero(fieldSym.info)))

--- a/test/async/run/a265.scala
+++ b/test/async/run/a265.scala
@@ -1,0 +1,21 @@
+//> using options -Xasync -Xsource:3-cross
+//> abusing options -Xasync -Xsource:3-cross -Vprint:typer,async
+
+import concurrent.*, ExecutionContext.Implicits.{given, *}, duration.Duration.Inf
+import scala.tools.testkit.AssertUtil.assertNotReachable
+import scala.tools.testkit.async.Async.*
+import org.junit.Assert.*
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val data = "hello, world"
+    val r = async {
+      //println(await(Future(data)))
+      await(Future(data))
+      "goodbye, all!" // check local var is null
+    }
+    assertNotReachable(data, r) {
+      assertEquals("goodbye, all!", Await.result(r, Inf))
+    }
+  }
+}

--- a/test/junit/scala/tools/nsc/async/AnnotationDrivenAsyncTest.scala
+++ b/test/junit/scala/tools/nsc/async/AnnotationDrivenAsyncTest.scala
@@ -450,8 +450,9 @@ class AnnotationDrivenAsyncTest {
             |tr = self.getCompleted(awaitable$async)
             |self.state_=(1)
             |if (null.!=(tr))\n  while$()\nelse\n  {\n    self.onComplete(awaitable$async);\n    return ()\n  }
-            |<synthetic> val await$1: Object = {\n  val tryGetResult$async: Object = self.tryGet(tr);\n  if (self.eq(tryGetResult$async))\n    return ()\n  else\n    tryGetResult$async.$asInstanceOf[Object]()\n}
-            |self.x = scala.Int.unbox(await$1)
+            |<synthetic> var await$1: Object = {\n  val tryGetResult$async: Object = self.tryGet(tr);\n  if (self.eq(tryGetResult$async))\n    return ()\n  else\n    tryGetResult$async.$asInstanceOf[Object]()\n}
+            |<synthetic> val x$1: Object = await$1
+            |self.x = scala.Int.unbox(x$1)
             |
             |
             |val y = id(2)
@@ -460,8 +461,9 @@ class AnnotationDrivenAsyncTest {
             |tr = self.getCompleted(awaitable$async)
             |self.state_=(2)
             |if (null.!=(tr))\n  while$()\nelse\n  {\n    self.onComplete(awaitable$async);\n    return ()\n  }
-            |<synthetic> val await$2: Object = {\n  val tryGetResult$async: Object = self.tryGet(tr);\n  if (self.eq(tryGetResult$async))\n    return ()\n  else\n    tryGetResult$async.$asInstanceOf[Object]()\n}
-            |val y: Int = scala.Int.unbox(await$2)
+            |<synthetic> var await$2: Object = {\n  val tryGetResult$async: Object = self.tryGet(tr);\n  if (self.eq(tryGetResult$async))\n    return ()\n  else\n    tryGetResult$async.$asInstanceOf[Object]()\n}
+            |<synthetic> val x$2: Object = await$2
+            |val y: Int = scala.Int.unbox(x$2)
             |
             |
             |x.$plus(y)


### PR DESCRIPTION
Fixes https://github.com/scala/scala-async/issues/265

Needs more soak time and a test. The idea is that if the incoming awaited value is not consumed, the synthetic reference to it will be a statement in the block. The `val` for the value is made mutable, so that the reference can be turned into an assign to null.
