### PR TITLE
One-only parallel instance for sbt-test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -960,7 +960,7 @@ lazy val sbtTest = project.in(file("test") / "sbt-test")
     sbtTestDirectory := baseDirectory.value,
 
     scriptedBatchExecution := true, // set to `false` to execute each test in a separate sbt instance
-    scriptedParallelInstances := 1, // default is 1, was 2
+    scriptedParallelInstances := (if (insideCI.value) 1 else 2), // default is 1; races cause spurious failures
 
     // hide sbt output of scripted tests
     scriptedBufferLog := true,

--- a/build.sbt
+++ b/build.sbt
@@ -960,7 +960,7 @@ lazy val sbtTest = project.in(file("test") / "sbt-test")
     sbtTestDirectory := baseDirectory.value,
 
     scriptedBatchExecution := true, // set to `false` to execute each test in a separate sbt instance
-    scriptedParallelInstances := 2, // default is 1
+    scriptedParallelInstances := 1, // default is 1, was 2
 
     // hide sbt output of scripted tests
     scriptedBufferLog := true,


### PR DESCRIPTION
https://github.com/scala/scala/pull/10740#issuecomment-2221111163

looks like collisions writing a file. It writes the metainf file and then packages the jar, so there are opportunities.

I haven't looked back at whether all failures have been in publishing artifacts, or looked forward at what this setting actually does.

Edit: sorry, Seth and Lukas, I realize "PRs are not questions!"