### PR TITLE
Fix infinite loop bug in the mutable LongMap

### DIFF
--- a/test/junit/scala/collection/mutable/LongMapTest.scala
+++ b/test/junit/scala/collection/mutable/LongMapTest.scala
@@ -1,0 +1,23 @@
+package scala.collection
+package mutable
+
+import org.junit.Assert._
+import org.junit.Test
+
+import scala.tools.testkit.ReflectUtil.getMethodAccessible
+
+class LongMapTest {
+
+  @Test
+  def `repack calculation must complete`: Unit = {
+    val vacant: Int = 10256777
+    val mask: Int   = 1073741823
+    val size: Int   = 603979777
+    //LongMap.repackMask
+    val name = "scala$collection$mutable$LongMap$$repackMask"
+    val sut = getMethodAccessible[LongMap.type](name)
+    val res = sut.invoke(LongMap, mask, size, vacant)
+    assertEquals(1073741823, res)
+  }
+
+}


### PR DESCRIPTION
This bug was discovered when I verified the mutable LongMap data structure with Stainless.
This work has been published at IJCAR24 (https://link.springer.com/chapter/10.1007/978-3-031-63498-7_18)

The bug appears in the computation of the new mask if _size*8 overflows. The counter-example that stainless finds can be seen here, along with the buggy and fixed algorithm: https://github.com/epfl-lara/bolts/blob/53919b74b65793323eb1786b632cdb4dfecbd3e2/data-structures/maps/mutablemaps/src/main/scala/ch/epfl/chassot/BuggyNewMaskComputation.scala

The bug is triggered if _size >= 2**28. If triggered, the mask will be equal to 7, and the process will loop forever when inserting all key-value pairs back.