### PR TITLE
[REVISIT SHRUGGIE] Act on early reports by nonunit-statement lint [ci: last-only]

### DIFF
--- a/src/library/scala/PartialFunction.scala
+++ b/src/library/scala/PartialFunction.scala
@@ -218,7 +218,7 @@ trait PartialFunction[-A, +B] extends (A => B) { self =>
    *  The action function is invoked only for its side effects; its result is ignored.
    *
    *  Note that expression `pf.runWith(action)(x)` is equivalent to
-   *  {{{ if(pf isDefinedAt x) { action(pf(x)); true } else false }}}
+   *  {{{ if (pf isDefinedAt x) { action(pf(x)); true } else false }}}
    *  except that `runWith` is implemented via `applyOrElse` and thus potentially more efficient.
    *  Using `runWith` avoids double evaluation of pattern matchers and guards for partial function literals.
    *  @see `applyOrElse`.
@@ -229,7 +229,9 @@ trait PartialFunction[-A, +B] extends (A => B) { self =>
    */
   def runWith[U](action: B => U): A => Boolean = { x =>
     val z = applyOrElse(x, checkFallback[B])
-    if (!fallbackOccurred(z)) { action(z); true } else false
+    val wasDefinedAt = !fallbackOccurred(z)
+    if (wasDefinedAt) action(z)
+    wasDefinedAt
   }
 }
 

--- a/src/library/scala/collection/LinearSeq.scala
+++ b/src/library/scala/collection/LinearSeq.scala
@@ -15,10 +15,9 @@ package collection
 
 import scala.annotation.{nowarn, tailrec}
 
-/** Base trait for linearly accessed sequences that have efficient `head` and
-  *  `tail` operations.
-  *  Known subclasses: List, LazyList
-  */
+/** Base trait for linearly accessed sequences that have efficient `head` and `tail` operations.
+ *  Known subclasses: List, LazyList.
+ */
 trait LinearSeq[+A] extends Seq[A]
   with LinearSeqOps[A, LinearSeq, LinearSeq[A]]
   with IterableFactoryDefaults[A, LinearSeq] {
@@ -61,13 +60,8 @@ trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] with LinearSeq
     else new LinearSeqIterator[A](this)
 
   def length: Int = {
-    var these = coll
-    var len = 0
-    while (these.nonEmpty) {
-      len += 1
-      these = these.tail
-    }
-    len
+    @tailrec def loop(these: LinearSeq[A], acc: Int): Int = if (these.isEmpty) acc else loop(these.tail, acc + 1)
+    loop(coll, acc = 0)
   }
 
   override def last: A = {
@@ -133,69 +127,43 @@ trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] with LinearSeq
   }
 
   override def foreach[U](f: A => U): Unit = {
-    var these: LinearSeq[A] = coll
-    while (!these.isEmpty) {
-      f(these.head)
-      these = these.tail
-    }
+    @tailrec def loop(these: LinearSeq[A]): Unit = if (!these.isEmpty) { f(these.head): Unit; loop(these.tail) }
+    loop(coll)
   }
 
   override def forall(p: A => Boolean): Boolean = {
-    var these: LinearSeq[A] = coll
-    while (!these.isEmpty) {
-      if (!p(these.head)) return false
-      these = these.tail
-    }
-    true
+    @tailrec def loop(these: LinearSeq[A]): Boolean = these.isEmpty || p(these.head) && loop(these.tail)
+    loop(coll)
   }
 
   override def exists(p: A => Boolean): Boolean = {
-    var these: LinearSeq[A] = coll
-    while (!these.isEmpty) {
-      if (p(these.head)) return true
-      these = these.tail
-    }
-    false
+    @tailrec def loop(these: LinearSeq[A]): Boolean = !these.isEmpty && (p(these.head) || loop(these.tail))
+    loop(coll)
   }
 
   override def contains[A1 >: A](elem: A1): Boolean = {
-    var these: LinearSeq[A] = coll
-    while (!these.isEmpty) {
-      if (these.head == elem) return true
-      these = these.tail
-    }
-    false
+    @tailrec def loop(these: LinearSeq[A]): Boolean = !these.isEmpty && (these.head == elem || loop(these.tail))
+    loop(coll)
   }
 
   override def find(p: A => Boolean): Option[A] = {
-    var these: LinearSeq[A] = coll
-    while (!these.isEmpty) {
-      if (p(these.head)) return Some(these.head)
-      these = these.tail
-    }
-    None
+    @tailrec def loop(these: LinearSeq[A]): Option[A] =
+      if (these.isEmpty) None
+      else if (p(these.head)) Some(these.head)
+      else loop(these.tail)
+    loop(coll)
   }
 
   override def foldLeft[B](z: B)(op: (B, A) => B): B = {
-    var acc = z
-    var these: LinearSeq[A] = coll
-    while (!these.isEmpty) {
-      acc = op(acc, these.head)
-      these = these.tail
-    }
-    acc
+    @tailrec def loop(these: LinearSeq[A], acc: B): B =
+      if (these.isEmpty) acc
+      else loop(these.tail, op(acc, these.head))
+    loop(coll, z)
   }
 
   override def sameElements[B >: A](that: IterableOnce[B]): Boolean = {
     @tailrec def linearSeqEq(a: LinearSeq[B], b: LinearSeq[B]): Boolean =
-      (a eq b) || {
-        if (a.nonEmpty && b.nonEmpty && a.head == b.head) {
-          linearSeqEq(a.tail, b.tail)
-        }
-        else {
-          a.isEmpty && b.isEmpty
-        }
-      }
+      (a eq b) || a.isEmpty && b.isEmpty || !a.isEmpty && !b.isEmpty && a.head == b.head && linearSeqEq(a.tail, b.tail)
 
     that match {
       case that: LinearSeq[B] => linearSeqEq(coll, that)
@@ -204,53 +172,39 @@ trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] with LinearSeq
   }
 
   override def segmentLength(p: A => Boolean, from: Int): Int = {
-    var i = 0
-    var seq = drop(from)
-    while (seq.nonEmpty && p(seq.head)) {
-      i += 1
-      seq = seq.tail
-    }
-    i
+    @tailrec def loop(these: LinearSeq[A], acc: Int): Int =
+      if (these.isEmpty || !p(these.head)) acc else loop(these.tail, acc + 1)
+    loop(coll.drop(from), acc = 0)
   }
 
   override def indexWhere(p: A => Boolean, from: Int): Int = {
-    var i = math.max(from, 0)
-    var these: LinearSeq[A] = this drop from
-    while (these.nonEmpty) {
-      if (p(these.head))
-        return i
-
-      i += 1
-      these = these.tail
-    }
-    -1
+    @tailrec def loop(these: LinearSeq[A], acc: Int): Int =
+      if (these.isEmpty) -1
+      else if (p(these.head)) acc
+      else loop(these.tail, acc + 1)
+    val i = math.max(from, 0)
+    loop(coll.drop(i), acc = i)
   }
 
   override def lastIndexWhere(p: A => Boolean, end: Int): Int = {
-    var i = 0
-    var these: LinearSeq[A] = coll
-    var last = -1
-    while (!these.isEmpty && i <= end) {
-      if (p(these.head)) last = i
-      these = these.tail
-      i += 1
-    }
-    last
+    @tailrec def loop(these: LinearSeq[A], i: Int, last: Int): Int =
+      if (these.isEmpty || i > end) last
+      else loop(these.tail, i = i + 1, last = (if (p(these.head)) i else last))
+    loop(coll, i = 0, last = -1)
   }
 
   override def findLast(p: A => Boolean): Option[A] = {
-    var these: LinearSeq[A] = coll
-    var found = false
-    var last: A = null.asInstanceOf[A] // don't use `Option`, to prevent excessive `Some` allocation
-    while (these.nonEmpty) {
-      val elem = these.head
-      if (p(elem)) {
-        found = true
-        last = elem
+    @tailrec def loop(these: LinearSeq[A], last: A, found: Boolean): Option[A] =
+      if (these.isEmpty)
+        if (found) Some(last) else None
+      else {
+        val elem = these.head
+        if (p(elem))
+          loop(these.tail, last = elem, found = true)
+        else
+          loop(these.tail, last, found)
       }
-      these = these.tail
-    }
-    if (found) Some(last) else None
+    loop(coll, last = null.asInstanceOf[A], found = false)
   }
 
   override def tails: Iterator[C] = {

--- a/src/reflect/scala/reflect/internal/BaseTypeSeqs.scala
+++ b/src/reflect/scala/reflect/internal/BaseTypeSeqs.scala
@@ -193,9 +193,8 @@ trait BaseTypeSeqs {
     val tsym = tp.typeSymbol
     val parents = tp.parents
 //    Console.println("computing baseTypeSeq of " + tsym.tpe + " " + parents)//DEBUG
-    val buf = new mutable.ListBuffer[Type]
+    val buf = mutable.ListBuffer.empty[Type]
     buf += tsym.tpe_*
-    var btsSize = 1
     if (parents.nonEmpty) {
       val nparents = parents.length
       val pbtss = new Array[BaseTypeSeq](nparents)
@@ -251,12 +250,9 @@ trait BaseTypeSeqs {
           i += 1
         }
         buf += intersectionTypeForLazyBaseType(minTypes) // TODO this reverses the order. Does this matter? Or should this be minTypes.reverse?
-        btsSize += 1
       }
     }
-    val elems = new Array[Type](btsSize)
-    @annotation.unused val copied = buf.copyToArray(elems, 0)
-    //assert(copied == btsSize, "array copied")
+    val elems = buf.toArray
 //    Console.println("computed baseTypeSeq of " + tsym.tpe + " " + parents + ": "+elems.toString)//DEBUG
     newBaseTypeSeq(parents, elems)
   }

--- a/test/junit/scala/collection/LinearSeqTest.scala
+++ b/test/junit/scala/collection/LinearSeqTest.scala
@@ -1,20 +1,15 @@
 package scala.collection
 
 import org.junit.Test
-import org.junit.Assert.{assertEquals, assertTrue}
+import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
 import scala.tools.testkit.AssertUtil.assertThrows
 
 class LinearSeqTest {
+  import LinearSeqTest._
+
   // Tests regression on issue 11262
-  @Test def extensionIteratorTest(): Unit = {
-    class ConstantLinearSeq[A](len: Int, elt: A) extends scala.collection.LinearSeq[A] {
-      override val isEmpty: Boolean = len == 0
-      override val head = elt
-      override lazy val tail = if(len > 0) new ConstantLinearSeq(len - 1, elt) else throw new Exception("tail of empty Seq")
-    }
-
+  @Test def `iterator of trivial subclass`: Unit = {
     val x = new ConstantLinearSeq(4, 7)
-
     val it = x.iterator // The main thing we want to test is that this does not throw an exception
     assertTrue(it.hasNext) // Call it at least once so that it won't be optimized away
   }
@@ -40,5 +35,64 @@ class LinearSeqTest {
     assertEquals("LinearSeq()", ls.toString)
     assertThrows[NoSuchElementException](ls.head)
     assertThrows[UnsupportedOperationException](ls.tail)
+  }
+  @Test def `length works`: Unit = assertEquals(3, ConstantLinearSeq(3, "").length)
+  @Test def `foreach works`: Unit = {
+    var res = 0
+    ConstantLinearSeq(0, "42").foreach(res += _.toInt)
+    assertEquals(0, res)
+    ConstantLinearSeq(3, "42").foreach(res += _.toInt)
+    assertEquals(126, res)
+  }
+  @Test def `forall works`: Unit = {
+    assertTrue(ConstantLinearSeq(3, "").forall(_.isEmpty))
+    assertFalse(ConstantLinearSeq(3, "x").forall(_.isEmpty))
+  }
+  @Test def `exists works`: Unit = {
+    var count = 0
+    assertTrue(ConstantLinearSeq(3, "").exists { x => count += 1; x.isEmpty })
+    assertEquals(1, count)
+    count = 0
+    assertFalse(ConstantLinearSeq(3, "x").exists { x => count += 1; x.isEmpty })
+    assertEquals(3, count)
+  }
+  @Test def `contains works`: Unit = {
+    assertTrue(ConstantLinearSeq(3, "x", limit = 0).contains("x"))
+    assertFalse(ConstantLinearSeq(3, "x", limit = 3).contains("y"))
+  }
+  @Test def `find works`: Unit = {
+    assertEquals(Some("x"), ConstantLinearSeq(3, "x", limit = 0).find(_ == "x"))
+    assertEquals(None, ConstantLinearSeq(3, "x", limit = 3).find(_ == "y"))
+  }
+  @Test def `foldLeft works`: Unit =
+    assertEquals(126, ConstantLinearSeq(3, 42).foldLeft(0)(_ + _))
+  @Test def `sameElements works`: Unit =
+    assertTrue(ConstantLinearSeq(3, 42, limit = 3).sameElements(List(42, 42, 42)))
+  @Test def `segmentLength works`: Unit =
+    assertEquals(3, ConstantLinearSeq(5, 42).segmentLength(_ == 42, from = 2))
+  @Test def `indexWhere works`: Unit =
+    assertEquals(3, ArrayLinearSeq(Array(1, 2, 3, 4, 5)).indexWhere(_ > 3))
+  @Test def `lastIndexWhere works`: Unit =
+    assertEquals(4, ArrayLinearSeq(Array(1, 2, 3, 3, 3, 4, 5)).lastIndexWhere(_ == 3))
+  @Test def `findLast works`: Unit =
+    assertEquals(Some(3), ArrayLinearSeq(Array(1, 2, 3, 4, 3, 5, 3, 4, 5)).findLast(_ < 4))
+}
+object LinearSeqTest {
+  private case class ConstantLinearSeq[A](len: Int, elem: A, limit: Int = Int.MaxValue) extends LinearSeq[A] {
+    require(len >= 0)
+    override val isEmpty: Boolean = len == 0
+    override val head = elem
+    override lazy val tail =
+      if (limit == 0) throw new NoSuchElementException("ConstantLinearSeq.limit")
+      else if (isEmpty) throw new NoSuchElementException("ConstantLinearSeq.tail")
+      else copy(len = len - 1, limit = limit - 1)
+  }
+  private case class ArrayLinearSeq[A](values: Array[A], index: Int = 0, limit: Int = Int.MaxValue) extends LinearSeq[A] {
+    override val isEmpty: Boolean = index == values.length
+    override lazy val head = values(index)
+    override lazy val tail =
+      if (limit == 0) throw new NoSuchElementException("ArrayLinearSeq.limit")
+      else if (isEmpty) throw new NoSuchElementException("ArrayLinearSeq.tail")
+      else copy(index = index + 1, limit = limit - 1)
   }
 }


### PR DESCRIPTION
Some mid-pandemic tweaks which still look reasonable.

The useful idiom expresses whether a value is to be discarded.

For example, one-legged if is taken as discarding.