### PR TITLE
Fixing initialization cycle between object `Predef` and `Vector`

### DIFF
--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -81,8 +81,9 @@ object Vector extends StrictOptimizedSeqFactory[Vector] {
   }
 
   private val defaultApplyPreferredMaxLength: Int =
-    try System.getProperty("scala.collection.immutable.Vector.defaultApplyPreferredMaxLength",
-      "250").toInt
+    // explicit StringOps to avoid initialization cycle with Predef (scala/bug#13009)
+    try new StringOps(System.getProperty("scala.collection.immutable.Vector.defaultApplyPreferredMaxLength",
+      "250")).toInt
     catch {
       case _: SecurityException => 250
     }

--- a/test/files/run/deadlock.scala
+++ b/test/files/run/deadlock.scala
@@ -1,0 +1,18 @@
+object Test extends App {
+  val createPredef = new Runnable {
+    def run = {
+      val _ = Predef;
+    }
+  }
+  val createVector = new Runnable {
+    def run = {
+      val _ = scala.collection.immutable.Vector;
+    }
+  }
+  val t1 = new Thread(createPredef)
+  val t2 = new Thread(createVector)
+  t1.start()
+  t2.start()
+  t1.join()
+  t2.join()
+}


### PR DESCRIPTION
This PR focuses on a bug about deadlock during initialization caused by initialization cycles between object `Predef` and `collection.immutable.Vector`. This test shows two threads initializing `Predef` and `collection.immutable.Vector` separately, and the deadlock can be reproduced with the following steps:

1. `git clone https://github.com/scala/scala.git`
2. `git checkout 2.13.x`
3. `sbt publishLocal`
4. `scalac deadlock2.scala`
5. `java -cp .:[path-to-published-library] Test`

The bug is found by the global initialization checker (option `-Ysafe-init-global`) when analyzing Scala2LibraryTasty. It is caused by the call to `Predef.augmentString` not being inlined in the published library. The fix resolves the bug by manually inlining such call in object `Vector`.

Fixes scala/bug#13009