### PR TITLE
Make lhs of `#:::` in `LazyList.Deferrer` lazier

### DIFF
--- a/src/library/scala/collection/immutable/LazyList.scala
+++ b/src/library/scala/collection/immutable/LazyList.scala
@@ -1144,7 +1144,16 @@ object LazyList extends SeqFactory[LazyList] {
     /** Construct a LazyList consisting of the concatenation of the given LazyList and
       *  another LazyList.
       */
-    def #:::[B >: A](prefix: LazyList[B]): LazyList[B] = prefix lazyAppendedAll l()
+    def #:::[B >: A](prefix: => LazyList[B]): LazyList[B] = newLL(prefix.state) lazyAppendedAll l()
+
+    /** @deprecated Use the #::: method with a by-name parameter instead.
+      *             This can be accomplished by simply recompiling.
+      */
+    @deprecated(
+      "Use the #::: method with a by-name parameter instead; see docs for more info",
+      since = "2.13.15"
+    )
+    def #:::[B >: A]()(prefix: LazyList[B]): LazyList[B] = prefix lazyAppendedAll l()
   }
 
   object #:: {

--- a/src/library/scala/collection/immutable/LazyList.scala
+++ b/src/library/scala/collection/immutable/LazyList.scala
@@ -1153,7 +1153,7 @@ object LazyList extends SeqFactory[LazyList] {
       "Use the #::: method with a by-name parameter instead; see docs for more info",
       since = "2.13.15"
     )
-    def #:::[B >: A]()(prefix: LazyList[B]): LazyList[B] = prefix lazyAppendedAll l()
+    protected[immutable] def #:::[B >: A]()(prefix: LazyList[B]): LazyList[B] = prefix lazyAppendedAll l()
   }
 
   object #:: {

--- a/test/junit/scala/collection/immutable/LazyListLazinessTest.scala
+++ b/test/junit/scala/collection/immutable/LazyListLazinessTest.scala
@@ -811,14 +811,12 @@ class LazyListLazinessTest {
 
     val tailInitFactory = lazyListFactory { init =>
       def gen(index: Int): LazyList[Int] = {
+        def elem(): LazyList[Int] = { init.evaluate(index); LazyList.fill(1)(index) }
         if (index >= LazinessChecker.count) LazyList.empty
-        else {
-          init.evaluate(index)
-          LazyList.fill(1)(index) #::: gen(index + 1)
-        }
+        else elem() #::: gen(index + 1)
       }
 
-      LazyList.empty lazyAppendedAll gen(0) // prevent initial state evaluation
+      gen(0)
     }
     assertRepeatedlyLazy(tailInitFactory)
   }
@@ -873,6 +871,7 @@ class LazyListLazinessTest {
     assertRepeatedlyLazy(factory)
   }
 
+  // TODO: fix this test after impl is made lazier
   @Test
   def range_properlyLazy(): Unit = {
     var counter = 0
@@ -905,7 +904,7 @@ class LazyListLazinessTest {
     def checkRange(ll: => LazyList[CustomLong]): Unit = {
       counter = 0
       ll
-      assert(counter < 10)
+      assert(counter < 10) // TODO: be much more precise
     }
 
     checkRange(LazyList.range(CustomLong(0), CustomLong(1000)))


### PR DESCRIPTION
not forward compatible

- [ ] wait until forward compatibility is disabled (2.13.16?)