### PR TITLE
Appease windows paths perhaps

### DIFF
--- a/test/files/run/t12289b.scala
+++ b/test/files/run/t12289b.scala
@@ -1,6 +1,7 @@
 
-import scala.tools.partest.StoreReporterDirectTest
+import scala.reflect.io.AbstractFile
 import scala.tools.nsc._
+import scala.tools.partest.StoreReporterDirectTest
 import scala.util.chaining._
 
 object Test extends StoreReporterDirectTest {
@@ -17,13 +18,14 @@ object Test extends StoreReporterDirectTest {
   def code = rounds(round).tap(_ => round += 1)
   // intercept the settings created for compile()
   override def newSettings(args: List[String]) = {
-    val outDir = testOutput.parent / testOutput / s"test-output-$round"
-    def prevOutDir = testOutput.parent / testOutput / s"test-output-${round - 1}"
-    outDir.createDirectory()
+    val outDir = testOutput / s"test-output-$round"
+    def prevOutDir = testOutput / s"test-output-${round - 1}"
+    outDir.createDirectory(force = true)
+    val af = AbstractFile.getDirectory(outDir)
     // put the previous round on the class path
-    val args1 = "-d" :: outDir.path :: args
-    val args2 = if (round > 0) "-cp" :: prevOutDir.path :: args1 else args1
-    super.newSettings(args2)
+    val args1 = if (round > 0) "-cp" :: prevOutDir.path :: args else args
+    super.newSettings(args1)
+      .tap(_.outputDirs.setSingleOutput(af))
   }
   // avoid setting -d
   override def newCompiler(args: String*): Global = {

--- a/test/files/run/t12289c.scala
+++ b/test/files/run/t12289c.scala
@@ -1,6 +1,6 @@
 
-import scala.tools.partest.StoreReporterDirectTest
 import scala.tools.nsc._
+import scala.tools.partest.StoreReporterDirectTest
 import scala.util.chaining._
 
 object Test extends StoreReporterDirectTest {
@@ -16,15 +16,13 @@ object Test extends StoreReporterDirectTest {
     else code1.tap(_ => round += 1)
   // intercept the settings created for compile()
   override def newSettings(args: List[String]) = {
-    val outDir = testOutput.parent / testOutput / s"test-output-$round"
-    def prevOutDir = testOutput.parent / testOutput / s"test-output-${round - 1}"
-    outDir.createDirectory()
+    val outDir = testOutput / s"test-output-$round"
+    def prevOutDir = testOutput / s"test-output-${round - 1}"
+    outDir.createDirectory(force = true)
     // put the previous round on the class path
-    val ss =
-      if (round > 0) super.newSettings("-cp" :: prevOutDir.path :: args)
-      else super.newSettings(args)
-    ss.outputDirs.add(srcDir = testPath.parent.path, outDir = outDir.path)
-    ss
+    val args1 = if (round > 0) "-cp" :: prevOutDir.path :: args else args
+    super.newSettings(args1)
+      .tap(_.outputDirs.add(srcDir = testPath.parent.path, outDir = outDir.path))
   }
   // avoid setting -d
   override def newCompiler(args: String*): Global = {


### PR DESCRIPTION
I observed locally this error:
```
D:\a\scala\scala\test\files\run\D:\a\scala\scala\test\files\run\t12289c-run.obj\test-output-0 does not exist or is not a directory
```
I did not observe this error:
```
D:/a/scala/scala/test/files/run/t12289b-run.obj/test-output-0 does not exist or is not a directory
```
notice the forward slashes.

I did observe `testOutput` supplied as absolute path so that `parent / out` concatenates two absolute paths.
```
testOutput C:\Users\andre\IdeaProjects\scala\test\files\run\t12289-run.obj
C:\Users\andre\IdeaProjects\scala\test\files\run\C:\Users\andre\IdeaProjects\scala\test\files\run\t12289-run.obj\round
```

The tweak here is to only `testOutput / name` and not care if the result is a relative path.

Use `createDirectory(force = true)` which means use `mkdirs`.

Using `AbstractFile.getDirectory` explicitly and `setSingleOutput` instead of supplying `-d` should not matter except for style points. The setting for `-d` just uses `pathFactory` and verifies that the result `isDirectory`.

`t12289c` still uses the string version of `outputDirs.add(src, dst)`.

The "extra help" message checks "is this file in the output dir" by comparing path (string) prefixes. (`outputDirs` also uses string prefix for "contains".) This is presumably fragile if paths are not always "normalized" or "absolute". Just calling `normalize` or `toAbsolute` did not do the obvious thing; at that point, my research ended.

Note that the intent of the previous idiom `testOutput.parent / testOutput` was to obtain the absolute path for `-d`.

An alternative might have been `testOutput.parent / testOutput.name` or similar.