### PR TITLE
Relax PhaseAssembly about loose constraints

### DIFF
--- a/src/partest/scala/tools/partest/DirectTest.scala
+++ b/src/partest/scala/tools/partest/DirectTest.scala
@@ -53,12 +53,15 @@ abstract class DirectTest {
   // a default Settings object using only extraSettings
   def settings: Settings = newSettings(tokenize(extraSettings))
   // settings factory using given args and also debug settings
-  def newSettings(args: List[String]) = (new Settings).tap { s =>
-    val allArgs = args ++ tokenize(debugSettings)
+  def newSettings(args: List[String]): Settings = newBaseSettings().tap { s =>
+    val allArgs = debugSettings.pipe(db => if (db.isEmpty) args else args ++ tokenize(db))
     log(s"newSettings: allArgs = $allArgs")
     val (success, residual) = s.processArguments(allArgs, processAll = false)
     assert(success && residual.isEmpty, s"Bad settings [${args.mkString(",")}], residual [${residual.mkString(",")}]")
   }
+  // scaladoc has custom settings
+  def newBaseSettings(): Settings = new Settings
+
   // new compiler using given ad hoc args, -d and extraSettings
   def newCompiler(args: String*): Global = {
     val settings = newSettings(tokenize(s"""-d "${testOutput.path}" ${extraSettings}""") ++ args.toList)

--- a/src/partest/scala/tools/partest/ScaladocModelTest.scala
+++ b/src/partest/scala/tools/partest/ScaladocModelTest.scala
@@ -12,13 +12,13 @@
 
 package scala.tools.partest
 
-import scala.sys.process.{Parser => CommandLineParser}
 import scala.tools.nsc._
+import scala.tools.nsc.doc.{DocFactory, Universe}
 import scala.tools.nsc.doc.base.comment._
 import scala.tools.nsc.doc.model._
 import scala.tools.nsc.doc.model.diagram._
-import scala.tools.nsc.doc.{DocFactory, Universe}
 import scala.tools.nsc.reporters.ConsoleReporter
+import scala.util.chaining._
 
 /** A class for testing scaladoc model generation
  *   - you need to specify the code in the `code` method
@@ -87,20 +87,21 @@ abstract class ScaladocModelTest extends DirectTest {
 
   private[this] var docSettings: doc.Settings = null
 
+  // custom settings, silencing "model contains X documentable templates"
+  override def newBaseSettings(): doc.Settings = new doc.Settings(_ => ()).tap(_.scaladocQuietRun = true)
+  override def newSettings(args: List[String]): doc.Settings = super.newSettings(args).asInstanceOf[doc.Settings]
+  override def settings: doc.Settings = newSettings(tokenize(s"$extraSettings $scaladocSettings"))
+
   // create a new scaladoc compiler
   def newDocFactory: DocFactory = {
-    docSettings = new doc.Settings(_ => ())
-    docSettings.scaladocQuietRun = true // yaay, no more "model contains X documentable templates"!
-    val args = extraSettings + " " + scaladocSettings
-    new ScalaDoc.Command((CommandLineParser tokenize (args)), docSettings) // side-effecting, I think
-    val docFact = new DocFactory(new ConsoleReporter(docSettings), docSettings)
-    docFact
+    docSettings = settings
+    new DocFactory(new ConsoleReporter(docSettings), docSettings)
   }
 
   // compile with scaladoc and output the result
   def model: Option[Universe] = newDocFactory.makeUniverse(Right(code))
 
-  // finally, enable easy navigation inside the entities
+  // enable easy navigation inside the entities
   object access {
 
     implicit class TemplateAccess(tpl: DocTemplateEntity) {

--- a/src/scaladoc/scala/tools/nsc/doc/ScaladocGlobal.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/ScaladocGlobal.scala
@@ -54,8 +54,6 @@ class ScaladocGlobal(settings: doc.Settings, reporter: Reporter) extends Global(
     phasesSet += analyzer.namerFactory
     phasesSet += analyzer.packageObjects
     phasesSet += analyzer.typerFactory
-    phasesSet += patmatSentinel
-    phasesSet += erasureSentinel
     phasesSet += terminal
   }
 
@@ -64,27 +62,6 @@ class ScaladocGlobal(settings: doc.Settings, reporter: Reporter) extends Global(
       lazy val global: self.type = self
       override def platformPhases = Nil // used by computePlatformPhases
     }
-
-  // Placeholders for plugins who wish to declare runsBefore patmat or erasure.
-  // A bit deceptive for plugins that run after them, as scaladoc ought to -Ystop-before:patmat
-  lazy val patmatSentinel: SubComponent = new { val global = self } with SubComponent {
-    val phaseName = "patmat"
-    val runsAfter = "typer" :: Nil
-    val runsRightAfter = None
-    def newPhase(prev: Phase): Phase = new Phase(prev) {
-      val name = phaseName
-      def run() = ()
-    }
-  }
-  lazy val erasureSentinel: SubComponent = new { val global = self } with SubComponent {
-    val phaseName = "erasure"
-    val runsAfter = "patmat" :: Nil
-    val runsRightAfter = None
-    def newPhase(prev: Phase): Phase = new Phase(prev) {
-      val name = phaseName
-      def run() = ()
-    }
-  }
 
   override def createJavadoc = if (settings.docNoJavaComments.value) false else true
 

--- a/test/files/neg/t7494-before-parser.check
+++ b/test/files/neg/t7494-before-parser.check
@@ -1,1 +1,7 @@
-fatal error: Phases form a cycle: parser -> beforeparser -> parser
+warning: Dropping phase beforeparser, it is not reachable from parser
+sample_2.scala:8: error: type mismatch;
+ found   : String("")
+ required: Int
+  def f: Int = ""
+               ^
+1 error

--- a/test/files/neg/t7494-before-parser/sample_2.scala
+++ b/test/files/neg/t7494-before-parser/sample_2.scala
@@ -3,4 +3,7 @@ package sample
 
 // just a sample that is compiled with the sample plugin enabled
 object Sample extends App {
+  // because `-Werror` doesn't work; after phase assembly warnings are issued,
+  // Run.compileUnits resets the reporter (and its warning count)
+  def f: Int = ""
 }

--- a/test/files/neg/t8755-regress-a.check
+++ b/test/files/neg/t8755-regress-a.check
@@ -1,0 +1,28 @@
+    phase name  id  description
+    ----------  --  -----------
+        parser   1  parse source into ASTs, perform simple desugaring
+         namer   2  resolve names, attach symbols to named trees
+packageobjects   3  load package objects
+         typer   4  the meat and potatoes: type the trees
+            C8   0  C8 makes C7 reachable
+superaccessors   6  add super accessors in traits and nested classes
+            C7   0  C7 has only a before constraint
+    extmethods   8  add extension methods for inline classes
+       pickler   9  serialize symbol tables
+     refchecks  10  reference/override checking, translate nested objects
+        patmat  11  translate match expressions
+       uncurry  12  uncurry, translate function values to anonymous classes
+        fields  13  synthesize accessors and fields, add bitmaps for lazy vals
+     tailcalls  14  replace tail calls by jumps
+    specialize  15  @specialized-driven class and method specialization
+ explicitouter  16  this refs to outer pointers
+       erasure  17  erase types, add interfaces for traits
+   posterasure  18  clean up erased inline classes
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+       cleanup  23  platform-specific cleanups, generate reflective calls
+    delambdafy  24  remove lambdas
+           jvm  25  generate JVM bytecode
+      terminal  26  the last phase during a compilation run

--- a/test/files/neg/t8755-regress-a/ploogin_1.scala
+++ b/test/files/neg/t8755-regress-a/ploogin_1.scala
@@ -1,0 +1,40 @@
+
+package t8755
+
+import scala.tools.nsc, nsc.{Global, Phase, plugins}, plugins.{Plugin, PluginComponent}
+
+class P(val global: Global) extends Plugin {
+  override val name = "Testing phase assembly"
+  override val description = "C7 is not dropped even though it has no runs[Right]After"
+  override val components = List[PluginComponent](
+    component7,
+    component8,
+  )
+
+  object component7 extends PluginComponent {
+    override val global = P.this.global
+    override val phaseName = "C7"
+    override val description = "C7 has only a before constraint"
+    override val runsRightAfter = None
+    override val runsAfter = Nil
+    override val runsBefore = List("patmat")
+    override def newPhase(prev: Phase) = new phase(prev)
+    class phase(prev: Phase) extends Phase(prev) {
+      override val name = s"phase $phaseName"
+      override def run() = println(name)
+    }
+  }
+  object component8 extends PluginComponent {
+    override val global = P.this.global
+    override val phaseName = "C8"
+    override val description = "C8 makes C7 reachable"
+    override val runsRightAfter = None
+    override val runsAfter = List("typer")
+    override val runsBefore = List("C7") // component name, not phase name!
+    override def newPhase(prev: Phase) = new phase(prev)
+    class phase(prev: Phase) extends Phase(prev) {
+      override val name = s"phase $phaseName"
+      override def run() = println(name)
+    }
+  }
+}

--- a/test/files/neg/t8755-regress-a/sample_2.scala
+++ b/test/files/neg/t8755-regress-a/sample_2.scala
@@ -1,0 +1,6 @@
+//> using options -Xplugin:. -Xplugin-require:"Testing phase assembly" -Vphases -Werror
+package sample
+
+// just a sample that is compiled with the sample plugin enabled
+object Sample extends App {
+}

--- a/test/files/neg/t8755-regress-a/scalac-plugin.xml
+++ b/test/files/neg/t8755-regress-a/scalac-plugin.xml
@@ -1,0 +1,5 @@
+<plugin>
+  <name>Testing phase assembly</name>
+  <classname>t8755.P</classname>
+</plugin>
+

--- a/test/files/neg/t8755.check
+++ b/test/files/neg/t8755.check
@@ -1,0 +1,29 @@
+warning: No phase `refchicks` for ploogin.runsAfter - did you mean refchecks?
+warning: No phase `java` for ploogin.runsBefore - did you mean jvm?
+warning: Dropping phase ploogin, it is not reachable from parser
+    phase name  id  description
+    ----------  --  -----------
+        parser   1  parse source into ASTs, perform simple desugaring
+         namer   2  resolve names, attach symbols to named trees
+packageobjects   3  load package objects
+         typer   4  the meat and potatoes: type the trees
+superaccessors   5  add super accessors in traits and nested classes
+    extmethods   6  add extension methods for inline classes
+       pickler   7  serialize symbol tables
+     refchecks   8  reference/override checking, translate nested objects
+        patmat   9  translate match expressions
+       uncurry  10  uncurry, translate function values to anonymous classes
+        fields  11  synthesize accessors and fields, add bitmaps for lazy vals
+     tailcalls  12  replace tail calls by jumps
+    specialize  13  @specialized-driven class and method specialization
+ explicitouter  14  this refs to outer pointers
+       erasure  15  erase types, add interfaces for traits
+   posterasure  16  clean up erased inline classes
+    lambdalift  17  move nested functions to top level
+  constructors  18  move field definitions into constructors
+       flatten  19  eliminate inner classes
+         mixin  20  mixin composition
+       cleanup  21  platform-specific cleanups, generate reflective calls
+    delambdafy  22  remove lambdas
+           jvm  23  generate JVM bytecode
+      terminal  24  the last phase during a compilation run

--- a/test/files/neg/t8755/ploogin_1.scala
+++ b/test/files/neg/t8755/ploogin_1.scala
@@ -1,0 +1,31 @@
+
+package t8755
+
+import scala.tools.nsc.{Global, Phase}
+import scala.tools.nsc.plugins.{Plugin, PluginComponent}
+import scala.reflect.io.Path
+import scala.reflect.io.File
+
+/** A test plugin.  */
+class Ploogin(val global: Global) extends Plugin {
+  import global._
+
+  val name = "ploogin"
+  val description = "A sample plugin for testing."
+  val components = List[PluginComponent](TestComponent)
+
+  private object TestComponent extends PluginComponent {
+    val global: Ploogin.this.global.type = Ploogin.this.global
+    override val runsBefore = List("java")
+    val runsAfter = List("refchicks")
+    val phaseName = Ploogin.this.name
+    override def description = "A sample phase that doesn't know when to run."
+    def newPhase(prev: Phase) = new TestPhase(prev)
+    class TestPhase(prev: Phase) extends StdPhase(prev) {
+      override def description = TestComponent.this.description
+      def apply(unit: CompilationUnit): Unit = {
+        // kewl kode
+      }
+    }
+  }
+}

--- a/test/files/neg/t8755/sample_2.scala
+++ b/test/files/neg/t8755/sample_2.scala
@@ -1,0 +1,6 @@
+//> using options -Xplugin:. -Xplugin-require:ploogin -Vphases -Werror
+package sample
+
+// just a sample that is compiled with the sample plugin enabled
+object Sample extends App {
+}

--- a/test/files/neg/t8755/scalac-plugin.xml
+++ b/test/files/neg/t8755/scalac-plugin.xml
@@ -1,0 +1,5 @@
+<plugin>
+  <name>ploogin</name>
+  <classname>t8755.Ploogin</classname>
+</plugin>
+

--- a/test/files/neg/t8755b.check
+++ b/test/files/neg/t8755b.check
@@ -1,0 +1,27 @@
+warning: Dropping phase ploogin, it is not reachable from parser
+    phase name  id  description
+    ----------  --  -----------
+        parser   1  parse source into ASTs, perform simple desugaring
+         namer   2  resolve names, attach symbols to named trees
+packageobjects   3  load package objects
+         typer   4  the meat and potatoes: type the trees
+superaccessors   5  add super accessors in traits and nested classes
+    extmethods   6  add extension methods for inline classes
+       pickler   7  serialize symbol tables
+     refchecks   8  reference/override checking, translate nested objects
+        patmat   9  translate match expressions
+       uncurry  10  uncurry, translate function values to anonymous classes
+        fields  11  synthesize accessors and fields, add bitmaps for lazy vals
+     tailcalls  12  replace tail calls by jumps
+    specialize  13  @specialized-driven class and method specialization
+ explicitouter  14  this refs to outer pointers
+       erasure  15  erase types, add interfaces for traits
+   posterasure  16  clean up erased inline classes
+    lambdalift  17  move nested functions to top level
+  constructors  18  move field definitions into constructors
+       flatten  19  eliminate inner classes
+         mixin  20  mixin composition
+       cleanup  21  platform-specific cleanups, generate reflective calls
+    delambdafy  22  remove lambdas
+           jvm  23  generate JVM bytecode
+      terminal  24  the last phase during a compilation run

--- a/test/files/neg/t8755b/ploogin_1.scala
+++ b/test/files/neg/t8755b/ploogin_1.scala
@@ -1,0 +1,29 @@
+
+package t8755
+
+import scala.tools.nsc.{Global, Phase}
+import scala.tools.nsc.plugins.{Plugin, PluginComponent}
+import scala.reflect.io.Path
+import scala.reflect.io.File
+
+/** A test plugin.  */
+class Ploogin(val global: Global) extends Plugin {
+  import global._
+
+  val name = "ploogin"
+  val description = "A sample plugin for testing."
+  val components = List[PluginComponent](TestComponent)
+
+  private object TestComponent extends PluginComponent {
+    val global: Ploogin.this.global.type = Ploogin.this.global
+    override val runsBefore = List("erasure")
+    val runsAfter = Nil
+    val phaseName = Ploogin.this.name
+    override def description = "A phase that another phase must run before."
+    def newPhase(prev: Phase) = new TestPhase(prev)
+    class TestPhase(prev: Phase) extends StdPhase(prev) {
+      override def description = TestComponent.this.description
+      def apply(unit: CompilationUnit): Unit = ()
+    }
+  }
+}

--- a/test/files/neg/t8755b/sample_2.scala
+++ b/test/files/neg/t8755b/sample_2.scala
@@ -1,0 +1,6 @@
+//> using options -Xplugin:. -Xplugin-require:ploogin -Vphases -Werror
+package sample
+
+// just a sample that is compiled with the sample plugin enabled
+object Sample extends App {
+}

--- a/test/files/neg/t8755b/scalac-plugin.xml
+++ b/test/files/neg/t8755b/scalac-plugin.xml
@@ -1,0 +1,5 @@
+<plugin>
+  <name>ploogin</name>
+  <classname>t8755.Ploogin</classname>
+</plugin>
+

--- a/test/files/neg/t8755c.check
+++ b/test/files/neg/t8755c.check
@@ -1,0 +1,28 @@
+    phase name  id  description
+    ----------  --  -----------
+        parser   1  parse source into ASTs, perform simple desugaring
+         namer   2  resolve names, attach symbols to named trees
+packageobjects   3  load package objects
+         typer   4  the meat and potatoes: type the trees
+            C1   0  C1 tests phase assembly
+superaccessors   6  add super accessors in traits and nested classes
+    extmethods   7  add extension methods for inline classes
+       pickler   8  serialize symbol tables
+     refchecks   9  reference/override checking, translate nested objects
+        patmat  10  translate match expressions
+            C6   0  C6 tests phase assembly after a phase missing in Scaladoc
+       uncurry  12  uncurry, translate function values to anonymous classes
+        fields  13  synthesize accessors and fields, add bitmaps for lazy vals
+     tailcalls  14  replace tail calls by jumps
+    specialize  15  @specialized-driven class and method specialization
+ explicitouter  16  this refs to outer pointers
+       erasure  17  erase types, add interfaces for traits
+   posterasure  18  clean up erased inline classes
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+       cleanup  23  platform-specific cleanups, generate reflective calls
+    delambdafy  24  remove lambdas
+           jvm  25  generate JVM bytecode
+      terminal  26  the last phase during a compilation run

--- a/test/files/neg/t8755c/ploogin_1.scala
+++ b/test/files/neg/t8755c/ploogin_1.scala
@@ -1,0 +1,127 @@
+
+package t8755
+
+import scala.tools.nsc
+import nsc.{Global, Phase, plugins}
+import plugins.{Plugin, PluginComponent}
+
+class P(val global: Global) extends Plugin {
+  override val name = "Testing"
+  override val description = "Testing phase assembly"
+  override val components = List[PluginComponent](
+    component1,
+    //component2,
+    //component3,
+    //component4,
+    //component5,
+    component6,
+    //component7,
+    //component8,
+  )
+
+  object component1 extends PluginComponent {
+    override val global = P.this.global
+    override val phaseName = "C1"
+    override val description = "C1 tests phase assembly"
+    override val runsRightAfter = Option("typer")
+    override val runsAfter = List("typer")
+    override val runsBefore = List("terminal")
+    override def newPhase(prev: Phase) = new phase(prev)
+    class phase(prev: Phase) extends Phase(prev) {
+      override val name = s"phase $phaseName"
+      override def run() = println(name)
+    }
+  }
+  object component2 extends PluginComponent {
+    override val global = P.this.global
+    override val phaseName = "C2"
+    override val description = "C2 tests phase assembly impossible constraint"
+    override val runsRightAfter = Option("patmat")
+    override val runsAfter = List("typer")
+    override val runsBefore = List("typer")
+    override def newPhase(prev: Phase) = new phase(prev)
+    class phase(prev: Phase) extends Phase(prev) {
+      override val name = s"phase $phaseName"
+      override def run() = println(name)
+    }
+  }
+  object component3 extends PluginComponent {
+    override val global = P.this.global
+    override val phaseName = "C3"
+    override val description = "C3 tests phase assembly missing before, phase is ignored"
+    override val runsRightAfter = None
+    override val runsAfter = List("typer")
+    override val runsBefore = List("germinal")
+    override def newPhase(prev: Phase) = new phase(prev)
+    class phase(prev: Phase) extends Phase(prev) {
+      override val name = s"phase $phaseName"
+      override def run() = println(name)
+    }
+  }
+  object component4 extends PluginComponent {
+    override val global = P.this.global
+    override val phaseName = "C4"
+    override val description = "C4 tests phase assembly impossible constraint not right after"
+    override val runsRightAfter = None
+    override val runsAfter = List("typer")
+    override val runsBefore = List("typer")
+    override def newPhase(prev: Phase) = new phase(prev)
+    class phase(prev: Phase) extends Phase(prev) {
+      override val name = s"phase $phaseName"
+      override def run() = println(name)
+    }
+  }
+  object component5 extends PluginComponent {
+    override val global = P.this.global
+    override val phaseName = "C5"
+    override val description = "C5 tests phase assembly before a phase missing in Scaladoc"
+    override val runsRightAfter = None
+    override val runsAfter = List("typer")
+    override val runsBefore = List("erasure")
+    override def newPhase(prev: Phase) = new phase(prev)
+    class phase(prev: Phase) extends Phase(prev) {
+      override val name = s"phase $phaseName"
+      override def run() = println(name)
+    }
+  }
+  object component6 extends PluginComponent {
+    override val global = P.this.global
+    override val phaseName = "C6"
+    override val description = "C6 tests phase assembly after a phase missing in Scaladoc"
+    override val runsRightAfter = None
+    override val runsAfter = List("patmat")
+    //override val runsBefore = List("terminal")
+    override def newPhase(prev: Phase) = new phase(prev)
+    class phase(prev: Phase) extends Phase(prev) {
+      println(s"construct c6 prev ${prev}")
+      override val name = s"phase $phaseName"
+      override def run() = println(name)
+    }
+  }
+  object component7 extends PluginComponent {
+    override val global = P.this.global
+    override val phaseName = "C7"
+    override val description = "C7 tests phase assembly if only a before constraint"
+    override val runsRightAfter = None
+    override val runsAfter = Nil
+    override val runsBefore = List("patmat")
+    override def newPhase(prev: Phase) = new phase(prev)
+    class phase(prev: Phase) extends Phase(prev) {
+      override val name = s"phase $phaseName"
+      override def run() = println(name)
+    }
+  }
+  object component8 extends PluginComponent {
+    override val global = P.this.global
+    override val phaseName = "C8"
+    override val description = "C8 is before C7 which specifies no after"
+    override val runsRightAfter = None
+    override val runsAfter = List("typer")
+    override val runsBefore = List("C7") // component name, not phase name!
+    override def newPhase(prev: Phase) = new phase(prev)
+    class phase(prev: Phase) extends Phase(prev) {
+      override val name = s"phase $phaseName"
+      override def run() = println(name)
+    }
+  }
+}

--- a/test/files/neg/t8755c/sample_2.scala
+++ b/test/files/neg/t8755c/sample_2.scala
@@ -1,0 +1,6 @@
+//> using options -Xplugin:. -Xplugin-require:Testing -Vphases -Werror
+package sample
+
+// just a sample that is compiled with the sample plugin enabled
+object Sample extends App {
+}

--- a/test/files/neg/t8755c/scalac-plugin.xml
+++ b/test/files/neg/t8755c/scalac-plugin.xml
@@ -1,0 +1,5 @@
+<plugin>
+  <name>Testing</name>
+  <classname>t8755.P</classname>
+</plugin>
+

--- a/test/junit/scala/tools/nsc/PhaseAssemblyTest.scala
+++ b/test/junit/scala/tools/nsc/PhaseAssemblyTest.scala
@@ -82,8 +82,7 @@ class PhaseAssemblyTest {
     val components = names.foldLeft(parserAndTerminal(global)) { (comps, nm) =>
       component(global, nm, rra(nm), ra(comps, nm), runsBefore = beforeTerminal) :: comps
     }
-    val graph = DependencyGraph(components)
-    assertThrows[FatalError](graph.compilerPhaseList(), _ == "Phases kerfuffle and konflikt both immediately follow phooey")
+    assertThrows[FatalError](DependencyGraph(components), _ == "Phases kerfuffle and konflikt both immediately follow phooey")
   }
   @Test def `trivial cycle`: Unit = {
     val settings = new Settings
@@ -100,8 +99,7 @@ class PhaseAssemblyTest {
     val components = names.foldLeft(parserAndTerminal(global)) { (comps, nm) =>
       component(global, nm, rra(nm), ra(comps, nm), runsBefore = beforeTerminal) :: comps
     }
-    val graph = DependencyGraph(components)
-    assertThrows[FatalError](graph.compilerPhaseList(), _ == "Phases form a cycle: phooey -> kerfuffle -> konflikt -> phooey")
+    assertThrows[FatalError](DependencyGraph(components), _ == "Phases form a cycle: phooey -> kerfuffle -> konflikt -> phooey")
   }
   @Test def `run before tightly bound phases`: Unit = {
     val settings = new Settings

--- a/test/scaladoc/run/t8755.check
+++ b/test/scaladoc/run/t8755.check
@@ -1,0 +1,8 @@
+warning: No phase `refchecks` for ploogin.runsAfter
+warning: Dropping phase ploogin, it is not reachable from parser
+parser -> namer -> packageobjects -> typer -> terminal
+[running phase parser on newSource]
+[running phase namer on newSource]
+[running phase packageobjects on newSource]
+[running phase typer on newSource]
+Done.

--- a/test/scaladoc/run/t8755/Test_2.scala
+++ b/test/scaladoc/run/t8755/Test_2.scala
@@ -1,0 +1,25 @@
+import scala.tools.nsc.doc.model._
+import scala.tools.nsc.doc.model.diagram._
+import scala.tools.partest.ScaladocModelTest
+import scala.tools.nsc.plugins.PluginDescription
+import scala.util.chaining._
+
+object Test extends ScaladocModelTest {
+
+  override def code = """
+    class C
+  """
+
+  override def scaladocSettings = s"-Vdebug -Xplugin:$testOutput -Xplugin-require:ploogin"
+
+  override def testModel(rootPackage: Package) = ()
+
+  override def newDocFactory =
+    super.newDocFactory.tap(df => println(df.compiler.phaseNames.mkString(" -> ")))
+
+  override def show() = {
+    val xml  = PluginDescription("ploogin", "t8755.Ploogin").toXML
+    (testOutput / "scalac-plugin.xml").toFile.writeAll(xml)
+    super.show()
+  }
+}

--- a/test/scaladoc/run/t8755/ploogin_1.scala
+++ b/test/scaladoc/run/t8755/ploogin_1.scala
@@ -1,0 +1,28 @@
+
+package t8755
+
+import scala.tools.nsc.{Global, Phase}
+import scala.tools.nsc.plugins.{Plugin, PluginComponent}
+import scala.reflect.io.Path
+import scala.reflect.io.File
+
+/** A test plugin.  */
+class Ploogin(val global: Global) extends Plugin {
+  import global._
+
+  val name = "ploogin"
+  val description = "A sample plugin for testing."
+  val components = List[PluginComponent](TestComponent)
+
+  private object TestComponent extends PluginComponent {
+    val global: Ploogin.this.global.type = Ploogin.this.global
+    val runsAfter = List("refchecks")
+    val phaseName = Ploogin.this.name
+    override def description = "Follows refchecks, so must not run in Scaladoc"
+    def newPhase(prev: Phase) = new TestPhase(prev)
+    class TestPhase(prev: Phase) extends StdPhase(prev) {
+      override def description = TestComponent.this.description
+      def apply(unit: CompilationUnit): Unit = ???
+    }
+  }
+}

--- a/test/scaladoc/run/t8755b.check
+++ b/test/scaladoc/run/t8755b.check
@@ -1,0 +1,10 @@
+warning: No phase `refchecks` for ploogin.runsAfter
+warning: No phase `jvm` for ploogin.runsBefore
+parser -> namer -> packageobjects -> typer -> ploogin -> terminal
+[running phase parser on newSource]
+[running phase namer on newSource]
+[running phase packageobjects on newSource]
+[running phase typer on newSource]
+[running phase ploogin on newSource]
+running plugin
+Done.

--- a/test/scaladoc/run/t8755b/Test_2.scala
+++ b/test/scaladoc/run/t8755b/Test_2.scala
@@ -1,0 +1,25 @@
+import scala.tools.nsc.doc.model._
+import scala.tools.nsc.doc.model.diagram._
+import scala.tools.partest.ScaladocModelTest
+import scala.tools.nsc.plugins.PluginDescription
+import scala.util.chaining._
+
+object Test extends ScaladocModelTest {
+
+  override def code = """
+    class C
+  """
+
+  override def scaladocSettings = s"-Vdebug -Xplugin:$testOutput -Xplugin-require:ploogin"
+
+  override def testModel(rootPackage: Package) = ()
+
+  override def newDocFactory =
+    super.newDocFactory.tap(df => println(df.compiler.phaseNames.mkString(" -> ")))
+
+  override def show() = {
+    val xml  = PluginDescription("ploogin", "t8755.Ploogin").toXML
+    (testOutput / "scalac-plugin.xml").toFile.writeAll(xml)
+    super.show()
+  }
+}

--- a/test/scaladoc/run/t8755b/ploogin_1.scala
+++ b/test/scaladoc/run/t8755b/ploogin_1.scala
@@ -1,0 +1,29 @@
+
+package t8755
+
+import scala.tools.nsc.{Global, Phase}
+import scala.tools.nsc.plugins.{Plugin, PluginComponent}
+import scala.reflect.io.Path
+import scala.reflect.io.File
+
+/** A test plugin.  */
+class Ploogin(val global: Global) extends Plugin {
+  import global._
+
+  val name = "ploogin"
+  val description = "A sample plugin for testing."
+  val components = List[PluginComponent](TestComponent)
+
+  private object TestComponent extends PluginComponent {
+    val global: Ploogin.this.global.type = Ploogin.this.global
+    override val runsBefore = List("jvm")
+    val runsAfter = List("typer", "refchecks")
+    val phaseName = Ploogin.this.name
+    override def description = "Multiple unsatisfiable constraints in Scaladoc"
+    def newPhase(prev: Phase) = new TestPhase(prev)
+    class TestPhase(prev: Phase) extends StdPhase(prev) {
+      override def description = TestComponent.this.description
+      def apply(unit: CompilationUnit): Unit = println("running plugin")
+    }
+  }
+}

--- a/test/scaladoc/run/t8755c.check
+++ b/test/scaladoc/run/t8755c.check
@@ -1,0 +1,8 @@
+warning: No phase `refchecks` for ploogin.runsBefore
+warning: Dropping phase ploogin, it is not reachable from parser
+parser -> namer -> packageobjects -> typer -> terminal
+[running phase parser on newSource]
+[running phase namer on newSource]
+[running phase packageobjects on newSource]
+[running phase typer on newSource]
+Done.

--- a/test/scaladoc/run/t8755c/Test_2.scala
+++ b/test/scaladoc/run/t8755c/Test_2.scala
@@ -1,0 +1,25 @@
+import scala.tools.nsc.doc.model._
+import scala.tools.nsc.doc.model.diagram._
+import scala.tools.partest.ScaladocModelTest
+import scala.tools.nsc.plugins.PluginDescription
+import scala.util.chaining._
+
+object Test extends ScaladocModelTest {
+
+  override def code = """
+    class C
+  """
+
+  override def scaladocSettings = s"-Xplugin:$testOutput -Xplugin-require:ploogin -Vdebug"
+
+  override def testModel(rootPackage: Package) = ()
+
+  override def newDocFactory =
+    super.newDocFactory.tap(df => println(df.compiler.phaseNames.mkString(" -> ")))
+
+  override def show() = {
+    val xml  = PluginDescription("ploogin", "t8755.Ploogin").toXML
+    (testOutput / "scalac-plugin.xml").toFile.writeAll(xml)
+    super.show()
+  }
+}

--- a/test/scaladoc/run/t8755c/ploogin_1.scala
+++ b/test/scaladoc/run/t8755c/ploogin_1.scala
@@ -1,0 +1,29 @@
+
+package t8755
+
+import scala.tools.nsc.{Global, Phase}
+import scala.tools.nsc.plugins.{Plugin, PluginComponent}
+import scala.reflect.io.Path
+import scala.reflect.io.File
+
+/** A test plugin.  */
+class Ploogin(val global: Global) extends Plugin {
+  import global._
+
+  val name = "ploogin"
+  val description = "A sample plugin for testing."
+  val components = List[PluginComponent](TestComponent)
+
+  private object TestComponent extends PluginComponent {
+    val global: Ploogin.this.global.type = Ploogin.this.global
+    override val runsBefore = List("refchecks")
+    val runsAfter = Nil
+    val phaseName = Ploogin.this.name
+    override def description = "Before refchecks but empty after; warn if debug"
+    def newPhase(prev: Phase) = new TestPhase(prev)
+    class TestPhase(prev: Phase) extends StdPhase(prev) {
+      override def description = TestComponent.this.description
+      def apply(unit: CompilationUnit): Unit = ???
+    }
+  }
+}


### PR DESCRIPTION
Phases referenced in constraints (runsAfter, runsBefore) may not exist when running Scaladoc.
  - Don't warn about constraints on non-existing phases in Scaladoc
  - Drop invalid constraints (runsAfter / runsRightAfter / runsBefore)
  - Drop unreachabele phases (no valid runsAfter / runsRightAfter)

Minimal changes so we can move ahead with 2.13.15. Includes all tests from https://github.com/scala/scala/pull/10856 but not the code cleanups.

Fixes https://github.com/scala/bug/issues/13028.