### PR TITLE
Require `-Xsource-features:eta-expand-always` for eta-expansion without an expected type

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1190,6 +1190,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
       def packagePrefixImplicits = isScala3 && contains(o.packagePrefixImplicits)
       def implicitResolution     = isScala3 && contains(o.implicitResolution) || settings.Yscala3ImplicitResolution.value
       def doubleDefinitions      = isScala3 && contains(o.doubleDefinitions)
+      def etaExpandAlways        = isScala3 && contains(o.etaExpandAlways)
     }
 
     // used in sbt

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -183,6 +183,7 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
     val packagePrefixImplicits = Choice("package-prefix-implicits", "The package prefix p is no longer part of the implicit search scope for type p.A.")
     val implicitResolution     = Choice("implicit-resolution", "Use Scala-3-style downwards comparisons for implicit search and overloading resolution (see github.com/scala/scala/pull/6037).")
     val doubleDefinitions      = Choice("double-definitions", "Correctly disallow double definitions differing in empty parens.")
+    val etaExpandAlways        = Choice("eta-expand-always", "Eta-expand even if the expected type is not a function type.")
 
     val v13_13_choices = List(caseApplyCopyAccess, caseCompanionFunction, inferOverride, any2StringAdd, unicodeEscapesRaw, stringContextScope, leadingInfix, packagePrefixImplicits)
 
@@ -203,10 +204,10 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
       "v2.13.14 plus double-definitions",
       expandsTo = v13_15_choices)
 
-    val v13_17_choices = noInferStructural :: v13_15_choices
+    val v13_17_choices = etaExpandAlways :: noInferStructural :: v13_15_choices
     val v13_17 = Choice(
       "v2.13.17",
-      "v2.13.15 plus no-infer-structural",
+      "v2.13.15 plus no-infer-structural, eta-expand-always",
       expandsTo = v13_17_choices)
   }
   val XsourceFeatures = MultiChoiceSetting(

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -819,7 +819,9 @@ trait ContextErrors extends splain.SplainErrors {
         val advice =
           if (meth.isConstructor || meth.info.params.lengthIs > definitions.MaxFunctionArity) ""
           else s"""
-            |Unapplied methods are only converted to functions when a function type is expected.
+            |Unapplied methods are only converted to functions when a function type is expected.${
+              if (!currentRun.isScala3) "" else """
+            |Use -Xsource-features:eta-expand-always to convert even if the expected type is not a function type."""}
             |You can make this conversion explicit by writing `$f _` or `$paf` instead of `$f`.""".stripMargin
         val message =
           if (meth.isMacro) MacroTooFewArgumentListsMessage

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -873,7 +873,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           if (arity == 0)
             expectingFunctionOfArity && warnEtaZero()
           else
-            expectingFunctionOfArity || expectingSamOfArity && warnEtaSam() || currentRun.isScala3
+            expectingFunctionOfArity || expectingSamOfArity && warnEtaSam() || currentRun.sourceFeatures.etaExpandAlways
         }
 
         def matchNullaryLoosely: Boolean = {
@@ -906,10 +906,11 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           val apply = Apply(tree, Nil).setPos(tree.pos).updateAttachment(AutoApplicationAttachment)
           if (tree.hasAttachment[PostfixAttachment.type]) apply.updateAttachment(InfixAttachment)
           adapt(typed(apply), mode, pt, original)
-        } else
-          if (context.implicitsEnabled) MissingArgsForMethodTpeError(tree, meth) // `context.implicitsEnabled` implies we are not in a pattern
-          else UnstableTreeError(tree)
-      }
+        }
+        // `context.implicitsEnabled` implies we are not in a pattern
+        else if (context.implicitsEnabled) MissingArgsForMethodTpeError(tree, meth)
+        else UnstableTreeError(tree)
+      } // end adaptMethodTypeToExpr
 
       def adaptType(): Tree = {
         // @M When not typing a type constructor (!context.inTypeConstructorAllowed)

--- a/test/files/neg/t13055.check
+++ b/test/files/neg/t13055.check
@@ -1,0 +1,7 @@
+t13055.scala:15: error: missing argument list for method forAll in object Main
+Unapplied methods are only converted to functions when a function type is expected.
+Use -Xsource-features:eta-expand-always to convert even if the expected type is not a function type.
+You can make this conversion explicit by writing `forAll _` or `forAll(_)(_)(_)` instead of `forAll`.
+  def what() = forAll {
+                      ^
+1 error

--- a/test/files/neg/t13055.scala
+++ b/test/files/neg/t13055.scala
@@ -1,0 +1,28 @@
+//> using options -Xsource:3
+
+//import org.scalacheck._, Prop._
+
+object Main extends App {
+  class Prop
+  class Gen[A]
+  object Gen {
+    implicit def const[T](x: T): Gen[T] = ???
+  }
+
+  def forAll[T1, P](g: Gen[T1])(f: T1 => P)(implicit p: P => Prop): Prop = ???
+  def forAll[A1, P](f: A1 => P)(implicit p: P => Prop): Prop = ???
+
+  def what() = forAll {
+    (a1: Int, a2: Int, a3: Int, a4: Int, a5: Int, a6: Int, a7: Int,
+     a8: Int,
+     a9: Int,
+    ) => false
+  }
+
+}
+
+/*
+    def what(): (((Int, Int, Int, Int, Int, Int, Int, Int, Int) => Boolean) => Nothing) => Main.Prop = {
+            <synthetic> val eta$0$1: Main.Gen[(Int, Int, Int, Int, Int, Int, Int, Int, Int) => Boolean] = Main.this.Gen.const[(Int, Int, Int, Int, Int, Int, Int, Int, Int) => Boolean](((a1: Int, a2: Int, a3: Int, a4: Int, a5: Int, a6: Int, a7: Int, a8: Int, a9: Int) => false));
+                  ((f: ((Int, Int, Int, Int, Int, Int, Int, Int, Int) => Boolean) => Nothing) => Main.this.forAll[(Int, Int, Int, Int, Int, Int, Int, Int, Int) => Boolean, Nothing](eta$0$1)(f)(scala.Predef.$conforms[Nothing]))
+*/

--- a/test/files/neg/t7187-3.scala
+++ b/test/files/neg/t7187-3.scala
@@ -1,4 +1,4 @@
-//> using options -Xsource:3 -Xlint:eta-zero
+//> using options -Xsource:3 -Xlint:eta-zero -Xsource-features:eta-expand-always
 //
 trait AcciSamZero { def apply(): Int }
 

--- a/test/files/neg/t7187-deprecation.scala
+++ b/test/files/neg/t7187-deprecation.scala
@@ -1,4 +1,4 @@
-//> using options -Xsource:3 -deprecation -Werror
+//> using options -Xsource:3 -deprecation -Werror -Xsource-features:eta-expand-always
 //
 trait AcciSamZero { def apply(): Int }
 

--- a/test/files/pos/t13055.scala
+++ b/test/files/pos/t13055.scala
@@ -1,0 +1,28 @@
+//> using options -Xsource:3 -Xsource-features:eta-expand-always
+
+//import org.scalacheck._, Prop._
+
+object Main extends App {
+  class Prop
+  class Gen[A]
+  object Gen {
+    implicit def const[T](x: T): Gen[T] = ???
+  }
+
+  def forAll[T1, P](g: Gen[T1])(f: T1 => P)(implicit p: P => Prop): Prop = ???
+  def forAll[A1, P](f: A1 => P)(implicit p: P => Prop): Prop = ???
+
+  def what() = forAll {
+    (a1: Int, a2: Int, a3: Int, a4: Int, a5: Int, a6: Int, a7: Int,
+     a8: Int,
+     a9: Int,
+    ) => false
+  }
+
+}
+
+/*
+    def what(): (((Int, Int, Int, Int, Int, Int, Int, Int, Int) => Boolean) => Nothing) => Main.Prop = {
+            <synthetic> val eta$0$1: Main.Gen[(Int, Int, Int, Int, Int, Int, Int, Int, Int) => Boolean] = Main.this.Gen.const[(Int, Int, Int, Int, Int, Int, Int, Int, Int) => Boolean](((a1: Int, a2: Int, a3: Int, a4: Int, a5: Int, a6: Int, a7: Int, a8: Int, a9: Int) => false));
+                  ((f: ((Int, Int, Int, Int, Int, Int, Int, Int, Int) => Boolean) => Nothing) => Main.this.forAll[(Int, Int, Int, Int, Int, Int, Int, Int, Int) => Boolean, Nothing](eta$0$1)(f)(scala.Predef.$conforms[Nothing]))
+*/

--- a/test/files/run/t3664.scala
+++ b/test/files/run/t3664.scala
@@ -1,4 +1,4 @@
-//> using options -Xsource:3 -Xsource-features:case-companion-function -deprecation
+//> using options -Xsource:3 -Xsource-features:case-companion-function,eta-expand-always -deprecation
 
 // use -Xsource:3 to warn that implicitly extending Function is deprecated
 // use -Xsource-features for dotty behavior: no extend Function, yes adapt C.apply.tupled


### PR DESCRIPTION
Require `-Xsource-features:eta-expand-always` for eta-expansion without an expected type.

Plain `-Xsource:3` is reserved for migration warnings and syntax backports that don't affect language semantics.

As a consequence, `-Xsource-features:case-companion-function` requires `-Xsource-features:eta-expand-always`.

Fixes scala/bug#13055