### PR TITLE
NonFatal opt needs type test

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
@@ -80,7 +80,7 @@ trait PatternMatching extends Transform
         if guard.isEmpty && qual.symbol == definitions.NonFatalModule =>
         transform(treeCopy.CaseDef(
           tree,
-          bind,
+          treeCopy.Bind(bind, bind.name, Typed(Ident(nme.WILDCARD), TypeTree(definitions.ThrowableTpe)).setType(definitions.ThrowableTpe)),
           localTyper.typed(atPos(tree.pos)(Apply(gen.mkAttributedRef(definitions.NonFatal_apply), List(Ident(bind.symbol))))),
           body))
 

--- a/test/files/run/nonfatal.scala
+++ b/test/files/run/nonfatal.scala
@@ -12,6 +12,7 @@ object Test extends BytecodeTest {
     val g = getMethod(classNode, "g")
     assertEquals(instructionsFromMethod(f), instructionsFromMethod(g))
     //sameBytecode(f, g) // prints
+    new C().run() // should not crash
   }
 }
 
@@ -19,5 +20,14 @@ class C {
   import scala.util.control.NonFatal
   def x = 42
   def f = try x catch { case NonFatal(e) => e.printStackTrace(); -1 }
-  def g = try x catch { case e if NonFatal(e) => e.printStackTrace(); -1 }
+  def g = try x catch { case e: Throwable if NonFatal(e) => e.printStackTrace(); -1 }
+
+  def run(): Unit = {
+    val any: Any = 42
+
+    any match {
+      case NonFatal(e) => ???
+      case _ =>
+    }
+  }
 }


### PR DESCRIPTION
Match translation adds a type test and cast for the extractor, which we must restore in the rewrite.

Fixes scala/bug#13018