### PR TITLE
Improve type inference for abstract type

### DIFF
--- a/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
@@ -531,7 +531,7 @@ trait TypeComparers {
       sym2 match {
         case SingletonClass                   => tp1.isStable || fourthTry
         case _: ClassSymbol                   => classOnRight
-        case _: TypeSymbol if sym2.isDeferred => abstractTypeOnRight(tp2.lowerBound) || fourthTry
+        case _: TypeSymbol if sym2.isDeferred => fourthTry || abstractTypeOnRight(tp2.lowerBound)
         case _: TypeSymbol                    => retry(normalizePlus(tp1), normalizePlus(tp2))
         case _                                => fourthTry
       }


### PR DESCRIPTION
The background of this PR is this code:
```scala
trait A
trait B

trait S[-I]

final class SOps[I](private val x: S[I]) extends AnyVal {
  def op[I2](y: S[I with I2]): S[I2] = ???
}

object Main {
  type W[T] = ({ type R <: T })#R

  private val a: S[A] = ???
  private val wa: S[W[A]] = ???

  private val ab: S[A with B] = ???
  private val wab: S[W[A] with B] = ???

  private val b: S[B] = new SOps(a).op(ab)
  private val wb: S[B] = new SOps(wa).op(wab)
}
```

It [compiles with Scala 3](https://scastie.scala-lang.org/yL6BypmETiKNRQrd5j1rDg), but [not with Scala 2](https://scastie.scala-lang.org/mnVwcnWnRpiHQ6PtCbi1MA).

The compiler cannot infer that `I2 = B` (in `wb`).
It goes this way:
```
S[W[A] with B]        isSubType S[W[A] with ?I2]
W[A] with ?I2         isSubType W[A] with B
W[A] with ?I2         isSubType W[A]
W[A] with ?I2         isSubType AnyRef{type R <: A}#R (1)
W[A] with ?I2         isSubType Nothing (2)
W[A]                  isSubType Nothing
AnyRef{type R <: A}#R isSubType Nothing
A                     isSubType Nothing
?I2                   isSubType Nothing
```

(1) -> (2) happens [here](https://github.com/scala/scala/blob/52b201330a5f45c8d9332a2a82be702988d53dff/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala#L534) (since `tp2.lowerBound = Nothing`).

Can we first try `fourthTry` and if it fails, then try `abstractTypeOnRight`?

Or is it valid to make this change?
```scala
case _: TypeSymbol if sym2.isDeferred =>
          (
            tp1 match {
              case RefinedType(parents, _) => parents.exists(retry(_, tp2))
              case _ => false
            }
          ) || abstractTypeOnRight(tp2.lowerBound) || fourthTry
```


