### PR TITLE
Fix 2.13.15-only false positives with `-Wunused:patvars`

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1588,7 +1588,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
         if (settings.browse.containsPhase(globalPhase))
           treeBrowser.browse(phase.name, units)
 
-        if ((settings.Yvalidatepos containsPhase globalPhase) && !reporter.hasErrors)
+        if (!reporter.hasErrors && settings.Yvalidatepos.containsPhase(globalPhase))
           currentRun.units.foreach(unit => validatePositions(unit.body))
 
         // move the pointer

--- a/src/compiler/scala/tools/nsc/reporters/StoreReporter.scala
+++ b/src/compiler/scala/tools/nsc/reporters/StoreReporter.scala
@@ -43,6 +43,6 @@ class StoreReporter(val settings: Settings) extends FilteringReporter {
 }
 object StoreReporter {
   case class Info(pos: Position, msg: String, severity: Severity, actions: List[CodeAction]) {
-    override def toString: String = s"pos: $pos $msg $severity${if (actions.isEmpty) "" else " " + actions}"
+    override def toString: String = s"pos: $pos $msg $severity${if (actions.isEmpty) "" else actions}"
   }
 }

--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -509,16 +509,9 @@ trait TypeDiagnostics extends splain.SplainDiagnostics {
     val setVars   = mutable.Set.empty[Symbol]
     val treeTypes = mutable.Set.empty[Type]
     val params    = mutable.Set.empty[Symbol]
-    val patvars   = mutable.Set.empty[Symbol]
-    val aliases   = mutable.Map.empty[Symbol, Symbol]
+    val patvars   = ListBuffer.empty[Tree /*Bind|ValDef*/]
 
-    def aliasOf(sym: Symbol): Symbol = aliases.getOrElse(sym, sym)
-    def followVarAlias(tree: Tree): Symbol =
-      tree.attachments.get[VarAlias] match {
-        case Some(VarAlias(original)) => followVarAlias(original)
-        case _ => tree.symbol
-      }
-    def recordReference(sym: Symbol): Unit = targets.addOne(aliasOf(sym))
+    def recordReference(sym: Symbol): Unit = targets.addOne(sym)
 
     def qualifiesTerm(sym: Symbol) = (
       (sym.isModule || sym.isMethod || sym.isPrivateLocal || sym.isLocalToBlock || isEffectivelyPrivate(sym))
@@ -534,6 +527,7 @@ trait TypeDiagnostics extends splain.SplainDiagnostics {
         && (sym.isTerm && qualifiesTerm(sym) || sym.isType && qualifiesType(sym))
       )
     def isExisting(sym: Symbol) = sym != null && sym.exists
+    def addPatVar(t: Tree) = patvars += t
 
     // so trivial that it never consumes params
     def isTrivial(rhs: Tree): Boolean =
@@ -551,11 +545,7 @@ trait TypeDiagnostics extends splain.SplainDiagnostics {
           t match {
             case t: ValDef =>
               if (wasPatVarDef(t)) {
-                if (settings.warnUnusedPatVars && !nowarn(t))
-                  if (t.hasAttachment[VarAlias])
-                    aliases += sym -> followVarAlias(t)
-                  else
-                    patvars += sym
+                if (settings.warnUnusedPatVars && !nowarn(t)) addPatVar(t)
               }
               else defnTrees += m
             case DefDef(_, _, _, vparamss, _, rhs) if !sym.isAbstract && !sym.isDeprecated && !sym.isMacro =>
@@ -589,11 +579,7 @@ trait TypeDiagnostics extends splain.SplainDiagnostics {
             case _ =>
           }
           pat.foreach {
-            case b @ Bind(n, _) if !nowarn(b) && n != nme.DEFAULT_CASE =>
-              if (b.hasAttachment[VarAlias])
-                aliases += b.symbol -> followVarAlias(b)
-              else
-                patvars += b.symbol
+            case b @ Bind(n, _) if !nowarn(b) && n != nme.DEFAULT_CASE => addPatVar(b)
             case _ =>
           }
         case _: RefTree => if (isExisting(sym) && !currentOwner.hasTransOwner(sym)) recordReference(sym)
@@ -602,13 +588,9 @@ trait TypeDiagnostics extends splain.SplainDiagnostics {
           for (p <- ps)
             if (wasPatVarDef(p)) {
               if (settings.warnUnusedPatVars && !nowarn(p))
-                if (p.hasAttachment[VarAlias])
-                  aliases += p.symbol -> followVarAlias(p)
-                else
-                  patvars += p.symbol
+                addPatVar(p)
             }
-            else if (settings.warnUnusedParams && !nowarn(p) && !p.symbol.isSynthetic)
-              params += p.symbol
+            else if (settings.warnUnusedParams && !nowarn(p) && !p.symbol.isSynthetic) params += p.symbol
         case Literal(_) =>
           t.attachments.get[OriginalTreeAttachment].foreach(ota => traverse(ota.original))
         case tt: TypeTree =>
@@ -705,7 +687,13 @@ trait TypeDiagnostics extends splain.SplainDiagnostics {
     }
     def unusedParams = params.iterator.filter(isUnusedParam)
     def inDefinedAt(p: Symbol) = p.owner.isMethod && p.owner.name == nme.isDefinedAt && p.owner.owner.isAnonymousFunction
-    def unusedPatVars = patvars.iterator.filter(p => isUnusedTerm(p) && !inDefinedAt(p))
+    def unusedPatVars = {
+      // in elaboration of for comprehensions, patterns are duplicated; track a patvar by its start position; "original" has a range pos
+      val all = patvars.filterInPlace(_.pos.isDefined)
+      val byPos = all.groupBy(_.pos.start)
+      def isUnusedPatVar(t: Tree): Boolean = byPos(t.pos.start).forall(p => !targets(p.symbol))
+      all.iterator.filter(p => p.pos.isOpaqueRange && isUnusedTerm(p.symbol) && isUnusedPatVar(p) && !inDefinedAt(p.symbol))
+    }
   }
 
   class checkUnused(typer: Typer) {
@@ -820,10 +808,9 @@ trait TypeDiagnostics extends splain.SplainDiagnostics {
           emitUnusedWarning(v.pos, s"local var ${v.nameString} in ${v.owner} ${varAdvice(v)}", WarningCategory.UnusedPrivates, v)
         }
       }
-      if (settings.warnUnusedPatVars) {
+      if (settings.warnUnusedPatVars)
         for (v <- unusedPrivates.unusedPatVars)
-          emitUnusedWarning(v.pos, s"pattern var ${v.name} in ${v.owner} is never used", WarningCategory.UnusedPatVars, v)
-      }
+          emitUnusedWarning(v.pos, s"pattern var ${v.symbol.name} in ${v.symbol.owner} is never used", WarningCategory.UnusedPatVars, v.symbol)
       if (settings.warnUnusedParams) {
         // don't warn unused args of overriding methods (or methods matching in self-type)
         def isImplementation(m: Symbol): Boolean = m.isMethod && {

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -183,7 +183,4 @@ trait StdAttachments {
   case object DiscardedExpr extends PlainAttachment
   /** Anonymous parameter of `if (_)` may be inferred as Boolean. */
   case object BooleanParameterType extends PlainAttachment
-
-  /** This Bind tree was derived immediately from the given tree, for unused accounting. */
-  case class VarAlias(tree: Tree /*Bind | ValDef*/) extends PlainAttachment
 }

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -420,6 +420,7 @@ trait StdNames {
     def isTraitSetterName(name: Name)       = isSetterName(name) && (name containsName TRAIT_SETTER_SEPARATOR_STRING)
     def isSingletonName(name: Name)         = name endsWith SINGLETON_SUFFIX
     def isModuleName(name: Name)            = name endsWith MODULE_SUFFIX_NAME
+    def isFreshTermName(name: Name)         = name.startsWith(FRESH_TERM_NAME_PREFIX)
 
     /** Is name a variable name? */
     def isVariableName(name: Name): Boolean = {

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -708,7 +708,8 @@ abstract class TreeGen {
       case x             => throw new MatchError(x)
     }
 
-    /* The position of the closure that starts with generator at position `genpos`. */
+    // The position of the closure that starts with generator at position `genpos`.
+    // This position is carried by ValFrom.
     def closurePos(genpos: Position): Position =
       if (genpos == NoPosition) NoPosition
       else {
@@ -725,7 +726,7 @@ abstract class TreeGen {
       case (t @ ValFrom(pat, rhs)) :: (rest @ (ValFrom(_, _) :: _)) =>
         makeCombination(closurePos(t.pos), flatMapName, rhs, pat, body = mkFor(rest, sugarBody))
       case (t @ ValFrom(pat, rhs)) :: Filter(test) :: rest =>
-        mkFor(ValFrom(patternAlias(pat), makeCombination(rhs.pos | test.pos, nme.withFilter, rhs, pat, test)).setPos(t.pos) :: rest, sugarBody)
+        mkFor(ValFrom(patternAlias(pat), makeCombination(pat.pos | rhs.pos | test.pos, nme.withFilter, rhs, pat, test)).setPos(t.pos) :: rest, sugarBody)
       case (t @ ValFrom(pat, rhs)) :: rest =>
         val valeqs = rest.take(definitions.MaxTupleArity - 1).takeWhile(ValEq.unapply(_).nonEmpty)
         assert(!valeqs.isEmpty, "Missing ValEq")

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -15,7 +15,7 @@ package reflect
 package internal
 
 import Flags._
-import util._
+import util.{FreshNameCreator, ListOfNil}
 import scala.annotation.tailrec
 import scala.collection.mutable.ListBuffer
 import scala.util.chaining._
@@ -673,13 +673,7 @@ abstract class TreeGen {
         case Some((name, tpt)) =>
           val p = atPos(pat.pos) {
             ValDef(Modifiers(PARAM), name.toTermName, tpt, EmptyTree)
-              .tap { p =>
-                if (pat.hasAttachment[VarAlias])
-                  varAliasTo(propagatePatVarDefAttachments(pat, p), pat)
-                else
-                  varAliasTo(pat, propagatePatVarDefAttachments(pat, p))
-              }
-          }
+          }.tap(propagatePatVarDefAttachments(pat, _))
           Function(List(p), body).setPos(splitpos)
         case None =>
           atPos(splitpos) {
@@ -726,7 +720,7 @@ abstract class TreeGen {
       case (t @ ValFrom(pat, rhs)) :: (rest @ (ValFrom(_, _) :: _)) =>
         makeCombination(closurePos(t.pos), flatMapName, rhs, pat, body = mkFor(rest, sugarBody))
       case (t @ ValFrom(pat, rhs)) :: Filter(test) :: rest =>
-        mkFor(ValFrom(patternAlias(pat), makeCombination(pat.pos | rhs.pos | test.pos, nme.withFilter, rhs, pat, test)).setPos(t.pos) :: rest, sugarBody)
+        mkFor(ValFrom(pat, makeCombination(rhs.pos | test.pos, nme.withFilter, rhs, pat.duplicate, test)).setPos(t.pos) :: rest, sugarBody)
       case (t @ ValFrom(pat, rhs)) :: rest =>
         val valeqs = rest.take(definitions.MaxTupleArity - 1).takeWhile(ValEq.unapply(_).nonEmpty)
         assert(!valeqs.isEmpty, "Missing ValEq")
@@ -744,7 +738,7 @@ abstract class TreeGen {
           Yield(Block(pdefs, tupled).setPos(wrappingPos(pdefs)))
         )
         val untupled = {
-          val allpats = (pat :: pats).map(patternAlias)
+          val allpats = (pat :: pats).map(_.duplicate)
           atPos(wrappingPos(allpats))(mkTuple(allpats))
         }
         val pos1 =
@@ -762,24 +756,9 @@ abstract class TreeGen {
     if (isPatVarWarnable && from.hasAttachment[NoWarnAttachment.type]) to.updateAttachment(NoWarnAttachment)
     else to
 
-  // Distinguish patvar in pattern `val C(x) = ???` from `val x = ???`.
+  // Distinguish patvar in pattern `val C(x) = ???` from `val x = ???`. Also `for (P(x) <- G)`.
   private def propagatePatVarDefAttachments(from: Tree, to: ValDef): to.type =
     propagateNoWarnAttachment(from, to).updateAttachment(PatVarDefAttachment)
-
-  // For unused patvar bookkeeping, `to.symbol` is the symbol of record.
-  private def varAliasTo(from: Tree, to: Tree /*Bind|ValDef*/): from.type =
-    from.updateAttachment(VarAlias(to))
-
-  private def patternAlias(pat: Tree): Tree = {
-    val dup = pat.duplicate
-    if (matchVarPattern(pat).isDefined)
-      varAliasTo(dup, pat)
-    else
-      foreach2(getVariables(dup), getVariables(pat)) { (d, v) =>
-        varAliasTo(d._4, v._4)
-      }
-    dup
-  }
 
   /** Create tree for pattern definition <val pat0 = rhs> */
   def mkPatDef(pat: Tree, rhs: Tree)(implicit fresh: FreshNameCreator): List[ValDef] =
@@ -792,12 +771,12 @@ abstract class TreeGen {
 
   private def mkPatDef(mods: Modifiers, pat: Tree, rhs: Tree, rhsPos: Position, forFor: Boolean)(implicit fresh: FreshNameCreator): List[ValDef] = matchVarPattern(pat) match {
     case Some((name, tpt)) =>
-      List(atPos(pat.pos union rhsPos) {
+      atPos(pat.pos union rhsPos) {
         ValDef(mods, name.toTermName, tpt, rhs)
           .tap(vd =>
-              if (forFor) varAliasTo(pat, propagatePatVarDefAttachments(pat, vd))
+              if (forFor) propagatePatVarDefAttachments(pat, vd)
               else propagateNoWarnAttachment(pat, vd))
-      })
+      } :: Nil
 
     case None =>
       //  in case there is exactly one variable x_1 in pattern
@@ -840,10 +819,10 @@ abstract class TreeGen {
       }
       vars match {
         case List((vname, tpt, pos, original)) =>
-          List(atPos(pat.pos union pos union rhsPos) {
+          atPos(pat.pos union pos union rhsPos) {
             ValDef(mods, vname.toTermName, tpt, matchExpr)
-              .tap(vd => varAliasTo(original, propagatePatVarDefAttachments(original, vd)))
-          })
+              .tap(propagatePatVarDefAttachments(original, _))
+          } :: Nil
         case _ =>
           val tmp = freshTermName()
           val firstDef =
@@ -860,7 +839,7 @@ abstract class TreeGen {
           val restDefs = for ((vname, tpt, pos, original) <- vars) yield atPos(pos) {
             cnt += 1
             ValDef(mods, vname.toTermName, tpt, Select(Ident(tmp), TermName("_" + cnt)))
-              .tap(vd => varAliasTo(original, propagatePatVarDefAttachments(original, vd)))
+              .tap(propagatePatVarDefAttachments(original, _))
           }
           firstDef :: restDefs
       }
@@ -873,7 +852,7 @@ abstract class TreeGen {
     else ValFrom(pat1, mkCheckIfRefutable(pat1, rhs)).setPos(pos)
   }
 
-  private def unwarnable(pat: Tree): Tree = {
+  private def unwarnable(pat: Tree): pat.type = {
     pat foreach {
       case b @ Bind(_, _) => b.updateAttachment(NoWarnAttachment)
       case _ =>
@@ -976,7 +955,7 @@ abstract class TreeGen {
     override def transform(tree: Tree): Tree = tree match {
       case Ident(name) if treeInfo.isVarPattern(tree) && name != nme.WILDCARD =>
         atPos(tree.pos) {
-          Bind(name, atPos(tree.pos.focus) (Ident(nme.WILDCARD)))
+          Bind(name, atPos(tree.pos.focus) { Ident(nme.WILDCARD) })
         }
       case Typed(id @ Ident(name), tpt) if treeInfo.isVarPattern(id) && name != nme.WILDCARD =>
         atPos(tree.pos.withPoint(id.pos.point)) {

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -91,7 +91,6 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.DiscardedValue
     this.DiscardedExpr
     this.BooleanParameterType
-    this.VarAlias
     this.noPrint
     this.typeDebug
     // inaccessible: this.posAssigner

--- a/test/files/neg/t10287.scala
+++ b/test/files/neg/t10287.scala
@@ -1,4 +1,4 @@
-//> using options -Werror -Wunused:_ -Xsource:3
+//> using options -Werror -Wunused:_ -Xsource:3 -Yvalidate-pos:typer
 
 class C {
   def unused_patvar =

--- a/test/files/pos/forcomp-treepos.scala
+++ b/test/files/pos/forcomp-treepos.scala
@@ -1,0 +1,5 @@
+//> using options -Yvalidate-pos:typer
+object A {
+  def foo(list: List[String]) = for (string <- list if string.length > 5)
+    println(string)
+}

--- a/test/files/pos/t13041.scala
+++ b/test/files/pos/t13041.scala
@@ -1,0 +1,26 @@
+
+//> using options -Werror -Wunused:patvars -Yvalidate-pos:typer
+
+class C {
+  val m = Map(
+    "first" -> Map((true, 1), (false, 2), (true, 3)),
+    "second" -> Map((true, 1), (false, 2), (true, 3))
+  )
+  def f =
+    m.map { case (a, m1) =>
+      for {
+        (status, lag) <- m1 if status
+      } yield (a, status, lag)
+    }
+  def g =
+    for {
+      (a, m1) <- m
+      (status, lag) <- m1 if status
+    } yield (a, status, lag)
+  def leading =
+    for {
+      _ <- List("42")
+      i = 1
+      _ <- List("0", "27")(i)
+    } yield ()
+}

--- a/test/junit/scala/reflect/internal/PositionsTest.scala
+++ b/test/junit/scala/reflect/internal/PositionsTest.scala
@@ -3,56 +3,72 @@ package scala.reflect.internal
 import org.junit.Test
 import org.junit.Assert.assertFalse
 
-import scala.reflect.internal.util.NoSourceFile
+import scala.reflect.internal.util.{NoSourceFile, Position}
 import scala.tools.nsc.reporters.StoreReporter
 import scala.tools.nsc.symtab.SymbolTableForUnitTesting
 import scala.tools.testkit.AssertUtil.assertThrows
 
 class PositionsTest {
 
-  private object symbolTable extends SymbolTableForUnitTesting {
+  object symbolTable extends SymbolTableForUnitTesting {
     override def useOffsetPositions: Boolean = false
     override val reporter = new StoreReporter(settings)
   }
+  import symbolTable._
 
-  @Test def positionValidation(): Unit = {
-    import symbolTable._
-    def checkInvalid(tree: Tree): Unit = {
-      reporter.reset()
-      assertThrows[ValidateException](validatePositions(tree))
-    }
+  def sentinel = Literal(Constant(())).setPos(offsetPos(100))
 
-    def checkValid(tree: Tree): Unit = {
-      reporter.reset()
-      validatePositions(tree)
-      assertFalse(reporter.hasErrors)
-    }
-    def rangePos(start: Int, end: Int): util.Position = util.Position.range(NoSourceFile, start, start, end)
-    def offsetPos(point: Int): util.Position = util.Position.offset(NoSourceFile, point)
-    def tree: Tree = Ident(TermName("x"))
-    def rangePositioned(start: Int, end: Int): Tree = {
-      Ident(TermName("x")).setPos(rangePos(start, end))
-    }
+  def checkInvalid(tree: Tree): Unit = {
+    reporter.reset()
+    assertThrows[ValidateException](validatePositions(tree))
+  }
+
+  def checkValid(tree: Tree): Unit = {
+    reporter.reset()
+    try validatePositions(tree)
+    finally reporter.infos.foreach(println)
+    assertFalse(reporter.hasErrors)
+  }
+
+  def checkInvalid(pos: Position)(trees: Tree*): Unit =
+    if (trees.length == 1) checkInvalid(Block(stats = Nil, expr = trees.head).setPos(pos))
+    else checkInvalid(Block(stats = trees.toList, expr = sentinel).setPos(pos))
+
+  def checkValid(pos: Position)(trees: Tree*): Unit =
+    if (trees.length == 1) checkValid(Block(stats = Nil, expr = trees.head).setPos(pos))
+    else checkValid(Block(stats = trees.toList, expr = sentinel).setPos(pos))
+
+  def rangePos(start: Int, end: Int): Position = Position.range(NoSourceFile, start, start, end)
+  def offsetPos(point: Int): Position = Position.offset(NoSourceFile, point)
+  def x: Tree = Ident(TermName("x"))
+  def rangePositioned(start: Int, end: Int): Tree = x.setPos(rangePos(start, end))
+
+  //@Test
+  def positionValidation: Unit = {
     // overlapping ranges
-    checkInvalid(Block(rangePositioned(0, 2), rangePositioned(1, 2), EmptyTree).setPos(rangePos(0, 2)))
-    checkInvalid(Block(rangePositioned(1, 2), rangePositioned(0, 2), EmptyTree).setPos(rangePos(0, 2)))
+    checkInvalid(rangePos(0, 2))(rangePositioned(0, 2), rangePositioned(1, 2))
+    checkInvalid(rangePos(0, 2))(rangePositioned(1, 2), rangePositioned(0, 2))
 
     // transparent position not deemed to overlap itself
-    checkValid(Block(rangePositioned(0, 2), tree.setPos(rangePos(1, 2).makeTransparent), EmptyTree).setPos(rangePos(0, 2)))
+    checkValid(rangePos(0, 2))(rangePositioned(0, 2), x.setPos(rangePos(1, 2).makeTransparent))
 
     // children of transparent position overlapping with sibling of transparent position.
-    checkInvalid(Block(rangePositioned(0, 2), Block(Nil, rangePositioned(1, 2)).setPos(rangePos(1, 2).makeTransparent), EmptyTree).setPos(rangePos(0, 2)))
+    checkInvalid(rangePos(0, 2))(rangePositioned(0, 2), Block(Nil, rangePositioned(1, 2)).setPos(rangePos(1, 2).makeTransparent))
 
     // adjacent ranges are allowed to touch
-    checkValid(Block(rangePositioned(0, 1), rangePositioned(1, 2), EmptyTree).setPos(rangePos(0, 2)))
+    checkValid(rangePos(0, 2))(rangePositioned(0, 1), rangePositioned(1, 2))
 
     // offset position between overlapping ranges
-    checkInvalid(Block(rangePositioned(0, 2), tree.setPos(offsetPos(0)), rangePositioned(1, 2), EmptyTree).setPos(rangePos(0, 2)))
+    checkInvalid(rangePos(0, 2))(rangePositioned(0, 2), x.setPos(offsetPos(0)), rangePositioned(1, 2))
 
     // child range position larger than parent
-    checkInvalid(Block(Nil, rangePositioned(0, 3)).setPos(rangePos(0, 2)))
+    checkInvalid(rangePos(0, 2))(rangePositioned(0, 3))
 
     // child offset position outside of parent
-    checkInvalid(Block(Nil, tree.setPos(offsetPos(3)).setPos(rangePos(0, 2))))
+    checkInvalid(rangePos(0, 2))(x.setPos(offsetPos(3)))
+  }
+
+  @Test def `focused position is synthetic`: Unit = checkValid(rangePos(27, 42)) {
+    x.setPos(offsetPos(3))
   }
 }


### PR DESCRIPTION
Fixes false positives from `-Wunused:patvars` in the presence of filters (`if`) — this was scala/bug#13041.

Note that `-Wunused:patvars` is part of `-Wunused` but is not enabled by `-Xlint`. With this fix, interested users may wish to make a fresh attempt to add `-Wunused:patvars` to their builds.

The now-correct position information may also aid tooling, as seen in scala/bug#13037 .

Followup to #10812, which (in 2.13.15) expanded unused checking into this area.

Fixes scala/bug#13041
Fixes scala/bug#13037

### Implementation notes

Summary: Track patvars by position (and correct span of guard closure)

The scheme of linking duplicated patvar trees via attachments is brittle because links are stale after duplication; in particular, they point to old trees which may not be typechecked, so symbols are not recoverable.

Instead, just identify associated trees by position: duplicates have a focused position and the "original" has its opaque range.

Fix range of guard closure in TreeGen.mkFor to include parameter. (In the previous scheme, the pattern and its duplicate were swapped to build the "links", but now have been swapped back again, so that bug is nullified.)

Some mild refactoring of position validation for readability.