### PR TITLE
Fix async transform in REPL

### DIFF
--- a/test/files/run/t13050.check
+++ b/test/files/run/t13050.check
@@ -1,0 +1,8 @@
+
+scala> import scala.tools.partest.async.OptionAwait._
+import scala.tools.partest.async.OptionAwait._
+
+scala> println(optionally { value(Some(1)) + value(Some(2)) })
+Some(3)
+
+scala> :quit

--- a/test/files/run/t13050.scala
+++ b/test/files/run/t13050.scala
@@ -1,0 +1,9 @@
+import scala.tools.nsc._
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  override def extraSettings = "-Xasync"
+  def code =
+    """import scala.tools.partest.async.OptionAwait._
+      |println(optionally { value(Some(1)) + value(Some(2)) })""".stripMargin
+}


### PR DESCRIPTION
The async transform only runs on source files with `await` calls. For REPL lines there are two SourceFile created for a single line. Make sure the async phase connects these dots.

Fixes https://github.com/scala/bug/issues/13050.