### PR TITLE
Add JDK 23 (early access) to nightly CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: [8, 11, 17, 21, 22]
+        java: [8, 11, 17, 21, 22, 23-ea]
     runs-on: ${{matrix.os}}
     steps:
       - run: git config --global core.autocrlf false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: ['2.*.x']
   workflow_dispatch:
+  pull_request:
 
 defaults:
   run:


### PR DESCRIPTION
```
  Java configuration:
    Distribution: temurin
    Version: 23.0.0+35.0.ea
    Path: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/23.0.0-ea.35.0.ea/x64
```

once CI likes it and we remove the extra commit and merge, we should merge this forward to 2.13.x as well