### PR TITLE
Don't insert box instructions around label jumps

### DIFF
--- a/test/files/run/t13043.scala
+++ b/test/files/run/t13043.scala
@@ -1,0 +1,30 @@
+class C(val x: String) extends AnyVal
+
+object TC {
+  def c(s: String): C = new C(s)
+  def p = 2
+  def test(v: Int, w: Int): Any = 
+    v match {
+      case 1 if p == w => c("a")
+      case _ => c("b")
+    }
+}
+
+object TI {
+  def c(i: Int): Int = i
+  def p = 2
+  def test(v: Int, w: Int): Any = 
+    v match {
+      case 1 if p == w => c(42)
+      case _ => c(43)
+    }
+}
+
+object Test extends App {
+  assert(TC.test(1, 2).asInstanceOf[C].x == "a")
+  assert(TC.test(1, 3).asInstanceOf[C].x == "b")
+  assert(TC.test(2, 2).asInstanceOf[C].x == "b")
+  assert(TI.test(1, 2) == 42)
+  assert(TI.test(1, 3) == 43)
+  assert(TI.test(2, 2) == 43)
+}


### PR DESCRIPTION
For match trees that are not eliminated during patmat, to be emitted as switches in bytecode, make sure erasure doesn't introduce boxing instructions around label jumps.

A label jump is a jump in bytecode, it doesn't produce a value on the stack that can be boxed. If the label type would need boxing, nothing needs to be done: the boxing instructions are already introduced at the jump target, where the label is defined.

Fixes https://github.com/scala/bug/issues/13043