### PR TITLE
Skip `checkNoDoubleDefs` in Java source files

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3539,7 +3539,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
         // As packages are open, it doesn't make sense to check double definitions here. Furthermore,
         // it is expensive if the package is large. Instead, such double definitions are checked in `Namers.enterInScope`
-        if (!context.owner.isPackageClass)
+        if (!context.owner.isPackageClass && !unit.isJava)
           checkNoDoubleDefs(scope)
 
         // Note that Java units don't have synthetics, but there's no point in making a special case (for performance or correctness),

--- a/test/files/pos/i20006-java/J.java
+++ b/test/files/pos/i20006-java/J.java
@@ -1,0 +1,4 @@
+public class J {
+  private String mo;
+  public String mo() { return this.mo; }
+}

--- a/test/files/pos/i20006-java/T.scala
+++ b/test/files/pos/i20006-java/T.scala
@@ -1,0 +1,5 @@
+//> using options -Ypickle-java
+
+class T {
+  new J().mo();
+}


### PR DESCRIPTION
Follow-up for https://github.com/scala/scala/pull/10727

Should fix some regressions in the community build