### PR TITLE
remove @implicitNotFound on Ordering

### DIFF
--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -69,7 +69,6 @@ import scala.annotation.migration
   *
   * @see [[scala.math.Ordered]], [[scala.util.Sorting]], [[scala.math.Ordering.Implicits]]
   */
-@annotation.implicitNotFound(msg = "No implicit Ordering defined for ${T}.")
 trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializable {
   outer =>
 

--- a/test/files/neg/t12919-3cross.check
+++ b/test/files/neg/t12919-3cross.check
@@ -1,4 +1,4 @@
-t12919-3cross.scala:24: error: No implicit Ordering defined for a.A.
+t12919-3cross.scala:24: error: could not find implicit value for parameter ord: Ordering[a.A]
     def f(xs: List[a.A]) = xs.sorted // not found
                               ^
 1 error


### PR DESCRIPTION
since it doesn't add any information that is actually specific to the `Ordering` type; and to prevent the message from also
being used for `Numeric` (a subtype of `Ordering`)

fixes scala/bug#13053
