### PR TITLE
Align with Scala 3: Under `-Xsource:3`, allow importing `given`, for cross-building

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2759,10 +2759,11 @@ self =>
         val selectors: List[ImportSelector] = in.token match {
           case USCORE =>
             List(wildImportSelector()) // import foo.bar._
-          case IDENTIFIER if currentRun.isScala3 && in.name == raw.STAR =>
-            List(wildImportSelector()) // import foo.bar.*
+          case IDENTIFIER if currentRun.isScala3 && (in.name == raw.STAR || in.name == nme.`given`) =>
+            if (in.name == raw.STAR) List(wildImportSelector()) // import foo.bar.*
+            else List(importSelector()) // import foo.bar.given
           case LBRACE =>
-            importSelectors()          // import foo.bar.{ x, y, z }
+            importSelectors()          // import foo.bar.{x, y, z, given, *}
           case _ =>
             if (currentRun.isScala3 && lookingAhead { isRawIdent && in.name == nme.as })
               List(importSelector())  // import foo.bar as baz
@@ -2775,7 +2776,7 @@ self =>
                 in.nextToken()
                 return loop(t)
               }
-              // import foo.bar.Baz;
+              // import foo.Bar
               else List(makeImportSelector(name, nameOffset))
             }
         }
@@ -2804,22 +2805,25 @@ self =>
      *  }}}
      */
     def importSelectors(): List[ImportSelector] = {
-      def isWilder(sel: ImportSelector) = sel.isWildcard || currentRun.isScala3 && !sel.isRename && sel.name == nme.`given`
+      def isWilder(sel: ImportSelector) = sel.isWildcard || sel.isGiven
       // error on duplicate target names, import x.{a=>z, b=>z}, and fix import x.{given, *} to x._
       def checkSelectors(xs: List[ImportSelector]): List[ImportSelector] = xs match {
         case h :: t =>
-          // wildcards must come last, and for -Xsource:3, take trailing given, * (or *, given) as _
+          // wildcards must come last, and for -Xsource:3, accept trailing given and/or *, converting {given, *} to *
           if (isWilder(h)) {
-            if (t.exists(!isWilder(_)))
+            if (t.exists(!isWilder(_))) {
               syntaxError(h.namePos, "wildcard import must be in last position")
-            xs.filter(_.isWildcard) match {
-              case ws @ (_ :: Nil) => ws
-              case Nil =>
-                syntaxError(h.namePos, "given requires a wildcard selector")
-                ImportSelector.wildAt(h.namePos) :: Nil
-              case ws @ (w :: _) =>
-                syntaxError(w.namePos, "duplicate wildcard selector")
-                w :: Nil
+              h :: Nil
+            }
+            else t match {
+              case Nil => h :: Nil
+              case other :: rest =>
+                if (!rest.isEmpty || h.isWildcard && other.isWildcard || h.isGiven && other.isGiven) {
+                  syntaxError(other.namePos, "duplicate wildcard selector")
+                  h :: Nil
+                }
+                else if (h.isWildcard) h :: Nil
+                else other :: Nil
             }
           }
           else {
@@ -2851,17 +2855,15 @@ self =>
       val start = in.offset
       val bbq   = in.token == BACKQUOTED_IDENT
       val name  = wildcardOrIdent()
-      val (rename, renameOffset) =
-        if (in.token == ARROW || (currentRun.isScala3 && isRawIdent && in.name == nme.as)) {
-          in.nextToken()
-          if (name == nme.WILDCARD && !bbq) syntaxError(in.offset, "Wildcard import cannot be renamed")
-          val pos = in.offset
-          (wildcardOrIdent(), pos)
-        }
-        else if (name == nme.WILDCARD && !bbq) (null, -1)
-        else (name, start)
-
-      ImportSelector(name, start, rename, renameOffset)
+      if (in.token == ARROW || (currentRun.isScala3 && isRawIdent && in.name == nme.as)) {
+        in.nextToken()
+        if (name == nme.WILDCARD && !bbq) syntaxError(in.offset, "Wildcard import cannot be renamed")
+        val renamePos = in.offset
+        ImportSelector(name, start, rename = wildcardOrIdent(), renamePos = renamePos)
+      }
+      else if (name == nme.WILDCARD && !bbq) ImportSelector.wildAt(start)
+      else if (currentRun.isScala3 && name == nme.`given` && !bbq) ImportSelector.givenAt(start)
+      else makeImportSelector(name, start)
     }
 
     def wildImportSelector(): ImportSelector = {

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1102,7 +1102,7 @@ trait Contexts { self: Analyzer =>
       def collect(sels: List[ImportSelector]): List[ImplicitInfo] = sels match {
         case List() =>
           List()
-        case sel :: _ if sel.isWildcard =>
+        case sel :: _ if sel.isWildcard || sel.isGiven =>
           // Using pre.implicitMembers seems to exposes a problem with out-dated symbols in the IDE,
           // see the example in https://www.assembla.com/spaces/scala-ide/tickets/1002552#/activity/ticket
           // I haven't been able to boil that down the an automated test yet.
@@ -1914,6 +1914,8 @@ trait Contexts { self: Analyzer =>
       case bad              => throw new FatalError(s"symbol ${tree.symbol} has bad type: ${bad}")
     }
 
+    def isGivenImport: Boolean = tree.selectors.exists(_.isGiven)
+
     /** Is name imported explicitly, not via wildcard? */
     def isExplicitImport(name: Name): Boolean = tree.selectors.exists(_.introduces(name))
 
@@ -1950,6 +1952,11 @@ trait Contexts { self: Analyzer =>
           renamed = true
         else if (current.isWildcard && !renamed && !requireExplicit)
           result = maybeNonLocalMember(name)
+        else if (current.isGiven && !requireExplicit) {
+          val maybe = maybeNonLocalMember(name)
+          if (maybe.isImplicit)
+            result = maybe
+        }
 
         if (result == NoSymbol)
           selectors = selectors.tail

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1914,8 +1914,6 @@ trait Contexts { self: Analyzer =>
       case bad              => throw new FatalError(s"symbol ${tree.symbol} has bad type: ${bad}")
     }
 
-    def isGivenImport: Boolean = tree.selectors.exists(_.isGiven)
-
     /** Is name imported explicitly, not via wildcard? */
     def isExplicitImport(name: Name): Boolean = tree.selectors.exists(_.introduces(name))
 

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -574,7 +574,7 @@ trait Namers extends MethodSynthesis {
           lookup(original.toTermName) != NoSymbol || lookup(original.toTypeName) != NoSymbol
         }
 
-        if (!s.isWildcard && base != ErrorType) {
+        if (!s.isWildcard && !s.isGiven && base != ErrorType) {
           val okay = isValid(from, base) || context.unit.isJava && (      // Java code...
                (nme.isModuleName(from) && isValid(from.dropModule, base)) // - importing Scala module classes
             || isValid(from, base.companion)                              // - importing type members from types

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -512,20 +512,22 @@ trait Trees extends api.Trees {
   case class ImportSelector(name: Name, namePos: Int, rename: Name, renamePos: Int) extends ImportSelectorApi {
     assert(isWildcard || rename != null, s"Bad import selector $name => $rename")
     def isWildcard = name == nme.WILDCARD && rename == null
-    def isMask = name != nme.WILDCARD && rename == nme.WILDCARD
+    def isGiven    = name == nme.WILDCARD && rename == nme.`given`
+    def isMask     = name != nme.WILDCARD && rename == nme.WILDCARD
+    def isRename   = name != rename && rename != null && rename != nme.WILDCARD
     def isSpecific = !isWildcard
-    def isRename = rename != null && rename != nme.WILDCARD && name != rename
     private def isLiteralWildcard = name == nme.WILDCARD && rename == nme.WILDCARD
     private def sameName(name: Name, other: Name) =  (name eq other) || (name ne null) && name.start == other.start && name.length == other.length
     def hasName(other: Name) = sameName(name, other)
     def introduces(target: Name) =
       if (target == nme.WILDCARD) isLiteralWildcard
-      else target != null && sameName(rename, target)
+      else target != null && !isGiven && sameName(rename, target)
   }
   object ImportSelector extends ImportSelectorExtractor {
     private val wild = ImportSelector(nme.WILDCARD, -1, null, -1)
     val wildList = List(wild) // OPT This list is shared for performance. Used for unpositioned synthetic only.
     def wildAt(pos: Int) = ImportSelector(nme.WILDCARD, pos, null, -1)
+    def givenAt(pos: Int) = ImportSelector(nme.WILDCARD, pos, nme.`given`, -1)
     def mask(name: Name) = ImportSelector(name, -1, nme.WILDCARD, -1)
   }
 

--- a/test/files/neg/import-future.check
+++ b/test/files/neg/import-future.check
@@ -4,4 +4,10 @@ import-future.scala:15: error: not found: value unrelated
 import-future.scala:40: error: not found: value f
   def g = f[Int] // error no f, was given is not a member
           ^
-2 errors
+import-future.scala:44: error: could not find implicit value for parameter t: T[Int]
+  def g = f[Int] // implicit unavailable
+           ^
+import-future.scala:48: error: could not find implicit value for parameter t: T[Int]
+  def g = f[Int] // implicit unavailable
+           ^
+4 errors

--- a/test/files/neg/import-future.check
+++ b/test/files/neg/import-future.check
@@ -1,4 +1,7 @@
 import-future.scala:15: error: not found: value unrelated
     unrelated(1) // error
     ^
-1 error
+import-future.scala:40: error: not found: value f
+  def g = f[Int] // error no f, was given is not a member
+          ^
+2 errors

--- a/test/files/neg/import-future.scala
+++ b/test/files/neg/import-future.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:3
+//> using options -Xsource:3
 //
 
 class D {
@@ -24,4 +24,18 @@ object Test {
 
     *(1)
   }
+}
+
+trait T[A] {
+  def t: A
+}
+object T {
+  implicit def tInt: T[Int] = new T[Int] {
+    def t: Int = 42
+  }
+  def f[A](implicit t: T[A]): A = t.t
+}
+object X {
+  import T.given
+  def g = f[Int] // error no f, was given is not a member
 }

--- a/test/files/neg/import-future.scala
+++ b/test/files/neg/import-future.scala
@@ -29,13 +29,21 @@ object Test {
 trait T[A] {
   def t: A
 }
-object T {
+object TX {
   implicit def tInt: T[Int] = new T[Int] {
     def t: Int = 42
   }
   def f[A](implicit t: T[A]): A = t.t
 }
 object X {
-  import T.given
+  import TX.given
   def g = f[Int] // error no f, was given is not a member
+}
+object Y {
+  import TX.{f, tInt as _, given}
+  def g = f[Int] // implicit unavailable
+}
+object Z {
+  import TX.{tInt as _, *}
+  def g = f[Int] // implicit unavailable
 }

--- a/test/files/neg/t12813b.check
+++ b/test/files/neg/t12813b.check
@@ -22,7 +22,4 @@ import O.{given, toString, a, _}    // error 3
 t12813b.scala:18: error: duplicate wildcard selector
 import O.{a, given, *, _} // error 3
                     ^
-t12813b.scala:19: error: given requires a wildcard selector
-import O.{a, given}       // error 3
-             ^
-9 errors
+8 errors

--- a/test/files/neg/t12813b.check
+++ b/test/files/neg/t12813b.check
@@ -21,5 +21,5 @@ import O.{given, toString, a, _}    // error 3
           ^
 t12813b.scala:18: error: duplicate wildcard selector
 import O.{a, given, *, _} // error 3
-                    ^
+                       ^
 8 errors

--- a/test/files/neg/t12813b.scala
+++ b/test/files/neg/t12813b.scala
@@ -1,4 +1,4 @@
-// scalac: -Xsource:3
+//> using options -Xsource:3
 
 object O { val a = 1 }
 
@@ -16,4 +16,4 @@ import O.{given, toString, a, _}    // error 3
 import O.{a, given, *}    // ok
 import O.{a, *, given}    // ok
 import O.{a, given, *, _} // error 3
-import O.{a, given}       // error 3
+import O.{a, given}       // ok

--- a/test/files/pos/import-future.scala
+++ b/test/files/pos/import-future.scala
@@ -1,5 +1,4 @@
-// scalac: -Xsource:3
-//
+//> using options -Xsource:3
 
 import java.io as jio
 import scala.{collection as c}
@@ -30,4 +29,18 @@ object starring {
 
   val f = Future(42)
   val r = Await.result(f, D.Inf)
+}
+
+trait T[A] {
+  def t: A
+}
+object T {
+  implicit def tInt: T[Int] = new T[Int] {
+    def t: Int = 42
+  }
+  def f[A](implicit t: T[A]): A = t.t
+}
+object X {
+  import T.given
+  def g = T.f[Int] // was given is not a member
 }


### PR DESCRIPTION
Fixes scala/bug#12999

Under `-Xsource:3`, instead of ignoring `import x.given`, use it to import implicits only. Take `import x.{given, *}` as `import x.*`.

Although `import x.*` will import "legacy implicits" under Scala 3 migration rules, it's desirable to express just `import x.given` and have it work in Scala 2..

Import by type is not supported.

The selector is encoded as if it were `_ as given`.
