### PR TITLE
Cleanup: lint boolean args

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -208,7 +208,7 @@ lazy val commonSettings = instanceSettings ++ clearSourceAndResourceDirectories 
     "-Wconf:cat=optimizer:is",
     // we use @nowarn for methods that are deprecated in JDK > 8, but CI/release is under JDK 8
     "-Wconf:cat=unused-nowarn:s",
-    //"-Wunnamed-boolean-literal-strict",
+    "-Wunnamed-boolean-literal-strict",
     ),
   Compile / doc / scalacOptions ++= Seq(
     "-doc-footer", "epfl",

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -181,7 +181,7 @@ trait Implicits extends splain.SplainData {
     val tvars = tpars map (TypeVar untouchable _)
     val tpSubsted = tp.subst(tpars, tvars)
 
-    val search = new ImplicitSearch(EmptyTree, functionType(List(tpSubsted), AnyTpe), true, context.makeImplicit(reportAmbiguousErrors = false), isByNamePt = false)
+    val search = new ImplicitSearch(EmptyTree, functionType(List(tpSubsted), AnyTpe), isView = true, context.makeImplicit(reportAmbiguousErrors = false), isByNamePt = false)
 
     search.allImplicitsPoly(tvars)
   }

--- a/src/testkit/scala/tools/testkit/AllocationTest.scala
+++ b/src/testkit/scala/tools/testkit/AllocationTest.scala
@@ -57,7 +57,7 @@ object AllocationTest {
   }
 
   private def costOf[T](fn: => T, tpe: String): Long = {
-    val cost = coster.calcAllocationInfo(fn, 0, "", false).min
+    val cost = coster.calcAllocationInfo(fn, 0, "", ignoreEqualCheck = false).min
     println(s"cost of tracking allocations - cost of $tpe = $cost")
     cost
   }


### PR DESCRIPTION
```
sbt:scala2> set ThisBuild/scalacOptions += "-quickfix:any"
sbt:scala2> clean
[success] Total time: 1 s, completed Oct 25, 2024, 10:09:04 AM
sbt:scala2> compile
[info] compiling 537 Scala sources and 32 Java sources to /home/amarki/projects/scala/build/quick/classes/library ...
[info] compiling 161 Scala sources and 3 Java sources to /home/amarki/projects/scala/build/quick/classes/reflect ...
[info] compiling 328 Scala sources and 5 Java sources to /home/amarki/projects/scala/build/quick/classes/compiler ...
[warn] /home/amarki/projects/scala/src/compiler/scala/tools/nsc/typechecker/Implicits.scala:184:87: [rewritten by -quickfix] Boolean literals should be passed using named argument syntax for parameter isView.
[warn]     val search = new ImplicitSearch(EmptyTree, functionType(List(tpSubsted), AnyTpe), true, context.makeImplicit(reportAmbiguousErrors = false), isByNamePt = false)
[warn]                                                                                       ^
[warn] one warning found
```
etc