### PR TITLE
Type provided arguments in presence of arity mismatch

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3857,6 +3857,15 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                 } else {
                   rollbackNamesDefaultsOwnerChanges()
                   tryTupleApply orElse {
+                    // If we don't have enough arguments we still try to type the arguments that we do have, in order to
+                    // propagate known types throughout the subtree to support queries in the presentation compiler.
+                    if (missing.nonEmpty) {
+                      // You would expect `missing` to be non-empty in this branch, but `addDefaults` has a corner case
+                      // for t3649 that causes it to drop some params from `missing` (see `addDefaults` for the reasoning).
+                      val allArgsPlusMissingErrors = allArgs ++ missing.map(s => NamedArg(Ident(s.name), gen.mkZero(NothingTpe)))
+                      silent(_.doTypedApply(tree, if (blockIsEmpty) fun else fun1, allArgsPlusMissingErrors, mode, pt))
+                    }
+
                     removeNames(Typer.this)(allArgs, params) // report bad names
                     duplErrorTree(NotEnoughArgsError(tree, fun, missing))
                   }

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -215,6 +215,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     }
 
     /** Overridden to false in scaladoc and/or interactive. */
+    def isInteractive                 = false
     def canAdaptConstantTypeToLiteral = true
     def canTranslateEmptyListToNil    = true
     def missingSelectErrorTree(tree: Tree, @unused qual: Tree, @unused name: Name): Tree = tree
@@ -3859,7 +3860,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                   tryTupleApply orElse {
                     // If we don't have enough arguments we still try to type the arguments that we do have, in order to
                     // propagate known types throughout the subtree to support queries in the presentation compiler.
-                    if (missing.nonEmpty) {
+                    if (isInteractive && missing.nonEmpty) {
                       // You would expect `missing` to be non-empty in this branch, but `addDefaults` has a corner case
                       // for t3649 that causes it to drop some params from `missing` (see `addDefaults` for the reasoning).
                       val allArgsPlusMissingErrors = allArgs ++ missing.map(s => NamedArg(Ident(s.name), gen.mkZero(NothingTpe)))

--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -51,6 +51,7 @@ trait InteractiveAnalyzer extends Analyzer {
   override def newNamer(context: Context): InteractiveNamer = new Namer(context) with InteractiveNamer
 
   trait InteractiveTyper extends Typer {
+    override def isInteractive = true
     override def canAdaptConstantTypeToLiteral = false
     override def canTranslateEmptyListToNil    = false
     override def missingSelectErrorTree(tree: Tree, qual: Tree, name: Name): Tree = tree match {

--- a/test/files/presentation/higher-order-completion.check
+++ b/test/files/presentation/higher-order-completion.check
@@ -1,0 +1,137 @@
+reload: Completions.scala
+
+askTypeCompletion at Completions.scala(12,14)
+================================================================================
+[response] askTypeCompletion at (12,14)
+retrieved 31 members
+[inaccessible] protected[package lang] def clone(): Object
+[inaccessible] protected[package lang] def finalize(): Unit
+def +(other: String): String
+def ->[B](y: B): (test.Foo, B)
+def Bar: Double
+def Baz: Double
+def ensuring(cond: Boolean): test.Foo
+def ensuring(cond: Boolean, msg: => Any): test.Foo
+def ensuring(cond: test.Foo => Boolean): test.Foo
+def ensuring(cond: test.Foo => Boolean, msg: => Any): test.Foo
+def equals(x$1: Object): Boolean
+def formatted(fmtstr: String): String
+def hashCode(): Int
+def toString(): String
+def →[B](y: B): (test.Foo, B)
+final def !=(x$1: Any): Boolean
+final def ## : Int
+final def ==(x$1: Any): Boolean
+final def asInstanceOf[T0]: T0
+final def eq(x$1: AnyRef): Boolean
+final def isInstanceOf[T0]: Boolean
+final def ne(x$1: AnyRef): Boolean
+final def notify(): Unit
+final def notifyAll(): Unit
+final def synchronized[T0](x$1: T0): T0
+final def wait(): Unit
+final def wait(x$1: Long): Unit
+final def wait(x$1: Long, x$2: Int): Unit
+================================================================================
+
+askTypeCompletion at Completions.scala(15,13)
+================================================================================
+[response] askTypeCompletion at (15,13)
+retrieved 31 members
+[inaccessible] protected[package lang] def clone(): Object
+[inaccessible] protected[package lang] def finalize(): Unit
+def +(other: String): String
+def ->[B](y: B): (test.Foo, B)
+def Bar: Double
+def Baz: Double
+def ensuring(cond: Boolean): test.Foo
+def ensuring(cond: Boolean, msg: => Any): test.Foo
+def ensuring(cond: test.Foo => Boolean): test.Foo
+def ensuring(cond: test.Foo => Boolean, msg: => Any): test.Foo
+def equals(x$1: Object): Boolean
+def formatted(fmtstr: String): String
+def hashCode(): Int
+def toString(): String
+def →[B](y: B): (test.Foo, B)
+final def !=(x$1: Any): Boolean
+final def ## : Int
+final def ==(x$1: Any): Boolean
+final def asInstanceOf[T0]: T0
+final def eq(x$1: AnyRef): Boolean
+final def isInstanceOf[T0]: Boolean
+final def ne(x$1: AnyRef): Boolean
+final def notify(): Unit
+final def notifyAll(): Unit
+final def synchronized[T0](x$1: T0): T0
+final def wait(): Unit
+final def wait(x$1: Long): Unit
+final def wait(x$1: Long, x$2: Int): Unit
+================================================================================
+
+askTypeCompletion at Completions.scala(18,17)
+================================================================================
+[response] askTypeCompletion at (18,17)
+retrieved 31 members
+[inaccessible] protected[package lang] def clone(): Object
+[inaccessible] protected[package lang] def finalize(): Unit
+def +(other: String): String
+def ->[B](y: B): (test.Foo, B)
+def Bar: Double
+def Baz: Double
+def ensuring(cond: Boolean): test.Foo
+def ensuring(cond: Boolean, msg: => Any): test.Foo
+def ensuring(cond: test.Foo => Boolean): test.Foo
+def ensuring(cond: test.Foo => Boolean, msg: => Any): test.Foo
+def equals(x$1: Object): Boolean
+def formatted(fmtstr: String): String
+def hashCode(): Int
+def toString(): String
+def →[B](y: B): (test.Foo, B)
+final def !=(x$1: Any): Boolean
+final def ## : Int
+final def ==(x$1: Any): Boolean
+final def asInstanceOf[T0]: T0
+final def eq(x$1: AnyRef): Boolean
+final def isInstanceOf[T0]: Boolean
+final def ne(x$1: AnyRef): Boolean
+final def notify(): Unit
+final def notifyAll(): Unit
+final def synchronized[T0](x$1: T0): T0
+final def wait(): Unit
+final def wait(x$1: Long): Unit
+final def wait(x$1: Long, x$2: Int): Unit
+================================================================================
+
+askTypeCompletion at Completions.scala(21,24)
+================================================================================
+[response] askTypeCompletion at (21,24)
+retrieved 31 members
+[inaccessible] protected[package lang] def clone(): Object
+[inaccessible] protected[package lang] def finalize(): Unit
+def +(other: String): String
+def ->[B](y: B): (test.Foo, B)
+def Bar: Double
+def Baz: Double
+def ensuring(cond: Boolean): test.Foo
+def ensuring(cond: Boolean, msg: => Any): test.Foo
+def ensuring(cond: test.Foo => Boolean): test.Foo
+def ensuring(cond: test.Foo => Boolean, msg: => Any): test.Foo
+def equals(x$1: Object): Boolean
+def formatted(fmtstr: String): String
+def hashCode(): Int
+def toString(): String
+def →[B](y: B): (test.Foo, B)
+final def !=(x$1: Any): Boolean
+final def ## : Int
+final def ==(x$1: Any): Boolean
+final def asInstanceOf[T0]: T0
+final def eq(x$1: AnyRef): Boolean
+final def isInstanceOf[T0]: Boolean
+final def ne(x$1: AnyRef): Boolean
+final def notify(): Unit
+final def notifyAll(): Unit
+final def synchronized[T0](x$1: T0): T0
+final def wait(): Unit
+final def wait(x$1: Long): Unit
+final def wait(x$1: Long, x$2: Int): Unit
+================================================================================

--- a/test/files/presentation/higher-order-completion/Test.scala
+++ b/test/files/presentation/higher-order-completion/Test.scala
@@ -1,0 +1,3 @@
+import scala.tools.nsc.interactive.tests.InteractiveTest
+
+object Test extends InteractiveTest

--- a/test/files/presentation/higher-order-completion/src/Completions.scala
+++ b/test/files/presentation/higher-order-completion/src/Completions.scala
@@ -1,0 +1,22 @@
+package test
+
+/* check that members are visible when completing inside an Apply with insufficient args */
+
+class Foo {
+  def Bar: Double = 2.0
+  def Baz: Double = 1.0
+}
+
+class Completion1 {
+  def singleArg(f: Foo => Double): Nothing = ???
+  singleArg(_./*!*/)
+
+  def multiArg(f: Foo => Double, s: String): Nothing = ???
+  multiArg(_./*!*/) // importantly we want to see Bar and Baz as completions here
+
+  def multiArgFull(f: Foo => Double, s: String): Nothing = ???
+  multiArgFull(_./*!*/,???)
+
+  def multiArgWithDefault(f: Foo => Double, s: String = "hello"): Nothing = ???
+  multiArgWithDefault(_./*!*/)
+}


### PR DESCRIPTION
When typing an application, the typer first checks whether the application supplies the correct number of arguments. If not, it emits a "not enough arguments" error and moves on without checking whether the arguments have the correct type. In the usual batch compilation mode this is fine because we've already found an error. 

But in the context of an IDE like Metals this is a problem. If we don't type the arguments their trees may remain untyped and IDE functionality like autocomplete and type hints won't work. This change addresses the most common presentation of this issue, which arises frequently when making a call to a higher-order function with multiple arguments, e.g.

```scala
class Foo {
  def Bar: Double = 2.0
  def Baz: Double = 1.0
}

def multiArg(f: Foo => Double, s: String): Nothing = ???
multiArg(_./*CURSOR*/) // importantly we want to see Bar and Baz as completions here
```

We want to see completions for the members of `Foo` as we type the call, without having to ensure the correct arity first.

Fixes scala/bug#12909