### PR TITLE
GHA CI: add JDK 23 (drop 23-ea), also drop 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: [8, 11, 17, 21, 22, 23-ea]
+        java: [8, 11, 17, 21, 23]
     runs-on: ${{matrix.os}}
     steps:
       - run: git config --global core.autocrlf false


### PR DESCRIPTION
before too much longer we should add 24-ea, but I've chosen not to do that today

this won't be tested by PR validation, but we usually wait for green status anyway before merging