### PR TITLE
Add quickfix for "synthetic case companion used as a function" error.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1295,8 +1295,11 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           adapt(tree.setType(repeatedToSeq(tree.tpe)), mode, pt, original = EmptyTree)
         else if (tree.tpe <:< pt) {
           val sym = tree.symbol
-          if (sym != null && !isPastTyper && currentRun.isScala3 && isFunctionType(pt) && sym.isModule && sym.isSynthetic && sym.companion.isCase)
-            context.warning(tree.pos, s"Synthetic case companion used as a function. In Scala 3 (or with -Xsource-features:case-companion-function), case companions no longer extend FunctionN. Use ${sym.name}.apply instead.", Scala3Migration)
+          if (sym != null && !isPastTyper && currentRun.isScala3 && isFunctionType(pt) && sym.isModule && sym.isSynthetic && sym.companion.isCase) {
+            val msg = s"Synthetic case companion used as a function. In Scala 3 (or with -Xsource-features:case-companion-function), case companions no longer extend FunctionN. Use ${sym.name}.apply instead."
+            val action = runReporting.codeAction("add `.apply`", tree.pos.focusEnd, ".apply", msg)
+            context.warning(tree.pos, msg, Scala3Migration, action)
+          }
           tree
         } else if (mode.inPatternMode && { inferModulePattern(tree, pt); isPopulated(tree.tpe, approximateAbstracts(pt)) })
           tree

--- a/test/files/neg/t3664.check
+++ b/test/files/neg/t3664.check
@@ -1,9 +1,9 @@
-t3664.scala:10: error: Synthetic case companion used as a function. In Scala 3 (or with -Xsource-features:case-companion-function), case companions no longer extend FunctionN. Use C.apply instead.
+t3664.scala:10: error: Synthetic case companion used as a function. In Scala 3 (or with -Xsource-features:case-companion-function), case companions no longer extend FunctionN. Use C.apply instead. [quickfixable]
 Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or @nowarn to demote them to warnings or suppress.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=Test.f
   def f(xs: List[Int]): List[C] = xs.map(C) // ident
                                          ^
-t3664.scala:11: error: Synthetic case companion used as a function. In Scala 3 (or with -Xsource-features:case-companion-function), case companions no longer extend FunctionN. Use D.apply instead.
+t3664.scala:11: error: Synthetic case companion used as a function. In Scala 3 (or with -Xsource-features:case-companion-function), case companions no longer extend FunctionN. Use D.apply instead. [quickfixable]
 Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or @nowarn to demote them to warnings or suppress.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=Test.g
   def g(xs: List[Int]): List[O.D] = xs.map(O.D) // select

--- a/test/junit/scala/tools/nsc/QuickfixTest.scala
+++ b/test/junit/scala/tools/nsc/QuickfixTest.scala
@@ -165,4 +165,20 @@ class QuickfixTest extends BytecodeTesting {
            |"""
     testQuickfix(a, b, "-Wunnamed-boolean-literal -quickfix:any")
   }
+
+  @Test def `synthetic case companion used as a function error has a fix`: Unit = {
+    val a =
+      sm"""|case class C(i: Int)
+           |object Test {
+           |  def test = List(1, 2, 3).map(C)
+           |}
+           |"""
+    val b =
+      sm"""|case class C(i: Int)
+           |object Test {
+           |  def test = List(1, 2, 3).map(C.apply)
+           |}
+           |"""
+    testQuickfix(a, b, "-Xsource:3 -quickfix:any")
+  }
 }


### PR DESCRIPTION
Code compiled with "-Xsource:3" errors on usages of the case class companion object as a function.
The error suggests using `.apply` explicitly and this commit adds a quickfix to do just that.