### PR TITLE
Fix false-positive unused warnings in for comprehensions [ci: last-only]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -538,7 +538,7 @@ lazy val compiler = configureAsSubproject(project)
       ).get
     },
     Compile / scalacOptions ++= Seq(
-      //"-Wunused", "-Wnonunit-statement",
+      //"-Wunused", //"-Wnonunit-statement",
       "-Wconf:cat=deprecation&msg=early initializers:s", // compiler heavily relies upon early initializers
     ),
     Compile / doc / scalacOptions ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -538,6 +538,7 @@ lazy val compiler = configureAsSubproject(project)
       ).get
     },
     Compile / scalacOptions ++= Seq(
+      //"-Wunused", "-Wnonunit-statement",
       "-Wconf:cat=deprecation&msg=early initializers:s", // compiler heavily relies upon early initializers
     ),
     Compile / doc / scalacOptions ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -161,6 +161,7 @@ lazy val commonSettings = instanceSettings ++ clearSourceAndResourceDirectories 
   run / fork := true,
   run / connectInput := true,
   Compile / scalacOptions ++= Seq("-feature", "-Xlint",
+    //"-Vprint",
     //"-Xmaxerrs", "5", "-Xmaxwarns", "5", // uncomment for ease of development while breaking things
     // work around https://github.com/scala/bug/issues/11534
     "-Wconf:cat=unchecked&msg=The outer reference in this type test cannot be checked at run time.:s",
@@ -463,6 +464,9 @@ lazy val reflect = configureAsSubproject(project)
     name := "scala-reflect",
     description := "Scala Reflection Library",
     Osgi.bundleName := "Scala Reflect",
+    Compile / scalacOptions ++= Seq(
+      "-Wconf:cat=deprecation&msg=early initializers:s", // compiler heavily relies upon early initializers
+    ),
     Compile / doc / scalacOptions ++= Seq(
       "-skip-packages", "scala.reflect.macros.internal:scala.reflect.internal:scala.reflect.io"
     ),
@@ -694,6 +698,9 @@ lazy val partest = configureAsSubproject(project)
     name := "scala-partest",
     description := "Scala Compiler Testing Tool",
     libraryDependencies ++= List(testInterfaceDep, diffUtilsDep, junitDep),
+    Compile / scalacOptions ++= Seq(
+      "-Wconf:cat=deprecation&msg=early initializers:s", // compiler heavily relies upon early initializers
+    ),
     Compile / javacOptions ++= Seq("-XDenableSunApiLintControl", "-Xlint") ++
       (if (fatalWarnings.value) Seq("-Werror") else Seq()),
     pomDependencyExclusions ++= List((organization.value, "scala-repl-frontend"), (organization.value, "scala-compiler-doc")),

--- a/src/compiler/scala/reflect/macros/compiler/DefaultMacroCompiler.scala
+++ b/src/compiler/scala/reflect/macros/compiler/DefaultMacroCompiler.scala
@@ -71,7 +71,7 @@ abstract class DefaultMacroCompiler extends Resolvers
     val vanillaResult = tryCompile(vanillaImplRef)
     val bundleResult = tryCompile(bundleImplRef)
 
-    def ensureUnambiguousSuccess() = {
+    def ensureUnambiguousSuccess(): Unit = {
       // we now face a hard choice of whether to report ambiguity:
       //   1) when there are eponymous methods in both bundle and object
       //   2) when both references to eponymous methods are resolved successfully
@@ -100,6 +100,7 @@ abstract class DefaultMacroCompiler extends Resolvers
     try {
       if (vanillaResult.isSuccess || bundleResult.isSuccess) ensureUnambiguousSuccess()
       if (vanillaResult.isFailure && bundleResult.isFailure) reportMostAppropriateFailure()
+      //else // TODO
       vanillaResult.orElse(bundleResult).get
     } catch {
       case MacroImplResolutionException(pos, msg) =>

--- a/src/compiler/scala/reflect/macros/compiler/Resolvers.scala
+++ b/src/compiler/scala/reflect/macros/compiler/Resolvers.scala
@@ -34,7 +34,7 @@ trait Resolvers {
     lazy val (macroImplRef, isBlackbox, macroImplOwner, macroImpl, targs) =
       typer.silent(_.typed(markMacroImplRef(untypedMacroImplRef)), reportAmbiguousErrors = false) match {
         case SilentResultValue(macroImplRef @ MacroImplReference(_, isBlackbox, owner, meth, targs)) => (macroImplRef, isBlackbox, owner, meth, targs)
-        case SilentResultValue(macroImplRef) => MacroImplReferenceWrongShapeError()
+        case SilentResultValue(_) => MacroImplReferenceWrongShapeError()
         case ste: SilentTypeError => abort(ste.err.errPos, ste.err.errMsg)
       }
   }

--- a/src/compiler/scala/reflect/macros/compiler/Validators.scala
+++ b/src/compiler/scala/reflect/macros/compiler/Validators.scala
@@ -127,7 +127,7 @@ trait Validators {
      */
     private lazy val macroImplSig: MacroImplSig = {
       val tparams = macroImpl.typeParams
-      val paramss = transformTypeTagEvidenceParams(macroImplRef, (param, tparam) => NoSymbol)
+      val paramss = transformTypeTagEvidenceParams(macroImplRef, (_, _) => NoSymbol)
       val ret = macroImpl.info.finalResultType
       MacroImplSig(tparams, paramss, ret)
     }

--- a/src/compiler/scala/reflect/quasiquotes/Parsers.scala
+++ b/src/compiler/scala/reflect/quasiquotes/Parsers.scala
@@ -42,16 +42,16 @@ trait Parsers { self: Quasiquotes =>
       val posMapList = posMap.toList
       def containsOffset(start: Int, end: Int) = start <= offset && offset < end
       def fallbackPosition = posMapList match {
-        case (pos1, (start1, end1)) :: _   if start1 > offset => pos1
-        case _ :+ ((pos2, (start2, end2))) if end2 <= offset  => pos2.withPoint(pos2.point + (end2 - start2))
-        case x                                                => throw new MatchError(x)
+        case (pos1, (start1, _)) :: _   if start1 > offset   => pos1
+        case _ :+ ((pos2, (start2, end2))) if end2 <= offset => pos2.withPoint(pos2.point + (end2 - start2))
+        case x                                               => throw new MatchError(x)
       }
       posMapList.sliding(2).collect {
-        case (pos1, (start1, end1)) :: _                        if containsOffset(start1, end1) => (pos1, offset - start1)
-        case (pos1, (start1, end1)) :: (pos2, (start2, _)) :: _ if containsOffset(end1, start2) => (pos1, end1 - start1)
-        case _ :: (pos2, (start2, end2)) :: _                   if containsOffset(start2, end2) => (pos2, offset - start2)
-      }.map { case (pos, offset) =>
-        pos.withPoint(pos.point + offset)
+        case (pos1, (start1, end1)) :: _                     if containsOffset(start1, end1) => (pos1, offset - start1)
+        case (pos1, (start1, end1)) :: (_, (start2, _)) :: _ if containsOffset(end1, start2) => (pos1, end1 - start1)
+        case _ :: (pos2, (start2, end2)) :: _                if containsOffset(start2, end2) => (pos2, offset - start2)
+      }.map {
+        case (pos, offset) => pos.withPoint(pos.point + offset)
       }.toList.headOption.getOrElse(fallbackPosition)
     }
 
@@ -92,7 +92,7 @@ trait Parsers { self: Quasiquotes =>
               case _ => gen.mkBlock(stats, doFlatten = true)
             }
           case nme.unapply => gen.mkBlock(stats, doFlatten = false)
-          case other       => global.abort("unreachable")
+          case _           => global.abort("unreachable")
         }
 
         // tq"$a => $b"

--- a/src/compiler/scala/reflect/quasiquotes/Reifiers.scala
+++ b/src/compiler/scala/reflect/quasiquotes/Reifiers.scala
@@ -319,7 +319,7 @@ trait Reifiers { self: Quasiquotes =>
      */
     def group[T](lst: List[T])(similar: (T, T) => Boolean) = lst.foldLeft[List[List[T]]](List()) {
       case (Nil, el) => List(List(el))
-      case (ll :+ (last @ (lastinit :+ lastel)), el) if similar(lastel, el) => ll :+ (last :+ el)
+      case (ll :+ (last @ _ :+ lastel), el) if similar(lastel, el) => ll :+ (last :+ el)
       case (ll, el) => ll :+ List(el)
     }
 
@@ -363,7 +363,7 @@ trait Reifiers { self: Quasiquotes =>
       case ParamPlaceholder(Hole(tree, DotDot)) => tree
       case SyntacticPatDef(mods, pat, tpt, rhs) =>
         reifyBuildCall(nme.SyntacticPatDef, mods, pat, tpt, rhs)
-      case SyntacticValDef(mods, p @ Placeholder(h: ApplyHole), tpt, rhs) if h.tpe <:< treeType =>
+      case SyntacticValDef(mods, Placeholder(h: ApplyHole), tpt, rhs) if h.tpe <:< treeType =>
         mirrorBuildCall(nme.SyntacticPatDef, reify(mods), h.tree, reify(tpt), reify(rhs))
     }
 

--- a/src/compiler/scala/reflect/reify/Taggers.scala
+++ b/src/compiler/scala/reflect/reify/Taggers.scala
@@ -78,13 +78,13 @@ abstract class Taggers {
           translatingReificationErrors(materializer)
       }
     try c.typecheck(result)
-    catch { case terr @ TypecheckException(pos, msg) => failTag(result, terr) }
+    catch { case terr: TypecheckException => failTag(result, terr) }
   }
 
   def materializeExpr(universe: Tree, mirror: Tree, expr: Tree): Tree = {
     val result = translatingReificationErrors(c.reifyTree(universe, mirror, expr))
     try c.typecheck(result)
-    catch { case terr @ TypecheckException(pos, msg) => failExpr(result, terr) }
+    catch { case terr: TypecheckException => failExpr(result, terr) }
   }
 
   private def translatingReificationErrors(materializer: => Tree): Tree = {
@@ -92,7 +92,7 @@ abstract class Taggers {
     catch {
       case ReificationException(pos, msg) =>
         c.abort(pos.asInstanceOf[c.Position], msg) // this cast is a very small price for the confidence of exception handling
-      case UnexpectedReificationException(pos, err, cause) if cause != null =>
+      case UnexpectedReificationException(_, _, cause) if cause != null =>
         throw cause
     }
   }

--- a/src/compiler/scala/reflect/reify/codegen/GenPositions.scala
+++ b/src/compiler/scala/reflect/reify/codegen/GenPositions.scala
@@ -23,6 +23,6 @@ trait GenPositions {
   // but I can hardly imagine when one would need a position that points to the reified code
   // usually reified trees are used to compose macro expansions or to be fed to the runtime compiler
   // however both macros and toolboxes have their own means to report errors in synthetic trees
-  def reifyPosition(pos: Position): Tree =
-    reifyMirrorObject(NoPosition)
+  @annotation.nowarn
+  def reifyPosition(pos: Position): Tree = reifyMirrorObject(NoPosition)
 }

--- a/src/compiler/scala/reflect/reify/codegen/GenTypes.scala
+++ b/src/compiler/scala/reflect/reify/codegen/GenTypes.scala
@@ -187,13 +187,13 @@ trait GenTypes {
 
     tpe match {
       case tpe @ RefinedType(parents, decls) =>
-        reifySymDef(tpe.typeSymbol)
+        List(tpe.typeSymbol).foreach(reifySymDef)
         mirrorBuildCall(nme.RefinedType, reify(parents), reifyScope(decls), reify(tpe.typeSymbol))
       case ExistentialType(tparams, underlying) =>
         tparams.foreach(reifySymDef)
         reifyBuildCall(nme.ExistentialType, tparams, underlying)
       case tpe @ ClassInfoType(parents, decls, clazz) =>
-        reifySymDef(clazz)
+        List(clazz).foreach(reifySymDef)
         mirrorBuildCall(nme.ClassInfoType, reify(parents), reifyScope(decls), reify(tpe.typeSymbol))
       case MethodType(params, restpe) =>
         params foreach reifySymDef

--- a/src/compiler/scala/reflect/reify/codegen/GenUtils.scala
+++ b/src/compiler/scala/reflect/reify/codegen/GenUtils.scala
@@ -117,7 +117,7 @@ trait GenUtils {
   @tailrec
   final def isCrossStageTypeBearer(tree: Tree): Boolean = tree match {
     case TypeApply(hk, _) => isCrossStageTypeBearer(hk)
-    case Select(sym @ Select(_, ctor), nme.apply) if ctor == nme.WeakTypeTag || ctor == nme.TypeTag || ctor == nme.Expr => true
+    case Select(Select(_, nme.WeakTypeTag|nme.TypeTag|nme.Expr), nme.apply) => true
     case _ => false
   }
 

--- a/src/compiler/scala/reflect/reify/utils/Extractors.scala
+++ b/src/compiler/scala/reflect/reify/utils/Extractors.scala
@@ -242,8 +242,8 @@ trait Extractors {
 
   object TypeRefToFreeType {
     def unapply(tree: Tree): Option[TermName] = tree match {
-      case Apply(Select(Select(uref @ Ident(_), typeRef), apply), List(Select(_, noSymbol), Ident(freeType: TermName), nil))
-      if (uref.name == nme.UNIVERSE_SHORT && typeRef == nme.TypeRef && noSymbol == nme.NoSymbol && freeType.startsWith(nme.REIFY_FREE_PREFIX)) =>
+      case Apply(Select(Select(Ident(nme.UNIVERSE_SHORT), nme.TypeRef), apply@_), List(Select(_, nme.NoSymbol), Ident(freeType: TermName), _))
+      if freeType.startsWith(nme.REIFY_FREE_PREFIX) =>
         Some(freeType)
       case _ =>
         None

--- a/src/compiler/scala/reflect/reify/utils/StdAttachments.scala
+++ b/src/compiler/scala/reflect/reify/utils/StdAttachments.scala
@@ -23,7 +23,7 @@ trait StdAttachments {
   def reifyBinding(tree: Tree): Tree =
     tree.attachments.get[ReifyBindingAttachment] match {
       case Some(ReifyBindingAttachment(binding)) => binding
-      case other => Ident(NoSymbol)
+      case _ => Ident(NoSymbol)
     }
 
   case class ReifyAliasAttachment(sym: Symbol, alias: TermName)

--- a/src/compiler/scala/reflect/reify/utils/SymbolTables.scala
+++ b/src/compiler/scala/reflect/reify/utils/SymbolTables.scala
@@ -13,7 +13,7 @@
 package scala.reflect.reify
 package utils
 
-import scala.annotation.unused
+import scala.annotation._
 import scala.collection.{immutable, mutable}, mutable.{ArrayBuffer, ListBuffer}
 import java.lang.System.{lineSeparator => EOL}
 
@@ -134,10 +134,11 @@ trait SymbolTables {
       s"""symtab = [$symtabString], aliases = [$aliasesString]${if (original.isDefined) ", has original" else ""}"""
     }
 
+    @nowarn // spurious unused buf.type
     def debugString: String = {
       val buf = new StringBuilder
       buf.append("symbol table = " + (if (syms.length == 0) "<empty>" else "")).append(EOL)
-      syms foreach (sym => buf.append(symDef(sym)).append(EOL))
+      syms.foreach(sym => buf.append(symDef(sym)).append(EOL))
       buf.delete(buf.length - EOL.length, buf.length)
       buf.toString
     }

--- a/src/compiler/scala/reflect/reify/utils/SymbolTables.scala
+++ b/src/compiler/scala/reflect/reify/utils/SymbolTables.scala
@@ -13,6 +13,7 @@
 package scala.reflect.reify
 package utils
 
+import scala.annotation.unused
 import scala.collection.{immutable, mutable}, mutable.{ArrayBuffer, ListBuffer}
 import java.lang.System.{lineSeparator => EOL}
 
@@ -89,7 +90,7 @@ trait SymbolTables {
       new SymbolTable(newSymtab, newAliases)
     }
 
-    def add(sym: Symbol, name0: TermName, reification: Tree): SymbolTable = {
+    def add(@unused sym: Symbol, name0: TermName, reification: Tree): SymbolTable = {
       def freshName(name0: TermName): TermName = {
         var name = name0.toString
         name = name.replace(".type", "$type")

--- a/src/compiler/scala/tools/nsc/ClassPathMemoryConsumptionTester.scala
+++ b/src/compiler/scala/tools/nsc/ClassPathMemoryConsumptionTester.scala
@@ -42,7 +42,7 @@ object ClassPathMemoryConsumptionTester {
   private def doTest(args: Array[String]) = {
     val settings = loadSettings(args.toList)
 
-    val mains = (1 to settings.requiredInstances.value) map (_ => new MainRetainsGlobal)
+    val mains = (1 to settings.requiredInstances.value).map(_ => new MainRetainsGlobal)
 
     // we need original settings without additional params to be able to use them later
     val baseArgs = argsWithoutRequiredInstances(args)
@@ -50,7 +50,7 @@ object ClassPathMemoryConsumptionTester {
     println(s"Loading classpath ${settings.requiredInstances.value} times")
     val startTime = System.currentTimeMillis()
 
-    mains map (_.process(baseArgs))
+    mains.foreach(_.process(baseArgs))
 
     val elapsed = System.currentTimeMillis() - startTime
     println(s"Operation finished - elapsed $elapsed ms")

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -18,7 +18,7 @@ import java.io.{Closeable, FileNotFoundException, IOException}
 import java.net.URL
 import java.nio.charset.{Charset, CharsetDecoder, IllegalCharsetNameException, StandardCharsets, UnsupportedCharsetException}, StandardCharsets.UTF_8
 
-import scala.annotation.{nowarn, tailrec}
+import scala.annotation._
 import scala.collection.{immutable, mutable}
 import scala.reflect.ClassTag
 import scala.reflect.internal.pickling.PickleBuffer
@@ -1470,6 +1470,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
 
     private def showMembers() = {
       // Allows for syntax like scalac -Xshow-class Random@erasure,typer
+      @nowarn
       def splitClassAndPhase(str: String, term: Boolean): Name = {
         def mkName(s: String) = if (term) newTermName(s) else newTypeName(s)
         (str indexOf '@') match {

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -376,7 +376,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
       def ccon = Class.forName(name).getConstructor(classOf[CharsetDecoder], classOf[InternalReporter])
 
       try Some(ccon.newInstance(charset.newDecoder(), reporter).asInstanceOf[SourceReader])
-      catch { case ex: Throwable =>
+      catch { case _: Throwable =>
         globalError("exception while trying to instantiate source reader '" + name + "'")
         None
       }
@@ -1651,7 +1651,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
         compileSources(sources)
       }
       catch {
-        case ex: InterruptedException => reporter.cancelled = true
+        case _: InterruptedException => reporter.cancelled = true
         case ex: IOException => globalError(ex.getMessage())
       }
     }
@@ -1672,7 +1672,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
         compileSources(sources)
       }
       catch {
-        case ex: InterruptedException => reporter.cancelled = true
+        case _: InterruptedException => reporter.cancelled = true
         case ex: IOException => globalError(ex.getMessage())
       }
     }

--- a/src/compiler/scala/tools/nsc/PhaseAssembly.scala
+++ b/src/compiler/scala/tools/nsc/PhaseAssembly.scala
@@ -190,7 +190,7 @@ class DependencyGraph(order: Int, start: String, val components: Map[String, Sub
       def sortVertex(i: Int, j: Int): Boolean = sortComponents(componentOf(i), componentOf(j))
 
       distance.zipWithIndex.groupBy(_._1).toList.sortBy(_._1)
-      .flatMap { case (d, dis) =>
+      .flatMap { case (_, dis) =>
         val vs = dis.map { case (_, i) => i }
         val (anchors, followers) = vs.partition(v => edgeTo(v) == null || edgeTo(v).weight != FollowsNow)
         //if (debugging) println(s"d=$d, anchors=${anchors.toList.map(n => names(n))}, followers=${followers.toList.map(n => names(n))}")

--- a/src/compiler/scala/tools/nsc/PipelineMain.scala
+++ b/src/compiler/scala/tools/nsc/PipelineMain.scala
@@ -67,7 +67,7 @@ class PipelineMainClass(argFiles: Seq[Path], pipelineSettings: PipelineMain.Pipe
     reporter.echo(NoPosition, msg)
   }
   private def reporterError(pos: Position, msg: String): Unit = synchronized {
-    reporter.echo(msg)
+    reporter.error(pos, msg)
   }
 
   private object handler extends UncaughtExceptionHandler {

--- a/src/compiler/scala/tools/nsc/ast/DocComments.scala
+++ b/src/compiler/scala/tools/nsc/ast/DocComments.scala
@@ -185,7 +185,7 @@ trait DocComments { self: Global =>
     }
 
     def mergeSection(srcSec: Option[(Int, Int)], dstSec: Option[(Int, Int)]) = dstSec match {
-      case Some((start, end)) =>
+      case Some((_, end)) =>
         if (end > tocopy) tocopy = end
       case None =>
         srcSec match {
@@ -312,7 +312,7 @@ trait DocComments { self: Global =>
 
       searchList collectFirst { case x if defs(x) contains vble => defs(x)(vble) } match {
         case Some(str) if str startsWith "$" => lookupVariable(str.tail, site)
-        case s @ Some(str)                   => s
+        case s @ Some(_)                     => s
         case None                            => lookupVariable(vble, site.owner)
       }
   }
@@ -560,5 +560,5 @@ trait DocComments { self: Global =>
     }
   }
 
-  class ExpansionLimitExceeded(str: String) extends Exception
+  class ExpansionLimitExceeded(str: String) extends Exception(str)
 }

--- a/src/compiler/scala/tools/nsc/ast/NodePrinters.scala
+++ b/src/compiler/scala/tools/nsc/ast/NodePrinters.scala
@@ -89,7 +89,7 @@ abstract class NodePrinters {
       tree match {
         case SelectFromTypeTree(qual, name) => showRefTreeName(qual) + "#" + showName(name)
         case Select(qual, name)             => showRefTreeName(qual) + "." + showName(name)
-        case id @ Ident(name)               => showNameAndPos(id)
+        case id: Ident                      => showNameAndPos(id)
         case _                              => "" + tree
       }
     }
@@ -358,7 +358,7 @@ abstract class NodePrinters {
           tree match {
             case t: RefTree               => println(showRefTree(t))
             case t if t.productArity == 0 => println(treePrefix(t))
-            case t                        => printMultiline(tree)(tree.productIterator foreach traverseAny)
+            case _                        => printMultiline(tree)(tree.productIterator foreach traverseAny)
           }
       }
     }

--- a/src/compiler/scala/tools/nsc/ast/NodePrinters.scala
+++ b/src/compiler/scala/tools/nsc/ast/NodePrinters.scala
@@ -124,6 +124,7 @@ abstract class NodePrinters {
       }
     }
     def println(s: String) = printLine(s, "")
+    def print(s: String) = buf.append(s)
 
     def printLine(value: String, comment: String): Unit = {
       buf append "  " * level
@@ -214,7 +215,7 @@ abstract class NodePrinters {
     }
 
     def traverse(tree: Tree): Unit = {
-      showPosition(tree)
+      print(showPosition(tree))
 
       tree match {
         case ApplyDynamic(fun, args)      => applyCommon(tree, fun, args)
@@ -234,7 +235,7 @@ abstract class NodePrinters {
 
         case ld @ LabelDef(name, params, rhs) =>
           printMultiline(tree) {
-            showNameAndPos(ld)
+            print(showNameAndPos(ld))
             traverseList("()", "params")(params)
             traverse(rhs)
           }

--- a/src/compiler/scala/tools/nsc/ast/Printers.scala
+++ b/src/compiler/scala/tools/nsc/ast/Printers.scala
@@ -34,7 +34,7 @@ trait Printers extends scala.reflect.internal.Printers { this: Global =>
         printTree(
             if (tree.isDef && tree.symbol != NoSymbol && tree.symbol.isInitialized) {
               tree match {
-                case ClassDef(_, _, _, impl @ Template(ps, noSelfType, body))
+                case ClassDef(_, _, _, impl @ Template(ps, `noSelfType`, body))
                 if (tree.symbol.thisSym != tree.symbol) =>
                   ClassDef(tree.symbol, Template(ps, ValDef(tree.symbol.thisSym), body))
                 case ClassDef(_, _, _, impl)           => ClassDef(tree.symbol, impl)
@@ -150,8 +150,8 @@ trait Printers extends scala.reflect.internal.Printers { this: Global =>
         // if a Block only continues one actual statement, just print it.
         case Block(stats, expr) =>
           allStatements(tree) match {
-            case List(x)            => printTree(x)
-            case xs                 => s()
+            case List(x) => printTree(x)
+            case _       => s()
           }
 
         // We get a lot of this stuff

--- a/src/compiler/scala/tools/nsc/ast/TreeBrowsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeBrowsers.scala
@@ -282,7 +282,7 @@ abstract class TreeBrowsers {
                 // skip through 1-ary trees
                 def expando(tree: Tree): List[Tree] = tree.children match {
                   case only :: Nil => only :: expando(only)
-                  case other => tree :: Nil
+                  case _ => tree :: Nil
                 }
 
                 val path = new TreePath((treeModel.getRoot :: unit :: expando(unit.unit.body)).toArray[AnyRef]) // targ necessary to disambiguate Object and Object[] ctors
@@ -465,10 +465,10 @@ abstract class TreeBrowsers {
       case Super(qualif, mix) =>
         List(qualif)
 
-      case This(qualif) =>
+      case This(_) =>
         Nil
 
-      case Select(qualif, selector) =>
+      case Select(qualif, _) =>
         List(qualif)
 
       case Ident(name) =>
@@ -486,7 +486,7 @@ abstract class TreeBrowsers {
       case SingletonTypeTree(ref) =>
         List(ref)
 
-      case SelectFromTypeTree(qualif, selector) =>
+      case SelectFromTypeTree(qualif, _) =>
         List(qualif)
 
       case CompoundTypeTree(templ) =>
@@ -619,13 +619,13 @@ abstract class TreeBrowsers {
                         toDocument(hi) :: ")")
         )
 
-       case RefinedType(parents, defs) =>
+       case RefinedType(parents, _) =>
         Document.group(
           Document.nest(4, "RefinedType(" :/:
                         toDocument(parents) :: ")")
         )
 
-      case ClassInfoType(parents, defs, clazz) =>
+      case ClassInfoType(parents, _, clazz) =>
         Document.group(
           Document.nest(4,"ClassInfoType(" :/:
                         toDocument(parents) :: ", " :/:

--- a/src/compiler/scala/tools/nsc/ast/TreeGen.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeGen.scala
@@ -13,12 +13,11 @@
 package scala.tools.nsc
 package ast
 
-import scala.annotation.tailrec
+import scala.annotation.{tailrec, unused}
 import scala.collection.mutable.ListBuffer
-import symtab.Flags._
-import scala.reflect.internal.util.FreshNameCreator
-import scala.reflect.internal.util.ListOfNil
+import scala.reflect.internal.util.{FreshNameCreator, ListOfNil}
 import scala.util.chaining._
+import symtab.Flags._
 
 /** XXX to resolve: TreeGen only assumes global is a SymbolTable, but
  *  TreeDSL at the moment expects a Global.  Can we get by with SymbolTable?
@@ -304,7 +303,7 @@ abstract class TreeGen extends scala.reflect.internal.TreeGen with TreeDSL {
     * @param name name for the new method
     * @param additionalFlags flags to be put on the method in addition to FINAL
     */
-  private def mkMethodForFunctionBody(localTyper: analyzer.Typer)
+  private def mkMethodForFunctionBody(@unused localTyper: analyzer.Typer)
                                      (owner: Symbol, fun: Function, name: TermName)
                                      (methParamProtos: List[Symbol] = fun.vparams.map(_.symbol),
                                       resTp: Type = functionResultType(fun.tpe),

--- a/src/compiler/scala/tools/nsc/ast/TreeInfo.scala
+++ b/src/compiler/scala/tools/nsc/ast/TreeInfo.scala
@@ -62,8 +62,8 @@ abstract class TreeInfo extends scala.reflect.internal.TreeInfo with MacroAnnoti
     // new B(v). Returns B and v.
     object Box {
       def unapply(t: Tree): Option[(Tree, Type)] = t match {
-        case Apply(sel @ Select(New(tpt), nme.CONSTRUCTOR), v :: Nil) => Some((v, tpt.tpe.finalResultType))
-        case _                                                        => None
+        case Apply(Select(New(tpt), nme.CONSTRUCTOR), v :: Nil) => Some((v, tpt.tpe.finalResultType))
+        case _                                                  => None
       }
     }
     // (new B(v)).unbox. returns v.

--- a/src/compiler/scala/tools/nsc/ast/Trees.scala
+++ b/src/compiler/scala/tools/nsc/ast/Trees.scala
@@ -204,7 +204,7 @@ trait Trees extends scala.reflect.internal.Trees { self: Global =>
         tree, transformer.transform(arg))
     case _: TypeTreeWithDeferredRefCheck =>
       transformer.treeCopy.TypeTreeWithDeferredRefCheck(tree)
-    case x => super.xtransform(transformer, tree)
+    case _ => super.xtransform(transformer, tree)
   }
 
   // Finally, no one uses resetAllAttrs anymore, so I'm removing it from the compiler.

--- a/src/compiler/scala/tools/nsc/ast/parser/MarkupParsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/MarkupParsers.scala
@@ -137,7 +137,7 @@ trait MarkupParsers {
 
             try handle.parseAttribute(r2p(start, mid, curOffset), tmp)
             catch {
-              case e: RuntimeException =>
+              case _: RuntimeException =>
                 errorAndResult("error parsing attribute value", parser.errorTermTree)
             }
 

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1286,7 +1286,7 @@ self =>
         val parents = ListBuffer.empty[Tree]
         var otherInfixOp: Tree = EmptyTree
         def collect(tpt: Tree): Unit = tpt match {
-          case AppliedTypeTree(op @ Ident(tpnme.AND), List(left, right)) =>
+          case AppliedTypeTree(Ident(tpnme.AND), List(left, right)) =>
             collect(left)
             collect(right)
           case AppliedTypeTree(op, args) if args.exists(arg => arg.pos.start < op.pos.point) =>
@@ -3090,8 +3090,8 @@ self =>
           }
           def warnNilary() = migrationWarning(nameOffset, unaryMsg("deprecated"), unaryMsg("unsupported"), since = "2.13.4", actions = action)
           vparamss match {
-            case List(List())                               => warnNilary()
-            case List(List(), x :: xs) if x.mods.isImplicit => warnNilary()
+            case List(List())                              => warnNilary()
+            case List(List(), x :: _) if x.mods.isImplicit => warnNilary()
             case _ => // ok
           }
         }

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1729,12 +1729,13 @@ self =>
             if (in.token == LBRACE) inBracesOrNil(enumerators())
             else inParensOrNil(enumerators())
           newLinesOpt()
-          if (in.token == YIELD) {
-            in.nextToken()
-            gen.mkFor(enums, gen.Yield(expr()))
-          } else {
-            gen.mkFor(enums, expr())
-          }
+          val body =
+            if (in.token == YIELD) {
+              in.nextToken()
+              gen.Yield(expr())
+            } else
+              expr()
+          gen.mkFor(enums, body)
         }
         def adjustStart(tree: Tree) =
           if (tree.pos.isRange && start < tree.pos.start)

--- a/src/compiler/scala/tools/nsc/ast/parser/Patch.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Patch.scala
@@ -12,5 +12,7 @@
 
 package scala.tools.nsc.ast.parser
 
-class Patch(off: Int, change: Change)
+import scala.annotation.unused
+
+class Patch(@unused off: Int, @unused change: Change)
 

--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -350,7 +350,7 @@ trait Scanners extends ScannersCommon {
     /** Are we in a `${ }` block? such that RBRACE exits back into multiline string. */
     private def inMultiLineInterpolatedExpression = {
       sepRegions match {
-        case RBRACE :: STRINGLIT :: STRINGPART :: rest => true
+        case RBRACE :: STRINGLIT :: STRINGPART :: _ => true
         case _ => false
       }
     }
@@ -1792,10 +1792,10 @@ trait Scanners extends ScannersCommon {
     def insertRBrace(): List[BracePatch] = {
       def insert(bps: List[BracePair]): List[BracePatch] = bps match {
         case List() => patches
-        case (bp @ BracePair(loff, lindent, roff, rindent, nested)) :: bps1 =>
+        case BracePair(loff, lindent, roff, rindent, nested) :: bps1 =>
           if (lindent <= rindent) insert(bps1)
           else {
-//           println("patch inside "+bp+"/"+line(loff)+"/"+lineStart(line(loff))+"/"+lindent"/"+rindent)//DEBUG
+//           println("patch inside "+bps.head+"/"+line(loff)+"/"+lineStart(line(loff))+"/"+lindent"/"+rindent)//DEBUG
             val patches1 = insert(nested)
             if (patches1 ne patches) patches1
             else {

--- a/src/compiler/scala/tools/nsc/ast/parser/SymbolicXMLBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/SymbolicXMLBuilder.scala
@@ -13,10 +13,11 @@
 package scala.tools.nsc
 package ast.parser
 
+import scala.annotation.unused
 import scala.collection.mutable
-import symtab.Flags.MUTABLE
 import scala.reflect.internal.util.ListOfNil
 import scala.reflect.internal.util.StringOps.splitWhere
+import symtab.Flags.MUTABLE
 
 /** This class builds instance of `Tree` that represent XML.
  *
@@ -28,7 +29,7 @@ import scala.reflect.internal.util.StringOps.splitWhere
  *
  *  @author  Burak Emir
  */
-abstract class SymbolicXMLBuilder(p: Parsers#Parser, preserveWS: Boolean) {
+abstract class SymbolicXMLBuilder(@unused p: Parsers#Parser, @unused preserveWS: Boolean) {
   val global: Global
   import global._
 

--- a/src/compiler/scala/tools/nsc/ast/parser/SyntaxAnalyzer.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/SyntaxAnalyzer.scala
@@ -38,12 +38,12 @@ abstract class SyntaxAnalyzer extends SubComponent with Parsers with MarkupParse
          md.mods.isSynthetic
       || md.mods.isParamAccessor
       || nme.isConstructorName(md.name)
-      || (md.name containsName nme.ANON_CLASS_NAME)
+      || md.name.containsName(nme.ANON_CLASS_NAME)
     )
 
     override def traverse(t: Tree): Unit = t match {
       case md: MemberDef if prune(md) =>
-      case md @ PackageDef(_, stats)  => traverseTrees(stats)
+      case PackageDef(_, stats)       => traverseTrees(stats)
       case md: ImplDef                => onMember(md) ; lower(traverseTrees(md.impl.body))
       case md: ValOrDefDef            => onMember(md) ; lower(traverse(md.rhs))
       case _                          => super.traverse(t)

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -15,14 +15,13 @@ package tools.nsc
 package backend.jvm
 
 import scala.PartialFunction.cond
-import scala.annotation.tailrec
-import scala.tools.asm
-import scala.tools.asm.{ClassWriter, Label}
+import scala.annotation.{tailrec, unused}
+import scala.tools.asm, asm.{ClassWriter, Label}
 import scala.tools.nsc.Reporting.WarningCategory
 import scala.tools.nsc.backend.jvm.BCodeHelpers.ScalaSigBytes
 import scala.tools.nsc.backend.jvm.BackendReporting._
 import scala.tools.nsc.reporters.NoReporter
-import scala.util.chaining.scalaUtilChainingOps
+import scala.util.chaining._
 
 /*
  *  Traits encapsulating functionality to convert Scala AST Trees into ASM ClassNodes.
@@ -266,7 +265,7 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
     /*
      * must-single-thread
      */
-    def apply(sym: Symbol, csymCompUnit: CompilationUnit, mainClass: Option[String]): Boolean = sym.hasModuleFlag && {
+    def apply(sym: Symbol, @unused csymCompUnit: CompilationUnit, mainClass: Option[String]): Boolean = sym.hasModuleFlag && {
       val warn = mainClass.fold(true)(_ == sym.fullNameString)
       def warnBadMain(msg: String, pos: Position): Unit = if (warn) runReporting.warning(pos,
         s"""|not a valid main method for ${sym.fullName('.')},
@@ -429,7 +428,7 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
      *
      *  must-single-thread
      */
-    def getAnnotPickle(jclassName: String, sym: Symbol): Option[AnnotationInfo] = {
+    def getAnnotPickle(@unused jclassName: String, sym: Symbol): Option[AnnotationInfo] = {
       currentRun.symData get sym match {
         case Some(pickle) if !sym.isModuleClass => // pickles for module classes are in the companion / mirror class
           val scalaAnnot = {
@@ -830,7 +829,7 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
      *
      * must-single-thread
      */
-    def addForwarders(jclass: asm.ClassVisitor, jclassName: String, moduleClass: Symbol): Unit = {
+    def addForwarders(jclass: asm.ClassVisitor, @unused jclassName: String, moduleClass: Symbol): Unit = {
       assert(moduleClass.isModuleClass, moduleClass)
 
       val linkedClass = moduleClass.companionClass

--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeSkelBuilder.scala
@@ -14,9 +14,10 @@ package scala.tools.nsc
 package backend
 package jvm
 
+import scala.annotation.unused
 import scala.collection.{immutable, mutable}
-import scala.tools.nsc.symtab._
 import scala.tools.asm
+import scala.tools.nsc.symtab._
 import GenBCode._
 import BackendReporting._
 
@@ -181,7 +182,7 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
     /*
      * must-single-thread
      */
-    private def initJClass(jclass: asm.ClassVisitor): Unit = {
+    private def initJClass(@unused jclass: asm.ClassVisitor): Unit = {
 
       val bType = classBTypeFromSymbol(claszSymbol)
       val superClass = bType.info.get.superClass.getOrElse(ObjectRef).internalName
@@ -710,7 +711,7 @@ abstract class BCodeSkelBuilder extends BCodeHelpers {
      *
      *  TODO document, explain interplay with `fabricateStaticInit()`
      */
-    private def appendToStaticCtor(dd: DefDef): Unit = {
+    private def appendToStaticCtor(@unused dd: DefDef): Unit = {
 
       def insertBefore(
             location: asm.tree.AbstractInsnNode,

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromClassfile.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromClassfile.scala
@@ -12,7 +12,7 @@
 
 package scala.tools.nsc.backend.jvm
 
-import scala.annotation.switch
+import scala.annotation.{switch, unused}
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import scala.tools.asm.Opcodes
@@ -82,7 +82,7 @@ abstract class BTypesFromClassfile {
     }
   }
 
-  private def computeClassInfoFromClassNode(classNode: ClassNode, classBType: ClassBType): Right[Nothing, ClassInfo] = {
+  private def computeClassInfoFromClassNode(classNode: ClassNode, @unused classBType: ClassBType): Right[Nothing, ClassInfo] = {
     val superClass = classNode.superName match {
       case null =>
         assert(classNode.name == ObjectRef.internalName, s"class with missing super type: ${classNode.name}")

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -643,7 +643,7 @@ abstract class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
   def mirrorClassClassBType(moduleClassSym: Symbol): ClassBType = {
     assert(isTopLevelModuleClass(moduleClassSym), s"not a top-level module class: $moduleClassSym")
     val internalName = moduleClassSym.javaBinaryNameString.stripSuffix(nme.MODULE_SUFFIX_STRING)
-    ClassBType(internalName, moduleClassSym, fromSymbol = true) { (c: ClassBType, moduleClassSym) =>
+    ClassBType(internalName, moduleClassSym, fromSymbol = true) { (_: ClassBType, moduleClassSym) =>
       val shouldBeLazy = moduleClassSym.isJavaDefined || !currentRun.compiles(moduleClassSym)
       val nested = Lazy.withLockOrEager(shouldBeLazy, exitingPickler(memberClassesForInnerClassTable(moduleClassSym)) map classBTypeFromSymbol)
       Right(ClassInfo(

--- a/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/CoreBTypes.scala
@@ -245,11 +245,11 @@ abstract class CoreBTypesFromSymbols[G <: Global] extends CoreBTypes {
 
   // Z -> MethodNameAndType(boxToBoolean,(Z)Ljava/lang/Boolean;)
   def srBoxesRuntimeBoxToMethods: Map[BType, MethodNameAndType] = _srBoxesRuntimeBoxToMethods.get
-  private[this] lazy val _srBoxesRuntimeBoxToMethods: LazyVar[Map[BType, MethodNameAndType]] = runLazy(srBoxesRuntimeMethods((primitive, boxed) => "boxTo" + boxed))
+  private[this] lazy val _srBoxesRuntimeBoxToMethods: LazyVar[Map[BType, MethodNameAndType]] = runLazy(srBoxesRuntimeMethods((_, boxed) => "boxTo" + boxed))
 
   // Z -> MethodNameAndType(unboxToBoolean,(Ljava/lang/Object;)Z)
   def srBoxesRuntimeUnboxToMethods: Map[BType, MethodNameAndType] = _srBoxesRuntimeUnboxToMethods.get
-  private[this] lazy val _srBoxesRuntimeUnboxToMethods: LazyVar[Map[BType, MethodNameAndType]] = runLazy(srBoxesRuntimeMethods((primitive, boxed) => "unboxTo" + primitive))
+  private[this] lazy val _srBoxesRuntimeUnboxToMethods: LazyVar[Map[BType, MethodNameAndType]] = runLazy(srBoxesRuntimeMethods((primitive, _) => "unboxTo" + primitive))
 
   private def singleParamOfClass(cls: Symbol) = (s: Symbol) => s.paramss match {
     case List(List(param)) => param.info.typeSymbol == cls

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/AliasingAnalyzer.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/AliasingAnalyzer.scala
@@ -463,7 +463,7 @@ class AliasSet(var set: Object /*SmallBitSet | Array[Long]*/, var size: Int) {
           bsAdd(this, value)
         }
     }
-    case bits: Array[Long] =>
+    case _: Array[Long] =>
       bsAdd(this, value)
   }
 
@@ -485,7 +485,7 @@ class AliasSet(var set: Object /*SmallBitSet | Array[Long]*/, var size: Int) {
         else if (value == s.c) {                       s.c = s.d; s.d = -1; size = 3 }
         else if (value == s.d) {                                  s.d = -1; size = 3 }
     }
-    case bits: Array[Long] =>
+    case _: Array[Long] =>
       bsRemove(this, value)
       if (this.size == 4)
         this.set = bsToSmall(this.set.asInstanceOf[Array[Long]])

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/BoxUnbox.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/BoxUnbox.scala
@@ -14,7 +14,7 @@ package scala.tools.nsc
 package backend.jvm
 package opt
 
-import scala.annotation.tailrec
+import scala.annotation.{tailrec, unused}
 import scala.collection.AbstractIterator
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
@@ -767,7 +767,7 @@ abstract class BoxUnbox {
       }
     }
 
-    def checkRefConsumer(insn: AbstractInsnNode, kind: Ref, prodCons: ProdConsAnalyzer): Option[BoxConsumer] = insn match {
+    def checkRefConsumer(insn: AbstractInsnNode, kind: Ref, @unused prodCons: ProdConsAnalyzer): Option[BoxConsumer] = insn match {
       case fi: FieldInsnNode if fi.owner == kind.refClass && fi.name == "elem" =>
         if (fi.getOpcode == GETFIELD) Some(StaticGetterOrInstanceRead(fi))
         else if (fi.getOpcode == PUTFIELD) Some(StaticSetterOrInstanceWrite(fi))

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
@@ -217,7 +217,7 @@ abstract class Inliner {
         }
         val indentString = " " * indent
         this match {
-          case s @ InlineLogSuccess(r, sizeBefore, sizeAfter) =>
+          case InlineLogSuccess(r, sizeBefore, sizeAfter) =>
             s"${indentString}inlined ${calleeString(r)} (${r.logText}). Before: $sizeBefore ins, after: $sizeAfter ins."
 
           case InlineLogRewrite(closureInit, invocations) =>

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/LocalOpt.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/LocalOpt.scala
@@ -905,7 +905,7 @@ object LocalOptImpls {
 
       // Ensure the length of `renumber`. Unused variable indices are mapped to -1.
       val minLength = if (isWide) index + 2 else index + 1
-      for (i <- renumber.length until minLength) renumber += -1
+      for (_ <- renumber.length until minLength) renumber += -1
 
       renumber(index) = index
       if (isWide) renumber(index + 1) = index
@@ -965,7 +965,7 @@ object LocalOptImpls {
     @tailrec
     def isEmpty(node: AbstractInsnNode): Boolean = node.getNext match {
       case null => true
-      case l: LineNumberNode => true
+      case _: LineNumberNode => true
       case n if n.getOpcode >= 0 => false
       case n => isEmpty(n)
     }

--- a/src/compiler/scala/tools/nsc/classpath/ClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ClassPath.scala
@@ -12,6 +12,7 @@
 
 package scala.tools.nsc.classpath
 
+import scala.annotation.unused
 import scala.reflect.io.AbstractFile
 import scala.tools.nsc.util.ClassRepresentation
 
@@ -78,10 +79,10 @@ private[nsc] case class PackageEntryImpl(name: String) extends PackageEntry
 
 private[nsc] trait NoSourcePaths {
   final def asSourcePathString: String = ""
-  final private[nsc] def sources(inPackage: PackageName): Seq[SourceFileEntry] = Seq.empty
+  final private[nsc] def sources(@unused inPackage: PackageName): Seq[SourceFileEntry] = Seq.empty
 }
 
 private[nsc] trait NoClassPaths {
   final def findClassFile(className: String): Option[AbstractFile] = None
-  private[nsc] final def classes(inPackage: PackageName): Seq[ClassFileEntry] = Seq.empty
+  private[nsc] final def classes(@unused inPackage: PackageName): Seq[ClassFileEntry] = Seq.empty
 }

--- a/src/compiler/scala/tools/nsc/classpath/ZipAndJarFileLookupFactory.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ZipAndJarFileLookupFactory.scala
@@ -252,7 +252,7 @@ final class FileBasedCache[K, T] {
     if (disableCache) Left("caching is disabled due to a policy setting")
     else if (!checkStamps) Right(paths)
     else {
-      val nonJarZips = urlsAndFiles.filter { case (url, file) => file == null || !Jar.isJarOrZip(file.file) }
+      val nonJarZips = urlsAndFiles.filter { case (_, file) => file == null || !Jar.isJarOrZip(file.file) }
       if (nonJarZips.nonEmpty) Left(s"caching is disabled because of the following classpath elements: ${nonJarZips.map(_._1).mkString(", ")}.")
       else Right(paths)
     }
@@ -267,7 +267,7 @@ final class FileBasedCache[K, T] {
       val fileKey = attrs.fileKey()
       Stamp(lastModified, attrs.size(), if (fileKey == null) NoFileKey else fileKey)
       } catch {
-        case ex: java.nio.file.NoSuchFileException =>
+        case _: java.nio.file.NoSuchFileException =>
           // Dummy stamp for (currently) non-existent file.
           Stamp(FileTime.fromMillis(0), -1, new Object)
       }

--- a/src/compiler/scala/tools/nsc/fsc/CompileServer.scala
+++ b/src/compiler/scala/tools/nsc/fsc/CompileServer.scala
@@ -152,7 +152,7 @@ class StandardCompileServer(fixPort: Int = 0) extends SocketServer(fixPort) {
       val c = compiler
       try new c.Run() compile command.files
       catch {
-        case ex @ FatalError(msg) =>
+        case FatalError(msg) =>
           reporter.error(null, "fatal error: " + msg)
           clearCompiler()
         case ex: Throwable =>

--- a/src/compiler/scala/tools/nsc/fsc/CompileSocket.scala
+++ b/src/compiler/scala/tools/nsc/fsc/CompileSocket.scala
@@ -105,7 +105,7 @@ class CompileSocket extends CompileOutputCommon {
     if (portsDir.list.toList.exists(_.name == fixPort.toString)) fixPort else -1
   } else portsDir.list.toList match {
     case Nil      => -1
-    case x :: xs  => try x.name.toInt catch {
+    case x :: _  => try x.name.toInt catch {
       case e: Exception => x.delete() ; throw e
     }
   }
@@ -161,8 +161,8 @@ class CompileSocket extends CompileOutputCommon {
 
     @tailrec
     def getsock(attempts: Int): Option[Socket] = attempts match {
-      case 0    => warn("Unable to establish connection to compilation daemon") ; None
-      case num  =>
+      case 0 => warn("Unable to establish connection to compilation daemon") ; None
+      case _ =>
         val port = if (create) getPort(vmArgs) else pollPort()
         if (port < 0) return None
 

--- a/src/compiler/scala/tools/nsc/fsc/ResidentScriptRunner.scala
+++ b/src/compiler/scala/tools/nsc/fsc/ResidentScriptRunner.scala
@@ -13,6 +13,7 @@
 package scala.tools.nsc
 package fsc
 
+import scala.annotation.unused
 import scala.reflect.io.Path
 import scala.util.control.NonFatal
 
@@ -38,7 +39,7 @@ class ResidentScriptRunner(settings: GenericRunnerSettings) extends AbstractScri
   }
 }
 
-final class DaemonKiller(settings: GenericRunnerSettings) extends ScriptRunner {
+final class DaemonKiller(@unused settings: GenericRunnerSettings) extends ScriptRunner {
   def runScript(script: String, scriptArgs: List[String]) = shutdownDaemon()
 
   def runScriptText(script: String, scriptArgs: List[String]) = shutdownDaemon()

--- a/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
@@ -387,7 +387,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
      * ElementValueList             ::= ElementValue {`,` ElementValue}
      */
     def annotation(): Tree = {
-      object LiteralK { def unapply(token: Token) = tryLiteral() }
+      object LiteralK { def unapply(@unused token: Token) = tryLiteral() }
 
       def elementValue(): Tree = in.token match {
         case LiteralK(k) => in.nextToken(); atPos(in.currentPos)(Literal(k))

--- a/src/compiler/scala/tools/nsc/plugins/Plugins.scala
+++ b/src/compiler/scala/tools/nsc/plugins/Plugins.scala
@@ -97,7 +97,7 @@ trait Plugins { global: Global =>
     val cache = pluginClassLoadersCache
     val checkStamps = policy == settings.CachePolicy.LastModified.name
     cache.checkCacheability(classpath.map(_.toURL), checkStamps, disableCache) match {
-      case Left(msg) =>
+      case Left(_) =>
         val loader = newLoader()
         closeableRegistry.registerCloseable(loader)
         loader

--- a/src/compiler/scala/tools/nsc/profile/Profiler.scala
+++ b/src/compiler/scala/tools/nsc/profile/Profiler.scala
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import javax.management.openmbean.CompositeData
 import javax.management.{Notification, NotificationEmitter, NotificationListener}
 
-import scala.annotation.nowarn
+import scala.annotation.{nowarn, unused}
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.internal.util.ChromeTrace
 import scala.reflect.io.AbstractFile
@@ -195,7 +195,7 @@ private [profile] class RealProfiler(reporter : ProfileReporter, val settings: S
     //we may miss a GC event if gc is occurring as we call this
     RealProfiler.gcMx foreach {
       case emitter: NotificationEmitter => emitter.removeNotificationListener(this)
-      case gc =>
+      case _ =>
     }
     reporter.close(this)
     if (chromeTrace != null) {
@@ -335,13 +335,12 @@ private [profile] class RealProfiler(reporter : ProfileReporter, val settings: S
     }
   }
 
-  private def completionName(root: Global#Symbol, associatedFile: AbstractFile): String = {
+  private def completionName(root: Global#Symbol, @unused associatedFile: AbstractFile): String =
     if (root.hasPackageFlag || root.isTopLevel) root.javaBinaryNameString
     else {
       val enclosing = root.enclosingTopLevelClass
       enclosing.javaBinaryNameString + "::" + root.rawname.toString
     }
-  }
 }
 
 object EventType extends Enumeration {

--- a/src/compiler/scala/tools/nsc/profile/ThreadPoolFactory.scala
+++ b/src/compiler/scala/tools/nsc/profile/ThreadPoolFactory.scala
@@ -16,6 +16,7 @@ import java.util.concurrent.ThreadPoolExecutor.AbortPolicy
 import java.util.concurrent._
 import java.util.concurrent.atomic.AtomicInteger
 
+import scala.annotation._
 import scala.tools.nsc.{Global, Phase}
 
 sealed trait ThreadPoolFactory {
@@ -44,7 +45,7 @@ object ThreadPoolFactory {
     private def childGroup(name: String) = new ThreadGroup(baseGroup, name)
 
     // Invoked when a new `Worker` is created, see `CommonThreadFactory.newThread`
-    protected def wrapWorker(worker: Runnable, shortId: String): Runnable = worker
+    protected def wrapWorker(worker: Runnable, @unused shortId: String): Runnable = worker
 
     protected final class CommonThreadFactory(
         shortId: String,

--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -818,8 +818,8 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
       @tailrec
       def loop(seen: List[String], args: List[String]): (List[String], List[String]) = args match {
         case Optionlike() :: _ if halting         => (seen, args)
-        case "help" :: rest if helpText.isDefined => sawHelp = true ; loop(seen, rest)
-        case head :: rest                         => loop(head :: seen, rest)
+        case "help" :: args if helpText.isDefined => sawHelp = true; loop(seen, args)
+        case head :: args                         => loop(head :: seen, args)
         case Nil                                  => (seen, Nil)
       }
       val (seen, rest) = loop(Nil, args)

--- a/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/MutableSettings.scala
@@ -286,14 +286,11 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
 
     /** Return the output directory for the given file.
      */
-    def outputDirFor(src: AbstractFile): AbstractFile = {
-      def isBelow(srcDir: AbstractFile, outDir: AbstractFile) = src.path.startsWith(srcDir.path)
-
-      singleOutDir.getOrElse(outputs.find((isBelow _).tupled) match {
+    def outputDirFor(src: AbstractFile): AbstractFile =
+      singleOutDir.getOrElse(outputs.find { case (srcDir, _) => src.path.startsWith(srcDir.path) } match {
         case Some((_, d)) => d
         case _ => throw new FatalError(s"Could not find an output directory for ${src.path} in ${outputs}")
       })
-    }
 
     /** Return the source file path(s) which correspond to the given
      *  classfile path and SourceFile attribute value, subject to the
@@ -312,19 +309,16 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
      *  output directory there will be two or more candidate source file
      *  paths.
      */
-    def srcFilesFor(classFile : AbstractFile, srcPath : String) : List[AbstractFile] = {
-      def isBelow(srcDir: AbstractFile, outDir: AbstractFile) = classFile.path.startsWith(outDir.path)
-
+    def srcFilesFor(classFile : AbstractFile, srcPath : String) : List[AbstractFile] =
       singleOutDir match {
         case Some(_: VirtualDirectory | _: io.ZipArchive) => Nil
         case Some(d) => List(d.lookupPathUnchecked(srcPath, directory = false))
         case None =>
-          (outputs filter (isBelow _).tupled) match {
+          outputs.filter { case (_, outDir) => classFile.path.startsWith(outDir.path) } match {
             case Nil => Nil
             case matches => matches.map(_._1.lookupPathUnchecked(srcPath, directory = false))
           }
       }
-    }
   }
 
   /** A base class for settings of all types.
@@ -333,7 +327,7 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
   abstract class Setting(val name: String, val helpDescription: String) extends AbsSetting with SettingValue {
 
     /** Will be called after this Setting is set for any extra work. */
-    private[this] var _postSetHook: this.type => Unit = (x: this.type) => ()
+    private[this] var _postSetHook: this.type => Unit = (_: this.type) => ()
     override def postSetHook(): Unit = _postSetHook(this)
     def withPostSetHook(f: this.type => Unit): this.type = { _postSetHook = f ; this }
 
@@ -885,7 +879,7 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
       case List("help")                   => sawHelp = true; SomeOfNil
       case List(x) if choices contains x  => value = x ; SomeOfNil
       case List(x)                        => errorAndValue("'" + x + "' is not a valid choice for '" + name + "'", None)
-      case xs                             => errorAndValue("'" + name + "' does not accept multiple arguments.", None)
+      case _                              => errorAndValue("'" + name + "' does not accept multiple arguments.", None)
     }
     def unparse: List[String] =
       if (value == default) Nil else List(name + ":" + value)
@@ -915,14 +909,13 @@ class MutableSettings(val errorFn: String => Unit, val pathFactory: PathFactory)
     private[this] var _v: T = Nil
     private[this] var _numbs: List[(Int,Int)] = Nil
     private[this] var _names: T = Nil
-    //protected var v: T = Nil
     protected def v: T = _v
     protected def v_=(t: T): Unit = {
       // throws NumberFormat on bad range (like -5-6)
-      def asRange(s: String): (Int,Int) = (s indexOf '-') match {
+      def asRange(s: String): (Int,Int) = s.indexOf('-') match {
         case -1 => (s.toInt, s.toInt)
         case 0  => (-1, s.tail.toInt)
-        case i if s.last == '-' => (s.init.toInt, Int.MaxValue)
+        case _ if s.last == '-' => (s.init.toInt, Int.MaxValue)
         case i  => (s.take(i).toInt, s.drop(i+1).toInt)
       }
       val numsAndStrs = t filter (_.nonEmpty) partition (_ forall (ch => ch.isDigit || ch == '-'))

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -352,10 +352,10 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
 
   // Allows a specialised jar to be written. For instance one that provides stable hashing of content, or customisation of the file storage
   val YjarFactory = StringSetting   ("-YjarFactory", "classname", "factory for jar files", classOf[DefaultJarFactory].getName)
-  val YaddBackendThreads = IntSetting   ("-Ybackend-parallelism", "maximum worker threads for backend", 1, Some((1,16)), (x: String) => None )
-  val YmaxQueue = IntSetting   ("-Ybackend-worker-queue", "backend threads worker queue size", 0, Some((0,1000)), (x: String) => None )
+  val YaddBackendThreads = IntSetting   ("-Ybackend-parallelism", "maximum worker threads for backend", 1, Some((1,16)), (_: String) => None )
+  val YmaxQueue = IntSetting   ("-Ybackend-worker-queue", "backend threads worker queue size", 0, Some((0,1000)), (_: String) => None )
   val YjarCompressionLevel = IntSetting("-Yjar-compression-level", "compression level to use when writing jar files",
-    Deflater.DEFAULT_COMPRESSION, Some((Deflater.DEFAULT_COMPRESSION,Deflater.BEST_COMPRESSION)), (x: String) => None)
+    Deflater.DEFAULT_COMPRESSION, Some((Deflater.DEFAULT_COMPRESSION,Deflater.BEST_COMPRESSION)), (_: String) => None)
   val YpickleJava = BooleanSetting("-Ypickle-java", "Pickler phase should compute pickles for .java defined symbols for use by build tools").internalOnly()
   val YpickleWrite = StringSetting("-Ypickle-write", "directory|jar", "destination for generated .sig files containing type signatures.", "", None).internalOnly()
   val YpickleWriteApiOnly = BooleanSetting("-Ypickle-write-api-only", "Exclude private members (other than those material to subclass compilation, such as private trait vals) from generated .sig files containing type signatures.").internalOnly()

--- a/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
@@ -16,11 +16,12 @@ package symtab
 import classfile.{ClassfileParser, ReusableDataReader}
 import java.io.IOException
 
+import scala.annotation._
 import scala.reflect.internal.MissingRequirementError
-import scala.reflect.io.{AbstractFile, NoAbstractFile}
-import scala.tools.nsc.util.{ClassPath, ClassRepresentation}
 import scala.reflect.internal.util.ReusableInstance
+import scala.reflect.io.{AbstractFile, NoAbstractFile}
 import scala.tools.nsc.Reporting.WarningCategory
+import scala.tools.nsc.util.{ClassPath, ClassRepresentation}
 
 /** This class ...
  *
@@ -50,7 +51,7 @@ abstract class SymbolLoaders {
   // forwards to runReporting.warning, but we don't have global in scope here
   def warning(pos: Position, msg: String, category: WarningCategory, site: String): Unit
 
-  protected def enterIfNew(owner: Symbol, member: Symbol, completer: SymbolLoader): Symbol = {
+  protected def enterIfNew(owner: Symbol, member: Symbol, @unused completer: SymbolLoader): Symbol = {
     assert(owner.info.decls.lookup(member.name) == NoSymbol, owner.fullName + "." + member.name)
     owner.info.decls enter member
     member

--- a/src/compiler/scala/tools/nsc/tasty/TreeUnpickler.scala
+++ b/src/compiler/scala/tools/nsc/tasty/TreeUnpickler.scala
@@ -16,7 +16,7 @@ import scala.tools.tasty.{TastyRefs, TastyReader, TastyName, TastyFormat, TastyF
 import TastyRefs._, TastyFlags._, TastyFormat._
 import ForceKinds._
 
-import scala.annotation.switch
+import scala.annotation.{switch, unused}
 import scala.collection.mutable
 import scala.reflect.io.AbstractFile
 import scala.reflect.internal.Variance
@@ -162,7 +162,7 @@ class TreeUnpickler[Tasty <: TastyUniverse](
       tag match {
         case VALDEF | DEFDEF | TYPEDEF | TYPEPARAM | PARAM | TEMPLATE =>
           val end = readEnd()
-          for (i <- 0 until numRefs(tag)) readNat()
+          for (_ <- 0 until numRefs(tag)) readNat()
           if (tag === TEMPLATE) {
             // Read all member definitions now, whereas non-members are children of
             // template's owner tree.
@@ -179,7 +179,7 @@ class TreeUnpickler[Tasty <: TastyUniverse](
             val end = readEnd()
             val nrefs = numRefs(tag)
             if (nrefs < 0) {
-              for (i <- nrefs until 0) scanTree(buf, AllDefs)
+              for (_ <- nrefs until 0) scanTree(buf, AllDefs)
               goto(end)
             }
             else {
@@ -514,7 +514,7 @@ class TreeUnpickler[Tasty <: TastyUniverse](
       flags
     }
 
-    def isAbstractType(ttag: Int)(implicit ctx: Context): Boolean = nextUnsharedTag match {
+    def isAbstractType(@unused ttag: Int)(implicit ctx: Context): Boolean = nextUnsharedTag match {
       case LAMBDAtpt =>
         val rdr = fork
         rdr.reader.readByte()  // tag
@@ -744,7 +744,7 @@ class TreeUnpickler[Tasty <: TastyUniverse](
     def indexStats(end: Addr)(implicit ctx: Context): Unit = {
       while (currentAddr.index < end.index) {
         nextByte match {
-          case tag @ (VALDEF | DEFDEF | TYPEDEF | TYPEPARAM | PARAM) =>
+          case VALDEF | DEFDEF | TYPEDEF | TYPEPARAM | PARAM =>
             symbolAtCurrent()
             skipTree()
           case IMPORT | EXPORT =>
@@ -1056,7 +1056,7 @@ class TreeUnpickler[Tasty <: TastyUniverse](
 
     def isTopLevel: Boolean = nextByte === IMPORT || nextByte === PACKAGE
 
-    def readIndexedStatAsSym(exprOwner: Symbol)(implicit ctx: Context): NoCycle = nextByte match {
+    def readIndexedStatAsSym(@unused exprOwner: Symbol)(implicit ctx: Context): NoCycle = nextByte match {
       case TYPEDEF | VALDEF | DEFDEF =>
         readIndexedMember()
       case IMPORT =>
@@ -1313,7 +1313,7 @@ class TreeUnpickler[Tasty <: TastyUniverse](
   private def traceReadWith[T](treader: TreeReader, mode: TastyMode, owner: Symbol) = TraceInfo[T](
     query = "read within owner",
     qual = s"${showSym(owner)} with modes `${mode.debug}` at ${treader.reader.currentAddr}",
-    res = t => s"exiting sub reader"
+    res = _ => s"exiting sub reader"
   )
 
   /** A lazy datastructure that records how definitions are nested in TASTY data.

--- a/src/compiler/scala/tools/nsc/tasty/bridge/ContextOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/ContextOps.scala
@@ -12,12 +12,10 @@
 
 package scala.tools.nsc.tasty.bridge
 
-import scala.annotation.tailrec
-
+import scala.annotation._
 import scala.collection.mutable
-import scala.reflect.io.AbstractFile
 import scala.reflect.internal.MissingRequirementError
-
+import scala.reflect.io.AbstractFile
 import scala.tools.tasty.{TastyName, TastyFlags}, TastyFlags._, TastyName.ObjectName
 import scala.tools.nsc.tasty.{TastyUniverse, TastyModes, SafeEq}, TastyModes._
 import scala.tools.nsc.tasty.{cyan, yellow, magenta, blue, green}
@@ -521,7 +519,7 @@ trait ContextOps { self: TastyUniverse =>
     final def processParents(cls: Symbol, parentTypes: List[Type]): parentTypes.type = {
       if (parentTypes.head.typeSymbolDirect === u.definitions.AnyValClass) {
         // TODO [tasty]: please reconsider if there is some shared optimised logic that can be triggered instead.
-        withPhaseNoLater("extmethods") { ctx0 =>
+        withPhaseNoLater("extmethods") { _ =>
           // duplicated from scala.tools.nsc.transform.ExtensionMethods
           cls.primaryConstructor.makeNotPrivate(noSymbol)
           for (decl <- cls.info.decls if decl.isMethod) {
@@ -781,7 +779,7 @@ trait ContextOps { self: TastyUniverse =>
           enterIfUnseen0(decls, d)
       }
 
-      def reportParameterizedTrait(cls: Symbol, decls: u.Scope): Unit = {
+      def reportParameterizedTrait(cls: Symbol, @unused decls: u.Scope): Unit = {
         val traitParams = traitParamAccessors(cls).getOrElse(Iterable.empty)
         if (traitParams.nonEmpty) {
           log {

--- a/src/compiler/scala/tools/nsc/tasty/bridge/SymbolOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/SymbolOps.scala
@@ -12,7 +12,7 @@
 
 package scala.tools.nsc.tasty.bridge
 
-import scala.annotation.tailrec
+import scala.annotation._
 import scala.tools.nsc.tasty.{SafeEq, TastyUniverse, ForceKinds, TastyModes}, TastyModes._, ForceKinds._
 import scala.tools.tasty.{TastyName, Signature, TastyFlags}, TastyName.SignedName, Signature.MethodSignature, TastyFlags._
 import scala.tools.tasty.ErasedTypeRef
@@ -84,7 +84,7 @@ trait SymbolOps { self: TastyUniverse =>
     def repr: TastyRepr = {
       try sym.rawInfo.asInstanceOf[TastyRepr]
       catch {
-        case err: ClassCastException =>
+        case _: ClassCastException =>
           val raw = u.showRaw(sym.rawInfo)
           val tastyRepr = u.typeOf[TastyRepr]
           throw new AssertionError(s"$sym is already completed. Expected $tastyRepr, is $raw.")
@@ -123,9 +123,9 @@ trait SymbolOps { self: TastyUniverse =>
   def symIsExperimental(sym: Symbol) = sym.hasAnnotation(defn.ExperimentalAnnotationClass)
 
   /** if isConstructor, make sure it has one non-implicit parameter list */
-  def normalizeIfConstructor(owner: Symbol, termParamss: List[List[Symbol]], paramClauses: List[List[NoCycle]], isConstructor: Boolean): List[List[Symbol]] =
+  def normalizeIfConstructor(@unused owner: Symbol, termParamss: List[List[Symbol]], paramClauses: List[List[NoCycle]], isConstructor: Boolean): List[List[Symbol]] =
     if (!isConstructor) termParamss
-    else {
+    else
       paramClauses match {
         case (vparam :: _) :: _ if vparam.tflags.is(Implicit, butNot=Given) => Nil :: termParamss
         case _ =>
@@ -135,7 +135,6 @@ trait SymbolOps { self: TastyUniverse =>
             termParamss
           }
       }
-    }
 
   private[bridge] def lookupSymbol(space: Type, tname: TastyName)(implicit ctx: Context): Symbol = {
     deepComplete(space)

--- a/src/compiler/scala/tools/nsc/tasty/bridge/TypeOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/TypeOps.scala
@@ -339,15 +339,15 @@ trait TypeOps { self: TastyUniverse =>
           case _ => tp
         }
         prefix match {
-          case pre: u.TypeRef => processInner(u.typeRef(prefix, sym, Nil)) // e.g. prefix is `Foo[Int]`
-          case _              => processInner(sym.tpeHK) // ignore prefix otherwise
+          case _: u.TypeRef => processInner(u.typeRef(prefix, sym, Nil)) // e.g. prefix is `Foo[Int]`
+          case _            => processInner(sym.tpeHK) // ignore prefix otherwise
         }
       }
       else if (sym.isType) {
         prefix match {
-          case tp: u.ThisType if !sym.isTypeParameter     => u.typeRef(prefix, sym, Nil)
-          case _:u.SingleType | _:u.RefinedType           => u.typeRef(prefix, sym, Nil)
-          case _                                          => u.appliedType(sym, Nil)
+          case _: u.ThisType if !sym.isTypeParameter => u.typeRef(prefix, sym, Nil)
+          case _:u.SingleType | _:u.RefinedType      => u.typeRef(prefix, sym, Nil)
+          case _                                     => u.appliedType(sym, Nil)
         }
       }
       else { // is a term
@@ -457,7 +457,7 @@ trait TypeOps { self: TastyUniverse =>
      *  Do the same for by name types => From[T] and => To[T]
      */
     def translateParameterized(self: Type)(from: u.ClassSymbol, to: u.ClassSymbol, wildcardArg: Boolean): Type = self match {
-      case self @ u.NullaryMethodType(tp) =>
+      case u.NullaryMethodType(tp) =>
         u.NullaryMethodType(translateParameterized(tp)(from, to, wildcardArg = false))
       case _ =>
         if (self.typeSymbol.isSubClass(from)) {

--- a/src/compiler/scala/tools/nsc/transform/AccessorSynthesis.scala
+++ b/src/compiler/scala/tools/nsc/transform/AccessorSynthesis.scala
@@ -328,7 +328,7 @@ trait AccessorSynthesis extends Transform with ast.TreeDSL {
             // TODO is this case ever hit? constructors does not generate Assigns with EmptyTree for the rhs AFAICT
             // !!! Ident(self) is never referenced, is it supposed to be confirming
             // that self is anything in particular?
-            case Apply(lhs@Select(Ident(self), _), EmptyTree.asList) if lhs.symbol.isSetter => Nil
+            case Apply(lhs@Select(Ident(_), _), EmptyTree.asList) if lhs.symbol.isSetter => Nil
             case stat => List(stat)
           }
 

--- a/src/compiler/scala/tools/nsc/transform/Constructors.scala
+++ b/src/compiler/scala/tools/nsc/transform/Constructors.scala
@@ -13,6 +13,7 @@
 package scala.tools.nsc
 package transform
 
+import scala.annotation._
 import scala.collection.mutable
 import scala.reflect.internal.util.ListOfNil
 import scala.tools.nsc.Reporting.WarningCategory
@@ -158,7 +159,7 @@ abstract class Constructors extends Statics with Transform with TypingTransforme
    *
    */
   private trait OmittablesHelper {
-    def computeOmittableAccessors(clazz: Symbol, defs: List[Tree], auxConstructors: List[Tree], constructor: List[Tree]): Set[Symbol] = {
+    def computeOmittableAccessors(clazz: Symbol, defs: List[Tree], auxConstructors: List[Tree], @unused constructor: List[Tree]): Set[Symbol] = {
       val decls = clazz.info.decls.toSet
       val isEffectivelyFinal = clazz.isEffectivelyFinal
 
@@ -306,7 +307,7 @@ abstract class Constructors extends Statics with Transform with TypingTransforme
     }
 
     /** For a DelayedInit subclass, wrap remainingConstrStats into a DelayedInit closure. */
-    def delayedInitDefsAndConstrStats(defs: List[Tree], remainingConstrStats: List[Tree]): (List[Tree], List[Tree]) = {
+    def delayedInitDefsAndConstrStats(@unused defs: List[Tree], remainingConstrStats: List[Tree]): (List[Tree], List[Tree]) = {
       val delayedHook     = delayedEndpointDef(remainingConstrStats)
       val delayedHookSym  = delayedHook.symbol.asInstanceOf[MethodSymbol]
 
@@ -355,7 +356,7 @@ abstract class Constructors extends Statics with Transform with TypingTransforme
         val arrayUpdateMethod = currentRun.runDefinitions.arrayUpdateMethod
         val adapter = new AstTransformer {
           override def transform(t: Tree): Tree = t match {
-            case Apply(fun @ Select(receiver, method), List(xs, idx, v)) if fun.symbol == arrayUpdateMethod =>
+            case Apply(fun @ Select(_, _), List(xs, idx, v)) if fun.symbol == arrayUpdateMethod =>
               localTyper.typed(Apply(gen.mkAttributedSelect(xs, arrayUpdateMethod), List(idx, v)))
             case _ => super.transform(t)
           }

--- a/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
+++ b/src/compiler/scala/tools/nsc/transform/Delambdafy.scala
@@ -15,6 +15,7 @@ package transform
 
 import symtab._
 import Flags._
+import scala.annotation._
 import scala.collection.mutable
 
 /**
@@ -148,7 +149,7 @@ abstract class Delambdafy extends Transform with TypingTransformers with ast.Tre
     }
 
     // determine which lambda target to use with java's LMF -- create a new one if scala-specific boxing is required
-    def createBoxingBridgeMethodIfNeeded(fun: Function, target: Symbol, functionalInterface: Symbol, sam: Symbol): Symbol = {
+    def createBoxingBridgeMethodIfNeeded(fun: Function, target: Symbol, @unused functionalInterface: Symbol, sam: Symbol): Symbol = {
       val oldClass = fun.symbol.enclClass
       val pos = fun.pos
 

--- a/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
+++ b/src/compiler/scala/tools/nsc/transform/ExplicitOuter.scala
@@ -392,7 +392,7 @@ abstract class ExplicitOuter extends InfoTransform
         if (sym.isProtected && !sym.isJavaDefined) sym setFlag notPROTECTED
       }
       tree match {
-        case Template(parents, self, decls) =>
+        case Template(_, _, _) =>
           val newDefs = new ListBuffer[Tree]
           atOwner(tree, currentOwner) {
             if (!currentClass.isInterface) {
@@ -468,7 +468,7 @@ abstract class ExplicitOuter extends InfoTransform
         // for the pattern matcher
         // base.<outer>.eq(o) --> base.$outer().eq(o) if there's an accessor, else the whole tree becomes TRUE
         // TODO remove the synthetic `<outer>` method from outerFor??
-        case Apply(eqsel@Select(eqapp@Apply(sel@Select(base, nme.OUTER_SYNTH), Nil), eq), args) =>
+        case Apply(eqsel@Select(Apply(sel@Select(base, nme.OUTER_SYNTH), Nil), eq), args) =>
           val outerFor = sel.symbol.owner
           val acc = outerAccessor(outerFor)
 

--- a/src/compiler/scala/tools/nsc/transform/Fields.scala
+++ b/src/compiler/scala/tools/nsc/transform/Fields.scala
@@ -13,7 +13,7 @@
 package scala.tools.nsc
 package transform
 
-import scala.annotation.tailrec
+import scala.annotation._
 import scala.reflect.internal.util.ListOfNil
 import symtab.Flags._
 
@@ -119,7 +119,7 @@ abstract class Fields extends InfoTransform with ast.TreeDSL with TypingTransfor
   }
 
   // TODO: add MIXEDIN (see e.g., `accessed` on `Symbol`)
-  private def setMixedinAccessorFlags(orig: Symbol, cloneInSubclass: Symbol): Unit =
+  private def setMixedinAccessorFlags(@unused orig: Symbol, cloneInSubclass: Symbol): Unit =
     cloneInSubclass setFlag OVERRIDE | NEEDS_TREES resetFlag DEFERRED | SYNTHESIZE_IMPL_IN_SUBCLASS
 
   private def setFieldFlags(accessor: Symbol, fieldInSubclass: TermSymbol): Unit = {
@@ -375,7 +375,7 @@ abstract class Fields extends InfoTransform with ast.TreeDSL with TypingTransfor
         } else tp
 
 
-      case tp@ClassInfoType(parents, oldDecls, clazz) if !classNeedsInfoTransform(clazz) => tp
+      case tp@ClassInfoType(_, _, clazz) if !classNeedsInfoTransform(clazz) => tp
 
       // mix in fields & accessors for all mixed in traits
       case tp@ClassInfoType(parents, oldDecls, clazz) =>

--- a/src/compiler/scala/tools/nsc/transform/Mixin.scala
+++ b/src/compiler/scala/tools/nsc/transform/Mixin.scala
@@ -616,7 +616,7 @@ abstract class Mixin extends Transform with ast.TreeDSL with AccessorSynthesis {
       val sym = tree.symbol
 
       tree match {
-        case templ @ Template(parents, self, body) =>
+        case Template(parents, self, body) =>
           // change parents of templates to conform to parents in the symbol info
           val parents1 = currentOwner.info.parents map (t => TypeTree(t) setPos tree.pos)
 

--- a/src/compiler/scala/tools/nsc/transform/SampleTransform.scala
+++ b/src/compiler/scala/tools/nsc/transform/SampleTransform.scala
@@ -13,6 +13,8 @@
 package scala.tools.nsc
 package transform
 
+import scala.annotation._
+
 /** A sample transform.
  */
 abstract class SampleTransform extends Transform {
@@ -27,7 +29,7 @@ abstract class SampleTransform extends Transform {
   protected def newTransformer(unit: CompilationUnit): AstTransformer =
     new SampleTransformer(unit)
 
-  class SampleTransformer(unit: CompilationUnit) extends AstTransformer {
+  class SampleTransformer(@unused unit: CompilationUnit) extends AstTransformer {
 
     override def transform(tree: Tree): Tree = {
       val tree1 = super.transform(tree);      // transformers always maintain `currentOwner`.

--- a/src/compiler/scala/tools/nsc/transform/TypeAdaptingTransformer.scala
+++ b/src/compiler/scala/tools/nsc/transform/TypeAdaptingTransformer.scala
@@ -62,7 +62,7 @@ trait TypeAdaptingTransformer { self: TreeDSL =>
             case x =>
               assert(x != ArrayClass, "array")
               tree match {
-                case Apply(boxFun, List(arg)) if isSafelyRemovableUnbox(tree, arg) =>
+                case Apply(_, List(arg)) if isSafelyRemovableUnbox(tree, arg) =>
                   arg
                 case _ =>
                   (REF(currentRun.runDefinitions.boxMethod(x)) APPLY tree) setPos (tree.pos) setType ObjectTpe
@@ -87,8 +87,8 @@ trait TypeAdaptingTransformer { self: TreeDSL =>
           if (treeInfo isExprSafeToInline side) value
           else BLOCK(side, value)
         val tree1 = pt match {
-          case ErasedValueType(clazz, BoxedUnitTpe) => cast(preservingSideEffects(tree, REF(BoxedUnit_UNIT)), pt)
-          case ErasedValueType(clazz, underlying)   => cast(unboxValueClass(tree, clazz, underlying), pt)
+          case ErasedValueType(_, BoxedUnitTpe) => cast(preservingSideEffects(tree, REF(BoxedUnit_UNIT)), pt)
+          case ErasedValueType(clazz, underlying) => cast(unboxValueClass(tree, clazz, underlying), pt)
           case _ =>
             pt.typeSymbol match {
               case UnitClass  =>

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -194,7 +194,7 @@ abstract class UnCurry extends InfoTransform
 
         import treeInfo.{catchesThrowable, isSyntheticCase}
         for {
-          Try(t, catches, _) <- body
+          Try(_, catches, _) <- body
           cdef <- catches
           if catchesThrowable(cdef) && !isSyntheticCase(cdef)
         } {
@@ -398,7 +398,7 @@ abstract class UnCurry extends InfoTransform
      *  all lambda impl methods as static.
      */
     private def translateSynchronized(tree: Tree) = tree match {
-      case dd @ DefDef(_, _, _, _, _, Apply(fn, body :: Nil)) if isSelfSynchronized(dd) =>
+      case dd @ DefDef(_, _, _, _, _, Apply(_, body :: Nil)) if isSelfSynchronized(dd) =>
         log("Translating " + dd.symbol.defString + " into synchronized method")
         dd.symbol setFlag SYNCHRONIZED
         deriveDefDef(dd)(_ => body)
@@ -838,7 +838,7 @@ abstract class UnCurry extends InfoTransform
 
       val theTyper = typer.atOwner(dd, currentClass)
       val forwTree = theTyper.typedPos(dd.pos) {
-        val seqArgs = map3(newPs, oldPs, isRepeated)((param, oldParam, isRep) => {
+        val seqArgs = map3(newPs, oldPs, isRepeated)((param, _, isRep) => {
           if (!isRep) Ident(param)
           else {
             val parTp = elementType(ArrayClass, param.tpe)

--- a/src/compiler/scala/tools/nsc/transform/async/AnfTransform.scala
+++ b/src/compiler/scala/tools/nsc/transform/async/AnfTransform.scala
@@ -177,7 +177,7 @@ private[async] trait AnfTransform extends TransformUtils {
             treeCopy.Match(tree, scrutExpr, casesWithAssign)
           }
 
-        case ld@LabelDef(name, params, rhs) =>
+        case LabelDef(name, params, rhs) =>
           treeCopy.LabelDef(tree, name, params, transformNewControlFlowBlock(rhs))
         case t@Typed(expr, tpt)             =>
           transform(expr).setType(t.tpe)
@@ -318,11 +318,11 @@ private[async] trait AnfTransform extends TransformUtils {
       val statsExpr0: ArrayBuffer[Tree] = new ArrayBuffer[Tree](statsExpr.length)
 
       statsExpr.reverseIterator.foreach {
-        case ld@LabelDef(_, param :: Nil, _) =>
+        case ld@LabelDef(_, _ :: Nil, _) =>
           val (ld1, after) = modifyLabelDef(ld)
           statsExpr0 += after
           statsExpr0 += ld1
-        case a@ValDef(mods, name, tpt, ld@LabelDef(_, param :: Nil, _)) =>
+        case a@ValDef(mods, name, tpt, ld@LabelDef(_, _ :: Nil, _)) =>
           val (ld1, after) = modifyLabelDef(ld)
           statsExpr0 += treeCopy.ValDef(a, mods, name, tpt, after)
           statsExpr0 += ld1

--- a/src/compiler/scala/tools/nsc/transform/async/AsyncPhase.scala
+++ b/src/compiler/scala/tools/nsc/transform/async/AsyncPhase.scala
@@ -48,7 +48,7 @@ abstract class AsyncPhase extends Transform with TypingTransformers with AnfTran
       reporter.warning(pos, s"${settings.async.name} must be enabled for async transformation.")
     sourceFilesToTransform += pos.source
     val postAnfTransform = config.getOrElse("postAnfTransform", (x: Block) => x).asInstanceOf[Block => Block]
-    val stateDiagram = config.getOrElse("stateDiagram", (sym: Symbol, tree: Tree) => None).asInstanceOf[(Symbol, Tree) => Option[String => Unit]]
+    val stateDiagram = config.getOrElse("stateDiagram", (_: Symbol, _: Tree) => None).asInstanceOf[(Symbol, Tree) => Option[String => Unit]]
     val allowExceptionsToPropagate = config.contains("allowExceptionsToPropagate")
     method.updateAttachment(new AsyncAttachment(awaitMethod, postAnfTransform, stateDiagram, allowExceptionsToPropagate))
     // Wrap in `{ expr: Any }` to force value class boxing before calling `completeSuccess`, see test/async/run/value-class.scala
@@ -124,7 +124,7 @@ abstract class AsyncPhase extends Transform with TypingTransformers with AnfTran
         case dd: DefDef if dd.hasAttachment[AsyncAttachment] =>
           val asyncAttachment = dd.getAndRemoveAttachment[AsyncAttachment].get
           val asyncBody = (dd.rhs: @unchecked) match {
-            case blk@Block(Apply(qual, body :: Nil) :: Nil, Literal(Constant(()))) => body
+            case Block(Apply(_, body :: Nil) :: Nil, Literal(Constant(()))) => body
           }
 
           atOwner(dd, dd.symbol) {

--- a/src/compiler/scala/tools/nsc/transform/async/ExprBuilder.scala
+++ b/src/compiler/scala/tools/nsc/transform/async/ExprBuilder.scala
@@ -525,7 +525,7 @@ trait ExprBuilder extends TransformUtils with AsyncAnalysis {
       private val compactStateTransform = new AstTransformer {
         val transformState = currentTransformState
         override def transform(tree: Tree): Tree = tree match {
-          case as @ Apply(qual: Select, (lit @ Literal(Constant(i: Integer))) :: Nil) if qual.symbol == transformState.stateSetter && compactStates =>
+          case Apply(qual: Select, (lit @ Literal(Constant(i: Integer))) :: Nil) if qual.symbol == transformState.stateSetter && compactStates =>
             val replacement = switchIdOf(i)
             treeCopy.Apply(tree, qual, treeCopy.Literal(lit, Constant(replacement)):: Nil)
           case _: Match | _: CaseDef | _: Block | _: If | _: LabelDef =>

--- a/src/compiler/scala/tools/nsc/transform/async/Lifter.scala
+++ b/src/compiler/scala/tools/nsc/transform/async/Lifter.scala
@@ -95,7 +95,7 @@ trait Lifter extends ExprBuilder {
 
     // The definitions trees
     val symToTree: mutable.LinkedHashMap[Symbol, Tree] = defs.map {
-      case (k, v) => (k.symbol, k)
+      case (k, _) => (k.symbol, k)
     }
 
     // The direct references of each definition tree
@@ -182,7 +182,7 @@ trait Lifter extends ExprBuilder {
                 case NoSymbol    =>
                   sym.setName(currentTransformState.name.freshen(sym.name.toTypeName))
                   sym.setName(sym.name.toTypeName)
-                case classSymbol => // will be renamed by above.
+                case classSymbol@_ => // will be renamed by above.
               }
               treeCopy.ClassDef(cd, Modifiers(sym.flags), sym.name, tparams, impl)
             }

--- a/src/compiler/scala/tools/nsc/transform/async/LiveVariables.scala
+++ b/src/compiler/scala/tools/nsc/transform/async/LiveVariables.scala
@@ -12,6 +12,7 @@
 
 package scala.tools.nsc.transform.async
 
+import scala.annotation._
 import scala.collection.immutable.ArraySeq
 import scala.collection.mutable
 import scala.reflect.internal.Flags._
@@ -28,7 +29,7 @@ trait LiveVariables extends ExprBuilder {
    *  @param   liftables   the lifted fields
    *  @return              a map which indicates fields which are used for the final time in each state.
    */
-  def fieldsToNullOut(asyncStates: List[AsyncState], finalState: AsyncState,
+  def fieldsToNullOut(asyncStates: List[AsyncState], @unused finalState: AsyncState,
                       liftables: List[Tree]): mutable.LinkedHashMap[Int, (mutable.LinkedHashSet[Symbol], mutable.LinkedHashSet[Symbol])] = {
 
     val liftedSyms = mutable.LinkedHashSet[Symbol]()

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchAnalysis.scala
@@ -12,7 +12,7 @@
 
 package scala.tools.nsc.transform.patmat
 
-import scala.annotation.tailrec
+import scala.annotation._
 import scala.collection.mutable
 import scala.tools.nsc.Reporting.WarningCategory
 
@@ -461,7 +461,7 @@ trait MatchAnalysis extends MatchApproximation {
     // the case is reachable if there is a model for -P /\ C,
     // thus, the case is unreachable if there is no model for -(-P /\ C),
     // or, equivalently, P \/ -C, or C => P
-    def unreachableCase(prevBinder: Symbol, cases: List[List[TreeMaker]], pt: Type): Option[Int] = {
+    def unreachableCase(prevBinder: Symbol, cases: List[List[TreeMaker]], @unused pt: Type): Option[Int] = {
       debug.patmat("reachability analysis")
       val start = if (settings.areStatisticsEnabled) statistics.startTimer(statistics.patmatAnaReach) else null
 
@@ -519,7 +519,7 @@ trait MatchAnalysis extends MatchApproximation {
 
     // exhaustivity
 
-    def exhaustive(prevBinder: Symbol, cases: List[List[TreeMaker]], pt: Type): List[String] = if (!settings.warnStrictUnsealedPatMat && uncheckableType(prevBinder.info)) Nil else {
+    def exhaustive(prevBinder: Symbol, cases: List[List[TreeMaker]], @unused pt: Type): List[String] = if (!settings.warnStrictUnsealedPatMat && uncheckableType(prevBinder.info)) Nil else {
       debug.patmat("exhaustiveness analysis")
       // customize TreeMakersToProps (which turns a tree of tree makers into a more abstract DAG of tests)
       // - approximate the pattern `List()` (unapplySeq on List with empty length) as `Nil`,
@@ -788,7 +788,7 @@ trait MatchAnalysis extends MatchApproximation {
       object VariableAssignment {
         private def findVar(path: List[Symbol]) = path match {
           case List(root) if root == scrutVar.path.symbol => Some(scrutVar)
-          case _ => varAssignment.find{case (v, a) => chop(v.path) == path}.map(_._1)
+          case _ => varAssignment.find{case (v, _) => chop(v.path) == path}.map(_._1)
         }
 
         private val uniques = new mutable.HashMap[Var, VariableAssignment]

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
@@ -12,7 +12,7 @@
 
 package scala.tools.nsc.transform.patmat
 
-import scala.annotation.tailrec
+import scala.annotation._
 import scala.collection.mutable
 import scala.tools.nsc.symtab.Flags.{MUTABLE, STABLE}
 import scala.tools.nsc.Reporting.WarningCategory
@@ -35,7 +35,7 @@ trait MatchOptimization extends MatchTreeMaking with MatchApproximation {
      * the variable is floated up so that its scope includes all of the program that shares it
      * we generalize sharing to implication, where b reuses a if a => b and priors(a) => priors(b) (the priors of a sub expression form the path through the decision tree)
      */
-    def doCSE(prevBinder: Symbol, cases: List[List[TreeMaker]], pt: Type, selectorPos: Position): List[List[TreeMaker]] = {
+    def doCSE(prevBinder: Symbol, cases: List[List[TreeMaker]], @unused pt: Type, selectorPos: Position): List[List[TreeMaker]] = {
       debug.patmat("before CSE:")
       showTreeMakers(cases)
 
@@ -130,9 +130,8 @@ trait MatchOptimization extends MatchTreeMaking with MatchApproximation {
             // if the shared prefix contains interesting conditions (!= True)
             // and the last of such interesting shared conditions reuses another treemaker's test
             // replace the whole sharedPrefix by a ReusingCondTreeMaker
-            for (lastShared <- sharedPrefix.reverse.dropWhile(_.prop == True).headOption;
-                 lastReused <- reusesTest(lastShared))
-              yield ReusingCondTreeMaker(sharedPrefix, reusesTest, reusedOrOrig) :: suffix.map(_.treeMaker)
+            for (lastShared <- sharedPrefix.reverse.dropWhile(_.prop == True).headOption; _ <- reusesTest(lastShared))
+            yield ReusingCondTreeMaker(sharedPrefix, reusesTest, reusedOrOrig) :: suffix.map(_.treeMaker)
           }
 
         collapsedTreeMakers getOrElse tests.map(_.treeMaker) // sharedPrefix need not be empty (but it only contains True-tests, which are dropped above)
@@ -306,7 +305,7 @@ trait MatchOptimization extends MatchTreeMaking with MatchApproximation {
               // the patterns in same are equal (according to caseEquals)
               // we can thus safely pick the first one arbitrarily, provided we correct binding
               val origPatWithoutBind = commonPattern match {
-                case Bind(b, orig) => orig
+                case Bind(_, orig) => orig
                 case o => o
               }
               // need to replace `defaultSym` as well -- it's used in `defaultBody` (see `jumpToDefault` above)

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTranslation.scala
@@ -13,6 +13,8 @@
 package scala.tools.nsc
 package transform.patmat
 
+import scala.annotation._
+
 /** Translate typed Trees that represent pattern matches into the patternmatching IR, defined by TreeMakers.
  */
 trait MatchTranslation {
@@ -186,7 +188,7 @@ trait MatchTranslation {
       val Match(selector, cases) = match_
 
       val (nonSyntheticCases, defaultOverride) = cases match {
-        case init :+ last if treeInfo isSyntheticDefaultCase last => (init, Some(((scrut: Tree) => last.body)))
+        case init :+ last if treeInfo isSyntheticDefaultCase last => (init, Some(((_: Tree) => last.body)))
         case _                                                    => (cases, None)
       }
 
@@ -263,7 +265,7 @@ trait MatchTranslation {
                 CaseDef(
                   Bind(exSym, Ident(nme.WILDCARD)), // TODO: does this need fixing upping?
                   EmptyTree,
-                  combineCases(REF(exSym), scrutSym, cases, pt, selectorPos, matchOwner, Some(scrut => Throw(REF(exSym))), suppression)
+                  combineCases(REF(exSym), scrutSym, cases, pt, selectorPos, matchOwner, Some(_ => Throw(REF(exSym))), suppression)
                 )
               })
         }
@@ -402,7 +404,7 @@ trait MatchTranslation {
       private def genDrop(binder: Symbol, n: Int): List[Tree]         = codegen.drop(seqTree(binder, forceImmutable = false))(n) :: Nil
 
       // codegen.drop(seqTree(binder))(nbIndexingIndices)))).toList
-      protected def seqTree(binder: Symbol, forceImmutable: Boolean) = tupleSel(binder)(firstIndexingBinder + 1)
+      protected def seqTree(binder: Symbol, @unused forceImmutable: Boolean) = tupleSel(binder)(firstIndexingBinder + 1)
       protected def tupleSel(binder: Symbol)(i: Int): Tree           = codegen.tupleSel(binder)(i)
 
       // the trees that select the subpatterns on the extractor's result,

--- a/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/PatternMatching.scala
@@ -76,11 +76,11 @@ trait PatternMatching extends Transform
         } finally
           inAsync = wasInAsync
 
-      case CaseDef(UnApply(Apply(Select(qual, nme.unapply), Ident(nme.SELECTOR_DUMMY) :: Nil), (bind@Bind(b, Ident(nme.WILDCARD))) :: Nil), guard, body)
+      case CaseDef(UnApply(Apply(Select(qual, nme.unapply), Ident(nme.SELECTOR_DUMMY) :: Nil), (bind@Bind(name, Ident(nme.WILDCARD))) :: Nil), guard, body)
         if guard.isEmpty && qual.symbol == definitions.NonFatalModule =>
         transform(treeCopy.CaseDef(
           tree,
-          treeCopy.Bind(bind, bind.name, Typed(Ident(nme.WILDCARD), TypeTree(definitions.ThrowableTpe)).setType(definitions.ThrowableTpe)),
+          treeCopy.Bind(bind, name, Typed(Ident(nme.WILDCARD), TypeTree(definitions.ThrowableTpe)).setType(definitions.ThrowableTpe)),
           localTyper.typed(atPos(tree.pos)(Apply(gen.mkAttributedRef(definitions.NonFatal_apply), List(Ident(bind.symbol))))),
           body))
 

--- a/src/compiler/scala/tools/nsc/typechecker/Adaptations.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Adaptations.scala
@@ -37,7 +37,7 @@ trait Adaptations {
         case _                    => EmptyTree
       }
       def isInfix = t match {
-        case Apply(_, arg :: Nil) => t.hasAttachment[MultiargInfixAttachment.type]
+        case Apply(_, _ :: Nil) => t.hasAttachment[MultiargInfixAttachment.type]
         case _                    => false
       }
       def callString = (
@@ -90,7 +90,7 @@ trait Adaptations {
       }
       @inline def warnAdaptation: true = {
         def discardedArgs = t match {
-          case Apply(_, stat @ Block(Apply(TypeApply(Select(adapter, _), _), adapted) :: Nil, expr) :: Nil) =>
+          case Apply(_, Block(Apply(TypeApply(Select(adapter, _), _), adapted) :: Nil, expr) :: Nil) =>
             isTupleSymbol(adapter.symbol.companion) && expr.tpe == UnitTpe && adapted == args
           case _ => false
         }

--- a/src/compiler/scala/tools/nsc/typechecker/AnalyzerPlugins.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/AnalyzerPlugins.scala
@@ -13,12 +13,15 @@
 package scala.tools.nsc
 package typechecker
 
+import scala.annotation._
+
 /**
  *  @author Lukas Rytz
  */
 trait AnalyzerPlugins { self: Analyzer with splain.SplainData =>
   import global._
 
+  @nowarn
   trait AnalyzerPlugin {
     /**
      * Selectively activate this analyzer plugin, e.g. according to the compiler phase.
@@ -197,6 +200,7 @@ trait AnalyzerPlugins { self: Analyzer with splain.SplainData =>
    * or something else if the plugin knows better that the implementation provided in scala-compiler.jar.
    * If multiple plugins return a non-empty result, it's going to be a compilation error.
    */
+  @nowarn
   trait MacroPlugin {
     /**
      * Selectively activate this analyzer plugin, e.g. according to the compiler phase.
@@ -435,7 +439,7 @@ trait AnalyzerPlugins { self: Analyzer with splain.SplainData =>
         if (plugin.isActive()) {
           op.custom(plugin) match {
             case None =>
-            case s @ Some(custom) =>
+            case s @ Some(_) =>
               if (result.isDefined) {
                 typer.context.error(op.position, s"both $resultPlugin and $plugin want to ${op.description}")
                 op.default

--- a/src/compiler/scala/tools/nsc/typechecker/Checkable.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Checkable.scala
@@ -144,7 +144,7 @@ trait Checkable {
     def Psym = P.typeSymbol
     def PErased =
       P match {
-        case GenericArray(n, core) => existentialAbstraction(core.typeSymbol :: Nil, P)
+        case GenericArray(_, core) => existentialAbstraction(core.typeSymbol :: Nil, P)
         case _                     => existentialAbstraction(Psym.typeParams, Psym.tpe_*)
       }
     def XR = if (Xsym == AnyClass) PErased else propagateKnownTypes(X, Psym)
@@ -276,7 +276,7 @@ trait Checkable {
     }
     // Important to dealias at any entry point (this is the only one at this writing but cf isNeverSubClass.)
     def isNeverSubType(tp1: Type, tp2: Type): Boolean = /*logResult(s"isNeverSubType($tp1, $tp2)")*/((tp1.dealias, tp2.dealias) match {
-      case (TypeRef(_, sym1, args1), TypeRef(_, sym2, args2)) =>
+      case (TypeRef(_, sym1, _), TypeRef(_, sym2, args2)) =>
         isNeverSubClass(sym1, sym2) || {
           (sym1 isSubClass sym2) && {
             val tp1seen = tp1 baseType sym2

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -13,17 +13,17 @@
 package scala.tools.nsc
 package typechecker
 
-import scala.reflect.internal.util.StringOps.{countAsString, countElementsAsString}
 import java.lang.System.{lineSeparator => EOL}
 import scala.PartialFunction.cond
-import scala.annotation.tailrec
+import scala.annotation._
+import scala.reflect.internal.util.{CodeAction, NoSourceFile}
+import scala.reflect.internal.util.StringOps.{countAsString, countElementsAsString}
+import scala.reflect.io.NoAbstractFile
 import scala.reflect.runtime.ReflectionUtils
 import scala.reflect.macros.runtime.AbortMacroException
-import scala.util.control.{ControlThrowable, NonFatal}
 import scala.tools.nsc.Reporting.WarningCategory
 import scala.tools.nsc.util.stackTraceString
-import scala.reflect.io.NoAbstractFile
-import scala.reflect.internal.util.{CodeAction, NoSourceFile}
+import scala.util.control.{ControlThrowable, NonFatal}
 
 trait ContextErrors extends splain.SplainErrors {
   self: Analyzer =>
@@ -314,13 +314,13 @@ trait ContextErrors extends splain.SplainErrors {
           case Some(holder) =>
             val prettyParent = formatTraitWithParams(parent, holder.params)
             s"$prettyParent is an illegal Scala 3 parameterized trait; so can not take constructor arguments"
-          case none => s"$parent is a trait; does not take constructor arguments"
+          case _ => s"$parent is a trait; does not take constructor arguments"
 
         }
         issueNormalTypeError(arg, msg)
       }
 
-      def ConstrArgsInParentOfTraitError(arg: Tree, parent: Symbol) =
+      def ConstrArgsInParentOfTraitError(arg: Tree, @unused parent: Symbol) =
         issueNormalTypeError(arg, "parents of traits may not have parameters")
 
       def MissingTypeArgumentsParentTpeError(supertpt: Tree) =
@@ -678,7 +678,7 @@ trait ContextErrors extends splain.SplainErrors {
 
       // doTypeApply
       //tryNamesDefaults
-      def NamedAndDefaultArgumentsNotSupportedForMacros(tree: Tree, fun: Tree) =
+      def NamedAndDefaultArgumentsNotSupportedForMacros(tree: Tree, @unused fun: Tree) =
         NormalTypeError(tree, "macro applications do not support named and/or default arguments")
 
       def TooManyArgsNamesDefaultsError(tree: Tree, fun: Tree, formals: List[Type], args: List[Tree], argPos: Array[Int]) = {
@@ -1277,7 +1277,7 @@ trait ContextErrors extends splain.SplainErrors {
       }
 
       def NotWithinBounds(tree: Tree, prefix: String, targs: List[Type],
-                          tparams: List[Symbol], kindErrors: List[String]) =
+                          tparams: List[Symbol], @unused kindErrors: List[String]) =
         issueNormalTypeError(tree,
           NotWithinBoundsErrorMessage(prefix, targs, tparams, settings.explaintypes.value))
 

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -383,8 +383,8 @@ trait Contexts { self: Analyzer =>
         def prune(trees: List[Tree], pending: List[(Symbol, Tree)], acc: List[(Symbol, Tree)]): List[(Symbol, Tree)] = pending match {
           case Nil => acc
           case ps =>
-            val (in, out) = ps.partition { case (vsym, rhs) => trees.exists(_.exists(_.symbol == vsym)) }
-            if(in.isEmpty) acc
+            val (in, out) = ps.partition { case (vsym, _) => trees.exists(_.exists(_.symbol == vsym)) }
+            if (in.isEmpty) acc
             else prune(in.map(_._2) ++ trees, out, in ++ acc)
         }
 
@@ -592,8 +592,8 @@ trait Contexts { self: Analyzer =>
                 tryOnce(isLastTry = false)
                 reporter.hasErrors
               } catch {
-                case ex: CyclicReference => throw ex
-                case ex: TypeError => true // recoverable cyclic references?
+                case e: CyclicReference => throw e
+                case _: TypeError => true // recoverable cyclic references?
               }
             }
           } else true
@@ -880,7 +880,7 @@ trait Contexts { self: Analyzer =>
         val pstr = if ((parents eq null) || parents.isEmpty) "Nil" else parents mkString " "
         val bstr = if (body eq null) "" else "" + body.length + " stats"
         s"""Template($pstr, _, $bstr)"""
-      case x => s"${tree.shortClass}${treeIdString}:${treeTruncated}"
+      case _ => s"${tree.shortClass}${treeIdString}:${treeTruncated}"
     }
 
     override def toString =
@@ -1815,7 +1815,7 @@ trait Contexts { self: Analyzer =>
           if (context.reportErrors) {
             context.issue(divergent.withPt(paramTp))
             errorBuffer.filterInPlace {
-              case dte: DivergentImplicitTypeError => false
+              case _: DivergentImplicitTypeError => false
               case _ => true
             }
           }
@@ -1976,8 +1976,8 @@ trait Contexts { self: Analyzer =>
         if (isRootImport) !definitions.isUnimportableUnlessRenamed(sym)
         else definitions.isImportable(sym)
       ) match {
-        case filtered: NoSymbol => TupleOfNullAndNoSymbol
-        case _                  => (current, result)
+        case _: NoSymbol => TupleOfNullAndNoSymbol
+        case _           => (current, result)
       }
     }
 

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -288,7 +288,7 @@ trait Implicits extends splain.SplainData {
     /** Does type `tp` contain an Error type as parameter or result?
      */
     private final def containsError(tp: Type): Boolean = tp match {
-      case PolyType(tparams, restpe) =>
+      case PolyType(_, restpe) =>
         containsError(restpe)
       case NullaryMethodType(restpe) =>
         containsError(restpe)
@@ -621,7 +621,7 @@ trait Implicits extends splain.SplainData {
           @tailrec
           def loop(ois: List[OpenImplicit], isByName: Boolean): Option[OpenImplicit] =
             ois match {
-              case hd :: tl if (isByName || hd.isByName) && hd.pt <:< pt => Some(hd)
+              case hd :: _ if (isByName || hd.isByName) && hd.pt <:< pt => Some(hd)
               case hd :: tl => loop(tl, isByName || hd.isByName)
               case _ => None
             }
@@ -736,7 +736,7 @@ trait Implicits extends splain.SplainData {
           if (mt.isImplicit)
             loop(restpe, pt)
           else pt match {
-            case tr @ TypeRef(pre, sym, args) =>
+            case TypeRef(pre, sym, args) =>
               if (sym.isAliasType) loop(tp, pt.dealias)
               else if (sym.isAbstractType) loop(tp, pt.lowerBound)
               else {
@@ -1205,7 +1205,7 @@ trait Implicits extends splain.SplainData {
             firstPending == alt || (
               try improves(firstPending, alt)
               catch {
-                case e: CyclicReference =>
+                case _: CyclicReference =>
                   devWarning(s"Discarding $firstPending during implicit search due to cyclic reference.")
                   true
               }
@@ -1569,7 +1569,7 @@ trait Implicits extends splain.SplainData {
             // can't generate a reference to a value that's abstracted over by an existential
             if (containsExistential(tp1)) EmptyTree
             else manifestFactoryCall("singleType", tp, gen.mkAttributedQualifier(tp1))
-          case ConstantType(value) =>
+          case ConstantType(_) =>
             manifestOfType(tp1.deconst, FullManifestClass)
           case TypeRef(pre, sym, args) =>
             if (isPrimitiveValueClass(sym) || isPhantomClass(sym)) {
@@ -1609,7 +1609,7 @@ trait Implicits extends splain.SplainData {
             if (hasLength(parents, 1)) findManifest(parents.head)
             else if (full) manifestFactoryCall("intersectionType", tp, parents map findSubManifest: _*)
             else mot(erasure.intersectionDominator(parents), from, to)
-          case ExistentialType(tparams, result) =>
+          case ExistentialType(_, _) =>
             mot(tp1.skolemizeExistential, from, to)
           case _ =>
             EmptyTree

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -1548,10 +1548,9 @@ trait Infer extends Checkable {
       def finish(sym: Symbol, tpe: Type) = tree setSymbol sym setType tpe
       // Alternatives which conform to bounds
       def checkWithinBounds(sym: Symbol): Unit = sym.alternatives match {
-        case Nil if argtypes.exists(_.isErroneous) =>
-        case Nil                                   => fail()
-        case alt :: Nil                            => finish(alt, pre memberType alt)
-        case alts @ (hd :: _)                      =>
+        case Nil            => if (!argtypes.exists(_.isErroneous)) fail()
+        case alt :: Nil     => finish(alt, pre memberType alt)
+        case alts @ hd :: _ =>
           log(s"Attaching AntiPolyType-carrying overloaded type to $sym")
           // Multiple alternatives which are within bounds; spin up an
           // overloaded type which carries an "AntiPolyType" as a prefix.
@@ -1561,7 +1560,7 @@ trait Infer extends Checkable {
           finish(sym setInfo tpe, tpe)
       }
       matchingLength.alternatives match {
-        case Nil => fail()
+        case Nil        => fail()
         case alt :: Nil => finish(alt, pre memberType alt)
         case _ =>
           checkWithinBounds(matchingLength.filter { alt =>

--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -473,7 +473,7 @@ trait Infer extends Checkable {
       if (isConservativelyCompatible(restpe.instantiateTypeParams(tparams, tvars), pt))
         map2(tparams, tvars)((tparam, tvar) =>
           try instantiateToBound(tvar, varianceInTypes(formals)(tparam))
-          catch { case ex: NoInstance => WildcardType }
+          catch { case _: NoInstance => WildcardType }
         )
       else
         WildcardType.fillList(tvars.length)
@@ -1513,9 +1513,9 @@ trait Infer extends Checkable {
           def finish(s: Symbol): Unit = tree.setSymbol(s).setType(pre.memberType(s))
           ranked match {
             case best :: competing :: _ => AmbiguousMethodAlternativeError(tree, pre, best, competing, argtpes, pt, isLastTry) // ambiguous
-            case best :: nil            => finish(best)
-            case nil if pt.isWildcard   => NoBestMethodAlternativeError(tree, argtpes, pt, isLastTry)  // failed
-            case nil                    => bestForExpectedType(WildcardType, isLastTry)                // failed, but retry with WildcardType
+            case best :: _              => finish(best)
+            case _   if pt.isWildcard   => NoBestMethodAlternativeError(tree, argtpes, pt, isLastTry)  // failed
+            case _                      => bestForExpectedType(WildcardType, isLastTry)                // failed, but retry with WildcardType
           }
         }
 

--- a/src/compiler/scala/tools/nsc/typechecker/MacroAnnotationNamers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/MacroAnnotationNamers.scala
@@ -58,11 +58,11 @@ trait MacroAnnotationNamers { self: Analyzer =>
           case _                  => abort("Unexpected tree: " + tree)
         }
         if (isPastTyper) sym.name.toTermName match {
-          case nme.IMPORT | nme.OUTER | nme.ANON_CLASS_NAME | nme.ANON_FUN_NAME | nme.CONSTRUCTOR => ()
-          case _                                                                                  =>
+          case nme.IMPORT | nme.OUTER | nme.ANON_CLASS_NAME | nme.ANON_FUN_NAME | nme.CONSTRUCTOR =>
+          case _ =>
             tree match {
-              case md: DefDef => log("[+symbol] " + sym.debugLocationString)
-              case _          =>
+              case _: DefDef => log("[+symbol] " + sym.debugLocationString)
+              case _ =>
             }
         }
         tree.symbol = sym
@@ -375,7 +375,7 @@ trait MacroAnnotationNamers { self: Analyzer =>
     private implicit class RichType(tpe: Type) {
       def completeOnlyExpansions(sym: Symbol) = tpe match {
         case mec: MacroAnnotationNamer#MaybeExpandeeCompleter => mec.complete(sym, onlyExpansions = true)
-        case c                                                => ()
+        case _ =>
       }
     }
 
@@ -774,7 +774,7 @@ trait MacroAnnotationNamers { self: Analyzer =>
       }
       def rewrapAfterTransform(stat: Tree, transformed: List[Tree]): List[Tree] = (stat, transformed) match {
         case (stat @ DocDef(comment, _), List(transformed: MemberDef)) => List(treeCopy.DocDef(stat, comment, transformed))
-        case (stat @ DocDef(comment, _), List(transformed: DocDef)) => List(transformed)
+        case (DocDef(_, _), List(transformed: DocDef)) => List(transformed)
         case (_, Nil | List(_: MemberDef)) => transformed
         case (_, unexpected) => unexpected // NOTE: who knows how people are already using macro annotations, so it's scary to fail here
       }

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -13,7 +13,7 @@
 package scala.tools.nsc
 package typechecker
 
-import scala.annotation.{nowarn, tailrec}
+import scala.annotation._
 import scala.collection.mutable
 import symtab.Flags._
 import scala.reflect.internal.util.ListOfNil
@@ -385,7 +385,7 @@ trait Namers extends MethodSynthesis {
       }
     }
 
-    private def enterClassSymbol(tree: ClassDef, clazz: ClassSymbol): Symbol = {
+    private def enterClassSymbol(@unused tree: ClassDef, clazz: ClassSymbol): Symbol = {
       var sourceFile = clazz.sourceFile
       if (sourceFile != null && sourceFile != contextFile)
         devWarning(s"Source file mismatch in $clazz: ${sourceFile} vs. $contextFile")
@@ -811,10 +811,10 @@ trait Namers extends MethodSynthesis {
     }
 
     // Hooks which are overridden in the presentation compiler
-    def enterExistingSym(sym: Symbol, tree: Tree): Context = {
+    def enterExistingSym(@unused sym: Symbol, @unused tree: Tree): Context = {
       this.context
     }
-    def enterIfNotThere(sym: Symbol): Unit = { }
+    def enterIfNotThere(sym: Symbol): Unit = ()
 
     def enterSyntheticSym(tree: Tree): Symbol = {
       enterSym(tree)
@@ -830,7 +830,7 @@ trait Namers extends MethodSynthesis {
         case TypeBounds(lo, _) =>
           // check that lower bound is not an F-bound
           // but carefully: class Foo[T <: Bar[_ >: T]] should be allowed
-          for (tp1 @ TypeRef(_, sym, _) <- lo) {
+          for (TypeRef(_, sym, _) <- lo) {
             if (settings.breakCycles.value) {
               if (!sym.maybeInitialize) {
                 log(s"Cycle inspecting $lo for possible f-bounds: ${sym.fullLocationString}")
@@ -1499,7 +1499,7 @@ trait Namers extends MethodSynthesis {
     /**
      * For every default argument, insert a method symbol computing that default
      */
-    def enterDefaultGetters(meth: Symbol, ddef: DefDef, vparamss: List[List[ValDef]], tparams: List[TypeDef]): Unit = {
+    def enterDefaultGetters(meth: Symbol, @unused ddef: DefDef, vparamss: List[List[ValDef]], @unused tparams: List[TypeDef]): Unit = {
       val methOwner  = meth.owner
       val search = DefaultGetterNamerSearch(context, meth, initCompanionModule = false)
       var posCounter = 1
@@ -1540,7 +1540,7 @@ trait Namers extends MethodSynthesis {
      * typechecked, the corresponding param would not yet have the "defaultparam"
      * flag.
      */
-    private def addDefaultGetters(meth: Symbol, ddef: DefDef, vparamss: List[List[ValDef]], tparams: List[TypeDef], overridden: Symbol): Unit = {
+    private def addDefaultGetters(meth: Symbol, ddef: DefDef, vparamss: List[List[ValDef]], @unused tparams: List[TypeDef], overridden: Symbol): Unit = {
       val DefDef(_, _, rtparams0, rvparamss0, _, _) = resetAttrs(deriveDefDef(ddef)(_ => EmptyTree).duplicate): @unchecked
       // having defs here is important to make sure that there's no sneaky tree sharing
       // in methods with multiple default parameters
@@ -1661,7 +1661,7 @@ trait Namers extends MethodSynthesis {
 
       def createAndEnter(f: Symbol => Symbol): Unit
     }
-    private class DefaultGetterInCompanion(c: Context, meth: Symbol, initCompanionModule: Boolean) extends DefaultGetterNamerSearch {
+    private class DefaultGetterInCompanion(@unused c: Context, meth: Symbol, initCompanionModule: Boolean) extends DefaultGetterNamerSearch {
       private val module = companionSymbolOf(meth.owner, context)
       if (initCompanionModule) module.initialize
       private val cda: Option[ConstructorDefaultsAttachment] = module.attachments.get[ConstructorDefaultsAttachment]
@@ -1699,7 +1699,7 @@ trait Namers extends MethodSynthesis {
 
       }
     }
-    private class DefaultMethodInOwningScope(c: Context, meth: Symbol) extends DefaultGetterNamerSearch {
+    private class DefaultMethodInOwningScope(@unused c: Context, meth: Symbol) extends DefaultGetterNamerSearch {
       private lazy val ownerNamer: Namer = {
         val ctx = context.nextEnclosing(c => c.scope.toList.contains(meth)) // TODO use lookup rather than toList.contains
         assert(ctx != NoContext, meth)
@@ -1811,12 +1811,9 @@ trait Namers extends MethodSynthesis {
       // log("typeDefSig(" + tpsym + ", " + tparams + ")")
       val tparamSyms = typer.reenterTypeParams(tparams) //@M make tparams available in scope (just for this abstypedef)
       val tp = typer.typedType(rhs).tpe match {
-        case TypeBounds(lt, rt) if (lt.isError || rt.isError) =>
-          TypeBounds.empty
-        case tp @ TypeBounds(lt, rt) if (tdef.symbol hasFlag JAVA) =>
-          TypeBounds(lt, rt)
-        case tp =>
-          tp
+        case TypeBounds(lt, rt) if lt.isError || rt.isError  => TypeBounds.empty
+        case TypeBounds(lt, rt) if tdef.symbol.hasFlag(JAVA) => TypeBounds(lt, rt)
+        case tp => tp
       }
       // see neg/bug1275, #3419
       // used to do a rudimentary kind check here to ensure overriding in refinements

--- a/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala
@@ -13,9 +13,9 @@
 package scala.tools.nsc
 package typechecker
 
-import symtab.Flags._
 import scala.collection.mutable
 import scala.reflect.ClassTag
+import symtab.Flags._
 import PartialFunction.cond
 
 /**
@@ -340,7 +340,7 @@ trait NamesDefaults { self: Analyzer =>
 
     // begin transform
     tree match {
-      case NamedApplyBlock(info) => tree
+      case NamedApplyBlock(_) => tree
       // `fun` is typed. `namelessArgs` might be typed or not, if they are types are kept.
       case Apply(fun, namelessArgs) =>
         val transformedFun = transformNamedApplication(typer, mode, pt)(fun, x => x)
@@ -352,7 +352,7 @@ trait NamesDefaults { self: Analyzer =>
           // type the application without names; put the arguments in definition-site order
           val typedApp = doTypedApply(tree, funOnly, reorderArgs(namelessArgs, argPos), mode, pt)
           typedApp match {
-            case Apply(expr, typedArgs) if (typedApp :: typedArgs).exists(_.isErrorTyped) =>
+            case Apply(_, typedArgs) if (typedApp :: typedArgs).exists(_.isErrorTyped) =>
               setError(tree) // bail out with and erroneous Apply *or* erroneous arguments, see scala/bug#7238, scala/bug#7509
             case Apply(expr, typedArgs) =>
               // Extract the typed arguments, restore the call-site evaluation order (using

--- a/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SuperAccessors.scala
@@ -19,8 +19,7 @@ package scala
 package tools.nsc
 package typechecker
 
-import scala.collection.{immutable, mutable}
-import mutable.ListBuffer
+import scala.collection.{immutable, mutable}, mutable.ListBuffer
 import scala.tools.nsc.Reporting.WarningCategory
 import symtab.Flags._
 
@@ -192,8 +191,8 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
       }
 
       def mixIsTrait = sup.tpe match {
-        case SuperType(thisTpe, superTpe) => superTpe.typeSymbol.isTrait
-        case x                            => throw new MatchError(x)
+        case SuperType(_, superTpe) => superTpe.typeSymbol.isTrait
+        case x                      => throw new MatchError(x)
       }
 
       val needAccessor = name.isTermName && {
@@ -376,7 +375,7 @@ abstract class SuperAccessors extends transform.Transform with transform.TypingT
         case DefDef(_, _, _, _, _, _) if tree.symbol.isMethodWithExtension =>
           deriveDefDef(tree)(rhs => withInvalidOwner(transform(rhs)))
 
-        case TypeApply(sel @ Select(qual, name), args) =>
+        case TypeApply(sel @ Select(_, _), args) =>
           mayNeedProtectedAccessor(sel, args, goToSuper = true)
 
         case Assign(lhs @ Select(qual, name), rhs) =>

--- a/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
@@ -241,7 +241,7 @@ trait SyntheticMethods extends ast.TreeDSL {
     /* The hashcode method for value classes
      * def hashCode(): Int = this.underlying.hashCode
      */
-    def hashCodeDerivedValueClassMethod: Tree = createMethod(nme.hashCode_, Nil, IntTpe) { m =>
+    def hashCodeDerivedValueClassMethod: Tree = createMethod(nme.hashCode_, Nil, IntTpe) { _ =>
       Select(mkThisSelect(clazz.derivedValueClassUnbox), nme.hashCode_)
     }
 
@@ -425,7 +425,7 @@ trait SyntheticMethods extends ast.TreeDSL {
         }
         def nameSuffixedByParamIndex = original.name.append(s"${nme.CASE_ACCESSOR}$$${i}").toTermName
         val newName = if (i < 0) freshAccessorName else nameSuffixedByParamIndex
-        val newAcc = deriveMethod(ddef.symbol, name => newName) { newAcc =>
+        val newAcc = deriveMethod(ddef.symbol, _ => newName) { newAcc =>
           newAcc.makePublic
           newAcc resetFlag (ACCESSOR | PARAMACCESSOR | OVERRIDE)
           ddef.rhs.duplicate

--- a/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TreeCheckers.scala
@@ -324,7 +324,7 @@ abstract class TreeCheckers extends Analyzer {
             if (args exists (_ == EmptyTree))
               errorFn(tree.pos, "Apply arguments to " + fn + " contains an empty tree: " + args)
 
-          case Select(qual, name) =>
+          case Select(_, _) =>
             checkSym(tree)
           case This(_) =>
             checkSym(tree)
@@ -406,7 +406,7 @@ abstract class TreeCheckers extends Analyzer {
           val fmt = "%-" + width + "s"
           val lines = pairs map {
             case (s: Symbol, msg) => fmt.format(msg) + "  in  " + ownersString(s)
-            case (x, msg)         => fmt.format(msg)
+            case (_, msg)         => fmt.format(msg)
           }
           lines.mkString("Out of scope symbol reference {\n", "\n", "\n}")
         }

--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -13,7 +13,7 @@
 package scala.tools.nsc
 package typechecker
 
-import scala.annotation.{nowarn, tailrec}
+import scala.annotation._
 import scala.collection.mutable, mutable.ListBuffer
 import scala.tools.nsc.Reporting.WarningCategory
 import scala.util.chaining._
@@ -48,9 +48,9 @@ trait TypeDiagnostics extends splain.SplainDiagnostics {
   /** For errors which are artifacts of the implementation: such messages
    *  indicate that the restriction may be lifted in the future.
    */
-  def restrictionWarning(pos: Position, unit: CompilationUnit, msg: String, category: WarningCategory, site: Symbol): Unit =
+  def restrictionWarning(pos: Position, @unused unit: CompilationUnit, msg: String, category: WarningCategory, site: Symbol): Unit =
     runReporting.warning(pos, "Implementation restriction: " + msg, category, site)
-  def restrictionError(pos: Position, unit: CompilationUnit, msg: String): Unit =
+  def restrictionError(pos: Position, @unused unit: CompilationUnit, msg: String): Unit =
     reporter.error(pos, "Implementation restriction: " + msg)
 
   /** A map of Positions to addendums - if an error involves a position in
@@ -116,8 +116,8 @@ trait TypeDiagnostics extends splain.SplainDiagnostics {
     else ""
 
   private def methodTypeErrorString(tp: Type) = tp match {
-    case mt @ MethodType(params, resultType)  =>
-      def forString = params map (_.defString)
+    case MethodType(params, resultType)  =>
+      def forString = params.map(_.defString)
 
        forString.mkString("(", ",", ")") + resultType
     case x                                    => x.toString

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -14,7 +14,7 @@ package scala
 package tools.nsc
 package typechecker
 
-import scala.annotation.{tailrec, unused}
+import scala.annotation._
 import scala.collection.mutable
 import mutable.ListBuffer
 import scala.reflect.internal.{Chars, TypesStats}
@@ -217,7 +217,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     /** Overridden to false in scaladoc and/or interactive. */
     def canAdaptConstantTypeToLiteral = true
     def canTranslateEmptyListToNil    = true
-    def missingSelectErrorTree(tree: Tree, qual: Tree, name: Name): Tree = tree
+    def missingSelectErrorTree(tree: Tree, @unused qual: Tree, @unused name: Name): Tree = tree
 
     // used to exempt synthetic accessors (i.e. those that are synthesized by the compiler to access a field)
     // from skolemization because there's a weird bug that causes spurious type mismatches
@@ -6479,7 +6479,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       if (pt != Kind.Wildcard && pt.typeParams.isEmpty) typedType(tree, mode) // kind is known and it's *
       else context withinTypeConstructorAllowed typed(tree, NOmode, pt)
 
-    def typedHigherKindedType(tree: Tree, mode: Mode): Tree =
+    def typedHigherKindedType(tree: Tree, @unused mode: Mode): Tree =
       context withinTypeConstructorAllowed typed(tree)
 
     /** Types a type constructor tree used in a new or supertype */

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5916,8 +5916,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           tree
         }
 
-
-        val Try(block, catches, fin) = tree
+        val Try(block, catches, finalizer) = tree
         val block1   = typed(block, pt)
         val cases    = catches match {
           case CaseDef(EmptyTree, EmptyTree, catchExpr) :: Nil =>
@@ -5932,7 +5931,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           case _ => catches
         }
         val catches1 = typedCases(cases, ThrowableTpe, pt)
-        val fin1     = if (fin.isEmpty) fin else typed(fin, UnitTpe)
+        val fin1     = if (finalizer.isEmpty) finalizer else typed(finalizer, UnitTpe)
 
         def finish(ownType: Type) = treeCopy.Try(tree, block1, catches1, fin1) setType ownType
 

--- a/src/compiler/scala/tools/nsc/typechecker/TypersTracking.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypersTracking.scala
@@ -14,6 +14,7 @@ package scala.tools.nsc
 package typechecker
 
 import Mode._
+import scala.annotation._
 
 trait TypersTracking {
   self: Analyzer =>
@@ -116,7 +117,7 @@ trait TypersTracking {
       show(resetIfEmpty(indented("""\-> """ + s)))
       typedTree
     }
-    def showAdapt(original: Tree, adapted: Tree, pt: Type, context: Context): Unit = {
+    def showAdapt(original: Tree, adapted: Tree, pt: Type, @unused context: Context): Unit = {
       if (!noPrintAdapt(original, adapted)) {
         def tree_s1 = inLightCyan(truncAndOneLine(ptTree(original)))
         def pt_s = if (pt.isWildcard) "" else s" based on pt $pt"

--- a/src/compiler/scala/tools/nsc/typechecker/splain/SplainErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/splain/SplainErrors.scala
@@ -48,7 +48,7 @@ trait SplainErrors { self: Analyzer with SplainFormatting =>
   def splainPushImplicitSearchFailure(implicitTree: Tree, expectedType: Type, originalError: AbsTypeError): Unit = {
     def pushImpFailure(fun: Tree, args: List[Tree]): Unit = {
       fun.tpe match {
-        case PolyType(tparams, restpe) if tparams.nonEmpty && sameLength(tparams, args) =>
+        case PolyType(tparams, _) if tparams.nonEmpty && sameLength(tparams, args) =>
           splainPushNonconformantBonds(expectedType, implicitTree, mapList(args)(_.tpe), tparams, Some(originalError))
         case _ =>
       }

--- a/src/compiler/scala/tools/nsc/util/DocStrings.scala
+++ b/src/compiler/scala/tools/nsc/util/DocStrings.scala
@@ -91,7 +91,7 @@ object DocStrings {
    *  usecase or the end of the string, as they might include other sections
    *  of their own
    */
-  def tagIndex(str: String, p: Int => Boolean = (idx => true)): List[(Int, Int)] = {
+  def tagIndex(str: String, p: Int => Boolean = (_ => true)): List[(Int, Int)] = {
     var indices = findAll(str, 0) (idx => str(idx) == '@' && p(idx))
     indices = mergeUsecaseSections(str, indices)
     indices = mergeInheritdocSections(str, indices)

--- a/src/compiler/scala/tools/reflect/FastStringInterpolator.scala
+++ b/src/compiler/scala/tools/reflect/FastStringInterpolator.scala
@@ -26,7 +26,7 @@ trait FastStringInterpolator extends FormatInterpolator {
   // rewrite a tree like `scala.StringContext.apply("hello \\n ", " ", "").s("world", Test.this.foo)`
   // to `"hello \n world ".+(Test.this.foo)`
   private def interpolated(macroApp: Tree, isRaw: Boolean): Tree = macroApp match {
-    case Apply(Select(Apply(stringCtx@Select(qualSC, _), parts), _interpol), args) if
+    case Apply(Select(Apply(stringCtx@Select(qualSC, _), parts), _interpol@_), args) if
       stringCtx.symbol == currentRun.runDefinitions.StringContext_apply &&
       treeInfo.isQualifierSafeToElide(qualSC) &&
       parts.forall(treeInfo.isLiteralString) &&
@@ -82,7 +82,7 @@ trait FastStringInterpolator extends FormatInterpolator {
       else concatenate(treated, args)
 
     // Fallback -- inline the original implementation of the `s` or `raw` interpolator.
-    case t@Apply(Select(someStringContext, _interpol), args) =>
+    case Apply(Select(someStringContext, _interpol@_), args) =>
       q"""{
         val sc = $someStringContext
         _root_.scala.StringContext.standardInterpolator(

--- a/src/compiler/scala/tools/reflect/FastTrack.scala
+++ b/src/compiler/scala/tools/reflect/FastTrack.scala
@@ -61,7 +61,7 @@ class FastTrack[MacrosAndAnalyzer <: Macros with Analyzer](val macros: MacrosAnd
       makeBlackbox(        materializeClassTag) { case Applied(_, ttag :: Nil, _)                 => _.materializeClassTag(ttag.tpe) },
       makeBlackbox(     materializeWeakTypeTag) { case Applied(_, ttag :: Nil, (u :: _) :: _)     => _.materializeTypeTag(u, EmptyTree, ttag.tpe, concrete = false) },
       makeBlackbox(         materializeTypeTag) { case Applied(_, ttag :: Nil, (u :: _) :: _)     => _.materializeTypeTag(u, EmptyTree, ttag.tpe, concrete = true) },
-      makeBlackbox(           ApiUniverseReify) { case Applied(_, ttag :: Nil, (expr :: _) :: _)  => c => c.materializeExpr(c.prefix.tree, EmptyTree, expr) },
+      makeBlackbox(           ApiUniverseReify) { case Applied(_, _ :: Nil, (expr :: _) :: _)     => c => c.materializeExpr(c.prefix.tree, EmptyTree, expr) },
       makeWhitebox(            StringContext_f) { case _                                          => _.interpolateF },
       makeWhitebox(            StringContext_s) { case _                                          => _.interpolateS },
       makeWhitebox(            StringContext_raw) { case _                                        => _.interpolateRaw },

--- a/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
+++ b/src/compiler/scala/tools/reflect/ToolBoxFactory.scala
@@ -200,7 +200,7 @@ abstract class ToolBoxFactory[U <: JavaUniverse](val u: U) { factorySelf =>
         transformDuringTyper(tree, TERMmode, withImplicitViewsDisabled = false, withMacrosDisabled = withMacrosDisabled)(
           (currentTyper, tree) => {
             trace("inferring implicit %s (macros = %s): ".format(if (isView) "view" else "value", !withMacrosDisabled))(showAttributed(pt, printOwners = settings.Yshowsymowners.value, printKinds = settings.Yshowsymkinds.value))
-            analyzer.inferImplicit(tree, pt, isView, currentTyper.context, silent, withMacrosDisabled, pos, (pos, msg) => throw ToolBoxError(msg))
+            analyzer.inferImplicit(tree, pt, isView, currentTyper.context, silent, withMacrosDisabled, pos, (_, msg) => throw ToolBoxError(msg))
           })
 
       private def wrapInPackageAndCompile(packageName: TermName, tree: ImplDef): Symbol = {

--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -1236,7 +1236,7 @@ private[collection] object RedBlackTree {
     if((t1 eq null) || (t2 eq null)) t1
     else if (t1 eq t2) null
     else {
-      val (l1, _, r1, k1) = split(t1, t2.key)
+      val (l1, _, r1, _) = split(t1, t2.key)
       val tl = _difference(l1, t2.left)
       val tr = _difference(r1, t2.right)
       join2(tl, tr)

--- a/src/partest/scala/tools/partest/nest/RunnerSpec.scala
+++ b/src/partest/scala/tools/partest/nest/RunnerSpec.scala
@@ -13,7 +13,6 @@
 package scala.tools.partest.nest
 
 import language.postfixOps
-import scala.annotation.nowarn
 
 trait RunnerSpec extends Spec with Meta.StdOpts with Interpolation {
   def referenceSpec       = RunnerSpec
@@ -70,6 +69,5 @@ object RunnerSpec extends RunnerSpec with Reference {
   def creator(args: List[String]): ThisCommandLine = new CommandLine(RunnerSpec, args)
 
   // TODO: restructure to avoid using early initializers
-  @nowarn("cat=deprecation&msg=early initializers")
   def forArgs(args: Array[String]): Config = new { val parsed = creator(args.toList) } with Config
 }

--- a/src/reflect/scala/reflect/internal/Printers.scala
+++ b/src/reflect/scala/reflect/internal/Printers.scala
@@ -232,7 +232,7 @@ trait Printers extends api.Printers { self: SymbolTable =>
     }
 
     protected def printValDef(tree: ValDef, resultName: => String)(printTypeSignature: => Unit)(printRhs: => Unit) = {
-      val ValDef(mods, name, tp, rhs) = tree
+      val ValDef(mods, _, _, _) = tree
       printAnnotations(tree)
       printModifiers(tree, mods)
       print(if (mods.isMutable) "var " else "val ", resultName)
@@ -241,7 +241,7 @@ trait Printers extends api.Printers { self: SymbolTable =>
     }
 
     protected def printDefDef(tree: DefDef, resultName: => String)(printTypeSignature: => Unit)(printRhs: => Unit) = {
-      val DefDef(mods, name, tparams, vparamss, tp, rhs) = tree
+      val DefDef(mods, _, tparams, vparamss, _, _) = tree
       printAnnotations(tree)
       printModifiers(tree, mods)
       print("def " + resultName)
@@ -252,7 +252,7 @@ trait Printers extends api.Printers { self: SymbolTable =>
     }
 
     protected def printTypeDef(tree: TypeDef, resultName: => String) = {
-      val TypeDef(mods, name, tparams, rhs) = tree
+      val TypeDef(mods, _, tparams, rhs) = tree
       if (mods hasFlag (PARAM | DEFERRED)) {
         printAnnotations(tree)
         printModifiers(tree, mods)
@@ -268,7 +268,7 @@ trait Printers extends api.Printers { self: SymbolTable =>
     }
 
     protected def printImport(tree: Import, resSelect: => String) = {
-      val Import(expr, selectors) = tree
+      val Import(_, selectors) = tree
 
       def selectorToString(s: ImportSelector): String = {
         def selectorName(n: Name): String = if (s.isWildcard) nme.WILDCARD.decoded else quotedName(n)
@@ -297,7 +297,7 @@ trait Printers extends api.Printers { self: SymbolTable =>
     }
 
     protected def printFunction(tree: Function)(printValueParams: => Unit) = {
-      val Function(vparams, body) = tree
+      val Function(_, body) = tree
       print("(")
       printValueParams
       print(" => ", body, ")")
@@ -824,7 +824,7 @@ trait Printers extends api.Printers { self: SymbolTable =>
         case md @ ModuleDef(mods, name, impl) =>
           printAnnotations(md)
           printModifiers(tree, mods)
-          val Template(parents, self, methods) = impl
+          val Template(parents, _, _) = impl
           val parWithoutAnyRef = removeDefaultClassesFromList(parents)
           print("object " + printedName(name), if (parWithoutAnyRef.nonEmpty) " extends " else "", impl)
 
@@ -849,12 +849,12 @@ trait Printers extends api.Printers { self: SymbolTable =>
 
         case LabelDef(name, params, rhs) =>
           if (name.startsWith(nme.WHILE_PREFIX)) {
-            val If(cond, thenp, elsep) = rhs: @unchecked
+            val If(cond, thenp, _) = rhs: @unchecked
             print("while (", cond, ") ")
             val Block(list, wh) = thenp: @unchecked
             printColumn(list, "", ";", "")
           } else if (name.startsWith(nme.DO_WHILE_PREFIX)) {
-            val Block(bodyList, ifCond @ If(cond, thenp, elsep)) = rhs: @unchecked
+            val Block(bodyList, If(cond, _, _)) = rhs: @unchecked
             print("do ")
             printColumn(bodyList, "", ";", "")
             print(" while (", cond, ") ")

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -183,4 +183,7 @@ trait StdAttachments {
   case object DiscardedExpr extends PlainAttachment
   /** Anonymous parameter of `if (_)` may be inferred as Boolean. */
   case object BooleanParameterType extends PlainAttachment
+
+  /** This Bind tree was derived immediately from the given tree, for unused accounting. */
+  case class VarAlias(tree: Tree /*Bind | ValDef*/) extends PlainAttachment
 }

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -17,7 +17,7 @@ package internal
 import java.security.MessageDigest
 
 import Chars.isOperatorPart
-import scala.annotation.{nowarn, switch}
+import scala.annotation.switch
 import scala.collection.immutable
 import scala.io.Codec
 
@@ -176,7 +176,6 @@ trait StdNames {
   //        the early initializer.
   /** This should be the first trait in the linearization. */
   // abstract class Keywords extends CommonNames {
-  @nowarn("cat=deprecation&msg=early initializers")
   abstract class Keywords extends {
     private[this] val kw = new KeywordSetBuilder
 

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -16,7 +16,7 @@ package internal
 
 import java.net.URLClassLoader
 
-import scala.annotation.{elidable, nowarn, tailrec}
+import scala.annotation.{elidable, tailrec}
 import scala.collection.mutable
 import util._
 import java.util.concurrent.TimeUnit
@@ -194,7 +194,6 @@ abstract class SymbolTable extends macros.Universe
   /** Dump each symbol to stdout after shutdown.
    */
   final val traceSymbolActivity = System.getProperty("scalac.debug.syms") != null
-  @nowarn("cat=deprecation&msg=early initializers")
   object traceSymbols extends {
     val global: SymbolTable.this.type = SymbolTable.this
   } with util.TraceSymbolActivity

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -18,6 +18,7 @@ import Flags._
 import util._
 import scala.annotation.tailrec
 import scala.collection.mutable.ListBuffer
+import scala.util.chaining._
 
 abstract class TreeGen {
   val global: SymbolTable
@@ -633,18 +634,18 @@ abstract class TreeGen {
   *  4.
   *
   *    for (P <- G; E; ...) ...
-  *      =>
+  *      ==>
   *    for (P <- G.filter (P => E); ...) ...
   *
   *  5. For N < MaxTupleArity:
   *
-  *    for (P_1 <- G; P_2 = E_2; val P_N = E_N; ...)
+  *    for (P_1 <- G; P_2 = E_2; P_N = E_N; ...)
   *      ==>
   *    for (TupleN(P_1, P_2, ... P_N) <-
   *      for (x_1 @ P_1 <- G) yield {
   *        val x_2 @ P_2 = E_2
   *        ...
-  *        val x_N & P_N = E_N
+  *        val x_N @ P_N = E_N
   *        TupleN(x_1, ..., x_N)
   *      } ...)
   *
@@ -670,9 +671,11 @@ abstract class TreeGen {
       def splitpos = (if (pos != NoPosition) wrapped.withPoint(pos.point) else pos).makeTransparent
       matchVarPattern(pat) match {
         case Some((name, tpt)) =>
-          Function(
-            List(atPos(pat.pos) { ValDef(Modifiers(PARAM), name.toTermName, tpt, EmptyTree) }),
-            body) setPos splitpos
+          val p = atPos(pat.pos) {
+            ValDef(Modifiers(PARAM), name.toTermName, tpt, EmptyTree)
+              .tap(p => varAliasTo(pat, propagatePatVarDefAttachments(pat, p)))
+          }
+          Function(List(p), body).setPos(splitpos)
         case None =>
           atPos(splitpos) {
             mkVisitor(List(CaseDef(pat, EmptyTree, body)), checkExhaustive = false)
@@ -685,23 +688,23 @@ abstract class TreeGen {
     def makeCombination(pos: Position, meth: TermName, qual: Tree, pat: Tree, body: Tree): Tree =
       // ForAttachment on the method selection is used to differentiate
       // result of for desugaring from a regular method call
-      Apply(Select(qual, meth) setPos qual.pos updateAttachment ForAttachment,
-        List(makeClosure(pos, pat, body))) setPos pos
+      Apply(Select(qual, meth).setPos(qual.pos).updateAttachment(ForAttachment),
+        List(makeClosure(pos, pat, body))).setPos(pos)
 
     /* If `pat` is not yet a `Bind` wrap it in one with a fresh name */
-    def makeBind(pat: Tree): Tree = pat match {
-      case Bind(_, _) => pat
-      case _ => Bind(freshTermName(), pat) setPos pat.pos
+    def makeBind(pat: Tree): Bind = pat match {
+      case pat: Bind => pat
+      case _ => Bind(freshTermName(), pat).setPos(pat.pos).updateAttachment(NoWarnAttachment)
     }
 
     /* A reference to the name bound in Bind `pat`. */
-    def makeValue(pat: Tree): Tree = pat match {
-      case Bind(name, _) => Ident(name) setPos pat.pos.focus
+    def makeValue(pat: Tree): Ident = pat match {
+      case Bind(name, _) => Ident(name).setPos(pat.pos.focus)
       case x             => throw new MatchError(x)
     }
 
     /* The position of the closure that starts with generator at position `genpos`. */
-    def closurePos(genpos: Position) =
+    def closurePos(genpos: Position): Position =
       if (genpos == NoPosition) NoPosition
       else {
         val end = body.pos match {
@@ -715,52 +718,79 @@ abstract class TreeGen {
       case (t @ ValFrom(pat, rhs)) :: Nil =>
         makeCombination(closurePos(t.pos), mapName, rhs, pat, body)
       case (t @ ValFrom(pat, rhs)) :: (rest @ (ValFrom(_, _) :: _)) =>
-        makeCombination(closurePos(t.pos), flatMapName, rhs, pat,
-                        mkFor(rest, sugarBody))
+        makeCombination(closurePos(t.pos), flatMapName, rhs, pat, body = mkFor(rest, sugarBody))
       case (t @ ValFrom(pat, rhs)) :: Filter(test) :: rest =>
-        mkFor(ValFrom(pat, makeCombination(rhs.pos union test.pos, nme.withFilter, rhs, pat.duplicate, test)).setPos(t.pos) :: rest, sugarBody)
+        mkFor(ValFrom(pat, makeCombination(rhs.pos union test.pos, nme.withFilter, rhs, patternAlias(pat), test)).setPos(t.pos) :: rest, sugarBody)
       case (t @ ValFrom(pat, rhs)) :: rest =>
-        val valeqs = rest.take(definitions.MaxTupleArity - 1).takeWhile { ValEq.unapply(_).nonEmpty }
+        val valeqs = rest.take(definitions.MaxTupleArity - 1).takeWhile(ValEq.unapply(_).nonEmpty)
         assert(!valeqs.isEmpty, "Missing ValEq")
         val rest1 = rest.drop(valeqs.length)
         val (pats, rhss) = valeqs.map(ValEq.unapply(_).get).unzip
         val defpat1 = makeBind(pat)
-        val defpats = pats map makeBind
-        val pdefs = defpats.lazyZip(rhss).flatMap(mkPatDef)
-        val ids = (defpat1 :: defpats) map makeValue
+        val defpats = pats.map(makeBind)
+        val pdefs = defpats.lazyZip(rhss).flatMap((p, r) => mkPatDef(Modifiers(0), p, r, r.pos, forFor = true))
+        val tupled = {
+          val ids = (defpat1 :: defpats).map(makeValue)
+          atPos(wrappingPos(ids))(mkTuple(ids).updateAttachment(ForAttachment))
+        }
         val rhs1 = mkFor(
           List(ValFrom(defpat1, rhs).setPos(t.pos)),
-          Yield(Block(pdefs, atPos(wrappingPos(ids)) { mkTuple(ids) }) setPos wrappingPos(pdefs)))
-        val allpats = (pat :: pats) map (_.duplicate)
+          Yield(Block(pdefs, tupled).setPos(wrappingPos(pdefs)))
+        )
+        val untupled = {
+          val allpats = (pat :: pats).map(patternAlias)
+          atPos(wrappingPos(allpats))(mkTuple(allpats))
+        }
         val pos1 =
           if (t.pos == NoPosition) NoPosition
           else rangePos(t.pos.source, t.pos.start, t.pos.point, rhs1.pos.end)
-        val vfrom1 = ValFrom(atPos(wrappingPos(allpats)) { mkTuple(allpats) }, rhs1).setPos(pos1)
+        val vfrom1 = ValFrom(untupled, rhs1).setPos(pos1)
         mkFor(vfrom1 :: rest1, sugarBody)
       case _ =>
         EmptyTree //may happen for erroneous input
-
     }
   }
 
-  /** Create tree for pattern definition <val pat0 = rhs> */
-  def mkPatDef(pat: Tree, rhs: Tree)(implicit fresh: FreshNameCreator): List[ValDef] =
-    mkPatDef(Modifiers(0), pat, rhs)
-
+  // Fresh terms are not warnable. Bindings written `x@_` may be deemed unwarnable.
   private def propagateNoWarnAttachment(from: Tree, to: ValDef): to.type =
     if (isPatVarWarnable && from.hasAttachment[NoWarnAttachment.type]) to.updateAttachment(NoWarnAttachment)
     else to
 
-  // Keep marker for `x@_`, add marker for `val C(x) = ???` to distinguish from ordinary `val x = ???`.
+  // Distinguish patvar in pattern `val C(x) = ???` from `val x = ???`.
   private def propagatePatVarDefAttachments(from: Tree, to: ValDef): to.type =
     propagateNoWarnAttachment(from, to).updateAttachment(PatVarDefAttachment)
 
+  // For unused patvar bookkeeping, `to.symbol` is the symbol of record.
+  private def varAliasTo(from: Tree, to: Tree /*Bind|ValDef*/): from.type =
+    from.updateAttachment(VarAlias(to))
+
+  private def patternAlias(pat: Tree): Tree = {
+    val dup = pat.duplicate
+    if (matchVarPattern(pat).isDefined)
+      varAliasTo(dup, pat)
+    else
+      foreach2(getVariables(dup), getVariables(pat)) { (d, v) =>
+        varAliasTo(d._4, v._4)
+      }
+    dup
+  }
+
+  /** Create tree for pattern definition <val pat0 = rhs> */
+  def mkPatDef(pat: Tree, rhs: Tree)(implicit fresh: FreshNameCreator): List[ValDef] =
+    mkPatDef(Modifiers(0), pat, rhs, rhs.pos)
+
   /** Create tree for pattern definition <mods val pat0 = rhs> */
-  def mkPatDef(mods: Modifiers, pat: Tree, rhs: Tree)(implicit fresh: FreshNameCreator): List[ValDef] = mkPatDef(mods, pat, rhs, rhs.pos)(fresh)
-  def mkPatDef(mods: Modifiers, pat: Tree, rhs: Tree, rhsPos: Position)(implicit fresh: FreshNameCreator): List[ValDef] = matchVarPattern(pat) match {
+  def mkPatDef(mods: Modifiers, pat: Tree, rhs: Tree)(implicit fresh: FreshNameCreator): List[ValDef] = mkPatDef(mods, pat, rhs, rhs.pos)
+
+  def mkPatDef(mods: Modifiers, pat: Tree, rhs: Tree, rhsPos: Position)(implicit fresh: FreshNameCreator): List[ValDef] = mkPatDef(mods, pat, rhs, rhsPos, forFor = false)
+
+  private def mkPatDef(mods: Modifiers, pat: Tree, rhs: Tree, rhsPos: Position, forFor: Boolean)(implicit fresh: FreshNameCreator): List[ValDef] = matchVarPattern(pat) match {
     case Some((name, tpt)) =>
       List(atPos(pat.pos union rhsPos) {
-        propagateNoWarnAttachment(pat, ValDef(mods, name.toTermName, tpt, rhs))
+        ValDef(mods, name.toTermName, tpt, rhs)
+          .tap(vd =>
+              if (forFor) varAliasTo(pat, propagatePatVarDefAttachments(pat, vd))
+              else propagateNoWarnAttachment(pat, vd))
       })
 
     case None =>
@@ -805,7 +835,8 @@ abstract class TreeGen {
       vars match {
         case List((vname, tpt, pos, original)) =>
           List(atPos(pat.pos union pos union rhsPos) {
-            propagatePatVarDefAttachments(original, ValDef(mods, vname.toTermName, tpt, matchExpr))
+            ValDef(mods, vname.toTermName, tpt, matchExpr)
+              .tap(vd => varAliasTo(original, propagatePatVarDefAttachments(original, vd)))
           })
         case _ =>
           val tmp = freshTermName()
@@ -822,7 +853,8 @@ abstract class TreeGen {
           var cnt = 0
           val restDefs = for ((vname, tpt, pos, original) <- vars) yield atPos(pos) {
             cnt += 1
-            propagatePatVarDefAttachments(original, ValDef(mods, vname.toTermName, tpt, Select(Ident(tmp), TermName("_" + cnt))))
+            ValDef(mods, vname.toTermName, tpt, Select(Ident(tmp), TermName("_" + cnt)))
+              .tap(vd => varAliasTo(original, propagatePatVarDefAttachments(original, vd)))
           }
           firstDef :: restDefs
       }
@@ -830,14 +862,14 @@ abstract class TreeGen {
 
   /** Create tree for for-comprehension generator <val pat0 <- rhs0> */
   def mkGenerator(pos: Position, pat: Tree, valeq: Boolean, rhs: Tree)(implicit fresh: FreshNameCreator): Tree = {
-    val pat1 = patvarTransformerForFor.transform(pat)
+    val pat1 = patvarTransformer.transform(pat)
     if (valeq) ValEq(pat1, rhs).setPos(pos)
     else ValFrom(pat1, mkCheckIfRefutable(pat1, rhs)).setPos(pos)
   }
 
   private def unwarnable(pat: Tree): Tree = {
     pat foreach {
-      case b @ Bind(_, _) => b updateAttachment NoWarnAttachment
+      case b @ Bind(_, _) => b.updateAttachment(NoWarnAttachment)
       case _ =>
     }
     pat
@@ -934,19 +966,15 @@ abstract class TreeGen {
    *    x                  becomes      x @ _
    *    x: T               becomes      x @ (_: T)
    */
-  class PatvarTransformer(forFor: Boolean) extends Transformer {
+  class PatvarTransformer extends Transformer {
     override def transform(tree: Tree): Tree = tree match {
       case Ident(name) if treeInfo.isVarPattern(tree) && name != nme.WILDCARD =>
         atPos(tree.pos) {
-          val b = Bind(name, atPos(tree.pos.focus) (Ident(nme.WILDCARD)))
-          if (forFor && isPatVarWarnable) b updateAttachment NoWarnAttachment
-          else b
+          Bind(name, atPos(tree.pos.focus) (Ident(nme.WILDCARD)))
         }
       case Typed(id @ Ident(name), tpt) if treeInfo.isVarPattern(id) && name != nme.WILDCARD =>
         atPos(tree.pos.withPoint(id.pos.point)) {
-          Bind(name, atPos(tree.pos.withStart(tree.pos.point)) {
-            Typed(Ident(nme.WILDCARD), tpt)
-          })
+          Bind(name, atPos(tree.pos.withStart(tree.pos.point)) { Typed(Ident(nme.WILDCARD), tpt) })
         }
       case Apply(fn @ Apply(_, _), args) =>
         treeCopy.Apply(tree, transform(fn), transformTrees(args))
@@ -970,10 +998,7 @@ abstract class TreeGen {
   def isVarDefWarnable: Boolean = false
 
   /** Not in for comprehensions, whether to warn unused pat vars depends on flag. */
-  object patvarTransformer       extends PatvarTransformer(forFor = false)
-
-  /** Tag pat vars in for comprehensions. */
-  object patvarTransformerForFor extends PatvarTransformer(forFor = true)
+  object patvarTransformer extends PatvarTransformer
 
   // annotate the expression with @unchecked
   def mkUnchecked(expr: Tree): Tree = atPos(expr.pos) {

--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -244,7 +244,7 @@ private[internal] trait TypeMaps {
       annots foreach foldOver
 
     def foldOver(annot: AnnotationInfo): Unit = {
-      val AnnotationInfo(atp, args, assocs) = annot
+      val AnnotationInfo(atp, args, _) = annot
       atp.foldOver(this)
       foldOverAnnotArgs(args)
     }

--- a/src/reflect/scala/reflect/internal/transform/Transforms.scala
+++ b/src/reflect/scala/reflect/internal/transform/Transforms.scala
@@ -15,7 +15,6 @@ package reflect
 package internal
 package transform
 
-import scala.annotation.nowarn
 import scala.language.existentials
 
 trait Transforms { self: SymbolTable =>
@@ -36,9 +35,9 @@ trait Transforms { self: SymbolTable =>
     }
   }
 
-  private[this] val uncurryLazy     = new Lazy(new { val global: Transforms.this.type = self } with UnCurry): @nowarn("cat=deprecation&msg=early initializers")
-  private[this] val erasureLazy     = new Lazy(new { val global: Transforms.this.type = self } with Erasure): @nowarn("cat=deprecation&msg=early initializers")
-  private[this] val postErasureLazy = new Lazy(new { val global: Transforms.this.type = self } with PostErasure): @nowarn("cat=deprecation&msg=early initializers")
+  private[this] val uncurryLazy     = new Lazy(new { val global: Transforms.this.type = self } with UnCurry)
+  private[this] val erasureLazy     = new Lazy(new { val global: Transforms.this.type = self } with Erasure)
+  private[this] val postErasureLazy = new Lazy(new { val global: Transforms.this.type = self } with PostErasure)
 
   def uncurry = uncurryLazy.force
   def erasure = erasureLazy.force

--- a/src/reflect/scala/reflect/runtime/JavaUniverse.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverse.scala
@@ -88,7 +88,6 @@ class JavaUniverse extends InternalSymbolTable with JavaUniverseForce with Refle
   }
 
   // can't put this in runtime.Trees since that's mixed with Global in ReflectGlobal, which has the definition from internal.Trees
-  @nowarn("cat=deprecation&msg=early initializers")
   object treeInfo extends {
     val global: JavaUniverse.this.type = JavaUniverse.this
   } with TreeInfo

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -91,6 +91,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.DiscardedValue
     this.DiscardedExpr
     this.BooleanParameterType
+    this.VarAlias
     this.noPrint
     this.typeDebug
     // inaccessible: this.posAssigner

--- a/test/files/neg/t10287.check
+++ b/test/files/neg/t10287.check
@@ -1,19 +1,19 @@
 t10287.scala:5: warning: pattern var x in method unused_patvar is never used
     Some(42) match { case x => 27 } // warn
                           ^
-t10287.scala:12: warning: parameter x in anonymous function is never used
+t10287.scala:12: warning: pattern var x in value $anonfun is never used
       x <- Some(42) // warn
       ^
-t10287.scala:16: warning: parameter x in anonymous function is never used
+t10287.scala:16: warning: pattern var x in value $anonfun is never used
       x <- Some(42) // warn
       ^
-t10287.scala:22: warning: parameter y in anonymous function is never used
+t10287.scala:22: warning: pattern var y in value $anonfun is never used
       y <- Some(27) // warn
       ^
 t10287.scala:27: warning: pattern var y in value $anonfun is never used
       y = 3 // warn
       ^
-t10287.scala:31: warning: parameter x in anonymous function is never used
+t10287.scala:31: warning: pattern var x in value $anonfun is never used
       x <- Some(42) // warn
       ^
 t10287.scala:37: warning: pattern var y in value $anonfun is never used

--- a/test/files/neg/t10287.check
+++ b/test/files/neg/t10287.check
@@ -1,0 +1,24 @@
+t10287.scala:5: warning: pattern var x in method unused_patvar is never used
+    Some(42) match { case x => 27 } // warn
+                          ^
+t10287.scala:12: warning: parameter x in anonymous function is never used
+      x <- Some(42) // warn
+      ^
+t10287.scala:16: warning: parameter x in anonymous function is never used
+      x <- Some(42) // warn
+      ^
+t10287.scala:22: warning: parameter y in anonymous function is never used
+      y <- Some(27) // warn
+      ^
+t10287.scala:27: warning: pattern var y in value $anonfun is never used
+      y = 3 // warn
+      ^
+t10287.scala:31: warning: parameter x in anonymous function is never used
+      x <- Some(42) // warn
+      ^
+t10287.scala:37: warning: pattern var y in value $anonfun is never used
+      y = 3 // warn
+      ^
+error: No warnings can be incurred under -Werror.
+7 warnings
+1 error

--- a/test/files/neg/t10287.scala
+++ b/test/files/neg/t10287.scala
@@ -43,6 +43,11 @@ class C {
       y = x * 2
       _ = println(x)
     } yield y
+  def i(xs: List[Int]) =
+    for {
+      x <- xs
+      if x > 42
+    } println(".")
 }
 
 case class K[A](a: A, i: Int)

--- a/test/files/neg/t10287.scala
+++ b/test/files/neg/t10287.scala
@@ -1,0 +1,65 @@
+//> using options -Werror -Wunused:_ -Xsource:3
+
+class C {
+  def unused_patvar =
+    Some(42) match { case x => 27 } // warn
+  def a =
+    for {
+      x <- Some(42) // ok
+    } yield (x + 1)
+  def b =
+    for {
+      x <- Some(42) // warn
+    } yield 27
+  def c =
+    for {
+      x <- Some(42) // warn
+      y <- Some(27) // ok
+    } yield y
+  def d =
+    for {
+      x <- Some(42) // ok
+      y <- Some(27) // warn
+    } yield x
+  def e =
+    for {
+      x <- Some(42) // ok
+      y = 3 // warn
+    } yield x
+  def f =
+    for {
+      x <- Some(42) // warn
+      y = 3 // ok
+    } yield y
+  def g =
+    for {
+      x <- Some(1 -> 2) // ok
+      y = 3 // warn
+      (a, b) = x // ok
+    } yield (a + b)
+  def h(xs: List[Int]) =
+    for {
+      x <- xs
+      y = x * 2
+      _ = println(x)
+    } yield y
+}
+
+case class K[A](a: A, i: Int)
+
+class Fixes {
+  def leavenstain(s: String, t: String) = {
+    val n = s.length
+    val m = t.length
+    for (i <- 1 to n; s_i = s(i - 1); j <- 1 to m) {
+      println("" + s_i + t(j - 1))
+    }
+  }
+
+  def f[A](ks: List[K[A]]): List[K[?]] = {
+    for {
+      K((s: String), j) <- ks
+      x = j*2
+    } yield K(s*2, x)
+  }
+}

--- a/test/files/neg/t10296-both.check
+++ b/test/files/neg/t10296-both.check
@@ -1,8 +1,8 @@
-Unused_2.scala:8: warning: private method k in object Unused is never used
-  private def k(): Int = 17
-              ^
 Unused_2.scala:7: warning: private method g in object Unused is never used
   private def g(): Int = 17
+              ^
+Unused_2.scala:8: warning: private method k in object Unused is never used
+  private def k(): Int = 17
               ^
 error: No warnings can be incurred under -Werror.
 2 warnings

--- a/test/files/neg/t10763.check
+++ b/test/files/neg/t10763.check
@@ -1,4 +1,4 @@
-t10763.scala:6: warning: pattern var x in value $anonfun is never used: use a wildcard `_` or suppress this warning with `x@_`
+t10763.scala:6: warning: pattern var x in value $anonfun is never used
   for (x @ 1 <- List(1.0)) ()
        ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t10790.check
+++ b/test/files/neg/t10790.check
@@ -1,12 +1,12 @@
-t10790.scala:13: warning: private val y in class X is never used
-  private val Some(y) = Option(answer) // warn
-                  ^
-t10790.scala:10: warning: private class C in class X is never used
-  private class C                  // warn
-                ^
 t10790.scala:8: warning: parameter x in method control is never used
   def control(x: Int) = answer         // warn to verify control
               ^
+t10790.scala:10: warning: private class C in class X is never used
+  private class C                  // warn
+                ^
+t10790.scala:13: warning: private val y in class X is never used
+  private val Some(y) = Option(answer) // warn
+                  ^
 error: No warnings can be incurred under -Werror.
 3 warnings
 1 error

--- a/test/files/neg/unused.check
+++ b/test/files/neg/unused.check
@@ -1,21 +1,9 @@
-unused.scala:7: warning: pattern var a in value patvars is never used: use a wildcard `_` or suppress this warning with `a@_`
-    case C(a, _, _, _) => 1
+unused.scala:7: warning: pattern var x in value patvars is never used
+    case C(x, 2, _, _) => 1
            ^
-unused.scala:8: warning: pattern var b in value patvars is never used: use a wildcard `_` or suppress this warning with `b@_`
-    case C(_, b, c@_, _) => 2
-              ^
-unused.scala:9: warning: pattern var a in value patvars is never used: use a wildcard `_` or suppress this warning with `a@_`
-    case C(a, b@_, c, d@_) => 3
-           ^
-unused.scala:9: warning: pattern var c in value patvars is never used: use a wildcard `_` or suppress this warning with `c@_`
-    case C(a, b@_, c, d@_) => 3
-                   ^
-unused.scala:10: warning: pattern var e in value patvars is never used: use a wildcard `_` or suppress this warning with `e@_`
+unused.scala:10: warning: pattern var e in value patvars is never used
     case e => 4
          ^
-unused.scala:8: warning: unreachable code
-    case C(_, b, c@_, _) => 2
-                            ^
 error: No warnings can be incurred under -Werror.
-6 warnings
+2 warnings
 1 error

--- a/test/files/neg/unused.scala
+++ b/test/files/neg/unused.scala
@@ -1,11 +1,11 @@
-//> using options -Wunused:patvars -Werror
+//> using options -Werror -Wunused:patvars
 
 case class C(a: Int, b: Int, c: Int, d: Int)
 
 object Test {
   val patvars = C(1, 2, 3, 4) match {
-    case C(a, _, _, _) => 1
-    case C(_, b, c@_, _) => 2
+    case C(x, 2, _, _) => 1
+    case C(2, b, y@_, _) => 2
     case C(a, b@_, c, d@_) => 3
     case e => 4
   }

--- a/test/files/neg/warn-unused-locals.check
+++ b/test/files/neg/warn-unused-locals.check
@@ -4,6 +4,9 @@ warn-unused-locals.scala:9: warning: local var x in method f0 is never used
 warn-unused-locals.scala:16: warning: local val b in method f1 is never used
     val b = new Outer // warn
         ^
+warn-unused-locals.scala:20: warning: local var x in method f2 is never updated: consider using immutable val
+    var x = 100 // warn about it being a var
+        ^
 warn-unused-locals.scala:27: warning: local object HiObject in method l1 is never used
     object HiObject { def f = this } // warn
            ^
@@ -16,9 +19,6 @@ warn-unused-locals.scala:32: warning: local class DingDongDoobie is never used
 warn-unused-locals.scala:35: warning: local type OtherThing is never used
     type OtherThing = String // warn
          ^
-warn-unused-locals.scala:20: warning: local var x in method f2 is never updated: consider using immutable val
-    var x = 100 // warn about it being a var
-        ^
 error: No warnings can be incurred under -Werror.
 7 warnings
 1 error

--- a/test/files/neg/warn-unused-params.check
+++ b/test/files/neg/warn-unused-params.check
@@ -25,9 +25,6 @@ warn-unused-params.scala:87: warning: parameter ev in method g2 is never used
 warn-unused-params.scala:91: warning: parameter i in anonymous function is never used
   def f = (i: Int) => answer      // warn
             ^
-warn-unused-params.scala:97: warning: parameter i in anonymous function is never used
-  def g = for (i <- List(1)) yield answer    // warn map.(i => 42)
-               ^
 warn-unused-params.scala:101: warning: parameter ctx in method f is never used
   def f[A](implicit ctx: Context[A]) = answer
                     ^
@@ -47,5 +44,5 @@ warn-unused-params.scala:142: warning: parameter s in method f is never used
   def f(s: Serializable) = toString.nonEmpty  // warn explicit param of marker trait
         ^
 error: No warnings can be incurred under -Werror.
-16 warnings
+15 warnings
 1 error

--- a/test/files/neg/warn-unused-params.scala
+++ b/test/files/neg/warn-unused-params.scala
@@ -94,7 +94,7 @@ trait Anonymous {
 
   def f2: Int => Int = _ + 1  // no warn placeholder syntax (a fresh name and synthetic parameter)
 
-  def g = for (i <- List(1)) yield answer    // warn map.(i => 42)
+  def g = for (i <- List(1)) yield answer    // no warn patvar elaborated as map.(i => 42)
 }
 trait Context[A] { def m(a: A): A = a }
 trait Implicits {

--- a/test/files/neg/warn-unused-privates.check
+++ b/test/files/neg/warn-unused-privates.check
@@ -46,15 +46,27 @@ warn-unused-privates.scala:68: warning: private var s2 in class StableAccessors 
 warn-unused-privates.scala:69: warning: private var s3 in class StableAccessors is never used
   private var s3: Int = 0 // warn, never got
               ^
+warn-unused-privates.scala:72: warning: local var s5 in class StableAccessors is never updated: consider using immutable val
+  private[this] var s5 = 0 // warn, never set
+                    ^
 warn-unused-privates.scala:87: warning: private default argument in trait DefaultArgs is never used
   private def bippy(x1: Int, x2: Int = 10, x3: Int = 15): Int = x1 + x2 + x3
                              ^
 warn-unused-privates.scala:87: warning: private default argument in trait DefaultArgs is never used
   private def bippy(x1: Int, x2: Int = 10, x3: Int = 15): Int = x1 + x2 + x3
                                            ^
+warn-unused-privates.scala:114: warning: local var x in method f2 is never updated: consider using immutable val
+    var x = 100 // warn about it being a var
+        ^
 warn-unused-privates.scala:120: warning: private object Dongo in object Types is never used
   private object Dongo { def f = this } // warn
                  ^
+warn-unused-privates.scala:121: warning: private class Bar1 in object Types is never used
+  private class Bar1 // warn
+                ^
+warn-unused-privates.scala:123: warning: private type Alias1 in object Types is never used
+  private type Alias1 = String // warn
+               ^
 warn-unused-privates.scala:153: warning: private method x_= in class OtherNames is never used
   private def x_=(i: Int): Unit = ()
               ^
@@ -64,18 +76,6 @@ warn-unused-privates.scala:154: warning: private method x in class OtherNames is
 warn-unused-privates.scala:155: warning: private method y_= in class OtherNames is never used
   private def y_=(i: Int): Unit = ()
               ^
-warn-unused-privates.scala:269: warning: private val n in class t12992 enclosing def is unused is never used
-  private val n = 42
-              ^
-warn-unused-privates.scala:274: warning: private method f in class recursive reference is not a usage is never used
-  private def f(i: Int): Int = // warn
-              ^
-warn-unused-privates.scala:121: warning: private class Bar1 in object Types is never used
-  private class Bar1 // warn
-                ^
-warn-unused-privates.scala:123: warning: private type Alias1 in object Types is never used
-  private type Alias1 = String // warn
-               ^
 warn-unused-privates.scala:233: warning: private class for your eyes only in object not even using companion privates is never used
   private implicit class `for your eyes only`(i: Int) {  // warn
                          ^

--- a/test/files/neg/warn-unused-privates.check
+++ b/test/files/neg/warn-unused-privates.check
@@ -82,15 +82,15 @@ warn-unused-privates.scala:233: warning: private class for your eyes only in obj
 warn-unused-privates.scala:249: warning: private class D in class nonprivate alias is enclosing is never used
   private class D extends C2   // warn
                 ^
+warn-unused-privates.scala:269: warning: private val n in class t12992 enclosing def is unused is never used
+  private val n = 42
+              ^
+warn-unused-privates.scala:274: warning: private method f in class recursive reference is not a usage is never used
+  private def f(i: Int): Int = // warn
+              ^
 warn-unused-privates.scala:277: warning: private class P in class recursive reference is not a usage is never used
   private class P {
                 ^
-warn-unused-privates.scala:72: warning: local var s5 in class StableAccessors is never updated: consider using immutable val
-  private[this] var s5 = 0 // warn, never set
-                    ^
-warn-unused-privates.scala:114: warning: local var x in method f2 is never updated: consider using immutable val
-    var x = 100 // warn about it being a var
-        ^
 error: No warnings can be incurred under -Werror.
 31 warnings
 1 error

--- a/test/files/run/t12720.check
+++ b/test/files/run/t12720.check
@@ -6,6 +6,12 @@ You can make this conversion explicit by writing `f _` or `f(_)` instead of `f`.
 newSource1.scala:9: warning: private constructor in class Test*** is never used
   private def this(stuff: Int) = this()
               ^
+newSource1.scala:11: warning: private class Subtle*** in class Test*** is never used
+  private class Subtle
+                ^
+newSource1.scala:15: warning: parameter x*** in method g*** is never used
+  def g(x: Int) = println("error")
+        ^
 newSource1.scala:19: warning: local method m*** in method forgone*** is never used
     def m = 17
         ^
@@ -15,24 +21,18 @@ newSource1.scala:20: warning: local object j*** in method forgone*** is never us
 newSource1.scala:21: warning: local var totally*** in method forgone*** is never used
     var totally = 27
         ^
+newSource1.scala:22: warning: local var unset*** in method forgone*** is never updated: consider using immutable val
+    var unset: Int = 0
+        ^
 newSource1.scala:23: warning: local val z*** in method forgone*** is never used
     val z = unset
         ^
+newSource1.scala:24: warning: parameter y*** in anonymous function is never used
+    for (x <- Option(42); y <- Option(27) if x < i; res = x - y) yield res
+                          ^
 newSource1.scala:27: warning: private var misbegotten*** in class Test*** is never used
   private var misbegotten: Int = 42
               ^
 newSource1.scala:29: warning: private var forgotten (forgotten_=***) in class Test*** is never updated: consider using immutable val
   private var forgotten: Int = 42
               ^
-newSource1.scala:11: warning: private class Subtle*** in class Test*** is never used
-  private class Subtle
-                ^
-newSource1.scala:22: warning: local var unset*** in method forgone*** is never updated: consider using immutable val
-    var unset: Int = 0
-        ^
-newSource1.scala:15: warning: parameter x*** in method g*** is never used
-  def g(x: Int) = println("error")
-        ^
-newSource1.scala:24: warning: parameter y*** in anonymous function is never used
-    for (x <- Option(42); y <- Option(27) if x < i; res = x - y) yield res
-                          ^

--- a/test/files/run/t12720.check
+++ b/test/files/run/t12720.check
@@ -27,9 +27,6 @@ newSource1.scala:22: warning: local var unset*** in method forgone*** is never u
 newSource1.scala:23: warning: local val z*** in method forgone*** is never used
     val z = unset
         ^
-newSource1.scala:24: warning: parameter y*** in anonymous function is never used
-    for (x <- Option(42); y <- Option(27) if x < i; res = x - y) yield res
-                          ^
 newSource1.scala:27: warning: private var misbegotten*** in class Test*** is never used
   private var misbegotten: Int = 42
               ^


### PR DESCRIPTION
`-Wunused:patvars` correctly warns for unused pattern variables in `for` comprehensions.

In the following snippet, both vars are pattern vars:
```
for (x <- e; y = x) yield y
```
and both are "used".

There is no warning when introducing a canonical parameter name:
```
case class C(x, y, z)
c match { case C(x, y, z) => true }
```

Fixes scala/bug#10287

Also improves by sorting altogether.