### PR TITLE
Do not use `rangeHash` when `rangeDiff` is 0 [ci: last-only]

### DIFF
--- a/src/library/scala/util/hashing/MurmurHash3.scala
+++ b/src/library/scala/util/hashing/MurmurHash3.scala
@@ -136,7 +136,7 @@ private[hashing] class MurmurHash3 {
     while (it.hasNext) {
       h = mix(h, prev)
       val hash = it.next().##
-      if(rangeDiff != hash - prev) {
+      if(rangeDiff != hash - prev || rangeDiff == 0) {
         h = mix(h, hash)
         i += 1
         while (it.hasNext) {
@@ -173,7 +173,7 @@ private[hashing] class MurmurHash3 {
         while (i < l) {
           h = mix(h, prev)
           val hash = a(i).##
-          if(rangeDiff != hash - prev) {
+          if(rangeDiff != hash - prev || rangeDiff == 0) {
             h = mix(h, hash)
             i += 1
             while (i < l) {
@@ -252,7 +252,7 @@ private[hashing] class MurmurHash3 {
         while (i < l) {
           h = mix(h, prev)
           val hash = a(i).##
-          if(rangeDiff != hash - prev) {
+          if(rangeDiff != hash - prev || rangeDiff == 0) {
             h = mix(h, hash)
             i += 1
             while (i < l) {
@@ -292,7 +292,7 @@ private[hashing] class MurmurHash3 {
           rangeDiff = hash - prev
           rangeState = 2
         case 2 =>
-          if(rangeDiff != hash - prev) rangeState = 3
+          if(rangeDiff != hash - prev || rangeDiff == 0) rangeState = 3
         case _ =>
       }
       prev = hash

--- a/test/junit/scala/util/hashing/MurmurHash3Test.scala
+++ b/test/junit/scala/util/hashing/MurmurHash3Test.scala
@@ -56,4 +56,16 @@ class MurmurHash3Test {
     assertEquals(r5, r6)
     assertEquals(r5.hashCode, r6.hashCode)
   }
+
+  @Test
+  def testEqualArray(): Unit = {
+    val z1 = (1 to 1).map(_ => 0).toArray
+    val z2 = (1 to 2).map(_ => 0).toArray
+    val z3 = (1 to 3).map(_ => 0).toArray
+    val z4 = (1 to 4).map(_ => 0).toArray
+    Seq(z1, z2, z3, z4).foreach(z => check(z.toIndexedSeq.hashCode(), z))
+    Seq(z1, z2, z3, z4).sliding(2).foreach{ case Seq(a, b) =>
+      assertNotEquals(a.toIndexedSeq.hashCode(), b.toIndexedSeq.hashCode())
+    }
+  }
 }


### PR DESCRIPTION
Closes https://github.com/scala/bug/issues/12826 via implementing https://github.com/scala/bug/issues/12826#issuecomment-1631690002