### PR TITLE
Merge 2.12.x to 2.13.x [ci: last-only]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ val asmDep            = "org.scala-lang.modules"         % "scala-asm"          
 val jlineDep          = "org.jline"                      % "jline"                            % versionProps("jline.version")     classifier "jdk8"
 val testInterfaceDep  = "org.scala-sbt"                  % "test-interface"                   % "1.0"
 val diffUtilsDep      = "io.github.java-diff-utils"      % "java-diff-utils"                  % "4.12"
-val compilerInterfaceDep = "org.scala-sbt"               % "compiler-interface"               % "1.10.3"
+val compilerInterfaceDep = "org.scala-sbt"               % "compiler-interface"               % "1.10.4"
 
 val projectFolder = settingKey[String]("subfolder in src when using configureAsSubproject, else the project name")
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.3
+sbt.version=1.10.5


### PR DESCRIPTION
just the sbt 1.10.{3=>5} upgrade

```
PICK * 103bc37c2b - Merge pull request #10911 from SethTisue/sbt-1.10.5
```

I did check that although 1.10.5 is latest sbt, zinc is still at 1.10.4, which is why compiler-interface only gets bumped to 1.10.4