### PR TITLE
Remove spurious return

### DIFF
--- a/src/library/scala/util/Try.scala
+++ b/src/library/scala/util/Try.scala
@@ -217,7 +217,7 @@ object Try {
       val r1 = r
       Success(r1)
     } catch {
-      case NonFatal(e) => return Failure(e)
+      case NonFatal(e) => Failure(e)
     }
 }
 


### PR DESCRIPTION
I confirmed the byte code is the same under `-opt`.

It looks intentional so it drew an inquiry. I assume it was a typo or due to looking at unoptimized bytecode.
