### PR TITLE
Optimize Option::toList

### DIFF
--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -572,7 +572,7 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
    * }}}
    */
   def toList: List[A] =
-    if (isEmpty) List() else new ::(this.get, Nil)
+    if (isEmpty) Nil else new ::(this.get, Nil)
 
   /** Returns a [[scala.util.Left]] containing the given
    * argument `left` if this $option is empty, or


### PR DESCRIPTION
Short circuit List() call by using Nil, which is already used in this method.  On the other hand, `List()` calls:

- `IterableFactory.apply` -> 
- `IterableFactor.from(new Array[A](0))` -> 
- `List.prependedAll(arr)`

This might all get inlined but it seems unnecessary to rely on.