### PR TITLE
Avoid /tmp in tests

### DIFF
--- a/test/files/neg/t12289.check
+++ b/test/files/neg/t12289.check
@@ -1,5 +1,0 @@
-c_2.scala:6: error: not found: type T
-A class on the class path is shadowed by a companion artifact currently compiled; companions must be compiled together.
-  class C extends T
-                  ^
-1 error

--- a/test/files/neg/t12289/c_2.scala
+++ b/test/files/neg/t12289/c_2.scala
@@ -1,7 +1,0 @@
-//> using options -d /tmp -Yskip:jvm
-// -d is required to permit helpful output.
-// compilation will fail but ensure no output files for this round.
-package p {
-  object T
-  class C extends T
-}

--- a/test/files/neg/t12289/t_1.scala
+++ b/test/files/neg/t12289/t_1.scala
@@ -1,3 +1,0 @@
-package p {
-  trait T
-}

--- a/test/files/neg/t12289b.check
+++ b/test/files/neg/t12289b.check
@@ -1,5 +1,0 @@
-c_2.scala:7: error: not found: value T
-A value on the class path is shadowed by a companion artifact currently compiled; companions must be compiled together.
-    def companion: AnyRef = T
-                            ^
-1 error

--- a/test/files/neg/t12289b/c_2.scala
+++ b/test/files/neg/t12289b/c_2.scala
@@ -1,9 +1,0 @@
-//> using options -d /tmp -Yskip:jvm
-// -d is required to permit helpful output.
-// compilation will fail but ensure no output files for this round.
-package p {
-  trait T
-  class C extends T {
-    def companion: AnyRef = T
-  }
-}

--- a/test/files/neg/t12289b/t_1.scala
+++ b/test/files/neg/t12289b/t_1.scala
@@ -1,3 +1,0 @@
-package p {
-  object T
-}

--- a/test/files/run/t12289.check
+++ b/test/files/run/t12289.check
@@ -1,0 +1,2 @@
+pos: source-newSource1.scala,line-3,offset=41 not found: type T
+A class on the class path is shadowed by a companion artifact currently compiled; companions must be compiled together. ERROR

--- a/test/files/run/t12289.scala
+++ b/test/files/run/t12289.scala
@@ -1,0 +1,37 @@
+
+import scala.tools.partest.StoreReporterDirectTest
+import scala.tools.nsc._
+import scala.util.chaining._
+
+object Test extends StoreReporterDirectTest {
+  var round = 0
+  val rounds = List(
+    "package p { trait T }",
+    sm"""|package p {
+         |  object T
+         |  class C extends T
+         |}""",
+  )
+  def code = rounds(round).tap(_ => round += 1)
+  // intercept the settings created for compile()
+  override def newSettings(args: List[String]) = {
+    val outDir = testOutput.parent / testOutput / s"test-output-$round"
+    def prevOutDir = testOutput.parent / testOutput / s"test-output-${round - 1}"
+    outDir.createDirectory()
+    // put the previous round on the class path
+    val args1 = "-d" :: outDir.path :: args
+    val args2 = if (round > 0) "-cp" :: prevOutDir.path :: args1 else args1
+    super.newSettings(args2)
+  }
+  // avoid setting -d
+  override def newCompiler(args: String*): Global = {
+    val settings = newSettings(tokenize(extraSettings) ++ args.toList)
+    newCompiler(settings)
+  }
+  // report helpful message when output dir is programmatically set
+  def show() = {
+    assert(compile())
+    assert(!compile())
+    filteredInfos.foreach(println)
+  }
+}

--- a/test/files/run/t12289b.check
+++ b/test/files/run/t12289b.check
@@ -1,0 +1,2 @@
+pos: RangePosition(newSource1.scala, 72, 72, 73) not found: value T
+A value on the class path is shadowed by a companion artifact currently compiled; companions must be compiled together. ERROR

--- a/test/files/run/t12289b.scala
+++ b/test/files/run/t12289b.scala
@@ -1,0 +1,39 @@
+
+import scala.tools.partest.StoreReporterDirectTest
+import scala.tools.nsc._
+import scala.util.chaining._
+
+object Test extends StoreReporterDirectTest {
+  var round = 0
+  val rounds = List(
+    "package p { object T }",
+    sm"""|package p {
+         |  trait T
+         |  class C extends T {
+         |    def companion: AnyRef = T
+         |  }
+         |}""",
+  )
+  def code = rounds(round).tap(_ => round += 1)
+  // intercept the settings created for compile()
+  override def newSettings(args: List[String]) = {
+    val outDir = testOutput.parent / testOutput / s"test-output-$round"
+    def prevOutDir = testOutput.parent / testOutput / s"test-output-${round - 1}"
+    outDir.createDirectory()
+    // put the previous round on the class path
+    val args1 = "-d" :: outDir.path :: args
+    val args2 = if (round > 0) "-cp" :: prevOutDir.path :: args1 else args1
+    super.newSettings(args2)
+  }
+  // avoid setting -d
+  override def newCompiler(args: String*): Global = {
+    val settings = newSettings(tokenize(extraSettings) ++ args.toList)
+    newCompiler(settings)
+  }
+  // report helpful message when output dir is programmatically set
+  def show() = {
+    assert(compile())
+    assert(!compile())
+    filteredInfos.foreach(println)
+  }
+}


### PR DESCRIPTION
follow up #10774 by fixing tests not to even say `-d /tmp`