### PR TITLE
Align with Scala 3: Support Scala 3.5 in TASTy reader

### DIFF
--- a/project/DottySupport.scala
+++ b/project/DottySupport.scala
@@ -26,7 +26,7 @@ object TastySupport {
  *  Dotty in .travis.yml.
  */
 object DottySupport {
-  val dottyVersion = "3.4.2" // TastySupport.supportedTASTyRelease // TODO: use same as tasty version when sources are fixed
+  val dottyVersion = TastySupport.supportedTASTyRelease
   val compileWithDotty: Boolean =
     Option(System.getProperty("scala.build.compileWithDotty")).exists(_.toBoolean)
   lazy val commonSettings = Seq(

--- a/project/DottySupport.scala
+++ b/project/DottySupport.scala
@@ -12,7 +12,7 @@ import sbt.librarymanagement.{
   * Settings to support validation of TastyUnpickler against the release of dotty with the matching TASTy version
   */
 object TastySupport {
-  val supportedTASTyRelease = "3.4.2" // TASTY: 28.4-0
+  val supportedTASTyRelease = "3.5.0-RC4" // TASTY: 28.5-1
   val scala3Compiler = "org.scala-lang" % "scala3-compiler_3" % supportedTASTyRelease
   val scala3Library = "org.scala-lang" % "scala3-library_3" % supportedTASTyRelease
 
@@ -26,7 +26,7 @@ object TastySupport {
  *  Dotty in .travis.yml.
  */
 object DottySupport {
-  val dottyVersion = TastySupport.supportedTASTyRelease
+  val dottyVersion = "3.4.2" // TastySupport.supportedTASTyRelease // TODO: use same as tasty version when sources are fixed
   val compileWithDotty: Boolean =
     Option(System.getProperty("scala.build.compileWithDotty")).exists(_.toBoolean)
   lazy val commonSettings = Seq(

--- a/src/compiler/scala/tools/nsc/tasty/TastyUnpickler.scala
+++ b/src/compiler/scala/tools/nsc/tasty/TastyUnpickler.scala
@@ -71,7 +71,9 @@ object TastyUnpickler {
     /** When Scala 3 is in an RC phase for a new minor version, we put here the TASTy of that Minor,
      * otherwise it should be empty.
      */
-    final val toolOverrides: List[TastyVersion] = Nil
+    final val toolOverrides: List[TastyVersion] = List(
+      TastyVersion(28, 5, 1) // 3.5.0-RC4 // TODO: remove this when 3.5.0 is released
+    )
 
     private def asScala3Compiler(version: TastyVersion): String =
       if (version.major == 28) {

--- a/src/compiler/scala/tools/nsc/tasty/bridge/FlagOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/FlagOps.scala
@@ -26,7 +26,7 @@ trait FlagOps { self: TastyUniverse =>
 
     val TastyOnlyFlags: TastyFlagSet = (
       Erased | Inline | InlineProxy | Opaque | Extension | Given | Exported | Transparent
-        | Enum | Infix | Open | ParamAlias | Invisible
+        | Enum | Infix | Open | ParamAlias | Invisible | Tracked
     )
 
     type FlagParser = TastyFlagSet => Context => TastyFlagSet
@@ -139,6 +139,7 @@ trait FlagOps { self: TastyUniverse =>
       if (flags.is(ParamAlias))  sb += "<paramalias>"
       if (flags.is(Infix))       sb += "infix"
       if (flags.is(Invisible))   sb += "<invisible>"
+      if (flags.is(Tracked))     sb += "<tracked>"
       sb.mkString(" | ")
     }
   }

--- a/src/compiler/scala/tools/tasty/TastyFlags.scala
+++ b/src/compiler/scala/tools/tasty/TastyFlags.scala
@@ -60,6 +60,7 @@ object TastyFlags {
   final val ParamAlias            = Open.next
   final val Infix                 = ParamAlias.next
   final val Invisible             = Infix.next
+  final val Tracked               = Invisible.next
 
   def optFlag(cond: Boolean)(flag: TastyFlagSet): TastyFlagSet = if (cond) flag else EmptyTastyFlags
 
@@ -125,6 +126,7 @@ object TastyFlags {
         if (is(ParamAlias))    sb += "ParamAlias"
         if (is(Infix))         sb += "Infix"
         if (is(Invisible))     sb += "Invisible"
+        if (is(Tracked))       sb += "Tracked"
         sb.mkString(" | ")
       }
     }

--- a/src/compiler/scala/tools/tasty/TastyFormat.scala
+++ b/src/compiler/scala/tools/tasty/TastyFormat.scala
@@ -12,7 +12,7 @@
 
 package scala.tools.tasty
 
-// revision: https://github.com/scala/scala3/commit/0938fe5603a17c7c786ac8fc6118a9d5d8b257de
+// revision: https://github.com/scala/scala3/commit/5189e6854ad1dacc3454542c2f124f5bcb7e2a9c
 object TastyFormat {
 
   /** The first four bytes of a TASTy file, followed by four values:
@@ -34,9 +34,9 @@ object TastyFormat {
   /** Natural number. Each increment of the `MinorVersion`, within
    *  a series declared by the `MajorVersion`, breaks forward
    *  compatibility, but remains backwards compatible, with all
-   *  preceeding `MinorVersion`.
+   *  preceding `MinorVersion`.
    */
-  final val MinorVersion: Int = 4
+  final val MinorVersion: Int = 5
 
   /** Natural Number. The `ExperimentalVersion` allows for
    *  experimentation with changes to TASTy without committing
@@ -222,6 +222,7 @@ object TastyFormat {
   final val INVISIBLE = 44
   final val EMPTYCLAUSE = 45
   final val SPLITCLAUSE = 46
+  final val TRACKED = 47
 
   // Tree Cat. 2:    tag Nat
   final val firstNatTreeTag = SHAREDterm
@@ -260,7 +261,6 @@ object TastyFormat {
   final val BOUNDED = 102
   final val EXPLICITtpt = 103
   final val ELIDED = 104
-
 
   // Tree Cat. 4:    tag Nat AST
   final val firstNatASTTreeTag = IDENT
@@ -327,14 +327,17 @@ object TastyFormat {
   final val TYPEREFin = 175
   final val SELECTin = 176
   final val EXPORT = 177
-  // final val ??? = 178
-  // final val ??? = 179
+  final val QUOTE = 178
+  final val SPLICE = 179
   final val METHODtype = 180
   final val APPLYsigpoly = 181
+  final val QUOTEPATTERN = 182
+  final val SPLICEPATTERN = 183
 
   final val MATCHtype = 190
   final val MATCHtpt = 191
   final val MATCHCASEtype = 192
+  final val FLEXIBLEtype = 193
 
   final val HOLE = 255
 
@@ -366,7 +369,7 @@ object TastyFormat {
     firstNatTreeTag <= tag && tag <= RENAMED ||
     firstASTTreeTag <= tag && tag <= BOUNDED ||
     firstNatASTTreeTag <= tag && tag <= NAMEDARG ||
-    firstLengthTreeTag <= tag && tag <= MATCHCASEtype ||
+    firstLengthTreeTag <= tag && tag <= FLEXIBLEtype ||
     tag == HOLE
 
   def isParamTag(tag: Int): Boolean = tag == PARAM || tag == TYPEPARAM
@@ -411,7 +414,8 @@ object TastyFormat {
        | INVISIBLE
        | ANNOTATION
        | PRIVATEqualified
-       | PROTECTEDqualified => true
+       | PROTECTEDqualified
+       | TRACKED => true
     case _ => false
   }
 
@@ -568,11 +572,16 @@ object TastyFormat {
     case MATCHCASEtype => "MATCHCASEtype"
     case MATCHtpt => "MATCHtpt"
     case PARAMtype => "PARAMtype"
+    case FLEXIBLEtype => "FLEXIBLEtype"
     case ANNOTATION => "ANNOTATION"
     case PRIVATEqualified => "PRIVATEqualified"
     case PROTECTEDqualified => "PROTECTEDqualified"
     case EXPLICITtpt => "EXPLICITtpt"
     case ELIDED => "ELIDED"
+    case QUOTE => "QUOTE"
+    case SPLICE => "SPLICE"
+    case QUOTEPATTERN => "QUOTEPATTERN"
+    case SPLICEPATTERN => "SPLICEPATTERN"
     case HOLE => "HOLE"
   }
 

--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -54,7 +54,7 @@ object Array {
   /**
    * Returns a new [[scala.collection.mutable.ArrayBuilder]].
    */
-  def newBuilder[T](implicit t: ClassTag[T]): ArrayBuilder[T] = ArrayBuilder.make[T](t)
+  def newBuilder[T](implicit t: ClassTag[T]): ArrayBuilder[T] = ArrayBuilder.make[T](using t)
 
   /** Build an array from the iterable collection.
    *

--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -589,7 +589,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     val len = xs.length
     def boxed = if(len < ArrayOps.MaxStableSortLength) {
       val a = xs.clone()
-      Sorting.stableSort(a)(ord.asInstanceOf[Ordering[A]])
+      Sorting.stableSort(a)(using ord.asInstanceOf[Ordering[A]])
       a
     } else {
       val a = Array.copyAs[AnyRef](xs, len)(ClassTag.AnyRef)
@@ -1299,7 +1299,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     val bb = new ArrayBuilder.ofRef[Array[B]]()(ClassTag[Array[B]](aClass))
     if (xs.length == 0) bb.result()
     else {
-      def mkRowBuilder() = ArrayBuilder.make[B](ClassTag[B](aClass.getComponentType))
+      def mkRowBuilder() = ArrayBuilder.make[B](using ClassTag[B](aClass.getComponentType))
       val bs = new ArrayOps(asArray(xs(0))).map((x: B) => mkRowBuilder())
       for (xs <- this) {
         var i = 0

--- a/src/library/scala/collection/Factory.scala
+++ b/src/library/scala/collection/Factory.scala
@@ -667,16 +667,16 @@ object ClassTagIterableFactory {
     * sound depending on the use of the `ClassTag` by the collection implementation. */
   @SerialVersionUID(3L)
   class AnyIterableDelegate[CC[_]](delegate: ClassTagIterableFactory[CC]) extends IterableFactory[CC] {
-    def empty[A]: CC[A] = delegate.empty(ClassTag.Any).asInstanceOf[CC[A]]
-    def from[A](it: IterableOnce[A]): CC[A] = delegate.from[Any](it)(ClassTag.Any).asInstanceOf[CC[A]]
-    def newBuilder[A]: Builder[A, CC[A]] = delegate.newBuilder(ClassTag.Any).asInstanceOf[Builder[A, CC[A]]]
-    override def apply[A](elems: A*): CC[A] = delegate.apply[Any](elems: _*)(ClassTag.Any).asInstanceOf[CC[A]]
-    override def iterate[A](start: A, len: Int)(f: A => A): CC[A] = delegate.iterate[A](start, len)(f)(ClassTag.Any.asInstanceOf[ClassTag[A]])
-    override def unfold[A, S](init: S)(f: S => Option[(A, S)]): CC[A] = delegate.unfold[A, S](init)(f)(ClassTag.Any.asInstanceOf[ClassTag[A]])
-    override def range[A](start: A, end: A)(implicit i: Integral[A]): CC[A] = delegate.range[A](start, end)(i, ClassTag.Any.asInstanceOf[ClassTag[A]])
-    override def range[A](start: A, end: A, step: A)(implicit i: Integral[A]): CC[A] = delegate.range[A](start, end, step)(i, ClassTag.Any.asInstanceOf[ClassTag[A]])
-    override def fill[A](n: Int)(elem: => A): CC[A] = delegate.fill[Any](n)(elem)(ClassTag.Any).asInstanceOf[CC[A]]
-    override def tabulate[A](n: Int)(f: Int => A): CC[A] = delegate.tabulate[Any](n)(f)(ClassTag.Any).asInstanceOf[CC[A]]
+    def empty[A]: CC[A] = delegate.empty(using ClassTag.Any).asInstanceOf[CC[A]]
+    def from[A](it: IterableOnce[A]): CC[A] = delegate.from[Any](it)(using ClassTag.Any).asInstanceOf[CC[A]]
+    def newBuilder[A]: Builder[A, CC[A]] = delegate.newBuilder(using ClassTag.Any).asInstanceOf[Builder[A, CC[A]]]
+    override def apply[A](elems: A*): CC[A] = delegate.apply[Any](elems: _*)(using ClassTag.Any).asInstanceOf[CC[A]]
+    override def iterate[A](start: A, len: Int)(f: A => A): CC[A] = delegate.iterate[A](start, len)(f)(using ClassTag.Any.asInstanceOf[ClassTag[A]])
+    override def unfold[A, S](init: S)(f: S => Option[(A, S)]): CC[A] = delegate.unfold[A, S](init)(f)(using ClassTag.Any.asInstanceOf[ClassTag[A]])
+    override def range[A](start: A, end: A)(implicit i: Integral[A]): CC[A] = delegate.range[A](start, end)(using i, ClassTag.Any.asInstanceOf[ClassTag[A]])
+    override def range[A](start: A, end: A, step: A)(implicit i: Integral[A]): CC[A] = delegate.range[A](start, end, step)(using i, ClassTag.Any.asInstanceOf[ClassTag[A]])
+    override def fill[A](n: Int)(elem: => A): CC[A] = delegate.fill[Any](n)(elem)(using ClassTag.Any).asInstanceOf[CC[A]]
+    override def tabulate[A](n: Int)(f: Int => A): CC[A] = delegate.tabulate[Any](n)(f)(using ClassTag.Any).asInstanceOf[CC[A]]
   }
 }
 

--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -518,7 +518,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
     *          element (which may be the only element) will be smaller
     *          if there are fewer than `size` elements remaining to be grouped.
     *  @example `List(1, 2, 3, 4, 5).sliding(2, 2) = Iterator(List(1, 2), List(3, 4), List(5))`
-    *  @example `List(1, 2, 3, 4, 5, 6).sliding(2, 3) = Iterator(List(1, 2), List(4, 5))` 
+    *  @example `List(1, 2, 3, 4, 5, 6).sliding(2, 3) = Iterator(List(1, 2), List(4, 5))`
     */
   def sliding(size: Int, step: Int): Iterator[C] =
     iterator.sliding(size, step).map(fromSpecific)
@@ -708,7 +708,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
     *  @tparam A2  the element type of the second resulting collection
     *  @param f    the 'split function' mapping the elements of this $coll to an [[scala.util.Either]]
     *
-    *  @return     a pair of ${coll}s: the first one made of those values returned by `f` that were wrapped in [[scala.util.Left]], 
+    *  @return     a pair of ${coll}s: the first one made of those values returned by `f` that were wrapped in [[scala.util.Left]],
     *              and the second one made of those wrapped in [[scala.util.Right]].
     */
   def partitionMap[A1, A2](f: A => Either[A1, A2]): (CC[A1], CC[A2]) = {
@@ -982,9 +982,9 @@ trait SortedSetFactoryDefaults[+A,
     +WithFilterCC[x] <: IterableOps[x, WithFilterCC, WithFilterCC[x]] with Set[x]] extends SortedSetOps[A @uncheckedVariance, CC, CC[A @uncheckedVariance]] {
   self: IterableOps[A, WithFilterCC, _] =>
 
-  override protected def fromSpecific(coll: IterableOnce[A @uncheckedVariance]): CC[A @uncheckedVariance]    = sortedIterableFactory.from(coll)(ordering)
-  override protected def newSpecificBuilder: mutable.Builder[A @uncheckedVariance, CC[A @uncheckedVariance]] = sortedIterableFactory.newBuilder[A](ordering)
-  override def empty: CC[A @uncheckedVariance] = sortedIterableFactory.empty(ordering)
+  override protected def fromSpecific(coll: IterableOnce[A @uncheckedVariance]): CC[A @uncheckedVariance]    = sortedIterableFactory.from(coll)(using ordering)
+  override protected def newSpecificBuilder: mutable.Builder[A @uncheckedVariance, CC[A @uncheckedVariance]] = sortedIterableFactory.newBuilder[A](using ordering)
+  override def empty: CC[A @uncheckedVariance] = sortedIterableFactory.empty(using ordering)
 
   override def withFilter(p: A => Boolean): SortedSetOps.WithFilter[A, WithFilterCC, CC] =
     new SortedSetOps.WithFilter[A, WithFilterCC, CC](this, p)
@@ -1036,9 +1036,9 @@ trait SortedMapFactoryDefaults[K, +V,
     +UnsortedCC[x, y] <: Map[x, y]] extends SortedMapOps[K, V, CC, CC[K, V @uncheckedVariance]] with MapOps[K, V, UnsortedCC, CC[K, V @uncheckedVariance]] {
   self: IterableOps[(K, V), WithFilterCC, _] =>
 
-  override def empty: CC[K, V @uncheckedVariance] = sortedMapFactory.empty(ordering)
-  override protected def fromSpecific(coll: IterableOnce[(K, V @uncheckedVariance)]): CC[K, V @uncheckedVariance] = sortedMapFactory.from(coll)(ordering)
-  override protected def newSpecificBuilder: mutable.Builder[(K, V @uncheckedVariance), CC[K, V @uncheckedVariance]] = sortedMapFactory.newBuilder[K, V](ordering)
+  override def empty: CC[K, V @uncheckedVariance] = sortedMapFactory.empty(using ordering)
+  override protected def fromSpecific(coll: IterableOnce[(K, V @uncheckedVariance)]): CC[K, V @uncheckedVariance] = sortedMapFactory.from(coll)(using ordering)
+  override protected def newSpecificBuilder: mutable.Builder[(K, V @uncheckedVariance), CC[K, V @uncheckedVariance]] = sortedMapFactory.newBuilder[K, V](using ordering)
 
   override def withFilter(p: ((K, V)) => Boolean): collection.SortedMapOps.WithFilter[K, V, WithFilterCC, UnsortedCC, CC] =
     new collection.SortedMapOps.WithFilter[K, V, WithFilterCC, UnsortedCC, CC](this, p)

--- a/src/library/scala/collection/SortedMap.scala
+++ b/src/library/scala/collection/SortedMap.scala
@@ -179,16 +179,16 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _],
   override def concat[V2 >: V](suffix: IterableOnce[(K, V2)]): CC[K, V2] = sortedMapFactory.from(suffix match {
     case it: Iterable[(K, V2)] => new View.Concat(this, it)
     case _ => iterator.concat(suffix.iterator)
-  })(ordering)
+  })(using ordering)
 
   /** Alias for `concat` */
   @`inline` override final def ++ [V2 >: V](xs: IterableOnce[(K, V2)]): CC[K, V2] = concat(xs)
 
   @deprecated("Consider requiring an immutable Map or fall back to Map.concat", "2.13.0")
-  override def + [V1 >: V](kv: (K, V1)): CC[K, V1] = sortedMapFactory.from(new View.Appended(this, kv))(ordering)
+  override def + [V1 >: V](kv: (K, V1)): CC[K, V1] = sortedMapFactory.from(new View.Appended(this, kv))(using ordering)
 
   @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
-  override def + [V1 >: V](elem1: (K, V1), elem2: (K, V1), elems: (K, V1)*): CC[K, V1] = sortedMapFactory.from(new View.Concat(new View.Appended(new View.Appended(this, elem1), elem2), elems))(ordering)
+  override def + [V1 >: V](elem1: (K, V1), elem2: (K, V1), elems: (K, V1)*): CC[K, V1] = sortedMapFactory.from(new View.Concat(new View.Appended(new View.Appended(this, elem1), elem2), elems))(using ordering)
 }
 
 object SortedMapOps {

--- a/src/library/scala/collection/StrictOptimizedSortedMapOps.scala
+++ b/src/library/scala/collection/StrictOptimizedSortedMapOps.scala
@@ -33,7 +33,7 @@ trait StrictOptimizedSortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOp
     strictOptimizedFlatMap(sortedMapFactory.newBuilder, f)
 
   override def concat[V2 >: V](xs: IterableOnce[(K, V2)]): CC[K, V2] =
-    strictOptimizedConcat(xs, sortedMapFactory.newBuilder(ordering))
+    strictOptimizedConcat(xs, sortedMapFactory.newBuilder(using ordering))
 
   override def collect[K2, V2](pf: PartialFunction[(K, V), (K2, V2)])(implicit @implicitNotFound(SortedMapOps.ordMsg) ordering: Ordering[K2]): CC[K2, V2] =
     strictOptimizedCollect(sortedMapFactory.newBuilder, pf)

--- a/src/library/scala/collection/generic/DefaultSerializationProxy.scala
+++ b/src/library/scala/collection/generic/DefaultSerializationProxy.scala
@@ -77,9 +77,9 @@ private[collection] case object SerializeEnd
 trait DefaultSerializable extends Serializable { this: scala.collection.Iterable[_] =>
   protected[this] def writeReplace(): AnyRef = {
     val f: Factory[Any, Any] = this match {
-      case it: scala.collection.SortedMap[_, _] => it.sortedMapFactory.sortedMapFactory[Any, Any](it.ordering.asInstanceOf[Ordering[Any]]).asInstanceOf[Factory[Any, Any]]
+      case it: scala.collection.SortedMap[_, _] => it.sortedMapFactory.sortedMapFactory[Any, Any](using it.ordering.asInstanceOf[Ordering[Any]]).asInstanceOf[Factory[Any, Any]]
       case it: scala.collection.Map[_, _] => it.mapFactory.mapFactory[Any, Any].asInstanceOf[Factory[Any, Any]]
-      case it: scala.collection.SortedSet[_] => it.sortedIterableFactory.evidenceIterableFactory[Any](it.ordering.asInstanceOf[Ordering[Any]])
+      case it: scala.collection.SortedSet[_] => it.sortedIterableFactory.evidenceIterableFactory[Any](using it.ordering.asInstanceOf[Ordering[Any]])
       case it => it.iterableFactory.iterableFactory
     }
     new DefaultSerializationProxy(f, this)

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -42,13 +42,13 @@ sealed abstract class ArraySeq[T]
   override def iterableFactory: scala.collection.SeqFactory[ArraySeq] = ArraySeq.untagged
 
   override protected def fromSpecific(coll: scala.collection.IterableOnce[T]): ArraySeq[T] = {
-    val b = ArrayBuilder.make(elemTag).asInstanceOf[ArrayBuilder[T]]
+    val b = ArrayBuilder.make(using elemTag).asInstanceOf[ArrayBuilder[T]]
     b.sizeHint(coll, delta = 0)
     b ++= coll
     ArraySeq.make(b.result())
   }
-  override protected def newSpecificBuilder: Builder[T, ArraySeq[T]] = ArraySeq.newBuilder(elemTag).asInstanceOf[Builder[T, ArraySeq[T]]]
-  override def empty: ArraySeq[T] = ArraySeq.empty(elemTag.asInstanceOf[ClassTag[T]])
+  override protected def newSpecificBuilder: Builder[T, ArraySeq[T]] = ArraySeq.newBuilder(using elemTag).asInstanceOf[Builder[T, ArraySeq[T]]]
+  override def empty: ArraySeq[T] = ArraySeq.empty(using elemTag.asInstanceOf[ClassTag[T]])
 
   /** The tag of the element type. This does not have to be equal to the element type of this ArraySeq. A primitive
     * ArraySeq can be backed by an array of boxed values and a reference ArraySeq can be backed by an array of a supertype

--- a/src/library/scala/collection/mutable/CollisionProofHashMap.scala
+++ b/src/library/scala/collection/mutable/CollisionProofHashMap.scala
@@ -766,7 +766,7 @@ object CollisionProofHashMap extends SortedMapFactory[CollisionProofHashMap] {
   @SerialVersionUID(3L)
   private final class DeserializationFactory[K, V](val tableLength: Int, val loadFactor: Double, val ordering: Ordering[K]) extends Factory[(K, V), CollisionProofHashMap[K, V]] with Serializable {
     def fromSpecific(it: IterableOnce[(K, V)]): CollisionProofHashMap[K, V] = new CollisionProofHashMap[K, V](tableLength, loadFactor)(ordering) ++= it
-    def newBuilder: Builder[(K, V), CollisionProofHashMap[K, V]] = CollisionProofHashMap.newBuilder(tableLength, loadFactor)(ordering)
+    def newBuilder: Builder[(K, V), CollisionProofHashMap[K, V]] = CollisionProofHashMap.newBuilder(tableLength, loadFactor)(using ordering)
   }
 
   @unused @`inline` private def compare[K, V](key: K, hash: Int, node: LLNode[K, V])(implicit ord: Ordering[K]): Int = {

--- a/src/tastytest/scala/tools/tastytest/Dotc.scala
+++ b/src/tastytest/scala/tools/tastytest/Dotc.scala
@@ -81,10 +81,14 @@ object Dotc extends Script.Command {
 
   private def makeConsoleReporter(stream: OutputStream)(implicit cl: Dotc.ClassLoader): Try[AnyRef] = Try {
     val consoleReporterCls = loadClass("dotty.tools.dotc.reporting.ConsoleReporter")
-    val ctor = consoleReporterCls.getConstructor(classOf[BufferedReader], classOf[PrintWriter])
+    val ctor = consoleReporterCls.getConstructor(
+      /* reader: BufferedReader */classOf[BufferedReader],
+      /* writer: PrintWriter */classOf[PrintWriter],
+      /* echoer: PrintWriter */classOf[PrintWriter] // since 3.5.0-RC2
+    )
     val pwriter = new PrintWriter(stream, true)
     inClassloader[AnyRef] {
-      ctor.newInstance(Console.in, pwriter)
+      ctor.newInstance(/* reader = */Console.in, /* writer = */pwriter, /* echoer= */pwriter)
     }
   }
 

--- a/test/tasty/neg-full-circle/src-3-app/TestExperimentalDefsPre.check
+++ b/test/tasty/neg-full-circle/src-3-app/TestExperimentalDefsPre.check
@@ -1,41 +1,37 @@
 -- Error: TestExperimentalDefsPre_fail.scala:1:18
 1 |import downstream.ExperimentalDefsPre.*
   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |       Experimental definition may only be used under experimental mode:
-  |         1. in a definition marked as @experimental, or
-  |         2. compiling with the -experimental compiler flag, or
-  |         3. with a nightly or snapshot version of the compiler.
-  |
   |       object ExperimentalDefsPre is marked @experimental
   |
+  |       Experimental definition may only be used under experimental mode:
+  |         1. in a definition marked as @experimental, or
+  |         2. an experimental feature is imported at the package level, or
+  |         3. compiling with the -experimental compiler flag.
 -- Error: TestExperimentalDefsPre_fail.scala:4:10
 4 |  def test = new SubExperimentalNotExperimental
   |          ^
-  |         Experimental definition may only be used under experimental mode:
-  |           1. in a definition marked as @experimental, or
-  |           2. compiling with the -experimental compiler flag, or
-  |           3. with a nightly or snapshot version of the compiler.
-  |
   |         object ExperimentalDefsPre is marked @experimental
   |
+  |         Experimental definition may only be used under experimental mode:
+  |           1. in a definition marked as @experimental, or
+  |           2. an experimental feature is imported at the package level, or
+  |           3. compiling with the -experimental compiler flag.
 -- Error: TestExperimentalDefsPre_fail.scala:4:17
 4 |  def test = new SubExperimentalNotExperimental
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |         Experimental definition may only be used under experimental mode:
-  |           1. in a definition marked as @experimental, or
-  |           2. compiling with the -experimental compiler flag, or
-  |           3. with a nightly or snapshot version of the compiler.
-  |
   |         object ExperimentalDefsPre is marked @experimental
   |
+  |         Experimental definition may only be used under experimental mode:
+  |           1. in a definition marked as @experimental, or
+  |           2. an experimental feature is imported at the package level, or
+  |           3. compiling with the -experimental compiler flag.
 -- Error: TestExperimentalDefsPre_fail.scala:6:35
 6 |  class SubSubExperimental extends SubExperimentalNotExperimental
   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |         Experimental definition may only be used under experimental mode:
-  |           1. in a definition marked as @experimental, or
-  |           2. compiling with the -experimental compiler flag, or
-  |           3. with a nightly or snapshot version of the compiler.
-  |
   |         object ExperimentalDefsPre is marked @experimental
   |
+  |         Experimental definition may only be used under experimental mode:
+  |           1. in a definition marked as @experimental, or
+  |           2. an experimental feature is imported at the package level, or
+  |           3. compiling with the -experimental compiler flag.
 4 errors found

--- a/test/tasty/neg/src-2/TestTrackedParam.check
+++ b/test/tasty/neg/src-2/TestTrackedParam.check
@@ -1,0 +1,6 @@
+TestTrackedParam_fail.scala:12: error: type mismatch;
+ found   : tastytest.TrackedParam.C#T
+ required: Int
+  def test: Int = new F(y).x.t // error: just ignore tracked flag - so x is not refined.
+                             ^
+1 error

--- a/test/tasty/neg/src-2/TestTrackedParam_fail.scala
+++ b/test/tasty/neg/src-2/TestTrackedParam_fail.scala
@@ -1,0 +1,14 @@
+package tastytest
+
+import scala.annotation.experimental
+
+@experimental
+object TestTrackedParam {
+
+  import TrackedParam._
+
+  val y: C { type T = Int } = ???
+
+  def test: Int = new F(y).x.t // error: just ignore tracked flag - so x is not refined.
+}
+

--- a/test/tasty/neg/src-3/TrackedParam.scala
+++ b/test/tasty/neg/src-3/TrackedParam.scala
@@ -1,0 +1,23 @@
+package tastytest
+
+import scala.language.future
+import scala.language.experimental.modularity
+
+object TrackedParam {
+
+  class C {
+    type T
+    lazy val t: T = ???
+  }
+
+  def f(x: C): x.T = x.t
+
+  val y: C { type T = Int } = ???
+
+  class F(tracked val x: C) {
+    lazy val result: x.T = f(x)
+  }
+
+  def test: Int = new F(y).result
+}
+

--- a/test/tasty/run/src-2/tastytest/TestAppliedTypeLambda.scala
+++ b/test/tasty/run/src-2/tastytest/TestAppliedTypeLambda.scala
@@ -1,0 +1,22 @@
+package tastytest
+
+object TestAppliedTypeLambda extends Suite("TestAppliedTypeLambda") {
+
+  test("make empty array") {
+    val arr: Array[Int] = AppliedTypeLambda.emptyArray[Int]
+    assert(arr.getClass().isArray() && arr.getClass().getComponentType() == java.lang.Integer.TYPE)
+  }
+
+  test("make empty array with class Tparam") {
+    val factory = new AppliedTypeLambda.InTypeParam[reflect.ClassTag]
+    val arr: Array[Int] = factory.emptyArray[Int]
+    assert(arr.getClass().isArray() && arr.getClass().getComponentType() == java.lang.Integer.TYPE)
+  }
+
+  test("make empty array with method Tparam") {
+    val arr: Array[Int] = AppliedTypeLambda.emptyArray2[Int, reflect.ClassTag]
+    assert(arr.getClass().isArray() && arr.getClass().getComponentType() == java.lang.Integer.TYPE)
+  }
+}
+
+

--- a/test/tasty/run/src-3/tastytest/AppliedTypeLambda.scala
+++ b/test/tasty/run/src-3/tastytest/AppliedTypeLambda.scala
@@ -1,0 +1,15 @@
+package tastytest
+
+object AppliedTypeLambda:
+
+  // This reflects the state of context function expansion in Scala 3.5.0-RC1
+  // this was fixed in 3.5.0-RC3, but technically any user could type this?
+  def emptyArray[T](using ct: ([T1] =>> reflect.ClassTag[T1])[T]): Array[T] =
+    new Array[T](0)
+
+  def emptyArray2[T, F[T2] <: ([T1] =>> reflect.ClassTag[T1])[T2]](using ct: F[T]): Array[T] =
+    new Array[T](0)
+
+  class InTypeParam[F[T] <: ([T1] =>> reflect.ClassTag[T1])[T]]:
+    def emptyArray[T](using ct: F[T]): Array[T] = new Array[T](0)
+

--- a/test/tasty/test/scala/tools/tastytest/TastyTestJUnit.scala
+++ b/test/tasty/test/scala/tools/tastytest/TastyTestJUnit.scala
@@ -3,7 +3,7 @@ package scala.tools.tastytest
 import org.junit.{Test => test, BeforeClass => setup, AfterClass => teardown}
 import org.junit.Assert._
 
-import scala.util.{Try, Failure, Properties}
+import scala.util.Properties
 
 import TastyTestJUnit._
 
@@ -16,7 +16,7 @@ class TastyTestJUnit {
     outDir                  = None,
     additionalSettings      = Nil,
     additionalDottySettings = Nil
-  ).eval()
+  ).get
 
   @test def runPipelined(): Unit = {
     TastyTest.runPipelinedSuite(
@@ -25,8 +25,8 @@ class TastyTestJUnit {
       pkgName                 = assertPropIsSet(propPkgName),
       outDirs                 = None,
       additionalSettings      = Nil,
-      additionalDottySettings = Nil
-    ).eval()
+      additionalDottySettings = Seq("-Yexplicit-nulls"), // test flexible types from Java
+    ).get
   }
 
   @test def pos(): Unit = TastyTest.posSuite(
@@ -36,7 +36,7 @@ class TastyTestJUnit {
     outDir                  = None,
     additionalSettings      = Nil,
     additionalDottySettings = Nil
-  ).eval()
+  ).get
 
   /** false positives that should fail, but work when annotations are not read */
   @test def posFalseNoAnnotations(): Unit = TastyTest.posSuite(
@@ -46,7 +46,7 @@ class TastyTestJUnit {
     outDir                  = None,
     additionalSettings      = Seq("-Ytasty-no-annotations"),
     additionalDottySettings = Nil
-  ).eval()
+  ).get
 
   @test def posDoctool(): Unit = TastyTest.posDocSuite(
     src                     = "pos-doctool",
@@ -55,7 +55,7 @@ class TastyTestJUnit {
     outDir                  = None,
     additionalSettings      = Nil,
     additionalDottySettings = Nil
-  ).eval()
+  ).get
 
   @test def neg(): Unit = TastyTest.negSuite(
     src                     = "neg",
@@ -64,7 +64,7 @@ class TastyTestJUnit {
     outDir                  = None,
     additionalSettings      = Nil,
     additionalDottySettings = Nil
-  ).eval()
+  ).get
 
   @test def negPipelined(): Unit = {
     TastyTest.negPipelinedSuite(
@@ -73,8 +73,8 @@ class TastyTestJUnit {
       pkgName                 = assertPropIsSet(propPkgName),
       outDirs                 = None,
       additionalSettings      = Nil,
-      additionalDottySettings = Nil
-    ).eval()
+      additionalDottySettings = Seq("-Yexplicit-nulls") // test flexible types from Java
+    ).get
   }
 
   @test def negMoveMacros(): Unit = TastyTest.negChangePreSuite(
@@ -84,7 +84,7 @@ class TastyTestJUnit {
     outDirs                 = None,
     additionalSettings      = Nil,
     additionalDottySettings = Nil
-  ).eval()
+  ).get
 
   @test def negIsolated(): Unit = TastyTest.negSuiteIsolated(
     src                     = "neg-isolated",
@@ -93,7 +93,7 @@ class TastyTestJUnit {
     outDirs                 = None,
     additionalSettings      = Nil,
     additionalDottySettings = Nil
-  ).eval()
+  ).get
 
   @test def negFullCircle(): Unit = TastyTest.negFullCircleSuite(
     src                     = "neg-full-circle",
@@ -102,7 +102,7 @@ class TastyTestJUnit {
     outDir                  = None,
     additionalSettings      = Nil,
     additionalDottySettings = Nil
-  ).eval()
+  ).get
 
   val propSrc     = "tastytest.src"
   val propPkgName = "tastytest.packageName"
@@ -128,12 +128,5 @@ object TastyTestJUnit {
   @teardown
   def finish(): Unit = {
     _dottyClassLoader = null
-  }
-
-  final implicit class TryOps(val op: Try[Unit]) extends AnyVal {
-    def eval(): Unit = op match {
-      case Failure(err) => fail(err.getMessage)
-      case _ => ()
-    }
   }
 }

--- a/test/tasty/test/scala/tools/tastytest/TastyTestJUnit.scala
+++ b/test/tasty/test/scala/tools/tastytest/TastyTestJUnit.scala
@@ -2,14 +2,12 @@ package scala.tools.tastytest
 
 import org.junit.{Test => test, BeforeClass => setup, AfterClass => teardown}
 import org.junit.Assert._
-import org.junit.Assume._
 
 import scala.util.{Try, Failure, Properties}
 
 import TastyTestJUnit._
 
 class TastyTestJUnit {
-  val isWindows = Properties.isWin
 
   @test def run(): Unit = TastyTest.runSuite(
     src                     = "run",
@@ -21,7 +19,6 @@ class TastyTestJUnit {
   ).eval()
 
   @test def runPipelined(): Unit = {
-    assumeFalse("Disabled on Windows due to bug in jar format", isWindows)
     TastyTest.runPipelinedSuite(
       src                     = "run-pipelined",
       srcRoot                 = assertPropIsSet(propSrc),
@@ -70,7 +67,6 @@ class TastyTestJUnit {
   ).eval()
 
   @test def negPipelined(): Unit = {
-    assumeFalse("Disabled on Windows due to bug in jar format", isWindows)
     TastyTest.negPipelinedSuite(
       src                     = "neg-pipelined",
       srcRoot                 = assertPropIsSet(propSrc),


### PR DESCRIPTION
restores pipelining tests on windows - (3.4.0 actually fixed the underlying problem with writing to Jars)

scala 3.5.0-RC4 changed the constructor of its ConsoleReporter - so patched that here.

also the experimental definition error message changed again :)

also test compilation of std library with 3.5.0