### PR TITLE
On the empty string, `.tail` and `.init` now throw (instead of returning the empty string)

### DIFF
--- a/src/library/scala/collection/StringOps.scala
+++ b/src/library/scala/collection/StringOps.scala
@@ -1201,14 +1201,16 @@ final class StringOps(private val s: String) extends AnyVal {
   def withFilter(p: Char => Boolean): StringOps.WithFilter = new StringOps.WithFilter(p, s)
 
   /** The rest of the string without its first char.
-    * @note $unicodeunaware
-    */
-  def tail: String = slice(1, s.length)
+   *  @throws UnsupportedOperationException if the string is empty.
+   *  @note $unicodeunaware
+   */
+  def tail: String = if(s.isEmpty) throw new UnsupportedOperationException("tail of empty String") else slice(1, s.length)
 
   /** The initial part of the string without its last char.
-    * @note $unicodeunaware
-    */
-  def init: String = slice(0, s.length-1)
+   *  @throws UnsupportedOperationException if the string is empty.
+   * @note $unicodeunaware
+   */
+  def init: String = if(s.isEmpty) throw new UnsupportedOperationException("init of empty String") else slice(0, s.length-1)
 
   /** A string containing the first `n` chars of this string.
     * @note $unicodeunaware

--- a/test/junit/scala/collection/StringOpsTest.scala
+++ b/test/junit/scala/collection/StringOpsTest.scala
@@ -102,4 +102,18 @@ class StringOpsTest {
     assertEquals("de", "abcdef".collect { case c @ ('b' | 'c') => (c+2).toChar })
     assertEquals(Seq('d'.toInt, 'e'.toInt), "abcdef".collect { case c @ ('b' | 'c') => (c+2).toInt })
   }
+
+  @Test def init(): Unit = {
+    assertEquals("ab", "abc".init)
+    assertEquals("a", "ab".init)
+    assertEquals("", "a".init)
+    assertThrows[UnsupportedOperationException]("".init)
+  }
+
+  @Test def tail(): Unit = {
+    assertEquals("bc", "abc".tail)
+    assertEquals("b", "ab".tail)
+    assertEquals("", "a".tail)
+    assertThrows[UnsupportedOperationException]("".tail)
+  }
 }


### PR DESCRIPTION
fix https://github.com/scala/bug/issues/13026