### PR TITLE
Issue messages at import selector only [ci: last-only]

### DIFF
--- a/project/PartestUtil.scala
+++ b/project/PartestUtil.scala
@@ -72,7 +72,7 @@ object PartestUtil {
                 val next = prefix + suffix
                 testFile.getParentFile / next
               }
-              val assocFiles = List(".check", ".flags").map(sibling)
+              val assocFiles = List(".check").map(sibling)
               val sourceFiles = if (testFile.isFile) List(testFile) else testFile.**(AllPassFilter).get.toList
               val allFiles = testFile :: assocFiles ::: sourceFiles
               allFiles.exists(f => f.isFile && re.findFirstIn(IO.read(f)).isDefined)
@@ -89,7 +89,7 @@ object PartestUtil {
         (matchingFileContent ++ matchingFileName).map(_._2).distinct.sorted
       }
 
-      val completion = Completions.strict(Set("<filename glob>", "<regex> (for source, flags or checkfile contents)").map(s => Completion.displayOnly(s)))
+      val completion = Completions.strict(Set("<filename glob>", "<regex> (for source or checkfile contents)").map(s => Completion.displayOnly(s)))
       val tokenCompletion = TokenCompletions.fixed((seen, level) => completion)
 
       val globOrPattern = StringBasic.map(expandGrep).flatMap {

--- a/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Analyzer.scala
@@ -33,6 +33,7 @@ trait Analyzer extends AnyRef
             with StdAttachments
             with MacroAnnotationAttachments
             with AnalyzerPlugins
+            with ImportTracking
 {
   val global : Global
   import global._

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -22,12 +22,11 @@ import scala.util.chaining._
 /**
  *  @author  Martin Odersky
  */
-trait Contexts { self: Analyzer =>
+trait Contexts { self: Analyzer with ImportTracking =>
   import global._
   import definitions.{JavaLangPackage, ScalaPackage, PredefModule, ScalaXmlTopScope, ScalaXmlPackage}
   import ContextMode._
   import scala.reflect.internal.Flags._
-
 
   protected def onTreeCheckerError(pos: Position, msg: String): Unit = ()
 
@@ -56,59 +55,6 @@ trait Contexts { self: Analyzer =>
     rootMirror.RootClass,
     rootMirror.RootClass.info.decls
   )
-
-  private lazy val allUsedSelectors =
-    mutable.Map.empty[ImportInfo, Set[ImportSelector]].withDefaultValue(Set.empty)
-  private lazy val allImportInfos =
-    mutable.Map.empty[CompilationUnit, List[(ImportInfo, Symbol)]].withDefaultValue(Nil)
-
-  def warnUnusedImports(unit: CompilationUnit) = if (!unit.isJava) {
-    def msg(sym: Symbol) = sym.deprecationMessage.map(": " + _).getOrElse("")
-    def checkDeprecatedElementInPath(selector: ImportSelector, info: ImportInfo): String = {
-      def badName(name: Name) =
-        info.qual.tpe.member(name) match {
-          case m if m.isDeprecated => Some(s" of deprecated $m${msg(m)}")
-          case _ => None
-        }
-      val badSelected =
-        if (!selector.isMask && selector.isSpecific) badName(selector.name).orElse(badName(selector.name.toTypeName))
-        else None
-      def badFrom = {
-        val sym = info.qual.symbol
-        if (sym.isDeprecated) Some(s" from deprecated $sym${msg(sym)}") else None
-      }
-      badSelected.orElse(badFrom).getOrElse("")
-    }
-    def warnUnusedSelections(infos0: List[(ImportInfo, Symbol)]): Unit = {
-      type Culled = (ImportSelector, ImportInfo, Symbol)
-      var unused = List.empty[Culled]
-      @tailrec def loop(infos: List[(ImportInfo, Symbol)]): Unit =
-        infos match {
-          case (info, owner) :: infos =>
-            val used = allUsedSelectors.remove(info).getOrElse(Set.empty)
-            def checkSelectors(selectors: List[ImportSelector]): Unit =
-              selectors match {
-                case selector :: selectors =>
-                  checkSelectors(selectors)
-                  if (!selector.isMask && !used(selector))
-                    unused ::= ((selector, info, owner))
-                case _ =>
-              }
-            checkSelectors(info.tree.selectors)
-            loop(infos)
-          case _ =>
-        }
-      loop(infos0)
-      unused.foreach {
-        case (selector, info, owner) =>
-          val pos = info.posOf(selector)
-          val origin = info.fullSelectorString(selector)
-          val addendum = checkDeprecatedElementInPath(selector, info)
-          runReporting.warning(pos, s"Unused import$addendum", WarningCategory.UnusedImports, owner, origin)
-      }
-    }
-    allImportInfos.remove(unit).foreach(warnUnusedSelections)
-  }
 
   var lastAccessCheckDetails: String = ""
 
@@ -733,7 +679,7 @@ trait Contexts { self: Analyzer =>
     def makeImportContext(tree: Import): Context =
       make(tree).tap { ctx =>
         if (settings.warnUnusedImport && openMacros.isEmpty && !ctx.isRootImport && !ctx.outer.owner.isInterpreterWrapper)
-          allImportInfos(ctx.unit) ::= ctx.importOrNull -> ctx.owner
+          recordImportContext(ctx)
       }
 
     /** Use reporter (possibly buffered) for errors/warnings and enable implicit conversion **/
@@ -1996,7 +1942,7 @@ trait Contexts { self: Analyzer =>
           else s"(expr=${tree.expr}, ${result.fullLocationString})"
         }")
       if (settings.warnUnusedImport && !isRootImport && result != NoSymbol && pos != NoPosition)
-        allUsedSelectors(this) += sel
+        recordImportUsage(this, sel)
     }
 
     def allImportedSymbols: Iterable[Symbol] =

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1909,8 +1909,7 @@ trait Contexts { self: Analyzer =>
 
   class ImportInfo(val tree: Import, val depth: Int, val isRootImport: Boolean) {
     def pos = tree.pos
-    def posOf(sel: ImportSelector) =
-      if (sel.namePos >= 0) tree.pos withPoint sel.namePos else tree.pos
+    def posOf(sel: ImportSelector) = tree.posOf(sel)
 
     /** The prefix expression */
     def qual: Tree = tree.symbol.info match {

--- a/src/compiler/scala/tools/nsc/typechecker/ImportTracking.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ImportTracking.scala
@@ -1,0 +1,202 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.tools.nsc
+package typechecker
+
+import scala.annotation.nowarn
+import scala.collection.mutable
+import scala.reflect.internal.Chars.{isLineBreakChar, isWhitespace}
+import scala.reflect.internal.util.CodeAction
+import scala.tools.nsc.Reporting.WarningCategory
+
+/** Track import clauses and usages for -Wunused:imports reporting.
+ */
+trait ImportTracking { self: Analyzer =>
+  import global._
+
+  // Associate info with info at import keyword, plus owner for warning filtering. `import a.x, b.x` -> `(b, a, owner)`
+  private type TrackedInfo = (ImportInfo, ImportInfo, Symbol)
+
+  private val usedSelectors = mutable.Map.empty[ImportInfo, Set[ImportSelector]].withDefaultValue(Set.empty)
+  private val importInfos   = mutable.Map.empty[CompilationUnit, List[TrackedInfo]].withDefaultValue(Nil)
+
+  def recordImportUsage(info: ImportInfo, sel: ImportSelector): Unit = usedSelectors(info) += sel
+
+  def recordImportContext(ctx: Context): Unit = ctx.firstImport.foreach { info =>
+    val keyword =
+      if (info.pos.start != info.pos.point) info
+      else ctx.imports.find(p => p.pos.isDefined && p.pos.start != p.pos.point).getOrElse(info)
+    importInfos(ctx.unit) ::= (info, keyword, ctx.owner) : @nowarn
+  }
+
+  def warnUnusedImports(unit: CompilationUnit): Unit = if (!unit.isJava) {
+    def checkDeprecatedElementInPath(selector: ImportSelector, info: ImportInfo): String = {
+      def msg(sym: Symbol) = sym.deprecationMessage.map(": " + _).getOrElse("")
+      def badName(name: Name) =
+        info.qual.tpe.member(name) match {
+          case m if m.isDeprecated => Some(s" of deprecated $m${msg(m)}")
+          case _ => None
+        }
+      val badSelected =
+        if (!selector.isMask && selector.isSpecific) badName(selector.name).orElse(badName(selector.name.toTypeName))
+        else None
+      def badFrom = {
+        val sym = info.qual.symbol
+        if (sym.isDeprecated) Some(s" from deprecated $sym${msg(sym)}") else None
+      }
+      badSelected.orElse(badFrom).getOrElse("")
+    }
+    def warnUnusedSelections(infos: List[TrackedInfo]): Unit = {
+      type Culled = (ImportSelector, TrackedInfo)
+      def keyInfoOfTracked(info: TrackedInfo): ImportInfo = info._2
+      def keyInfoOfCulled(culled: Culled): ImportInfo = keyInfoOfTracked(culled._2)
+      def infoOfCulled(culled: Culled): ImportInfo = culled._2._1
+      val unused: List[Culled] = {
+        var res = List.empty[Culled]
+        def cull(infos: List[TrackedInfo]): Unit =
+          infos match {
+            case (tracked @ (info, _, _)) :: infos =>
+              val used = usedSelectors.remove(info).getOrElse(Set.empty)
+              def checkSelectors(selectors: List[ImportSelector]): Unit =
+                selectors match {
+                  case selector :: selectors =>
+                    checkSelectors(selectors)
+                    if (!selector.isMask && !used(selector))
+                      res ::= selector -> tracked
+                  case _ =>
+                }
+              checkSelectors(info.tree.selectors)
+              cull(infos)
+            case _ =>
+          }
+        cull(infos)
+        res
+      }
+      def emit(culled: Culled, actions: List[CodeAction]): Unit = culled match {
+        case (selector, (info, _, owner)) =>
+          val pos = info.posOf(selector)
+          val origin = info.fullSelectorString(selector)
+          val addendum = checkDeprecatedElementInPath(selector, info)
+          runReporting.warning(pos, s"Unused import$addendum", WarningCategory.UnusedImports, owner, origin, actions)
+      }
+      // If the rest of the line is blank, include it in the final edit position. (Delete trailing whitespace.)
+      // If replacement is empty, and the prefix of the line is also blank, then include that, too. (Del blank line.)
+      def editPosAt(pos: Position, replacement: String): Position = {
+        val content = pos.source.content
+        val prev = content.lastIndexWhere(c => !isWhitespace(c), end = pos.start - 1)
+        val emptyLeft = prev < 0 || isLineBreakChar(content(prev))
+        val next = content.indexWhere(c => !isWhitespace(c), from = pos.end)
+        val emptyRight = next < 0 || isLineBreakChar(content(next))
+        val deleteLine = emptyLeft && emptyRight && replacement.isEmpty
+        val bump = if (deleteLine) 1 else 0
+        val p1 = if (next >= 0 && emptyRight) pos.withEnd(next + bump) else pos
+        val p2 = if (deleteLine) p1.withStart(prev + 1) else p1
+        p2
+      }
+      def isSingleSelector(infos: List[TrackedInfo]): Boolean = infos match {
+        case (info, _, _) :: Nil => info.tree.selectors.size == 1
+        case _ => false
+      }
+      def emitEdits(): Unit = {
+        def edit(pos: Position, replacement: String) =
+          runReporting.codeAction("unused import", editPosAt(pos, replacement), replacement, desc = "remove import")
+        def delete(pos: Position) = edit(pos, replacement = "")
+
+        val statements = infos.groupBy(keyInfoOfTracked) // keyInfo -> tracked infos in statement
+
+        unused.groupBy(keyInfoOfCulled).foreach {        // keyInfo -> culled selectors in statement
+        case (keyInfo, culled :: Nil) if isSingleSelector(statements(keyInfo)) => // import a.x
+          emit(culled, actions = delete(keyInfo.pos)) // just one warning with delete
+        case (keyInfo, culleds) => // import a.x, b.{y, z}
+          val tracking = culleds.groupBy(infoOfCulled) // info -> Culled selectors (group by import clause)
+          val deleting = tracking.view.mapValues(_.map(_._1)).toMap // info -> selectors to remove: b.{y, z} -> y
+          val existing = statements(keyInfo).map(_._1).sortBy(_.tree.pos.start) // infos for a, b
+          val (editing, keeping) = existing.partition(deleting.contains(_)) // deleting = info has a selector to del
+          val (removing, updating) = editing.partition(info => info.tree.selectors.length == deleting(info).size)
+          if (keeping.isEmpty && updating.isEmpty) { // all clauses are removed in the current statement
+            // existing.flatMap(tracking)
+            val ordered = culleds.sortBy(_._1.namePos)
+            ordered.init.foreach(emit(_, actions = Nil)) // emit warnings for N-1 selectors
+            val imports = existing.map(_.tree)
+            val editPos = wrappingPos(imports.head.pos, imports) // reconstitute range of import statement
+            emit(ordered.last, actions = delete(editPos)) // at Nth selector, delete the statement
+          }
+          else
+            foreachWithIndex(existing) { (info, i) =>
+              if (removing.contains(info)) {
+                val toEmit = tracking(info).sortBy(_._1.namePos)
+                toEmit.init.foreach(emit(_, actions = Nil)) // emit warnings for N-1 selectors for clause
+                // normally, delete from start of this clause to start of next clause: a.x, b.{y, z} from a to b
+                // but if this is the last clause, then also delete the comma following the last undeleted clause.
+                // also if this is the first clause, start includes the keyword, so advance it to the name (point)
+                val n = existing.size
+                val editPos = {
+                  val p0 = info.tree.pos.withStart(info.tree.pos.point)
+                  if (i == n - 1) p0
+                  else p0.withEnd(existing(i + 1).tree.pos.start)
+                }
+                val actions =
+                  if (n > 1 && i == n - 1) {
+                    val prev = existing.lastIndexWhere(!deleting.contains(_))
+                    val prevPos = existing(prev).tree.pos
+                    val commaPos = prevPos.withStart(prevPos.end).withEnd(existing(prev + 1).tree.pos.start)
+                    delete(commaPos) ++ delete(editPos)
+                  }
+                  else delete(editPos)
+                emit(toEmit.last, actions) // at Nth selector, delete the clause (and maybe a comma)
+              }
+              else if (updating.contains(info)) {
+                val toEmit = tracking(info).sortBy(_._1.namePos)
+                val remaining = info.tree.selectors.filter(!deleting(info).contains(_))
+                if (remaining.size == 1) { // reformat without braces if remaining selector a.x
+                  toEmit.init.foreach(emit(_, actions = Nil))
+                  val editPos = info.tree.pos.withStart(info.tree.pos.point) // exclude import keyword if i == 0
+                  val revised = info.tree.copy(selectors = remaining)
+                  emit(toEmit.last, edit(editPos, revised.toString.stripPrefix("import "))) // exclude the keyword
+                }
+                else {
+                  // emit an edit at each change to preserve formatting.
+                  // there are multiple selectors, comma-separated in braces {x, y => w, z}.
+                  // delete from start of name to start of next name,
+                  // except at last selector, where it's necessary to delete a preceding comma.
+                  // find the previous selector that is not deleted, and delete from its comma to start of next name.
+                  val selectors = info.tree.selectors
+                  val infoPos = info.tree.pos
+                  val last = selectors.last
+                  val content = infoPos.source.content
+                  toEmit.foreach { case culled @ (selector, (_, _, _)) =>
+                    if (selector != last) {
+                      val index = selectors.indexWhere(_ == selector)
+                      val editPos = infoPos.withStart(selector.namePos).withEnd(selectors(index + 1).namePos)
+                      emit(culled, delete(editPos))
+                    }
+                    else {
+                      // info.tree.pos.end is one char after rbrace
+                      val prev = selectors.lastIndexWhere(remaining.contains(_))
+                      val comma = content.indexWhere(_ == ',', from = selectors(prev).namePos)
+                      val commaPos = infoPos.withStart(comma).withEnd(selectors(prev + 1).namePos)
+                      val editPos = infoPos.withStart(selector.namePos).withEnd(info.tree.pos.end - 1)
+                      emit(culled, delete(commaPos) ++ delete(editPos))
+                    }
+                  }
+                }
+              }
+            }
+        }
+      }
+      if (settings.quickfix.isSetByUser && !settings.quickFixSilent) emitEdits()
+      else unused.foreach(emit(_, actions = Nil))
+    }
+    importInfos.remove(unit).foreach(warnUnusedSelections)
+  }
+}

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -339,7 +339,7 @@ trait Namers extends MethodSynthesis {
     }
 
     def createImportSymbol(tree: Import) =
-      NoSymbol.newImport(tree.pos) setInfo (namerOf(tree.symbol) importTypeCompleter tree)
+      NoSymbol.newImport(tree.pos).setInfo(namerOf(tree.symbol).importTypeCompleter(tree))
 
     /** All PackageClassInfoTypes come from here. */
     def createPackageSymbol(pos: Position, pid: RefTree): Symbol = {
@@ -725,7 +725,7 @@ trait Namers extends MethodSynthesis {
       newNamer(context.make(tree, sym.moduleClass, sym.info.decls)) enterSyms tree.stats
     }
 
-    private def enterImport(tree: Import) = {
+    private def enterImport(tree: Import): Unit = {
       val sym = createImportSymbol(tree)
       tree.symbol = sym
     }

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -539,6 +539,16 @@ trait Trees extends api.Trees {
       traverser.traverse(expr)
       selectors foreach traverser.traverseImportSelector
     }
+    def posOf(sel: ImportSelector): Position = {
+      val pos0 = this.pos
+      val start = sel.namePos
+      if (start >= 0 && selectors.contains(sel)) {
+        val hasRename = sel.rename != null && sel.renamePos >= 0 // !sel.isWildcard
+        val end = if (hasRename) sel.renamePos + sel.rename.length else start + sel.name.length
+        pos0.withStart(start).withEnd(end) ^ start
+      }
+      else pos0
+    }
   }
   object Import extends ImportExtractor
 

--- a/test/files/neg/suggest-similar.check
+++ b/test/files/neg/suggest-similar.check
@@ -12,7 +12,7 @@ did you mean Weehawken?
 suggest-similar.scala:16: error: value readline is not a member of object scala.io.StdIn
 did you mean readLine? or perhaps readByte, readInt, or readLong?
   import scala.io.StdIn.{readline, readInt}
-         ^
+                         ^
 suggest-similar.scala:20: error: object stdin is not a member of package io
 did you mean StdIn?
   import scala.io.stdin.{readLine => line}

--- a/test/files/neg/t12734.check
+++ b/test/files/neg/t12734.check
@@ -1,0 +1,10 @@
+[ERROR] [RangePosition(t12734.scala, 94, 94, 108)]: object AssertionErrer is not a member of package java.lang
+did you mean AssertionError?
+[ERROR] [RangePosition(t12734.scala, 176, 182, 192)]: object connection is not a member of package scala
+did you mean collection?
+[WARNING] [RangePosition(t12734.scala, 110, 110, 125)]: Unused import
+[WARNING] [RangePosition(t12734.scala, 127, 127, 133)]: Unused import
+[WARNING] [RangePosition(t12734.scala, 167, 167, 168)]: Unused import
+[WARNING] [RangePosition(t12734.scala, 193, 193, 194)]: Unused import
+4 warnings
+2 errors

--- a/test/files/neg/t12734.check
+++ b/test/files/neg/t12734.check
@@ -6,5 +6,7 @@ did you mean collection?
 [WARNING] [RangePosition(t12734.scala, 127, 127, 133)]: Unused import
 [WARNING] [RangePosition(t12734.scala, 167, 167, 168)]: Unused import
 [WARNING] [RangePosition(t12734.scala, 193, 193, 194)]: Unused import
-4 warnings
+[WARNING] [RangePosition(t12734.scala, 397, 397, 403)]: Unused import
+[WARNING] [RangePosition(t12734.scala, 489, 489, 494)]: Unused import
+6 warnings
 2 errors

--- a/test/files/neg/t12734.scala
+++ b/test/files/neg/t12734.scala
@@ -1,0 +1,16 @@
+//> using options -Xlint -Xreporter:scala.tools.partest.nest.PlainReporter
+
+import java.lang.{AssertionErrer, Integer => JInt, String, Thread}
+import scala.annotation._
+import scala.connection._
+
+trait T {
+  def t: Thread
+}
+
+/*
+Previous result shows the selectors with same range but different points.
+[ERROR] [RangePosition(t12734.scala, 76, 83, 117)]: object AssertionErrer is not a member of package java.lang
+did you mean AssertionError?
+[WARNING] [RangePosition(t12734.scala, 76, 94, 117)]: Unused import
+*/

--- a/test/files/neg/t12734.scala
+++ b/test/files/neg/t12734.scala
@@ -8,6 +8,22 @@ trait T {
   def t: Thread
 }
 
+// these import infos are not seen in position order
+// warnings are not sorted later
+class C {
+  def f(): Int = {
+    def compute(): Int = {
+      import scala.concurrent.Future
+      //Future(42).get
+      42
+    }
+    compute()
+  }
+  import scala.util.matching.Regex
+  //def g: Regex = "(\\d+)".r
+  def g = "(\\d+)".r
+}
+
 /*
 Previous result shows the selectors with same range but different points.
 [ERROR] [RangePosition(t12734.scala, 76, 83, 117)]: object AssertionErrer is not a member of package java.lang

--- a/test/files/neg/t2773.check
+++ b/test/files/neg/t2773.check
@@ -1,6 +1,6 @@
 t2773.scala:5: error: value x is not a member of C
   import c.x
-         ^
+           ^
 t2773.scala:6: error: not found: value x
   println(x)
           ^

--- a/test/files/neg/t5801.check
+++ b/test/files/neg/t5801.check
@@ -1,6 +1,6 @@
 t5801.scala:1: error: object sth is not a member of package scala
 import scala.sth
-       ^
+             ^
 t5801.scala:4: error: not found: value sth
   def foo(a: Int)(implicit b: sth.Sth): Unit = {}
                               ^

--- a/test/files/neg/t6340.check
+++ b/test/files/neg/t6340.check
@@ -1,10 +1,13 @@
 t6340.scala:11: error: value D is not a member of object Foo
   import Foo.{ A, B, C, D, E, X, Y, Z }
-         ^
+                        ^
+t6340.scala:11: error: value E is not a member of object Foo
+  import Foo.{ A, B, C, D, E, X, Y, Z }
+                           ^
 t6340.scala:16: error: not found: type D
   val d = new D
               ^
 t6340.scala:17: error: not found: type W
   val w = new W
               ^
-3 errors
+4 errors

--- a/test/junit/scala/tools/nsc/QuickfixTest.scala
+++ b/test/junit/scala/tools/nsc/QuickfixTest.scala
@@ -4,6 +4,7 @@ import org.junit.Assert._
 import org.junit.Test
 
 import java.nio.file.Files
+import scala.jdk.CollectionConverters._
 import scala.reflect.internal.util.BatchSourceFile
 import scala.reflect.io.AbstractFile
 import scala.tools.nsc.reporters.StoreReporter
@@ -11,26 +12,32 @@ import scala.tools.testkit.AssertUtil._
 import scala.tools.testkit.BytecodeTesting
 import scala.tools.testkit.ReleasablePath._
 import scala.util.Using
+import scala.util.chaining._
 
 class QuickfixTest extends BytecodeTesting {
 
-  def testQuickfixs(as: List[String], b: String, args: String, checkInfo: StoreReporter.Info => Boolean = _ => true): Unit =
+  private val allGood: StoreReporter.Info => Boolean = _ => true
+
+  // expected result b is lines (of resulting files) with NL termination (i.e., trailing empty line)
+  def testQuickfixes(as: List[String], b: String, args: String, checkInfo: StoreReporter.Info => Boolean = allGood): Unit =
     noWin() {
       Using.resource(Files.createTempDirectory("quickfixTest")) { tmpDir =>
-        val srcs = as.indices.map(i => tmpDir.resolve(s"unitSource$i.scala")).toList
-        as.lazyZip(srcs).foreach { case (a, src) => Files.write(src, a.getBytes) }
+        val srcs = as.zipWithIndex.map {
+          case (a, i) => tmpDir.resolve(s"unitSource$i.scala").tap(Files.write(_, a.getBytes))
+        }
         val c = BytecodeTesting.newCompiler(extraArgs = args)
         val r = c.newRun()
         val fs = srcs.map(src => AbstractFile.getFile(src.toFile.getAbsolutePath))
         r.compileSources(fs.map(new BatchSourceFile(_)))
-        assertEquals(b.replaceAll("\n+", "\n"), srcs.map(src => new String(Files.readAllBytes(src))).mkString("\n").replaceAll("\n+", "\n"))
-        for (info <- c.global.reporter.asInstanceOf[StoreReporter].infos)
-          assert(checkInfo(info), info)
+        assertEquals(b, srcs.flatMap(src => Files.readAllLines(src).asScala).mkString("", "\n", "\n"))
+        if (checkInfo ne allGood)
+          for (info <- c.global.reporter.asInstanceOf[StoreReporter].infos)
+            assert(checkInfo(info), info)
       }
     }
 
   def testQuickfix(a: String, b: String, args: String, checkInfo: StoreReporter.Info => Boolean = _ => true): Unit =
-    testQuickfixs(List(a), b, args, checkInfo)
+    testQuickfixes(List(a), b, args, checkInfo)
 
   def comp(args: String) = BytecodeTesting.newCompiler(extraArgs = args)
 
@@ -93,8 +100,8 @@ class QuickfixTest extends BytecodeTesting {
   }
 
   @Test def `do not lie about fixing`: Unit = {
-    val a = "import foo.bar"
-    testQuickfix(a, a, "-quickfix:any", !_.msg.contains("[rewritten by -quickfix]"))
+    val a = "import foo.bar" // not found: object foo (not quickfixable; no -Wunused:imports)
+    testQuickfix(a, a+"\n", "-quickfix:any", !_.msg.contains("[rewritten by -quickfix]"))
   }
 
   // https://github.com/scala/bug/issues/12941
@@ -122,7 +129,7 @@ class QuickfixTest extends BytecodeTesting {
         |  def one = Test1.foo
         |}
         |""".stripMargin
-    testQuickfixs(a1s, b1, "-Xsource:3 -quickfix:any")
+    testQuickfixes(a1s, b1, "-Xsource:3 -quickfix:any")
 
     val a2s = List(
       """object Test2 {
@@ -147,7 +154,7 @@ class QuickfixTest extends BytecodeTesting {
         |  def foo: None.type = None
         |}
         |""".stripMargin
-    testQuickfixs(a2s, b2, "-Xsource:3 -quickfix:any")
+    testQuickfixes(a2s, b2, "-Xsource:3 -quickfix:any")
   }
 
   @Test def `named boolean literal lint has a fix`: Unit = {
@@ -180,5 +187,138 @@ class QuickfixTest extends BytecodeTesting {
            |}
            |"""
     testQuickfix(a, b, "-Xsource:3 -quickfix:any")
+  }
+
+  @Test def `unused import is quickfixable`: Unit = {
+    val precedingNL =
+      sm"""|import java.lang.Runnable
+           |import java.lang.Thread
+           |class C extends Runnable { def run() = () }
+           |"""
+    val resPrecedingNL =
+      sm"""|import java.lang.Runnable
+           |class C extends Runnable { def run() = () }
+           |"""
+    val noPrecedingNL =
+      sm"""|import java.lang.Thread
+           |class C
+           |"""
+    val resNoPrecedingNL =
+      sm"""|class C
+           |"""
+    val multiplePrefix =
+      sm"""|import java.lang.Runnable
+           |import java.lang.Thread
+           |class C
+           |"""
+    val multipleSuffix = // competing edits to delete line separator, was AIOOB in insertEdits
+      sm"""|class C
+           |import java.lang.Runnable
+           |import java.lang.Thread"""
+    testQuickfix(precedingNL, resPrecedingNL, "-Wunused:imports -quickfix:any")
+    testQuickfix(noPrecedingNL, resNoPrecedingNL, "-Wunused:imports -quickfix:any")
+    testQuickfix(multiplePrefix, resNoPrecedingNL, "-Wunused:imports -quickfix:any")
+    testQuickfix(multipleSuffix, resNoPrecedingNL, "-Wunused:imports -quickfix:any")
+  }
+
+  @Test def `unused imports are selectively quickfixable`: Unit = {
+    val keepEither =
+      sm"""|import java.lang.{Runnable, Thread}
+           |class C extends Runnable { def run() = () }
+           |"""
+    val keptEither =
+      sm"""|import java.lang.Runnable
+           |class C extends Runnable { def run() = () }
+           |"""
+    val keepOne =
+      sm"""|import java.lang.Runnable, java.lang.Thread
+           |class C extends Runnable { def run() = () }
+           |"""
+    val keptOne =
+      sm"""|import java.lang.Runnable
+           |class C extends Runnable { def run() = () }
+           |"""
+    val keepOther =
+      sm"""|import java.lang.Thread, java.lang.Runnable
+           |class C extends Runnable { def run() = () }
+           |"""
+    val keepOtherSpacey =
+      sm"""|import java.lang.Thread  , java.lang.Runnable
+           |class C extends Runnable { def run() = () }
+           |"""
+    val keepNeither =
+      sm"""|import java.lang.Thread, java.lang.Runnable
+           |class C
+           |"""
+    val keepNothing =
+      sm"""|import java.lang.{Runnable, Thread}
+           |class C
+           |"""
+    val keptNothing =
+      sm"""|class C
+           |"""
+    val keepTwo =
+      sm"""|import java.lang.{Runnable, System, Thread}, System.out
+           |class C extends Runnable { def run() = out.println() }
+           |"""
+    val keptTwo =
+      sm"""|import java.lang.{Runnable, System}, System.out
+           |class C extends Runnable { def run() = out.println() }
+           |"""
+    val keepTwoDropHead =
+      sm"""|import java.lang.{Thread, Runnable, System}, System.out
+           |class C extends Runnable { def run() = out.println() }
+           |"""
+    val keepTwoDropMiddle =
+      sm"""|import java.lang.{Runnable, Thread, System}, System.out
+           |class C extends Runnable { def run() = out.println() }
+           |"""
+    testQuickfix(keepEither, keptEither, "-Wunused:imports -quickfix:any")
+    testQuickfix(keepOne, keptOne, "-Wunused:imports -quickfix:any")
+    testQuickfix(keepOther, keptOne, "-Wunused:imports -quickfix:any")
+    testQuickfix(keepOtherSpacey, keptOne, "-Wunused:imports -quickfix:any")
+    testQuickfix(keepNeither, keptNothing, "-Wunused:imports -quickfix:any")
+    testQuickfix(keepNothing, keptNothing, "-Wunused:imports -quickfix:any")
+    testQuickfix(keepTwo, keptTwo, "-Wunused:imports -quickfix:any")
+    testQuickfix(keepTwoDropHead, keptTwo, "-Wunused:imports -quickfix:any")
+    testQuickfix(keepTwoDropMiddle, keptTwo, "-Wunused:imports -quickfix:any")
+  }
+
+  @Test def `unused imports respects your weird formatting`: Unit = {
+    val keepColumns =
+      sm"""|import java.lang.{Runnable,
+           |                  Thread,
+           |                  System}, System.out
+           |class C extends Runnable { def run() = out.println() }
+           |"""
+    val keptColumns =
+      sm"""|import java.lang.{Runnable,
+           |                  System}, System.out
+           |class C extends Runnable { def run() = out.println() }
+           |"""
+    val overlapping =
+      sm"""|import java.lang.{AutoCloseable,
+           |                  Thread,
+           |                  Runnable,
+           |                  System}, System.out
+           |class C extends Runnable { def run() = out.println() }
+           |"""
+    val lapped =
+      sm"""|import java.lang.{Runnable,
+           |                  System}, System.out
+           |class C extends Runnable { def run() = out.println() }
+           |"""
+    val keepRename =
+      sm"""|import java.lang.{Runnable => R, System,
+           |                  Thread}, System.out
+           |class C extends R { def run() = out.println() }
+           |"""
+    val keptRename =
+      sm"""|import java.lang.{Runnable => R, System}, System.out
+           |class C extends R { def run() = out.println() }
+           |"""
+    testQuickfix(keepColumns, keptColumns, "-Wunused:imports -quickfix:any")
+    testQuickfix(overlapping, lapped, "-Wunused:imports -quickfix:any")
+    testQuickfix(keepRename, keptRename, "-Wunused:imports -quickfix:any")
   }
 }


### PR DESCRIPTION
When issuing "unused import" or "member not found" for an import selector (where the tree is an `Import`), try to locate the offending name more precisely.

The use case is metals not seeing the point of warnings, but the fix also improves the point for errors.

Sort unused import warnings, which were not issued in position order. (Import statements are not seen in source order.)

Offer `-quickfix` rewrites of unused selectors, which deletes but attempts to preserve formatting to some degree.

Fixes scala/bug#12734