### PR TITLE
Fix compiler crash involving pattern match with literal type

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -641,7 +641,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         // A module reference in a pattern has type Foo.type, not "object Foo"
         narrowIf(checkStable(tree), sym.isModuleNotMethod)
       else if (isModuleTypedExpr)                     // (3)
-        narrowIf(tree, condition = true)
+        narrowIf(tree, condition = !sym.isConstant)
       else if (isGetClassCall)                        // (4)
         tree setType MethodType(Nil, getClassReturnType(pre))
       else
@@ -1055,7 +1055,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         if (sym != null && !context.unit.isJava && sym.isDeprecated)
           context.deprecationWarning(tree.pos, sym)
         tree match {
-          case Literal(`value`) => tree
+          case Literal(`value`) /*| Bind(_, _)*/ => tree
           case _ =>
             // If the original tree is not a literal, make it available to plugins in an attachment
             treeCopy.Literal(tree, value).updateAttachment(OriginalTreeAttachment(tree))

--- a/test/files/neg/t1503.scala
+++ b/test/files/neg/t1503.scala
@@ -30,7 +30,7 @@ class Test {
 
   def h(x: Any): String = x match { case s @ "hello, world" => s }
   def h2(x: Any): String = x match { case s @ (_: "hello, world") => s }
-  //def h3(x: Any): "hello, world" = x match { case s @ "hello, world" => s }  // crash
+  def h3(x: Any): "hello, world" = x match { case s @ "hello, world" => s }
 
   //def j(x: Any): Array[Int] = x match { case xs @ Array(42) => xs } // found Array[T] required Array[Int]
 }

--- a/test/files/pos/t12127.scala
+++ b/test/files/pos/t12127.scala
@@ -1,0 +1,10 @@
+
+//> using options -Werror -Wunused
+
+class C {
+  def f(x: Any): "hi" = x match { case s @ "hi" => s } // was: Error while emitting (in backend)
+  def g(x: Any): String = x match { case s @ "hi" => s }
+  def h(x: Any): String = x match { case s: String => s }
+
+  def check(x: Any): "bi" = x match { case s @ "hi" => "bi" }
+}


### PR DESCRIPTION
In `case s @ "" => s`, it may be dubious to elide
the binding. With an expected literal type,
the case body was incorrectly `s.type`, so that it was not adapted to constant type. This commit
fixes the latter issue only, especially since
-Wunused does not warn about terms of constant type anyway (because they were probably inlined): `case "" => ""`.

Fixes scala/bug#12127