### PR TITLE
[backport] Collect statistics without printing them

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1285,7 +1285,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
       checkPhaseSettings(including = false, exclusions map (_.value): _*)
 
       // Report the overhead of statistics measurements per every run
-      if (settings.areStatisticsEnabled)
+      if (settings.areStatisticsEnabled && settings.Ystatistics.value.nonEmpty)
         statistics.reportStatisticsOverhead(reporter)
 
       phase = first   //parserPhase
@@ -1588,7 +1588,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
       }
       symSource.keys foreach (x => resetPackageClass(x.owner))
 
-      if (timePhases) {
+      if (timePhases && settings.Ystatistics.value.nonEmpty) {
         statistics.stopTimer(totalCompileTime, startTotal)
         informTime("total", totalCompileTime.nanos)
         inform("*** Cumulative timers for phases")

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -420,13 +420,16 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
 
   val YoptLogInline = StringSetting("-Yopt-log-inline", "package/Class.method", "Print a summary of inliner activity; `_` to print all, prefix match to select.", "")
 
-  val Ystatistics = PhasesSetting("-Ystatistics", "Print compiler statistics for specific phases", "parser,typer,patmat,erasure,cleanup,jvm")
-    .withPostSetHook(s => if (s.value.nonEmpty) StatisticsStatics.enableColdStatsAndDeoptimize())
+  val Ystatistics = PhasesSetting("-Ystatistics", "Print compiler statistics for specific phases (implies `-Ycollect-statistics`)", "parser,typer,patmat,erasure,cleanup,jvm")
+    .withPostSetHook(s => if (s.value.nonEmpty) YcollectStatistics.value = true)
+
+  val YcollectStatistics = BooleanSetting("-Ycollect-statistics", "Collect cold statistics (quietly, unless `-Ystatistics` is set)")
+    .withPostSetHook(s => if (s.value) StatisticsStatics.enableColdStatsAndDeoptimize())
 
   val YhotStatistics = BooleanSetting("-Yhot-statistics-enabled", s"Enable `${Ystatistics.name}` to print hot statistics.")
     .withPostSetHook(s => if (s && YstatisticsEnabled) StatisticsStatics.enableHotStatsAndDeoptimize())
 
-  override def YstatisticsEnabled = Ystatistics.value.nonEmpty
+  override def YstatisticsEnabled = YcollectStatistics.value
   override def YhotStatisticsEnabled = YhotStatistics.value
 
   val YprofileEnabled = BooleanSetting("-Yprofile-enabled", "Enable profiling.")


### PR DESCRIPTION
Backport of https://github.com/scala/scala/pull/10795:

This change adds a new flag `-Ycollect-statistics` that enables the same statistics gathering as `-Ystatistics` but without dumping all the statistics to the console. This is useful for build tools that want to collect statistics via a compiler plugin without interfering with the console output or the operation of `-Ystatistics` (if specified explicitly by the user).

Note that there is an internal `YstatisticsEnabled` setting that may appear to do this already, but in fact it controls both collecting and printing together. Even if you switched it on internally (without enabling any phase statistics via `-Ystatistics` / `-Yhot-statistics`) you would still get at least the phase timings summary.