### PR TITLE
New reference compiler is Scala 2.13.15-M1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -1,5 +1,5 @@
 # Scala version used for bootstrapping (see README.md)
-starr.version=2.13.14
+starr.version=2.13.15-M1
 
 # These are the versions of the modules that go with this release.
 # Artifact dependencies:


### PR DESCRIPTION
we need the reference compiler to have JDK 23 support in the optimizer in order for nightly CI to pass on JDK 23
