### PR TITLE
Compare productPrefix in synthetic case class canEqual

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
@@ -135,7 +135,11 @@ trait SyntheticMethods extends ast.TreeDSL {
     def canEqualMethod: Tree = {
       syntheticCanEqual = true
       createMethod(nme.canEqual_, List(AnyTpe), BooleanTpe) { m =>
-        Ident(m.firstParam) IS_OBJ classExistentialType(context.prefix, clazz)
+        val isInst = Ident(m.firstParam) IS_OBJ classExistentialType(context.prefix, clazz)
+        isInst AND fn(
+          gen.mkAttributedSelect(mkThis, Product_productPrefix),
+          Any_==,
+          gen.mkAttributedSelect(thatCast(m), Product_productPrefix))
       }
     }
 

--- a/test/files/run/idempotency-case-classes.check
+++ b/test/files/run/idempotency-case-classes.check
@@ -21,7 +21,7 @@ C(2,3)
       case _ => scala.runtime.Statics.ioobe[Any](x$1)
     };
     override <synthetic> def productIterator: Iterator[Any] = scala.runtime.ScalaRunTime.typedProductIterator[Any](C.this);
-    <synthetic> def canEqual(x$1: Any): Boolean = x$1.$isInstanceOf[C]();
+    <synthetic> def canEqual(x$1: Any): Boolean = x$1.$isInstanceOf[C]().&&(C.this.productPrefix.==(x$1.asInstanceOf[C].productPrefix));
     override <synthetic> def productElementName(x$1: Int): String = x$1 match {
       case 0 => "x"
       case 1 => "y"

--- a/test/files/run/t13033.scala
+++ b/test/files/run/t13033.scala
@@ -1,0 +1,22 @@
+//> using options -deprecation
+
+import scala.tools.testkit.AssertUtil.assertThrows
+
+abstract case class C1(a: Int)
+class C2(a: Int) extends C1(a) { override def productPrefix = "C2" }
+class C3(a: Int) extends C1(a) { override def productPrefix = "C3" }
+
+case class VCC(x: Int) extends AnyVal
+
+object Test extends App {
+  val c2 = new C2(1)
+  val c3 = new C3(1)
+  assert(c2 != c3)
+  assert(c2.hashCode != c3.hashCode)
+  assert(!c2.canEqual(c3))
+
+  // should be true -- scala/bug#13034
+  assert(!VCC(1).canEqual(VCC(1)))
+  // also due to scala/bug#13034
+  assertThrows[ClassCastException](VCC(1).canEqual(1))
+}


### PR DESCRIPTION
Since 2.13, case class `hashCode` mixes in the hash code of the
`productPrefix` string. The synthetic `equals` method has fallen
out of sync in that regard, so two instances can be equal but have
different hash codes.

This commit changes the synthetic `canEqual` method to also compare
the `productPrefix` of the two instances.

Fixes https://github.com/scala/bug/issues/13033