### PR TITLE
Under `-Xsource:3`, deprecate infix named args [ci: last-only]

### DIFF
--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -641,7 +641,6 @@ object Reporting {
         LintBynameImplicit,
         LintRecurseWithDefault,
         LintUnitSpecialization,
-        LintMultiargInfix,
         LintPerformance,
         LintIntDivToFloat,
         LintUniversalMethods,

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -947,7 +947,13 @@ self =>
           }
         }
       }
-      def mkNamed(args: List[Tree]) = if (isExpr) args.map(treeInfo.assignmentToMaybeNamedArg) else args
+      def mkNamed(args: List[Tree]) = if (!isExpr) args else
+        args.map { arg =>
+          val arg1 = treeInfo.assignmentToMaybeNamedArg(arg)
+          if ((arg1 ne arg) && currentRun.isScala3)
+            deprecationWarning(arg.pos.point, "named argument is deprecated for infix syntax", since="2.13.16")
+          arg1
+        }
       var isMultiarg = false
       val arguments = right match {
         case Parens(Nil)               => literalUnit :: Nil

--- a/src/compiler/scala/tools/nsc/ast/parser/SyntaxAnalyzer.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/SyntaxAnalyzer.scala
@@ -106,7 +106,7 @@ abstract class SyntaxAnalyzer extends SubComponent with Parsers with MarkupParse
         unit.body = initialUnitBody(unit)
 
       if (settings.Ymemberpos.isSetByUser)
-        new MemberPosReporter(unit) show (style = settings.Ymemberpos.value)
+        new MemberPosReporter(unit).show(style = settings.Ymemberpos.value)
     }
   }
 }

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -129,6 +129,8 @@ trait Warnings {
   val warnUnnamedBoolean   = BooleanSetting("-Wunnamed-boolean-literal", "Warn about unnamed boolean literals if there is more than one or defaults are used, unless parameter has @deprecatedName.")
   val warnUnnamedStrict    = BooleanSetting("-Wunnamed-boolean-literal-strict", "Warn about all unnamed boolean literals, unless parameter has @deprecatedName or the method has a single leading boolean parameter.").enabling(warnUnnamedBoolean :: Nil)
   val warnToString         = BooleanSetting("-Wtostring-interpolated", "Warn when a standard interpolator uses toString.")
+  val warnMultiargInfix    = BooleanSetting("-Wmultiarg-infix", "Infix operator was defined or used with multiarg operand.")
+  def multiargInfix        = warnMultiargInfix.value
 
   object PerformanceWarnings extends MultiChoiceEnumeration {
     val Captured       = Choice("captured",        "Modification of var in closure causes boxing.")
@@ -219,7 +221,6 @@ trait Warnings {
     val ByNameImplicit         = LintWarning("byname-implicit",           "Block adapted by implicit with by-name parameter.")
     val RecurseWithDefault     = LintWarning("recurse-with-default",      "Recursive call used default argument.")
     val UnitSpecialization     = LintWarning("unit-special",              "Warn for specialization of Unit in parameter position.")
-    val MultiargInfix          = LintWarning("multiarg-infix",            "Infix operator was defined or used with multiarg operand.")
     val ImplicitRecursion      = LintWarning("implicit-recursion",        "Implicit resolves to an enclosing definition.")
     val UniversalMethods       = LintWarning("universal-methods",         "Require arg to is/asInstanceOf. No Unit receiver.")
     val NumericMethods         = LintWarning("numeric-methods",           "Dubious usages, such as `42.isNaN`.")
@@ -257,7 +258,6 @@ trait Warnings {
   def warnByNameImplicit         = lint contains ByNameImplicit
   def warnRecurseWithDefault     = lint contains RecurseWithDefault
   def unitSpecialization         = lint contains UnitSpecialization
-  def multiargInfix              = lint contains MultiargInfix
   def lintImplicitRecursion      = lint.contains(ImplicitRecursion) || (warnSelfImplicit.value: @nowarn("cat=deprecation"))
   def lintUniversalMethods       = lint.contains(UniversalMethods)
   def lintNumericMethods         = lint.contains(NumericMethods)

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1583,7 +1583,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     }
 
     private def warnMultiargInfix(tree: Tree): Unit =
-      context.warning(tree.pos, "multiarg infix syntax looks like a tuple and will be deprecated", WarningCategory.LintMultiargInfix)
+      context.warning(tree.pos, "multiarg infix syntax looks like a tuple", WarningCategory.Other)
 
     /** Typechecks a parent type reference.
      *

--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -295,12 +295,12 @@ final class PathResolver(settings: Settings, closeableRegistry: CloseableRegistr
   def result: ClassPath = {
     val cp = computeResult()
     if (settings.Ylogcp.value) {
-      Console print f"Classpath built from ${settings.toConciseString} %n"
-      Console print s"Defaults: ${PathResolver.Defaults}"
-      Console print s"Calculated: $Calculated"
+      Console.print(f"Classpath built from ${settings.toConciseString} %n")
+      Console.print(s"Defaults: ${PathResolver.Defaults}")
+      Console.print(s"Calculated: $Calculated")
 
-      val xs = (Calculated.basis drop 2).flatten.distinct
-      Console print (xs mkLines (s"After java boot/extdirs classpath has ${xs.size} entries:", indented = true))
+      val xs = Calculated.basis.drop(2).flatten.distinct
+      Console.print(xs.mkLines(s"After java boot/extdirs classpath has ${xs.size} entries:", indented = true))
     }
     cp
   }

--- a/test/files/neg/dotless-targs-ranged-a.check
+++ b/test/files/neg/dotless-targs-ranged-a.check
@@ -13,12 +13,9 @@ dotless-targs-ranged-a.scala:13: warning: type application is not allowed for in
 dotless-targs-ranged-a.scala:14: warning: type application is not allowed for infix operators [quickfixable]
   def evil = new A() op  [Int,   String     ]  42
                      ^
-dotless-targs-ranged-a.scala:9: warning: multiarg infix syntax looks like a tuple and will be deprecated
-  def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
-                ^
 dotless-targs-ranged-a.scala:11: warning: type parameter A defined in method op shadows class A defined in package <empty>. You may want to rename your type parameter, or possibly remove it.
   def op[A, B](i: Int): Int = 2*i
          ^
 error: No warnings can be incurred under -Werror.
-7 warnings
+6 warnings
 1 error

--- a/test/files/neg/infix-named-arg.check
+++ b/test/files/neg/infix-named-arg.check
@@ -1,9 +1,6 @@
 infix-named-arg.scala:5: warning: named argument is deprecated for infix syntax
   def f = 42 + (x = 1)
                   ^
-infix-named-arg.scala:7: warning: multiarg infix syntax looks like a tuple and will be deprecated
-  def g = new C() `multi` (x = 42, y = 27)
-                  ^
 error: No warnings can be incurred under -Werror.
-2 warnings
+1 warning
 1 error

--- a/test/files/neg/infix-named-arg.check
+++ b/test/files/neg/infix-named-arg.check
@@ -1,0 +1,15 @@
+infix-named-arg.scala:5: warning: named argument is deprecated for infix syntax
+  def f = 42 + (x = 1)
+                  ^
+infix-named-arg.scala:7: warning: named argument is deprecated for infix syntax
+  def g = new C() `multi` (x = 42, y = 27)
+                             ^
+infix-named-arg.scala:7: warning: named argument is deprecated for infix syntax
+  def g = new C() `multi` (x = 42, y = 27)
+                                     ^
+infix-named-arg.scala:7: warning: multiarg infix syntax looks like a tuple and will be deprecated
+  def g = new C() `multi` (x = 42, y = 27)
+                  ^
+error: No warnings can be incurred under -Werror.
+4 warnings
+1 error

--- a/test/files/neg/infix-named-arg.check
+++ b/test/files/neg/infix-named-arg.check
@@ -1,15 +1,9 @@
 infix-named-arg.scala:5: warning: named argument is deprecated for infix syntax
   def f = 42 + (x = 1)
                   ^
-infix-named-arg.scala:7: warning: named argument is deprecated for infix syntax
-  def g = new C() `multi` (x = 42, y = 27)
-                             ^
-infix-named-arg.scala:7: warning: named argument is deprecated for infix syntax
-  def g = new C() `multi` (x = 42, y = 27)
-                                     ^
 infix-named-arg.scala:7: warning: multiarg infix syntax looks like a tuple and will be deprecated
   def g = new C() `multi` (x = 42, y = 27)
                   ^
 error: No warnings can be incurred under -Werror.
-4 warnings
+2 warnings
 1 error

--- a/test/files/neg/infix-named-arg.scala
+++ b/test/files/neg/infix-named-arg.scala
@@ -1,0 +1,8 @@
+
+//> using options -Werror -Xlint -Xsource:3
+
+class C {
+  def f = 42 + (x = 1)
+  def multi(x: Int, y: Int): Int = x + y
+  def g = new C() `multi` (x = 42, y = 27)
+}

--- a/test/files/neg/nowarn-lint.check
+++ b/test/files/neg/nowarn-lint.check
@@ -7,7 +7,7 @@ class C[@specialized(Unit) A](a: A)
 nowarn-lint.scala:7: warning: Class parameter is specialized for type Unit. Consider using `@specialized(Specializable.Arg)` instead.
 class D[@specialized(Specializable.Primitives) A](a: A)
                                                  ^
-nowarn-lint.scala:41: warning: @nowarn annotation does not suppress any warnings
+nowarn-lint.scala:35: warning: @nowarn annotation does not suppress any warnings
 @nowarn("any")
  ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/nowarn-lint.scala
+++ b/test/files/neg/nowarn-lint.scala
@@ -1,4 +1,4 @@
-//> using options -Werror -Xlint:multiarg-infix,unit-special,unused
+//> using options -Werror -Xlint:unit-special,unused
 
 import annotation.nowarn
 
@@ -29,12 +29,6 @@ class HH[@specialized(Unit) A](val a: A)(val aa: A)
 class J {
   private val j = 42
   def f: Unit = ()
-}
-
-@nowarn("cat=lint-multiarg-infix")
-trait T {
-  def m(i: Int, j: Int) = i + j
-  def f1(t: T) = t m (1, 2)           // multiarg, warn
 }
 
 // canonically unused nowarn

--- a/test/files/neg/sd503.check
+++ b/test/files/neg/sd503.check
@@ -7,37 +7,37 @@ sd503.scala:23: error: type mismatch;
  required: Int
   def f7() = d.x = (42, 27)           // type mismatch (same as doti)
                    ^
-sd503.scala:9: warning: multiarg infix syntax looks like a tuple and will be deprecated
+sd503.scala:9: warning: multiarg infix syntax looks like a tuple
   def % (i: Int, j: Int) = i + j      // operator, warn
       ^
-sd503.scala:13: warning: multiarg infix syntax looks like a tuple and will be deprecated
+sd503.scala:13: warning: multiarg infix syntax looks like a tuple
   def f1(t: T) = t m (1, 2)           // multiarg, warn
                    ^
-sd503.scala:15: warning: multiarg infix syntax looks like a tuple and will be deprecated
+sd503.scala:15: warning: multiarg infix syntax looks like a tuple
   def f3(t: T) = t % (1, 2)           // multiarg, warn
                    ^
-sd503.scala:19: warning: multiarg infix syntax looks like a tuple and will be deprecated
+sd503.scala:19: warning: multiarg infix syntax looks like a tuple
   def f5() = c x_= (42, 27)           // multiarg, warn
                ^
-sd503.scala:54: warning: multiarg infix syntax looks like a tuple and will be deprecated
+sd503.scala:54: warning: multiarg infix syntax looks like a tuple
   def +=(x: A, y: A, zs: A*): this.type = addAll(x +: y +: zs)                // very multiarg, warn
       ^
-sd503.scala:59: warning: multiarg infix syntax looks like a tuple and will be deprecated
+sd503.scala:59: warning: multiarg infix syntax looks like a tuple
   def f[A](as: Embiggen[A], x: A, y: A, z: A): as.type = as += (x, y, z)      // very multiarg, warn
                                                             ^
-sd503.scala:70: warning: multiarg infix syntax looks like a tuple and will be deprecated
+sd503.scala:70: warning: multiarg infix syntax looks like a tuple
   def f(x: A, y: A, zs: A*): this.type = this += (x, y, zs: _*)               // warn but could defer to deprecation
                                               ^
-sd503.scala:80: warning: multiarg infix syntax looks like a tuple and will be deprecated
+sd503.scala:80: warning: multiarg infix syntax looks like a tuple
   def f = this lines_! (42, 27)                                               // warn usage, of course
                ^
-sd503.scala:86: warning: multiarg infix syntax looks like a tuple and will be deprecated
+sd503.scala:86: warning: multiarg infix syntax looks like a tuple
   def +(i: Int, j: Int): Adder = new Adder(c + i*j)   // warn multiarg symbolic def
       ^
-sd503.scala:92: warning: multiarg infix syntax looks like a tuple and will be deprecated
+sd503.scala:92: warning: multiarg infix syntax looks like a tuple
     x = x + (3, 9)                 // warn multiarg infix apply
           ^
-sd503.scala:102: warning: multiarg infix syntax looks like a tuple and will be deprecated
+sd503.scala:102: warning: multiarg infix syntax looks like a tuple
     x += (3, 9)                    // warn multiarg infix assignment!
       ^
 11 warnings

--- a/test/files/neg/sd503.scala
+++ b/test/files/neg/sd503.scala
@@ -1,4 +1,4 @@
-//> using options -Xlint:multiarg-infix
+//> using options -Wmultiarg-infix
 //
 // lint multiarg infix syntax, e.g., vs += (1, 2, 3)
 // Since infix is encouraged by symbolic operator names, discourage defining def += (x: A, y: A, zs: A*)


### PR DESCRIPTION
In Scala 3.6, named tuples makes `Option apply (x = 42)` an optional tuple.

Under `-Xsource:3`, deprecate named args in infix applications (arity one, a single arg).

Demote `-Xlint:multiarg-infix` to `-Wmultiarg-infix`, to warn for infix-style applications of arity greater than one. These work the same in Scala 3.6.

Addresses https://github.com/scala/scala3/discussions/19072