### PR TITLE
Support alternative JVM system images (via `-system`, like javac)

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -148,7 +148,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
   def optimizerClassPath(base: ClassPath): ClassPath =
     base match {
       case AggregateClassPath(entries) if entries.head.isInstanceOf[CtSymClassPath] =>
-        JrtClassPath(release = None, unsafe = None, closeableRegistry) match {
+        JrtClassPath(release = None, settings.systemPathValue, unsafe = None, closeableRegistry) match {
           case jrt :: Nil => AggregateClassPath(entries.drop(1).prepended(jrt))
           case _ => base
         }

--- a/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
@@ -32,6 +32,7 @@ trait StandardScalaSettings { _: MutableSettings =>
   val javaextdirs =       PathSetting ("-javaextdirs", "Override java extdirs classpath.", Defaults.javaExtDirs) withAbbreviation "--java-extension-directories"
   val sourcepath =        PathSetting ("-sourcepath", "Specify location(s) of source files.", "") withAbbreviation "--source-path" // Defaults.scalaSourcePath
   val rootdir =           PathSetting ("-rootdir", "The absolute path of the project root directory, usually the git/scm checkout. Used by -Wconf.", "") withAbbreviation "--root-directory"
+  val systemPath =        PathSetting ("-system", "Override location of Java system modules", "") withAbbreviation "--system"
 
   /** Other settings.
    */
@@ -75,11 +76,13 @@ trait StandardScalaSettings { _: MutableSettings =>
         val current = setting.value.toInt
         if (!isJavaAtLeast("9") && current > 8) errorFn.apply("-release is only supported on JVM 9 and higher")
         if (target.valueSetByUser.map(_.toInt > current).getOrElse(false)) errorFn("-release cannot be less than -target")
+        if (systemPath.isSetByUser) errorFn("-release cannot be used with -system")
         //target.value = setting.value  // this would trigger deprecation
       }
       .withAbbreviation("--release")
       .withAbbreviation("-java-output-version")
   def releaseValue: Option[String] = release.valueSetByUser
+  def systemPathValue: Option[String] = systemPath.valueSetByUser
   val target =
     ChoiceSetting("-target", "target", "Target platform for object files.", AllTargetVersions, "8")
       .withPreSetHook(normalizeTarget)
@@ -90,7 +93,6 @@ trait StandardScalaSettings { _: MutableSettings =>
       // .withAbbreviation("--Xtarget")
       // .withAbbreviation("-Xtarget")
       .withAbbreviation("-Xunchecked-java-output-version")
-      .withDeprecationMessage("Use -release instead to compile against the correct platform API.")
   def targetValue: String = target.valueSetByUser.orElse(releaseValue).getOrElse(target.value)
   val unchecked =      BooleanSetting ("-unchecked", "Enable additional warnings where generated code depends on assumptions. See also -Wconf.") withAbbreviation "--unchecked" withPostSetHook { s =>
     if (s.value) Wconf.tryToSet(List(s"cat=unchecked:w"))

--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -270,7 +270,7 @@ final class PathResolver(settings: Settings, closeableRegistry: CloseableRegistr
       sourcesInPath(sourcePath)                     // 7. The Scala source path.
     )
 
-    private def jrt: List[ClassPath] = JrtClassPath.apply(settings.releaseValue, settings.unsafe.valueSetByUser, closeableRegistry)
+    private def jrt: List[ClassPath] = JrtClassPath.apply(settings.releaseValue, settings.systemPathValue, settings.unsafe.valueSetByUser, closeableRegistry)
 
     lazy val containers = basis.flatten.distinct
 

--- a/test/junit/scala/tools/nsc/classpath/JrtClassPathTest.scala
+++ b/test/junit/scala/tools/nsc/classpath/JrtClassPathTest.scala
@@ -27,7 +27,7 @@ class JrtClassPathTest {
         val elements = new ClassPathFactory(settings, closeableRegistry).classesInPath(resolver.Calculated.javaBootClassPath)
         AggregateClassPath(elements)
       }
-      else JrtClassPath(None, None, closeableRegistry).head
+      else JrtClassPath(None, None, None, closeableRegistry).head
 
     assertEquals(Nil, cp.classes(""))
     assertTrue(cp.packages("java").toString, cp.packages("java").exists(_.name == "java.lang"))


### PR DESCRIPTION
This PR adds a new `-system` / `--system` setting to scalac which mimics its counterpart in javac.

This allows having a different Java API version on the classpath than the Java version used to run the compiler.

The common way to compile against a different Java API is to use the `-release N` flag. Java releases (since version 9) include a file `ct.sym` which contains shims of classfiles for each previous Java release. With `-release 11`, only public API available in Java 11 is visible. (Note that `-release N` also sets `-target N` in the compiler, which sets the classfile version. This prevents loading the generated classfiles on a Java version smaller than N.)

However, the `ct.sym` file only includes classes from the API Specification (what is listed in the official Javadocs, https://docs.oracle.com/en/java/javase/21/docs/api/index.html). In particular, classes in the `sun` package (`sun.misc.Unsafe`) are missing and therefore not available when using `-release` (see https://github.com/scala/bug/issues/12824).

For source code that accesses internal Java API, the first recommendation is to run the Scala compiler using the desired target Java version instead of using `-release`.

In case that is not practical, the new `-system` flag can be used instead. This allows exchanging the file from which the Scala compiler reads the Java API (the `lib/modules` file of the JDK release, which is opened using the `JrtFileSystem`).

Whether you are compiling using Java N or using `-system` to target a Java version N, you may want to also set the `-target N` compiler flag which sets the classfile version. This prevents loading the generated classfiles on a Java version smaller than N.

-----

This fixes the biggest problem (at least for Databricks) of https://github.com/scala/bug/issues/13015. It is now possible to compile code against an older system image without enforcing strict module access. scalac generally does not enforce modules (https://github.com/scala/scala-dev/issues/529) but it does when using `-release` (with class lookup based on `ct.sym`) and there was no way to opt out of these restrictions.

The usual opt-out in javac is `--add-exports` but it is not supported for system modules in combination with `--release` (https://bugs.openjdk.org/browse/JDK-8178152) so there is no expectation that scalac could support it. Instead the solution for javac is to replace `--release` with a combination of `-source`, `-target` and a system image for the target version via `--system`. This combination, unlike `--release`, can be used with `--add-exports`. If scalac adds full module support at a later time (with access restrictions enabled by default) it will also need to support `--add-exports` and allow its use in combination with `--system`.

I am also un-deprecating `-target` (which was deprecated in favor of `-release`) because it now has a legitimate use in combination with an alternative system image (just like in javac where it is serves the same purpose and is not deprecated, either).