### PR TITLE
REPL: JLine 3.26.3 (was 3.25.1)

### DIFF
--- a/src/intellij/scala.ipr.SAMPLE
+++ b/src/intellij/scala.ipr.SAMPLE
@@ -233,7 +233,7 @@
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/ow2/asm/asm/5.0.3/asm-5.0.3.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/openjdk/jmh/jmh-core/1.20/jmh-core-1.20.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/scala-lang/modules/scala-asm/9.3.0-scala-1/scala-asm-9.6.0-scala-1.jar/" />
-        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/jline/jline/3.25.1/jline-3.25.1.jar!/" />
+        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/jline/jline/3.26.3/jline-3.26.3.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/openjdk/jmh/jmh-generator-reflection/1.20/jmh-generator-reflection-1.20.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/openjdk/jmh/jmh-generator-asm/1.20/jmh-generator-asm-1.20.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/openjdk/jol/jol-core/0.13/jol-core-0.13.jar!/" />
@@ -244,7 +244,7 @@
     <library name="compiler-deps">
       <CLASSES>
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/scala-lang/modules/scala-asm/9.3.0-scala-1/scala-asm-9.6.0-scala-1.jar/" />
-        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/jline/jline/3.25.1/jline-3.25.1.jar!/" />
+        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/jline/jline/3.26.3/jline-3.26.3.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/net/java/dev/jna/jna/5.3.1/jna-5.3.1.jar!/" />
       </CLASSES>
       <JAVADOC />
@@ -253,7 +253,7 @@
     <library name="interactive-deps">
       <CLASSES>
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/scala-lang/modules/scala-asm/9.3.0-scala-1/scala-asm-9.6.0-scala-1.jar/" />
-        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/jline/jline/3.25.1/jline-3.25.1.jar!/" />
+        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/jline/jline/3.26.3/jline-3.26.3.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/net/java/dev/jna/jna/5.3.1/jna-5.3.1.jar!/" />
       </CLASSES>
       <JAVADOC />
@@ -267,7 +267,7 @@
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/com/googlecode/java-diff-utils/diffutils/1.3.0/diffutils-1.3.0.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/webjars/jquery/3.4.1/jquery-3.4.1.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/scala-lang/modules/scala-asm/9.3.0-scala-1/scala-asm-9.6.0-scala-1.jar/" />
-        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/jline/jline/3.25.1/jline-3.25.1.jar!/" />
+        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/jline/jline/3.26.3/jline-3.26.3.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/junit/junit/4.12/junit-4.12.jar!/" />
       </CLASSES>
       <JAVADOC />
@@ -288,7 +288,7 @@
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/com/googlecode/java-diff-utils/diffutils/1.3.0/diffutils-1.3.0.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/webjars/jquery/3.4.1/jquery-3.4.1.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/scala-lang/modules/scala-asm/9.3.0-scala-1/scala-asm-9.6.0-scala-1.jar/" />
-        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/jline/jline/3.25.1/jline-3.25.1.jar!/" />
+        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/jline/jline/3.26.3/jline-3.26.3.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/junit/junit/4.12/junit-4.12.jar!/" />
       </CLASSES>
       <JAVADOC />
@@ -304,7 +304,7 @@
     <library name="repl-deps">
       <CLASSES>
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/scala-lang/modules/scala-asm/9.3.0-scala-1/scala-asm-9.6.0-scala-1.jar/" />
-        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/jline/jline/3.25.1/jline-3.25.1.jar!/" />
+        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/jline/jline/3.26.3/jline-3.26.3.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/net/java/dev/jna/jna/5.3.1/jna-5.3.1.jar!/" />
       </CLASSES>
       <JAVADOC />
@@ -313,7 +313,7 @@
     <library name="replFrontend-deps">
       <CLASSES>
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/scala-lang/modules/scala-asm/9.3.0-scala-1/scala-asm-9.6.0-scala-1.jar/" />
-        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/jline/jline/3.25.1/jline-3.25.1.jar!/" />
+        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/jline/jline/3.26.3/jline-3.26.3.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/net/java/dev/jna/jna/5.3.1/jna-5.3.1.jar!/" />
       </CLASSES>
       <JAVADOC />
@@ -367,7 +367,7 @@
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/openjdk/jmh/jmh-generator-reflection/1.20/jmh-generator-reflection-1.20.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/apache/logging/log4j/log4j-slf4j-impl/2.11.2/log4j-slf4j-impl-2.11.2.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/net/java/dev/jna/jna-platform/5.14.0/jna-platform-5.14.0.jar!/" />
-        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/jline/jline/3.25.1/jline-3.25.1.jar!/" />
+        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/jline/jline/3.26.3/jline-3.26.3.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/scala-sbt/sbt/1.6.2/sbt-1.6.2.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/scala-sbt/protocol_2.12/1.6.2/protocol_2.12-1.6.2.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/commons-codec/commons-codec/1.10/commons-codec-1.10.jar!/" />
@@ -449,7 +449,7 @@
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/net/java/dev/jna/jna/5.3.1/jna-5.3.1.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/webjars/jquery/3.4.1/jquery-3.4.1.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/scala-lang/modules/scala-asm/9.3.0-scala-1/scala-asm-9.6.0-scala-1.jar/" />
-        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/jline/jline/3.25.1/jline-3.25.1.jar!/" />
+        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/jline/jline/3.26.3/jline-3.26.3.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/scalacheck/scalacheck_2.13/1.14.3/scalacheck_2.13-1.14.3.jar!/" />
       </CLASSES>
       <JAVADOC />
@@ -458,7 +458,7 @@
     <library name="scaladoc-deps">
       <CLASSES>
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/scala-lang/modules/scala-asm/9.3.0-scala-1/scala-asm-9.6.0-scala-1.jar/" />
-        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/jline/jline/3.25.1/jline-3.25.1.jar!/" />
+        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/jline/jline/3.26.3/jline-3.26.3.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/net/java/dev/jna/jna/5.3.1/jna-5.3.1.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/webjars/jquery/3.4.1/jquery-3.4.1.jar!/" />
       </CLASSES>
@@ -468,7 +468,7 @@
     <library name="scalap-deps">
       <CLASSES>
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/scala-lang/modules/scala-asm/9.3.0-scala-1/scala-asm-9.6.0-scala-1.jar/" />
-        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/jline/jline/3.25.1/jline-3.25.1.jar!/" />
+        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/jline/jline/3.26.3/jline-3.26.3.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/net/java/dev/jna/jna/5.3.1/jna-5.3.1.jar!/" />
       </CLASSES>
       <JAVADOC />
@@ -481,7 +481,7 @@
           <root url="file://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/scala-lang/scala-reflect/2.13.1/scala-reflect-2.13.1.jar" />
           <root url="file://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/scala-lang/scala-library/2.13.1/scala-library-2.13.1.jar" />
           <root url="file://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/net/java/dev/jna/jna/5.3.1/jna-5.3.1.jar" />
-          <root url="file://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/jline/jline/3.25.1/jline-3.25.1.jar" />
+          <root url="file://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/jline/jline/3.26.3/jline-3.26.3.jar" />
         </compiler-classpath>
       </properties>
       <CLASSES />
@@ -496,12 +496,12 @@
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/jline/jline/3.14.0/jline-3.14.0.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/net/java/dev/jna/jna/5.3.1/jna-5.3.1.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/com/googlecode/java-diff-utils/diffutils/1.3.0/diffutils-1.3.0.jar!/" />
-        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/jline/jline-terminal-jna/3.25.1/jline-terminal-jna-3.25.1.jar!/" />
-        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/jline/jline-reader/3.25.1/jline-reader-3.25.1.jar!/" />
+        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/jline/jline-terminal-jna/3.26.3/jline-terminal-jna-3.26.3.jar!/" />
+        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/jline/jline-reader/3.26.3/jline-reader-3.26.3.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/scala-lang/modules/scala-asm/9.3.0-scala-1/scala-asm-9.6.0-scala-1.jar/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/ch/epfl/lamp/dotty-library_0.23/0.23.0-RC1/dotty-library_0.23-0.23.0-RC1.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/ch/epfl/lamp/dotty-interfaces/0.23.0-RC1/dotty-interfaces-0.23.0-RC1.jar!/" />
-        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/jline/jline-terminal/3.25.1/jline-terminal-3.25.1.jar!/" />
+        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/jline/jline-terminal/3.26.3/jline-terminal-3.26.3.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/ch/epfl/lamp/tasty-core_0.23/0.23.0-RC1/tasty-core_0.23-0.23.0-RC1.jar!/" />
       </CLASSES>
       <JAVADOC />
@@ -515,7 +515,7 @@
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/com/googlecode/java-diff-utils/diffutils/1.3.0/diffutils-1.3.0.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/webjars/jquery/3.4.1/jquery-3.4.1.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/scala-lang/modules/scala-asm/9.3.0-scala-1/scala-asm-9.6.0-scala-1.jar/" />
-        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/jline/jline/3.25.1/jline-3.25.1.jar!/" />
+        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/jline/jline/3.26.3/jline-3.26.3.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/junit/junit/4.12/junit-4.12.jar!/" />
       </CLASSES>
       <JAVADOC />
@@ -526,7 +526,7 @@
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/net/java/dev/jna/jna/5.3.1/jna-5.3.1.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/org/scala-lang/modules/scala-asm/9.3.0-scala-1/scala-asm-9.6.0-scala-1.jar/" />
-        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/jline/jline/3.25.1/jline-3.25.1.jar!/" />
+        <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/jline/jline/3.26.3/jline-3.26.3.jar!/" />
         <root url="jar://$USER_HOME$/.coursier/cache/v1/http/127.0.0.1%3A8081/artifactory/scala-ci-virtual/junit/junit/4.12/junit-4.12.jar!/" />
       </CLASSES>
       <JAVADOC />

--- a/versions.properties
+++ b/versions.properties
@@ -9,6 +9,6 @@ starr.version=2.13.14
 scala-asm.version=9.6.0-scala-1
 
 # REPL
-jline.version=3.25.1
+jline.version=3.26.3
 ## also update jline-terminal-jna in the IntelliJ sample
 jna.version=5.14.0


### PR DESCRIPTION
release notes:

* https://github.com/jline/jline3/releases/tag/jline-parent-3.26.0
* https://github.com/jline/jline3/releases/tag/jline-parent-3.26.1
* https://github.com/jline/jline3/releases/tag/jline-parent-3.26.2
* https://github.com/jline/jline3/releases/tag/jline-parent-3.26.3

a lot of bugfixes, nothing really stands out that I can see

we usually take these upgrades in the hopes they will improve things in small ways, especially for Windows users