### PR TITLE
Fix case-apply rewrite in case of private constr and overloaded apply

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1657,7 +1657,7 @@ abstract class RefChecks extends Transform {
       sym.name == nme.apply &&
         sym.isCase && // only synthetic case apply methods
         isClassTypeAccessible &&
-        !fun.tpe.finalResultType.typeSymbol.primaryConstructor.isLessAccessibleThan(sym)
+        !sym.tpe.finalResultType.typeSymbol.primaryConstructor.isLessAccessibleThan(sym)
     }
 
     private def transformCaseApply(tpe: Type, pos: Position) = {

--- a/test/files/pos/t13025.scala
+++ b/test/files/pos/t13025.scala
@@ -1,0 +1,11 @@
+package p1 {
+  case class Foo[X] private (a: Int)
+  object Foo {
+    def apply[X](a: String): Foo[Any] = ???
+  }
+}
+package p2 {
+  class C {
+    def x = p1.Foo[Any](0)
+  }
+}


### PR DESCRIPTION
In the example, `apply` is overloaded.

Overloading resolution uses `setSymbol` and `setType` once it has selected a winner.

https://github.com/scala/scala/blob/v2.13.14/src/compiler/scala/tools/nsc/typechecker/Infer.scala#L1530

In the case of a `TypeApply` tree:
  - `setSymbol` delegates to the nested `Apply` tree
  - `setType` sets the type of the `TypeApply`

This means that the nested `Apply` tree keeps its OverloadedType. This tripped up `fun.tpe.finalResultType.typeSymbol` in RefChecks (NoSymbol).

It's not obvious how to assign the right type to the `Apply` tree, so I left it alone.

Fixes https://github.com/scala/bug/issues/13025.