### PR TITLE
Fix empty TreeSeqMap iterator

### DIFF
--- a/src/library/scala/collection/immutable/TreeSeqMap.scala
+++ b/src/library/scala/collection/immutable/TreeSeqMap.scala
@@ -411,8 +411,7 @@ object TreeSeqMap extends MapFactory[TreeSeqMap] {
     }
 
     object Iterator {
-      val Empty = new Iterator[Nothing](Ordering.empty[Nothing])
-      def empty[V]: Iterator[V] = Empty.asInstanceOf[Iterator[V]]
+      def empty[V]: Iterator[V] = new Iterator(Ordering.empty)
     }
 
     case object Zero extends Ordering[Nothing] {

--- a/test/junit/scala/collection/immutable/TreeSeqMapTest.scala
+++ b/test/junit/scala/collection/immutable/TreeSeqMapTest.scala
@@ -7,6 +7,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
+import scala.util.Try
+
 @RunWith(classOf[JUnit4])
 class TreeSeqMapTest {
   @Test
@@ -173,6 +175,13 @@ class TreeSeqMapTest {
       val e3 = e2.tail
       assertEquals(s"modification empty from instance keeps modification order", List(1 -> 3, 3 -> 4), e3.toList)
     }
+  }
+
+  @Test
+  def t13019(): Unit = {
+    val m = Try(TreeSeqMap.empty.iterator.next())
+    assertTrue(m.isFailure)
+    assertFalse("empty iterator does not have next", TreeSeqMap.empty.iterator.hasNext)
   }
 }
 object TreeSeqMapTest extends App {


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/13019