### PR TITLE
Add `-Ycollect-statistics` for collecting statistics without printing them

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1326,7 +1326,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
       checkPhaseSettings(including = false, exclusions.map(_.value): _*)
 
       // Report the overhead of statistics measurements per every run
-      if (settings.areStatisticsEnabled)
+      if (settings.areStatisticsEnabled && settings.Ystatistics.value.nonEmpty)
         statistics.reportStatisticsOverhead(reporter)
 
       phase = first   //parserPhase
@@ -1628,7 +1628,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
       }
       symSource.keys foreach (x => resetPackageClass(x.owner))
 
-      if (timePhases) {
+      if (timePhases && settings.Ystatistics.value.nonEmpty) {
         statistics.stopTimer(totalCompileTime, startTotal)
         informTime("total", totalCompileTime.nanos)
         inform("*** Cumulative timers for phases")

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -607,12 +607,14 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
     .withAbbreviation("-Yshow-symkinds")
   val Yshowsymowners  = BooleanSetting    ("-Vshow-symowners", "Print owner identifiers next to symbol names.")
     .withAbbreviation("-Yshow-symowners")
-  val Ystatistics = PhasesSetting("-Vstatistics", "Print compiler statistics for specific phases", "parser,typer,patmat,erasure,cleanup,jvm")
-    .withPostSetHook(s => YstatisticsEnabled.value = s.value.nonEmpty)
+  val Ystatistics = PhasesSetting("-Vstatistics", "Print compiler statistics for specific phases (implies `-Ycollect-statistics`)", "parser,typer,patmat,erasure,cleanup,jvm")
+    .withPostSetHook(s => if (s.value.nonEmpty) YstatisticsEnabled.value = true)
     .withAbbreviation("-Ystatistics")
   val YstatisticsEnabled = BooleanSetting("-Ystatistics-enabled", "Internal setting, indicating that statistics are enabled for some phase.").internalOnly().withPostSetHook(s => if (s.value) StatisticsStatics.enableColdStatsAndDeoptimize())
   val YhotStatisticsEnabled = BooleanSetting("-Vhot-statistics", s"Enable `${Ystatistics.name}` to also print hot statistics.")
     .withAbbreviation("-Yhot-statistics").withPostSetHook(s => if (s.value && YstatisticsEnabled.value) StatisticsStatics.enableHotStatsAndDeoptimize())
+  val YcollectStatistics = BooleanSetting("-Ycollect-statistics", "Collect cold statistics (quietly, unless `-Vstatistics` is set)")
+    .withPostSetHook(s => if (s.value) YstatisticsEnabled.value = true)
   val Yshowsyms       = BooleanSetting("-Vsymbols", "Print the AST symbol hierarchy after each phase.") withAbbreviation "-Yshow-syms"
   val Ytyperdebug        = BooleanSetting("-Vtyper", "Trace type assignments.") withAbbreviation "-Ytyper-debug"
   val Vimplicits            = BooleanSetting("-Vimplicits", "Print dependent missing implicits.").withAbbreviation("-Xlog-implicits")


### PR DESCRIPTION
This change adds a new flag `-Ycollect-statistics` that enables the same statistics gathering as `-Ystatistics` but without dumping all the statistics to the console. This is useful for build tools that want to collect statistics via a compiler plugin without interfering with the console output or the operation of `-Ystatistics` (if specified explicitly by the user).

Note that there is an internal `YstatisticsEnabled` setting that may appear to do this already, but in fact it controls both collecting and printing together. Even if you switched it on internally (without enabling any phase statistics via `-Ystatistics` / `-Yhot-statistics`) you would still get at least the phase timings summary.

I have a 2.12 version ready as well. It's not quite merge compatible for direct cherry-picking.