### PR TITLE
any2stringadd is ineligible under -Xsource:3-cross

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1040,7 +1040,9 @@ trait Implicits extends splain.SplainData {
 
       private def isIneligible(info: ImplicitInfo) = (
            info.isCyclicOrErroneous
-        || isView && ((info.sym eq Predef_conforms) || (info.sym eq SubType_refl)) // as implicit conversions, Predef.$conforms and <:<.refl are no-op, so exclude them
+        || isView && ((info.sym eq Predef_conforms) || (info.sym eq SubType_refl) ||
+              currentRun.sourceFeatures.any2StringAdd && (info.sym eq currentRun.runDefinitions.Predef_any2stringaddMethod)
+          ) // as implicit conversions, Predef.$conforms and <:<.refl are no-op, so exclude them
         || (!context.macrosEnabled && info.sym.isTermMacro)
       )
 

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1040,9 +1040,7 @@ trait Implicits extends splain.SplainData {
 
       private def isIneligible(info: ImplicitInfo) = (
            info.isCyclicOrErroneous
-        || isView && ((info.sym eq Predef_conforms) || (info.sym eq SubType_refl) ||
-              currentRun.sourceFeatures.any2StringAdd && (info.sym eq currentRun.runDefinitions.Predef_any2stringaddMethod)
-          ) // as implicit conversions, Predef.$conforms and <:<.refl are no-op, so exclude them
+        || isView && ((info.sym eq Predef_conforms) || (info.sym eq SubType_refl)) // as implicit conversions, Predef.$conforms and <:<.refl are no-op, so exclude them
         || (!context.macrosEnabled && info.sym.isTermMacro)
       )
 

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1414,19 +1414,15 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           case _ =>
         }
         inferView(qual, qual.tpe, searchTemplate, reportAmbiguous, saveErrors) match {
-          case EmptyTree  => qual
-          case coercion   =>
+          case EmptyTree => qual
+          case coercion  =>
             if (settings.logImplicitConv.value)
               context.echo(qual.pos, s"applied implicit conversion from ${qual.tpe} to ${searchTemplate} = ${coercion.symbol.defString}")
 
-            if (currentRun.isScala3 && coercion.symbol == currentRun.runDefinitions.Predef_any2stringaddMethod) {
-              if (currentRun.sourceFeatures.any2StringAdd) qual
-              else {
+            if (currentRun.isScala3 && coercion.symbol == currentRun.runDefinitions.Predef_any2stringaddMethod)
+              if (!currentRun.sourceFeatures.any2StringAdd)
                 runReporting.warning(qual.pos, s"Converting to String for concatenation is not supported in Scala 3 (or with -Xsource-features:any2stringadd).", Scala3Migration, coercion.symbol)
-                typedQualifier(atPos(qual.pos)(new ApplyImplicitView(coercion, List(qual))))
-              }
-            }
-            else typedQualifier(atPos(qual.pos)(new ApplyImplicitView(coercion, List(qual))))
+            typedQualifier(atPos(qual.pos)(new ApplyImplicitView(coercion, List(qual))))
         }
       }
       else qual

--- a/test/files/neg/t13004b.check
+++ b/test/files/neg/t13004b.check
@@ -1,0 +1,9 @@
+t13004b.scala:14: applied implicit conversion from Money to ?{def + : ?} = final implicit def any2stringadd[A](self: A): any2stringadd[A]
+    Money(3.14) + Money(1.7)
+         ^
+t13004b.scala:14: error: type mismatch;
+ found   : Money
+ required: String
+    Money(3.14) + Money(1.7)
+                       ^
+1 error

--- a/test/files/neg/t13004b.scala
+++ b/test/files/neg/t13004b.scala
@@ -1,0 +1,16 @@
+//> using options -Vimplicit-conversions -Xlint -Xsource:3 -Xsource-features:any2stringadd
+
+import scala.Predef.*
+
+case class Money(value: Double)
+object Money {
+  implicit class MoneySyntax(private val self: Money)  extends AnyVal {
+    def +(other: Money): Money = Money(self.value + other.value)
+  }
+}
+
+object Test extends App {
+  println {
+    Money(3.14) + Money(1.7)
+  }
+}

--- a/test/files/run/t13004.check
+++ b/test/files/run/t13004.check
@@ -1,0 +1,4 @@
+t13004.scala:12: applied implicit conversion from Money to ?{def + : ?} = implicit def MoneySyntax(self: Money): Money.MoneySyntax
+    Money(3.14) + Money(1.7)
+         ^
+Money(4.84)

--- a/test/files/run/t13004.scala
+++ b/test/files/run/t13004.scala
@@ -1,0 +1,14 @@
+//> using options -Xsource:3 -Xsource-features:any2stringadd -Vimplicit-conversions
+
+case class Money(value: Double)
+object Money {
+  implicit class MoneySyntax(private val self: Money)  extends AnyVal {
+    def +(other: Money): Money = Money(self.value + other.value)
+  }
+}
+
+object Test extends App {
+  println {
+    Money(3.14) + Money(1.7)
+  }
+}

--- a/test/files/run/t13004c.check
+++ b/test/files/run/t13004c.check
@@ -1,0 +1,7 @@
+t13004c.scala:9: applied implicit conversion from Money to ?{def + : ?} = final implicit def any2stringadd[A](self: A): any2stringadd[A]
+    Money(3.14) + " is a lotta dough!"
+         ^
+t13004c.scala:9: warning: method any2stringadd in object Predef is deprecated (since 2.13.0): Implicit injection of + is deprecated. Convert to String to call +
+    Money(3.14) + " is a lotta dough!"
+         ^
+Money(3.14) is a lotta dough!

--- a/test/files/run/t13004c.scala
+++ b/test/files/run/t13004c.scala
@@ -1,0 +1,11 @@
+//> using options -Vimplicit-conversions -Xlint -Xsource:3 -Xsource-features:any2stringadd
+
+import scala.Predef.*
+
+case class Money(value: Double)
+
+object Test extends App {
+  println {
+    Money(3.14) + " is a lotta dough!"
+  }
+}


### PR DESCRIPTION
Fixes scala/bug#13004

`-Xsource-features:any2stringadd` correctly suppresses the conversion without breaking inference where it would otherwise apply.
