### PR TITLE
Avoid comparing RefinementClassSymbols with isSubClass in RefChecks

### DIFF
--- a/test/files/pos/t13013.scala
+++ b/test/files/pos/t13013.scala
@@ -1,0 +1,9 @@
+object Node {
+  trait Root { self: Node =>
+    val root = this
+  }
+}
+trait Node {
+  def root: Node
+}
+final class RootNode extends Node with Node.Root


### PR DESCRIPTION
RefinementClassSymbols are created ad hoc for types in asSeenFrom, two symbols with the same parents don't compare `isSubClass`.

This regressed compared to 2.12.x in https://github.com/scala/scala/pull/7439, which is a pretty complex PR. I didn't revisit all the discussions from back then, so it's possible I missed something.

Fixes https://github.com/scala/bug/issues/13013