### PR TITLE
Avoid call to inaccessible protected java method through self type

### DIFF
--- a/test/files/neg/t13007.check
+++ b/test/files/neg/t13007.check
@@ -1,0 +1,10 @@
+Test.scala:9: error: Unable to emit reference to method j in class J, class J is not accessible in trait T
+  def t4 = j()
+           ^
+Test.scala:10: error: Unable to emit reference to method j in class J, class J is not accessible in trait T
+  def t5 = this.j()
+                ^
+Test.scala:11: error: Unable to emit reference to method j in class J, class J is not accessible in trait T
+  def t6 = self.j()
+                ^
+3 errors

--- a/test/files/neg/t13007/J.java
+++ b/test/files/neg/t13007/J.java
@@ -1,0 +1,7 @@
+package j;
+
+public class J {
+  protected boolean i() { return false; }
+  protected boolean j() { return false; }
+  public boolean k() { return false; }
+}

--- a/test/files/neg/t13007/Test.scala
+++ b/test/files/neg/t13007/Test.scala
@@ -1,0 +1,18 @@
+package s
+
+trait T { self: j.J =>
+  override def i(): Boolean = true
+  def t1 = i()
+  def t2 = this.i()
+  def t3 = self.i()
+
+  def t4 = j()
+  def t5 = this.j()
+  def t6 = self.j()
+
+  def t7 = k()
+  def t8 = this.k()
+  def t9 = self.k()
+}
+
+class C extends j.J with T

--- a/test/files/neg/t13307b.check
+++ b/test/files/neg/t13307b.check
@@ -1,0 +1,9 @@
+Test.scala:8: error: Implementation restriction: trait T accesses protected method j inside a concrete trait method.
+Add an accessor in a class extending class J as a workaround.
+  def t4 = j()
+           ^
+Test.scala:9: error: Implementation restriction: trait T accesses protected method j inside a concrete trait method.
+Add an accessor in a class extending class J as a workaround.
+  def t5 = this.j()
+                ^
+2 errors

--- a/test/files/neg/t13307b/J.java
+++ b/test/files/neg/t13307b/J.java
@@ -1,0 +1,7 @@
+package j;
+
+public class J {
+  protected boolean i() { return false; }
+  protected boolean j() { return false; }
+  public boolean k() { return false; }
+}

--- a/test/files/neg/t13307b/Test.scala
+++ b/test/files/neg/t13307b/Test.scala
@@ -1,0 +1,15 @@
+package s
+
+trait T extends j.J {
+  override def i(): Boolean = true
+  def t1 = i()
+  def t2 = this.i()
+
+  def t4 = j()
+  def t5 = this.j()
+
+  def t7 = k()
+  def t8 = this.k()
+}
+
+class C extends j.J with T

--- a/test/files/run/t13007/J.java
+++ b/test/files/run/t13007/J.java
@@ -1,0 +1,7 @@
+package j;
+
+public class J {
+  protected boolean i() { return false; }
+  protected boolean j() { return false; }
+  public boolean k() { return false; }
+}

--- a/test/files/run/t13007/Test.scala
+++ b/test/files/run/t13007/Test.scala
@@ -1,0 +1,33 @@
+package s {
+
+  trait T {
+    self: j.J =>
+    override def i(): Boolean = true
+
+    def t1 = i()
+    def t2 = this.i()
+    def t3 = self.i()
+
+    // def t4 = j()
+    // def t5 = this.j()
+    // def t6 = self.j()
+
+    def t7 = k()
+    def t8 = this.k()
+    def t9 = self.k()
+  }
+
+  class C extends j.J with T
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val c = new s.C
+    assert(c.t1)
+    assert(c.t2)
+    assert(c.t3)
+    assert(!c.t7)
+    assert(!c.t8)
+    assert(!c.t9)
+  }
+}

--- a/test/files/run/t13307b/J.java
+++ b/test/files/run/t13307b/J.java
@@ -1,0 +1,7 @@
+package j;
+
+public class J {
+  protected boolean i() { return false; }
+  protected boolean j() { return false; }
+  public boolean k() { return false; }
+}

--- a/test/files/run/t13307b/Test.scala
+++ b/test/files/run/t13307b/Test.scala
@@ -1,0 +1,27 @@
+package s {
+
+  trait T extends j.J {
+    override def i(): Boolean = true
+
+    def t1 = i()
+    def t2 = this.i()
+
+    // def t4 = j()
+    // def t5 = this.j()
+
+    def t7 = k()
+    def t8 = this.k()
+  }
+
+  class C extends j.J with T
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val c = new s.C
+    assert(c.t1)
+    assert(c.t2)
+    assert(!c.t7)
+    assert(!c.t8)
+  }
+}

--- a/test/junit/scala/lang/traits/BytecodeTest.scala
+++ b/test/junit/scala/lang/traits/BytecodeTest.scala
@@ -278,6 +278,22 @@ class BytecodeTest extends BytecodeTesting {
   }
 
   @Test
+  def sd143a(): Unit = {
+    val code =
+      """trait A { def m = 1 }
+        |class B extends A { override def m = 2 }
+        |trait T extends A
+        |class C extends B with T {
+        |  override def m = super[T].m
+        |}
+      """.stripMargin
+
+    val List(a, b, c, t) = compileClasses(code)
+    val ins = getInstructions(c, "m")
+    assert(ins contains Invoke(INVOKESTATIC, "A", "m$", "(LA;)I", itf = true), ins.stringLines)
+  }
+
+  @Test
   def sd143b(): Unit = {
     val jCode = List("interface A { default int m() { return 1; } }" -> "A.java")
     val code =


### PR DESCRIPTION
With a self type `self: J =>`, calling a method `this.p` which is protected and defined in Java is not valid and results in an `IllegalAccessError` at runtime.

If the class with the self type overrides the method, use that class as the receiver type. Otherwise issue an error.

Fixes https://github.com/scala/bug/issues/13007