### PR TITLE
Prevent cross-talk in scripted tests when running multiple builds

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -960,7 +960,7 @@ lazy val sbtTest = project.in(file("test") / "sbt-test")
     sbtTestDirectory := baseDirectory.value,
 
     scriptedBatchExecution := true, // set to `false` to execute each test in a separate sbt instance
-    scriptedParallelInstances := (if (insideCI.value) 1 else 2), // default is 1; races cause spurious failures
+    scriptedParallelInstances := 2,
 
     // hide sbt output of scripted tests
     scriptedBufferLog := true,

--- a/project/ScriptCommands.scala
+++ b/project/ScriptCommands.scala
@@ -49,6 +49,9 @@ object ScriptCommands {
     * The optional argument is the Artifactory snapshot repository URL. */
   def setupValidateTest = setup("setupValidateTest") { args =>
     Seq(
+      // include sha to prevent multiple builds running on the same jenkins worker from overriding each other
+      // sbtTest/scripted uses publishLocal
+      Global / baseVersionSuffix := "SHA-TEST-SNAPSHOT",
       LocalProject("test") / IntegrationTest / testOptions ++= Seq(Tests.Argument("--show-log"), Tests.Argument("--show-diff"))
     ) ++ (args match {
       case Seq(url) => Seq(Global / resolvers += "scala-pr" at url)

--- a/project/VersionUtil.scala
+++ b/project/VersionUtil.scala
@@ -142,11 +142,12 @@ object VersionUtil {
     }
 
     val (canonicalV, mavenSuffix, osgiV, release) = suffix match {
-      case "SNAPSHOT"     => (s"$base-$date-$sha",   s"-$cross-SNAPSHOT",      s"$base.v$date-$sha",         false)
-      case "SHA-SNAPSHOT" => (s"$base-$date-$sha",   s"-$cross-$sha-SNAPSHOT", s"$base.v$date-$sha",         false)
-      case "SHA"          => (s"$base-$sha",         s"-$cross-$sha",          s"$base.v$date-$sha",         false)
-      case ""             => (s"$base",              "",                       s"$base.v$date-VFINAL-$sha",  true)
-      case _              => (s"$base-$suffix",      s"-$suffix",              s"$base.v$date-$suffix-$sha", true)
+      case "SNAPSHOT"          => (s"$base-$date-$sha",   s"-$cross-SNAPSHOT",           s"$base.v$date-$sha",         false)
+      case "SHA-SNAPSHOT"      => (s"$base-$date-$sha",   s"-$cross-$sha-SNAPSHOT",      s"$base.v$date-$sha",         false)
+      case "SHA-TEST-SNAPSHOT" => (s"$base-$date-$sha",   s"-$cross-$sha-TEST-SNAPSHOT", s"$base.v$date-$sha",         false)
+      case "SHA"               => (s"$base-$sha",         s"-$cross-$sha",               s"$base.v$date-$sha",         false)
+      case ""                  => (s"$base",              "",                            s"$base.v$date-VFINAL-$sha",  true)
+      case _                   => (s"$base-$suffix",      s"-$suffix",                   s"$base.v$date-$suffix-$sha", true)
     }
 
 


### PR DESCRIPTION
Scripted tests use the scala build generated by `publishLocal`. Make sure every build has a different Scala version, otherwise two builds running on the same machine override each others `2.13.15-bin-SNAPSHOT` artifacts.

Presumably fixes https://github.com/scala/scala-dev/issues/868.