### PR TITLE
Refine MapOps in concurrent.Map, add MapFactory

### DIFF
--- a/src/library/scala/collection/concurrent/Map.scala
+++ b/src/library/scala/collection/concurrent/Map.scala
@@ -11,9 +11,11 @@
  */
 
 package scala
-package collection.concurrent
+package collection
+package concurrent
 
 import scala.annotation.tailrec
+import scala.collection.mutable
 
 /** A template trait for mutable maps that allow concurrent access.
   *
@@ -35,7 +37,11 @@ import scala.annotation.tailrec
   *  @define atomicop
   *  This is an atomic operation.
   */
-trait Map[K, V] extends scala.collection.mutable.Map[K, V] {
+trait Map[K, V] extends mutable.Map[K, V]
+  with mutable.MapOps[K, V, Map, Map[K, V]]
+  with MapFactoryDefaults[K, V, Map, mutable.Iterable] {
+
+  override def mapFactory: MapFactory[Map] = Map
 
   /**
     * Associates the given key with a given value, unless the key was already
@@ -188,3 +194,5 @@ trait Map[K, V] extends scala.collection.mutable.Map[K, V] {
     this
   }
 }
+
+object Map extends MapFactory.Delegate[Map](TrieMap)

--- a/src/library/scala/collection/convert/JavaCollectionWrappers.scala
+++ b/src/library/scala/collection/convert/JavaCollectionWrappers.scala
@@ -474,6 +474,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
   @SerialVersionUID(3L)
   class JConcurrentMapWrapper[K, V](val underlying: juc.ConcurrentMap[K, V])
     extends AbstractJMapWrapper[K, V]
+      with JMapWrapperLike[K, V, concurrent.Map, concurrent.Map[K, V]]
       with concurrent.Map[K, V] {
 
     override def get(k: K) = Option(underlying get k)

--- a/test/junit/scala/collection/BuildFromTest.scala
+++ b/test/junit/scala/collection/BuildFromTest.scala
@@ -187,6 +187,8 @@ class BuildFromTest {
   implicitly[BuildFrom[immutable.LongMap[_], (Long, String), immutable.LongMap[String]]]
   implicitly[BuildFrom[mutable.AnyRefMap[_ <: AnyRef, _], (String, String), mutable.AnyRefMap[String, String]]]
   implicitly[BuildFrom[mutable.AnyRefMap[String, String], (String, String), _]]
+  implicitly[BuildFrom[mutable.Map[String, String], (String, String), mutable.Map[String, String]]]
+  implicitly[BuildFrom[concurrent.Map[String, String], (String, String), concurrent.Map[String, String]]]
 
   // Check that collection companions can implicitly be converted to a `BuildFrom` instance
   Iterable: BuildFrom[_, Int, Iterable[Int]]


### PR DESCRIPTION
The `buildFromMapOps` implicit has
`CC[X, Y] <: Map[X, Y] with MapOps[X, Y, CC, _]`

For `CC = concurrent.Map` the bound is not satisfied, we had `MapOps[_, _, mutable.Map, _]`.

Fixes https://github.com/scala/bug/issues/13047

Need to see about bin compat...