### PR TITLE
Install `sbt` explicitly during Github Action run [ci: last-only]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
           java-version: ${{matrix.java}}
           cache: sbt
 
+      - name: Setup SBT
+        uses: sbt/setup-sbt@v1
+
       - name: Build
         run: |
           sbt setupPublishCore generateBuildCharacterPropertiesFile headerCheck publishLocal


### PR DESCRIPTION
Github removed `sbt` from `ubuntu-latest` runner image. As a result CIs all over the world using `sbt` and `ubuntu-latest` are failing.

c.c. https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md

This PR fixes the issue by using Eugene's `sbt/setup-sbt@v1` action to install `sbt` manually.