### PR TITLE
Fix typo in collection.mutable.Builder

### DIFF
--- a/src/library/scala/collection/mutable/Builder.scala
+++ b/src/library/scala/collection/mutable/Builder.scala
@@ -91,7 +91,7 @@ trait Builder[-A, +To] extends Growable[A] { self =>
     }
   }
 
-  /** A builder resulting from this builder my mapping the result using `f`. */
+  /** A builder resulting from this builder by mapping the result using `f`. */
   def mapResult[NewTo](f: To => NewTo): Builder[A, NewTo] = new Builder[A, NewTo] {
     def addOne(x: A): this.type = { self += x; this }
     def clear(): Unit = self.clear()


### PR DESCRIPTION
Originally posted in https://github.com/scala/scala3/pull/21580 by @truecrunchyfrog 