### PR TITLE
Compiler plugin phase assembly: restore plugins to Scaladoc (fixing post-2.13.14 regression)

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -735,7 +735,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
 
   protected def computePlatformPhases() = platform.platformPhases.foreach(p => addToPhasesSet(p, otherPhaseDescriptions(p.phaseName)))
 
-  // sequences the phase assembly
+  // compute the order in which phases will run; subclasses may override the template methods used here.
   protected def computePhaseDescriptors: List[SubComponent] = {
     /* Allow phases to opt out of the phase assembly. */
     def cullPhases(phases: List[SubComponent]) = {

--- a/src/scaladoc/scala/tools/nsc/ScalaDoc.scala
+++ b/src/scaladoc/scala/tools/nsc/ScalaDoc.scala
@@ -41,11 +41,11 @@ class ScalaDoc {
     else if (docSettings.showPlugins.value)
       reporter.warning(null, "Plugins are not available when using Scaladoc")
     else if (docSettings.showPhases.value)
-      reporter.warning(null, "Phases are restricted when using Scaladoc")
+      reporter.warning(null, s"Phases are restricted when using Scaladoc.\n${new DocFactory(reporter, docSettings).compiler.phaseDescriptions}")
     else if (docSettings.help.value || !hasFiles)
       reporter.echo(command.usageMsg)
     else
-      try { new DocFactory(reporter, docSettings) document command.files }
+      try new DocFactory(reporter, docSettings).document(command.files)
       catch {
         case ex @ FatalError(msg) =>
           if (docSettings.isDebug) ex.printStackTrace()

--- a/src/scaladoc/scala/tools/nsc/doc/DocParser.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/DocParser.scala
@@ -35,6 +35,8 @@ class DocParser(settings: nsc.Settings, reporter: Reporter) extends Global(setti
     phasesSet += syntaxAnalyzer
     phasesSet += terminal
   }
+  override protected def computePluginPhases(): Unit = ()
+
   override lazy val platform: ThisPlatform =
     new JavaPlatform {
       lazy val global: self.type = self

--- a/src/scaladoc/scala/tools/nsc/doc/ScaladocGlobal.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/ScaladocGlobal.scala
@@ -54,6 +54,8 @@ class ScaladocGlobal(settings: doc.Settings, reporter: Reporter) extends Global(
     phasesSet += analyzer.namerFactory
     phasesSet += analyzer.packageObjects
     phasesSet += analyzer.typerFactory
+    phasesSet += patmatSentinel
+    phasesSet += erasureSentinel
     phasesSet += terminal
   }
 
@@ -62,6 +64,27 @@ class ScaladocGlobal(settings: doc.Settings, reporter: Reporter) extends Global(
       lazy val global: self.type = self
       override def platformPhases = Nil // used by computePlatformPhases
     }
+
+  // Placeholders for plugins who wish to declare runsBefore patmat or erasure.
+  // A bit deceptive for plugins that run after them, as scaladoc ought to -Ystop-before:patmat
+  lazy val patmatSentinel: SubComponent = new { val global = self } with SubComponent {
+    val phaseName = "patmat"
+    val runsAfter = "typer" :: Nil
+    val runsRightAfter = None
+    def newPhase(prev: Phase): Phase = new Phase(prev) {
+      val name = phaseName
+      def run() = ()
+    }
+  }
+  lazy val erasureSentinel: SubComponent = new { val global = self } with SubComponent {
+    val phaseName = "erasure"
+    val runsAfter = "patmat" :: Nil
+    val runsRightAfter = None
+    def newPhase(prev: Phase): Phase = new Phase(prev) {
+      val name = phaseName
+      def run() = ()
+    }
+  }
 
   override def createJavadoc = if (settings.docNoJavaComments.value) false else true
 


### PR DESCRIPTION
Overriding `computePhaseDescriptors` inadvertently kept plugins from being installed.

Instead, make sure there are no backend phases. This could be done by overriding `computeBackendPhases`, but for style points, install a `JavaPlatform` which contributes no phases.

Since better monadic for has a constraint to run before patmat, avoid build noise by adding a dummy phase. Because why not, do the same for erasure.

It would be nice for Scaladoc to run under `-Ystop-before:patmat`, or perhaps `after:typer`, but any further tightening of screws is left for a future improvement.

The DocParser explicitly runs only its initial syntax analyzer phase, so no plugin and no other phase runs except terminal. This usage requires testing.

Follow-up to https://github.com/scala/scala/pull/10687