### PR TITLE
Restore case for `NothingClass` in `LabelDef` boxing.

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/TypeAdaptingTransformer.scala
+++ b/src/compiler/scala/tools/nsc/transform/TypeAdaptingTransformer.scala
@@ -65,6 +65,7 @@ trait TypeAdaptingTransformer { self: TreeDSL =>
             case UnitClass =>
               if (treeInfo isExprSafeToInline tree) REF(BoxedUnit_UNIT)
               else BLOCK(tree, REF(BoxedUnit_UNIT))
+            case NothingClass => tree // a non-terminating expression doesn't need boxing
             case x =>
               assert(x != ArrayClass, "array")
               tree match {

--- a/test/files/pos/t13060.scala
+++ b/test/files/pos/t13060.scala
@@ -1,0 +1,17 @@
+class Bug1955 {
+  var result: Int = 0
+
+  def doSomething[A](a: Int, b: Int, r: A): A = {
+    result = a + b
+    r
+  }
+
+  def bug(x: Int, e: Boolean): Unit = {
+    x match {
+      case 1 => doSomething(123, 456, ())
+      case 2 if e =>
+    }
+
+    if (false) ()
+  }
+}


### PR DESCRIPTION
This was removed in 8b0637fa3c36c7310faadbd2906abc44acbdf9a2 but actually caused regressions.

Fixes https://github.com/scala/bug/issues/13060