### PR TITLE
No double def in Scala 2 for private[this] param and matching method

### DIFF
--- a/test/files/neg/i20006.check
+++ b/test/files/neg/i20006.check
@@ -6,21 +6,9 @@ i20006.scala:7: error: method hasNext is defined twice;
   the conflicting value hasNext was defined at line 5:7
   override def hasNext: Boolean = first || hasNext(acc) // error
                ^
-i20006.scala:21: error: method hasNext is defined twice;
-  the conflicting value hasNext was defined at line 18:42
-  override def hasNext: Boolean = first || hasNext(acc) // error
-               ^
-i20006.scala:35: error: method hasNext is defined twice;
-  the conflicting value hasNext was defined at line 32:42
-  def hasNext: Boolean = first || hasNext(acc) // error
-      ^
 i20006.scala:47: error: x is already defined as value x
   val x: String = "member" // error
       ^
-i20006.scala:50: error: variable x is defined twice;
-  the conflicting value x was defined at line 49:9
-  private var x: Int = 42 // error
-              ^
 i20006.scala:53: error: x is already defined as value x
   private[this] var x: Int = 42 // error
                     ^
@@ -31,4 +19,4 @@ i20006.scala:67: error: method x is defined twice;
 i20006.scala:77: error: x is already defined as variable x
     def x(): Int = x // error
         ^
-9 errors
+6 errors

--- a/test/files/neg/i20006b.check
+++ b/test/files/neg/i20006b.check
@@ -6,21 +6,9 @@ i20006b.scala:8: error: method hasNext is defined twice;
   the conflicting value hasNext was defined at line 6:7
   override def hasNext: Boolean = first || hasNext(acc) // error
                ^
-i20006b.scala:22: error: method hasNext is defined twice;
-  the conflicting value hasNext was defined at line 19:42
-  override def hasNext: Boolean = first || hasNext(acc) // error
-               ^
-i20006b.scala:36: error: method hasNext is defined twice;
-  the conflicting value hasNext was defined at line 33:42
-  def hasNext: Boolean = first || hasNext(acc) // error
-      ^
 i20006b.scala:48: error: x is already defined as value x
   val x: String = "member" // error
       ^
-i20006b.scala:51: error: variable x is defined twice;
-  the conflicting value x was defined at line 50:9
-  private var x: Int = 42 // error
-              ^
 i20006b.scala:54: error: x is already defined as value x
   private[this] var x: Int = 42 // error
                     ^
@@ -36,11 +24,26 @@ Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or 
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=YIterateIterator
   override def next(): T = { // werror
                ^
+i20006b.scala:22: error: Double definition will be detected in Scala 3; the conflicting value hasNext is defined at 19:42
+Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or @nowarn to demote them to warnings or suppress.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=YIterateIterator
+  override def hasNext: Boolean = first || hasNext(acc) // error
+               ^
 i20006b.scala:37: error: Double definition will be detected in Scala 3; the conflicting value next is defined at 33:65
 Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or @nowarn to demote them to warnings or suppress.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=ZIterateIterator
   def next(): T = { // werror
       ^
+i20006b.scala:36: error: Double definition will be detected in Scala 3; the conflicting value hasNext is defined at 33:42
+Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or @nowarn to demote them to warnings or suppress.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=ZIterateIterator
+  def hasNext: Boolean = first || hasNext(acc) // error
+      ^
+i20006b.scala:51: error: Double definition will be detected in Scala 3; the conflicting value x is defined at 50:9
+Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or @nowarn to demote them to warnings or suppress.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=D
+  private var x: Int = 42 // error
+              ^
 i20006b.scala:57: error: Double definition will be detected in Scala 3; the conflicting value x is defined at 56:9
 Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or @nowarn to demote them to warnings or suppress.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=F

--- a/test/files/neg/i20006d.check
+++ b/test/files/neg/i20006d.check
@@ -1,0 +1,62 @@
+i20006d.scala:12: error: method x is defined twice;
+  the conflicting value x was defined at line 11:22
+  def x: Int = 4 // err
+      ^
+i20006d.scala:17: error: method x is defined twice;
+  the conflicting value x was defined at line 16:28
+    def x: Int = 4 // err
+        ^
+i20006d.scala:22: error: method x is defined twice;
+  the conflicting value x was defined at line 21:24
+  def x: Int = 4 // err
+      ^
+i20006d.scala:27: error: method x is defined twice;
+  the conflicting value x was defined at line 26:30
+    def x: Int = 4 // err
+        ^
+i20006d.scala:32: error: method x is defined twice;
+  the conflicting value x was defined at line 31:14
+  def x: Int = 4 // err
+      ^
+i20006d.scala:44: error: method x is defined twice;
+  the conflicting value x was defined at line 43:22
+  def x(): Int = 4 // err
+      ^
+i20006d.scala:49: error: method x is defined twice;
+  the conflicting value x was defined at line 48:28
+    def x(): Int = 4 // err
+        ^
+i20006d.scala:54: error: method x is defined twice;
+  the conflicting value x was defined at line 53:24
+  def x(): Int = 4 // err
+      ^
+i20006d.scala:59: error: method x is defined twice;
+  the conflicting value x was defined at line 58:30
+    def x(): Int = 4 // err
+        ^
+i20006d.scala:64: error: method x is defined twice;
+  the conflicting value x was defined at line 63:14
+  def x(): Int = 4 // err
+      ^
+i20006d.scala:68: error: x is already defined as value x
+  val x: Int = 4 // err
+      ^
+i20006d.scala:72: error: x is already defined as value x
+  val x: Int = 4 // err
+      ^
+i20006d.scala:76: error: x is already defined as value x
+  val x: Int = 4 // err
+      ^
+i20006d.scala:81: error: x is already defined as value x
+    val x: Int = 4 // err
+        ^
+i20006d.scala:86: error: x is already defined as value x
+  val x: Int = 4 // err
+      ^
+i20006d.scala:91: error: x is already defined as value x
+    val x: Int = 4 // err
+        ^
+i20006d.scala:96: error: x is already defined as value x
+  val x: Int = 4 // err
+      ^
+17 errors

--- a/test/files/neg/i20006d.scala
+++ b/test/files/neg/i20006d.scala
@@ -1,0 +1,97 @@
+//> using options -Werror
+
+class C1(x: String) {
+  def x: Int = 4 // ok in Scala 2
+}
+
+class C2(private[this] val x: String) {
+  def x: Int = 4 // ok in Scala 2
+}
+
+class C3(private val x: String) {
+  def x: Int = 4 // err
+}
+
+object o4 {
+  class C4(private[o4] val x: String) {
+    def x: Int = 4 // err
+  }
+}
+
+class C5(protected val x: String) {
+  def x: Int = 4 // err
+}
+
+object o6 {
+  class C6(protected[o6] val x: String) {
+    def x: Int = 4 // err
+  }
+}
+
+class C7(val x: String) {
+  def x: Int = 4 // err
+}
+
+class D1(x: String) {
+  def x(): Int = 4 // ok
+}
+
+class D2(private[this] val x: String) {
+  def x(): Int = 4 // ok
+}
+
+class D3(private val x: String) {
+  def x(): Int = 4 // err
+}
+
+object p4 {
+  class D4(private[p4] val x: String) {
+    def x(): Int = 4 // err
+  }
+}
+
+class D5(protected val x: String) {
+  def x(): Int = 4 // err
+}
+
+object p6 {
+  class D6(protected[p6] val x: String) {
+    def x(): Int = 4 // err
+  }
+}
+
+class D7(val x: String) {
+  def x(): Int = 4 // err
+}
+
+class E1(x: String) {
+  val x: Int = 4 // err
+}
+
+class E2(private[this] val x: String) {
+  val x: Int = 4 // err
+}
+
+class E3(private val x: String) {
+  val x: Int = 4 // err
+}
+
+object q4 {
+  class E4(private[q4] val x: String) {
+    val x: Int = 4 // err
+  }
+}
+
+class E5(protected val x: String) {
+  val x: Int = 4 // err
+}
+
+object q6 {
+  class E6(protected[q6] val x: String) {
+    val x: Int = 4 // err
+  }
+}
+
+class E7(val x: String) {
+  val x: Int = 4 // err
+}

--- a/test/files/neg/i20006e.check
+++ b/test/files/neg/i20006e.check
@@ -1,0 +1,82 @@
+i20006e.scala:12: error: method x is defined twice;
+  the conflicting value x was defined at line 11:22
+  def x: Int = 4 // err
+      ^
+i20006e.scala:17: error: method x is defined twice;
+  the conflicting value x was defined at line 16:28
+    def x: Int = 4 // err
+        ^
+i20006e.scala:22: error: method x is defined twice;
+  the conflicting value x was defined at line 21:24
+  def x: Int = 4 // err
+      ^
+i20006e.scala:27: error: method x is defined twice;
+  the conflicting value x was defined at line 26:30
+    def x: Int = 4 // err
+        ^
+i20006e.scala:32: error: method x is defined twice;
+  the conflicting value x was defined at line 31:14
+  def x: Int = 4 // err
+      ^
+i20006e.scala:44: error: method x is defined twice;
+  the conflicting value x was defined at line 43:22
+  def x(): Int = 4 // err
+      ^
+i20006e.scala:49: error: method x is defined twice;
+  the conflicting value x was defined at line 48:28
+    def x(): Int = 4 // err
+        ^
+i20006e.scala:54: error: method x is defined twice;
+  the conflicting value x was defined at line 53:24
+  def x(): Int = 4 // err
+      ^
+i20006e.scala:59: error: method x is defined twice;
+  the conflicting value x was defined at line 58:30
+    def x(): Int = 4 // err
+        ^
+i20006e.scala:64: error: method x is defined twice;
+  the conflicting value x was defined at line 63:14
+  def x(): Int = 4 // err
+      ^
+i20006e.scala:68: error: x is already defined as value x
+  val x: Int = 4 // err
+      ^
+i20006e.scala:72: error: x is already defined as value x
+  val x: Int = 4 // err
+      ^
+i20006e.scala:76: error: x is already defined as value x
+  val x: Int = 4 // err
+      ^
+i20006e.scala:81: error: x is already defined as value x
+    val x: Int = 4 // err
+        ^
+i20006e.scala:86: error: x is already defined as value x
+  val x: Int = 4 // err
+      ^
+i20006e.scala:91: error: x is already defined as value x
+    val x: Int = 4 // err
+        ^
+i20006e.scala:96: error: x is already defined as value x
+  val x: Int = 4 // err
+      ^
+i20006e.scala:4: error: Double definition will be detected in Scala 3; the conflicting value x is defined at 3:10
+Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or @nowarn to demote them to warnings or suppress.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=C1
+  def x: Int = 4 // warn in Xsource:3
+      ^
+i20006e.scala:8: error: Double definition will be detected in Scala 3; the conflicting value x is defined at 7:28
+Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or @nowarn to demote them to warnings or suppress.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=C2
+  def x: Int = 4 // warn in Xsource:3
+      ^
+i20006e.scala:36: error: Double definition will be detected in Scala 3; the conflicting value x is defined at 35:10
+Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or @nowarn to demote them to warnings or suppress.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=D1
+  def x(): Int = 4 // warn in Xsource:3
+      ^
+i20006e.scala:40: error: Double definition will be detected in Scala 3; the conflicting value x is defined at 39:28
+Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or @nowarn to demote them to warnings or suppress.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=D2
+  def x(): Int = 4 // warn in Xsource:3
+      ^
+21 errors

--- a/test/files/neg/i20006e.scala
+++ b/test/files/neg/i20006e.scala
@@ -1,0 +1,97 @@
+//> using options -Werror -Xsource:3
+
+class C1(x: String) {
+  def x: Int = 4 // warn in Xsource:3
+}
+
+class C2(private[this] val x: String) {
+  def x: Int = 4 // warn in Xsource:3
+}
+
+class C3(private val x: String) {
+  def x: Int = 4 // err
+}
+
+object o4 {
+  class C4(private[o4] val x: String) {
+    def x: Int = 4 // err
+  }
+}
+
+class C5(protected val x: String) {
+  def x: Int = 4 // err
+}
+
+object o6 {
+  class C6(protected[o6] val x: String) {
+    def x: Int = 4 // err
+  }
+}
+
+class C7(val x: String) {
+  def x: Int = 4 // err
+}
+
+class D1(x: String) {
+  def x(): Int = 4 // warn in Xsource:3
+}
+
+class D2(private[this] val x: String) {
+  def x(): Int = 4 // warn in Xsource:3
+}
+
+class D3(private val x: String) {
+  def x(): Int = 4 // err
+}
+
+object p4 {
+  class D4(private[p4] val x: String) {
+    def x(): Int = 4 // err
+  }
+}
+
+class D5(protected val x: String) {
+  def x(): Int = 4 // err
+}
+
+object p6 {
+  class D6(protected[p6] val x: String) {
+    def x(): Int = 4 // err
+  }
+}
+
+class D7(val x: String) {
+  def x(): Int = 4 // err
+}
+
+class E1(x: String) {
+  val x: Int = 4 // err
+}
+
+class E2(private[this] val x: String) {
+  val x: Int = 4 // err
+}
+
+class E3(private val x: String) {
+  val x: Int = 4 // err
+}
+
+object q4 {
+  class E4(private[q4] val x: String) {
+    val x: Int = 4 // err
+  }
+}
+
+class E5(protected val x: String) {
+  val x: Int = 4 // err
+}
+
+object q6 {
+  class E6(protected[q6] val x: String) {
+    val x: Int = 4 // err
+  }
+}
+
+class E7(val x: String) {
+  val x: Int = 4 // err
+}

--- a/test/files/neg/t521b.check
+++ b/test/files/neg/t521b.check
@@ -1,5 +1,6 @@
-t521b.scala:15: error: method path is defined twice;
-  the conflicting value path was defined at line 14:30
+t521b.scala:16: error: Double definition will be detected in Scala 3; the conflicting value path is defined at 15:30
+Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or @nowarn to demote them to warnings or suppress.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=test.ZipArchive.Entry
     override def path = "";
                  ^
 1 error

--- a/test/files/neg/t521b.scala
+++ b/test/files/neg/t521b.scala
@@ -1,3 +1,4 @@
+//> using options -Xsource:3
 package test
 
 import java.io.File


### PR DESCRIPTION
```
class C(x: A) { def x: B }
```

should not give a double definition error in Scala 2.

Noticed at https://github.com/scala/bug/issues/13028#issuecomment-2326633128