### PR TITLE
Align with Scala 3: Add `-Xsource-features:double-definitions` to warn or error for double definitions

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1195,6 +1195,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
       def leadingInfix           = isScala3 && contains(o.leadingInfix)
       def packagePrefixImplicits = isScala3 && contains(o.packagePrefixImplicits)
       def implicitResolution     = isScala3 && contains(o.implicitResolution) || settings.Yscala3ImplicitResolution.value
+      def doubleDefinitions      = isScala3 && contains(o.doubleDefinitions)
     }
 
     // used in sbt

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -181,6 +181,7 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
     val leadingInfix           = Choice("leading-infix", "Leading infix operators continue the previous line.")
     val packagePrefixImplicits = Choice("package-prefix-implicits", "The package prefix p is no longer part of the implicit search scope for type p.A.")
     val implicitResolution     = Choice("implicit-resolution", "Use Scala-3-style downwards comparisons for implicit search and overloading resolution (see github.com/scala/scala/pull/6037).")
+    val doubleDefinitions      = Choice("double-definitions", "Correctly disallow double definitions differing in empty parens.")
 
     val v13_13_choices = List(caseApplyCopyAccess, caseCompanionFunction, inferOverride, any2StringAdd, unicodeEscapesRaw, stringContextScope, leadingInfix, packagePrefixImplicits)
 
@@ -190,11 +191,16 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
       expandsTo = v13_13_choices)
 
     val v13_14_choices = implicitResolution :: v13_13_choices
-
     val v13_14 = Choice(
       "v2.13.14",
       "v2.13.13 plus implicit-resolution",
       expandsTo = v13_14_choices)
+
+    val v13_15_choices = doubleDefinitions :: v13_14_choices
+    val v13_15 = Choice(
+      "v2.13.15",
+      "v2.13.14 plus double-definitions",
+      expandsTo = v13_15_choices)
   }
   val XsourceFeatures = MultiChoiceSetting(
     name = "-Xsource-features",

--- a/test/files/neg/i20006.check
+++ b/test/files/neg/i20006.check
@@ -6,18 +6,10 @@ i20006.scala:7: error: method hasNext is defined twice;
   the conflicting value hasNext was defined at line 5:7
   override def hasNext: Boolean = first || hasNext(acc) // error
                ^
-i20006.scala:22: error: method next is defined twice;
-  the conflicting value next was defined at line 18:65
-  override def next(): T = { // error
-               ^
 i20006.scala:21: error: method hasNext is defined twice;
   the conflicting value hasNext was defined at line 18:42
   override def hasNext: Boolean = first || hasNext(acc) // error
                ^
-i20006.scala:36: error: method next is defined twice;
-  the conflicting value next was defined at line 32:65
-  def next(): T = { // error
-      ^
 i20006.scala:35: error: method hasNext is defined twice;
   the conflicting value hasNext was defined at line 32:42
   def hasNext: Boolean = first || hasNext(acc) // error
@@ -32,16 +24,11 @@ i20006.scala:50: error: variable x is defined twice;
 i20006.scala:53: error: x is already defined as value x
   private[this] var x: Int = 42 // error
                     ^
-i20006.scala:56: error: method x is defined twice;
-  the conflicting value x was defined at line 55:9
-  def x(): Int = 42 // error
-      ^
-i20006.scala:63: error: method x is defined twice;
-  the conflicting value x was defined at line 62:21
-  def x(): Int = 42 // error
-      ^
 i20006.scala:67: error: method x is defined twice;
   the conflicting method x was defined at line 66:21
   def x(): Int = 42 // error
       ^
-12 errors
+i20006.scala:77: error: x is already defined as variable x
+    def x(): Int = x // error
+        ^
+9 errors

--- a/test/files/neg/i20006b.check
+++ b/test/files/neg/i20006b.check
@@ -1,0 +1,59 @@
+i20006b.scala:9: error: method next is defined twice;
+  the conflicting value next was defined at line 7:7
+  override def next(): T = { // error
+               ^
+i20006b.scala:8: error: method hasNext is defined twice;
+  the conflicting value hasNext was defined at line 6:7
+  override def hasNext: Boolean = first || hasNext(acc) // error
+               ^
+i20006b.scala:22: error: method hasNext is defined twice;
+  the conflicting value hasNext was defined at line 19:42
+  override def hasNext: Boolean = first || hasNext(acc) // error
+               ^
+i20006b.scala:36: error: method hasNext is defined twice;
+  the conflicting value hasNext was defined at line 33:42
+  def hasNext: Boolean = first || hasNext(acc) // error
+      ^
+i20006b.scala:48: error: x is already defined as value x
+  val x: String = "member" // error
+      ^
+i20006b.scala:51: error: variable x is defined twice;
+  the conflicting value x was defined at line 50:9
+  private var x: Int = 42 // error
+              ^
+i20006b.scala:54: error: x is already defined as value x
+  private[this] var x: Int = 42 // error
+                    ^
+i20006b.scala:68: error: method x is defined twice;
+  the conflicting method x was defined at line 67:21
+  def x(): Int = 42 // error
+      ^
+i20006b.scala:78: error: x is already defined as variable x
+    def x(): Int = x // error
+        ^
+i20006b.scala:23: error: Double definition will be detected in Scala 3; the conflicting value next is defined at 19:65
+Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or @nowarn to demote them to warnings or suppress.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=YIterateIterator
+  override def next(): T = { // werror
+               ^
+i20006b.scala:37: error: Double definition will be detected in Scala 3; the conflicting value next is defined at 33:65
+Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or @nowarn to demote them to warnings or suppress.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=ZIterateIterator
+  def next(): T = { // werror
+      ^
+i20006b.scala:57: error: Double definition will be detected in Scala 3; the conflicting value x is defined at 56:9
+Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or @nowarn to demote them to warnings or suppress.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=F
+  def x(): Int = 42 // werror
+      ^
+i20006b.scala:64: error: Double definition will be detected in Scala 3; the conflicting value x is defined at 63:21
+Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or @nowarn to demote them to warnings or suppress.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=H
+  def x(): Int = 42 // werror
+      ^
+i20006b.scala:72: error: Double definition will be detected in Scala 3; the conflicting variable x is defined at 71:21
+Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or @nowarn to demote them to warnings or suppress.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=PrivateConflict
+  def x(): Int = x // werror
+      ^
+14 errors

--- a/test/files/neg/i20006b.scala
+++ b/test/files/neg/i20006b.scala
@@ -1,0 +1,158 @@
+//> using options -Werror -Xsource:3
+
+abstract class XIterateIterator[T](seed: T) extends collection.AbstractIterator[T] {
+  private var first = true
+  private var acc = seed
+  val hasNext: T => Boolean
+  val next: T => T
+  override def hasNext: Boolean = first || hasNext(acc) // error
+  override def next(): T = { // error
+    if (first) {
+      first = false
+    } else {
+      acc = next(acc)
+    }
+    acc
+  }
+}
+
+final class YIterateIterator[T](seed: T, hasNext: T => Boolean, next: T => T) extends collection.AbstractIterator[T] {
+  private var first = true
+  private var acc = seed
+  override def hasNext: Boolean = first || hasNext(acc) // error
+  override def next(): T = { // werror
+    if (first) {
+      first = false
+    } else {
+      acc = next(acc)
+    }
+    acc
+  }
+}
+
+final class ZIterateIterator[T](seed: T, hasNext: T => Boolean, next: T => T) {
+  private var first = true
+  private var acc = seed
+  def hasNext: Boolean = first || hasNext(acc) // error
+  def next(): T = { // werror
+    if (first) {
+      first = false
+    } else {
+      acc = next(acc)
+    }
+    acc
+  }
+}
+
+class C(x: String) {
+  val x: String = "member" // error
+}
+class D(x: String) {
+  private var x: Int = 42 // error
+}
+class E(x: String) {
+  private[this] var x: Int = 42 // error
+}
+class F(x: String) {
+  def x(): Int = 42 // werror
+}
+class G(x: String) {
+  def x(i: Int): Int = i
+}
+class H {
+  private[this] val x: String = ""
+  def x(): Int = 42 // werror
+}
+class I {
+  private[this] def x: String = ""
+  def x(): Int = 42 // error
+}
+class PrivateConflict {
+  private[this] var x = 42
+  def x(): Int = x // werror
+  def x_=(n: Int) = x = n
+}
+class LocalConflict {
+  def f(): Unit = {
+    var x = 42
+    def x(): Int = x // error
+  }
+}
+
+/*
+-- [E120] Naming Error: test/files/neg/i20006.scala:8:15 ---------------------------------------------------------------
+8 |  override def hasNext: Boolean = first || hasNext(acc)
+  |               ^
+  |               Double definition:
+  |               val hasNext: T => Boolean in class XIterateIterator at line 6 and
+  |               override def hasNext: Boolean in class XIterateIterator at line 8
+-- [E120] Naming Error: test/files/neg/i20006.scala:9:15 ---------------------------------------------------------------
+9 |  override def next(): T = {
+  |               ^
+  |               Double definition:
+  |               val next: T => T in class XIterateIterator at line 7 and
+  |               override def next(): T in class XIterateIterator at line 9
+-- [E120] Naming Error: test/files/neg/i20006.scala:22:15 --------------------------------------------------------------
+22 |  override def hasNext: Boolean = first || hasNext(acc)
+   |               ^
+   |               Double definition:
+   |               private[this] val hasNext: T => Boolean in class YIterateIterator at line 19 and
+   |               override def hasNext: Boolean in class YIterateIterator at line 22
+-- [E120] Naming Error: test/files/neg/i20006.scala:23:15 --------------------------------------------------------------
+23 |  override def next(): T = {
+   |               ^
+   |               Double definition:
+   |               private[this] val next: T => T in class YIterateIterator at line 19 and
+   |               override def next(): T in class YIterateIterator at line 23
+-- [E120] Naming Error: test/files/neg/i20006.scala:36:6 ---------------------------------------------------------------
+36 |  def hasNext: Boolean = first || hasNext(acc)
+   |      ^
+   |      Double definition:
+   |      private[this] val hasNext: T => Boolean in class ZIterateIterator at line 33 and
+   |      def hasNext: Boolean in class ZIterateIterator at line 36
+-- [E120] Naming Error: test/files/neg/i20006.scala:37:6 ---------------------------------------------------------------
+37 |  def next(): T = {
+   |      ^
+   |      Double definition:
+   |      private[this] val next: T => T in class ZIterateIterator at line 33 and
+   |      def next(): T in class ZIterateIterator at line 37
+-- [E120] Naming Error: test/files/neg/i20006.scala:48:6 ---------------------------------------------------------------
+48 |  val x: String = "member" // error
+   |      ^
+   |      Double definition:
+   |      private[this] val x: String in class C at line 47 and
+   |      val x: String in class C at line 48
+-- [E120] Naming Error: test/files/neg/i20006.scala:51:14 --------------------------------------------------------------
+51 |  private var x: Int = 42 // error
+   |              ^
+   |              Double definition:
+   |              private[this] val x: String in class D at line 50 and
+   |              private[this] var x: Int in class D at line 51
+-- [E120] Naming Error: test/files/neg/i20006.scala:54:20 --------------------------------------------------------------
+54 |  private[this] var x: Int = 42 // error
+   |                    ^
+   |                    Double definition:
+   |                    private[this] val x: String in class E at line 53 and
+   |                    private[this] var x: Int in class E at line 54
+-- [E120] Naming Error: test/files/neg/i20006.scala:57:6 ---------------------------------------------------------------
+57 |  def x(): Int = 42 // error
+   |      ^
+   |      Double definition:
+   |      private[this] val x: String in class F at line 56 and
+   |      def x(): Int in class F at line 57
+-- [E120] Naming Error: test/files/neg/i20006.scala:65:6 ---------------------------------------------------------------
+65 |  def x(): Int = 42
+   |      ^
+   |      Double definition:
+   |      val x: String in class H at line 63 and
+   |      def x(): Int in class H at line 65
+-- Warning: test/files/neg/i20006.scala:54:16 --------------------------------------------------------------------------
+54 |  private[this] var x: Int = 42 // error
+   |                ^
+   |                Ignoring [this] qualifier.
+   |                This syntax will be deprecated in the future; it should be dropped.
+   |                See: https://docs.scala-lang.org/scala3/reference/dropped-features/this-qualifier.html
+   |                This construct can be rewritten automatically under -rewrite -source 3.4-migration.
+1 warning found
+11 errors found
+*/

--- a/test/files/neg/i20006c.check
+++ b/test/files/neg/i20006c.check
@@ -1,0 +1,54 @@
+i20006c.scala:9: error: method next is defined twice;
+  the conflicting value next was defined at line 7:7
+  override def next(): T = { // error
+               ^
+i20006c.scala:8: error: method hasNext is defined twice;
+  the conflicting value hasNext was defined at line 6:7
+  override def hasNext: Boolean = first || hasNext(acc) // error
+               ^
+i20006c.scala:23: error: method next is defined twice;
+  the conflicting value next was defined at line 19:65
+  override def next(): T = { // error
+               ^
+i20006c.scala:22: error: method hasNext is defined twice;
+  the conflicting value hasNext was defined at line 19:42
+  override def hasNext: Boolean = first || hasNext(acc) // error
+               ^
+i20006c.scala:37: error: method next is defined twice;
+  the conflicting value next was defined at line 33:65
+  def next(): T = { // error
+      ^
+i20006c.scala:36: error: method hasNext is defined twice;
+  the conflicting value hasNext was defined at line 33:42
+  def hasNext: Boolean = first || hasNext(acc) // error
+      ^
+i20006c.scala:48: error: x is already defined as value x
+  val x: String = "member" // error
+      ^
+i20006c.scala:51: error: variable x is defined twice;
+  the conflicting value x was defined at line 50:9
+  private var x: Int = 42 // error
+              ^
+i20006c.scala:54: error: x is already defined as value x
+  private[this] var x: Int = 42 // error
+                    ^
+i20006c.scala:57: error: method x is defined twice;
+  the conflicting value x was defined at line 56:9
+  def x(): Int = 42 // error
+      ^
+i20006c.scala:64: error: method x is defined twice;
+  the conflicting value x was defined at line 63:21
+  def x(): Int = 42 // error
+      ^
+i20006c.scala:68: error: method x is defined twice;
+  the conflicting method x was defined at line 67:21
+  def x(): Int = 42 // error
+      ^
+i20006c.scala:72: error: method x is defined twice;
+  the conflicting variable x was defined at line 71:21
+  def x(): Int = x // error
+      ^
+i20006c.scala:78: error: x is already defined as variable x
+    def x(): Int = x // error
+        ^
+14 errors

--- a/test/files/neg/i20006c.scala
+++ b/test/files/neg/i20006c.scala
@@ -1,3 +1,4 @@
+//> using options -Werror -Xsource:3 -Xsource-features:double-definitions
 
 abstract class XIterateIterator[T](seed: T) extends collection.AbstractIterator[T] {
   private var first = true
@@ -19,7 +20,7 @@ final class YIterateIterator[T](seed: T, hasNext: T => Boolean, next: T => T) ex
   private var first = true
   private var acc = seed
   override def hasNext: Boolean = first || hasNext(acc) // error
-  override def next(): T = { // noerror
+  override def next(): T = { // error
     if (first) {
       first = false
     } else {
@@ -33,7 +34,7 @@ final class ZIterateIterator[T](seed: T, hasNext: T => Boolean, next: T => T) {
   private var first = true
   private var acc = seed
   def hasNext: Boolean = first || hasNext(acc) // error
-  def next(): T = { // noerror
+  def next(): T = { // error
     if (first) {
       first = false
     } else {
@@ -53,14 +54,14 @@ class E(x: String) {
   private[this] var x: Int = 42 // error
 }
 class F(x: String) {
-  def x(): Int = 42 // noerror
+  def x(): Int = 42 // error
 }
 class G(x: String) {
   def x(i: Int): Int = i
 }
 class H {
   private[this] val x: String = ""
-  def x(): Int = 42 // noerror
+  def x(): Int = 42 // error
 }
 class I {
   private[this] def x: String = ""
@@ -68,7 +69,7 @@ class I {
 }
 class PrivateConflict {
   private[this] var x = 42
-  def x(): Int = x
+  def x(): Int = x // error
   def x_=(n: Int) = x = n
 }
 class LocalConflict {


### PR DESCRIPTION
Optionally warn or error for double definitions that went undetected in Scala 2.

The new condition is a source feature, so it warns under `-Xsource:3` and errors under `-Xsource-features:double-definitions`. It is also available under `-Xsource-features:v2.13.15`.

This is for "user convenience": fixing the bug outright would require users to change code that is probably benign.

Revises the earlier https://github.com/scala/scala/pull/10727
