### PR TITLE
Reference to enclosing element is not a usage

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
+++ b/src/compiler/scala/tools/nsc/transform/SpecializeTypes.scala
@@ -120,13 +120,6 @@ abstract class SpecializeTypes extends InfoTransform with TypingTransformers {
     }
   }
 
-  @annotation.tailrec private def findSymbol[T](candidates: List[T], f: T => Symbol): Symbol = {
-    if (candidates.isEmpty) NoSymbol
-    else f(candidates.head) match {
-      case NoSymbol => findSymbol(candidates.tail, f)
-      case sym      => sym
-    }
-  }
   private def hasNewParents(tree: Tree) = {
     val parents = tree.symbol.info.parents
     val prev    = enteringPrevPhase(tree.symbol.info.parents)

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -576,15 +576,6 @@ abstract class UnCurry extends InfoTransform
           tree
       }
 
-      @tailrec def isThrowable(pat: Tree): Boolean = pat match {
-        case Typed(Ident(nme.WILDCARD), tpt) =>
-          tpt.tpe =:= ThrowableTpe
-        case Bind(_, pat) =>
-          isThrowable(pat)
-        case _ =>
-          false
-      }
-
       tree match {
         /* Some uncurry post transformations add members to templates.
          *

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -126,10 +126,6 @@ abstract class RefChecks extends Transform {
 
       defaultMethodNames.toList.distinct foreach { name =>
         val methods      = clazz.info.findMember(name, 0L, requiredFlags = METHOD, stableOnly = false).alternatives
-        def hasDefaultParam(tpe: Type): Boolean = tpe match {
-          case MethodType(params, restpe) => (params exists (_.hasDefault)) || hasDefaultParam(restpe)
-          case _                          => false
-        }
         val haveDefaults = methods.filter(sym => mexists(sym.info.paramss)(_.hasDefault) && !nme.isProtectedAccessorName(sym.name))
 
         if (haveDefaults.lengthCompare(1) > 0) {

--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -562,7 +562,7 @@ trait TypeDiagnostics extends splain.SplainDiagnostics {
             case b @ Bind(n, _) if !atBounded(b) && n != nme.DEFAULT_CASE => patvars += b.symbol
             case _ =>
           }
-        case _: RefTree if isExisting(sym)            => targets += sym
+        case _: RefTree => if (isExisting(sym) && !currentOwner.hasTransOwner(sym)) targets += sym
         case Assign(lhs, _) if isExisting(lhs.symbol) => setVars += lhs.symbol
         case Function(ps, _) if settings.warnUnusedParams && !t.isErrorTyped => params ++=
           ps.filterNot(p => atBounded(p) || p.symbol.isSynthetic).map(_.symbol)

--- a/src/reflect/scala/reflect/internal/Printers.scala
+++ b/src/reflect/scala/reflect/internal/Printers.scala
@@ -291,12 +291,8 @@ trait Printers extends api.Printers { self: SymbolTable =>
     protected def printCaseDef(tree: CaseDef) = {
       val CaseDef(pat, guard, body) = tree
       print("case ")
-      @tailrec def patConstr(pat: Tree): Tree = pat match {
-        case Apply(fn, args) => patConstr(fn)
-        case _ => pat
-      }
-
-      print(pat); printOpt(" if ", guard)
+      print(pat)
+      printOpt(" if ", guard)
       print(" => ", body)
     }
 

--- a/test/files/neg/warn-unused-privates.check
+++ b/test/files/neg/warn-unused-privates.check
@@ -4,6 +4,9 @@ class Boppy extends {
 warn-unused-privates.scala:5: warning: private constructor in class Bippy is never used
   private def this(c: Int) = this(c, c)           // warn
               ^
+warn-unused-privates.scala:6: warning: private method bippy in class Bippy is never used
+  private def bippy(x: Int): Int      = bippy(x)  // warn
+              ^
 warn-unused-privates.scala:7: warning: private method boop in class Bippy is never used
   private def boop(x: Int)            = x+a+b     // warn
               ^
@@ -64,6 +67,9 @@ warn-unused-privates.scala:155: warning: private method y_= in class OtherNames 
 warn-unused-privates.scala:269: warning: private val n in class t12992 enclosing def is unused is never used
   private val n = 42
               ^
+warn-unused-privates.scala:274: warning: private method f in class recursive reference is not a usage is never used
+  private def f(i: Int): Int = // warn
+              ^
 warn-unused-privates.scala:121: warning: private class Bar1 in object Types is never used
   private class Bar1 // warn
                 ^
@@ -76,6 +82,9 @@ warn-unused-privates.scala:233: warning: private class for your eyes only in obj
 warn-unused-privates.scala:249: warning: private class D in class nonprivate alias is enclosing is never used
   private class D extends C2   // warn
                 ^
+warn-unused-privates.scala:277: warning: private class P in class recursive reference is not a usage is never used
+  private class P {
+                ^
 warn-unused-privates.scala:72: warning: local var s5 in class StableAccessors is never updated: consider using immutable val
   private[this] var s5 = 0 // warn, never set
                     ^
@@ -83,5 +92,5 @@ warn-unused-privates.scala:114: warning: local var x in method f2 is never updat
     var x = 100 // warn about it being a var
         ^
 error: No warnings can be incurred under -Werror.
-28 warnings
+31 warnings
 1 error

--- a/test/files/neg/warn-unused-privates.scala
+++ b/test/files/neg/warn-unused-privates.scala
@@ -1,9 +1,9 @@
 //
-//> using options -deprecation -Wunused:privates -Xfatal-warnings
+//> using options -deprecation -Werror -Wunused:privates
 //
 class Bippy(a: Int, b: Int) {
   private def this(c: Int) = this(c, c)           // warn
-  private def bippy(x: Int): Int      = bippy(x)  // TODO: could warn
+  private def bippy(x: Int): Int      = bippy(x)  // warn
   private def boop(x: Int)            = x+a+b     // warn
   final private val MILLIS1           = 2000      // no warn, might have been inlined
   final private val MILLIS2: Int      = 1000      // warn
@@ -268,4 +268,13 @@ class `issue 12600 ignore abstract types` {
 class `t12992 enclosing def is unused` {
   private val n = 42
   @annotation.unused def f() = n + 2 // unused code uses n
+}
+
+class `recursive reference is not a usage` {
+  private def f(i: Int): Int = // warn
+    if (i <= 0) i
+    else f(i-1)
+  private class P {
+    def f() = new P()
+  }
 }


### PR DESCRIPTION
In the linting arms race with dotty, fix an old `TODO`.

This will conflict with the PR which fixes message sorting.

Edit: it actually detected a few unused methods here.