### PR TITLE
Type `defaultBody` in match translation

### DIFF
--- a/test/files/pos/t13060.scala
+++ b/test/files/pos/t13060.scala
@@ -1,0 +1,10 @@
+class C {
+  def id[A](r: A): A = r
+  def bug(x: Int, e: Boolean): Unit = {
+    x match {
+      case 1 => id(())
+      case 2 if e =>
+    }
+    println()
+  }
+}


### PR DESCRIPTION
The tree.tpe is used in `wrapInDefaultLabelDef`.
Without it, the translation creates a LabelDef

    LabelDef("default4", throw new MatchError(x1))

whose symbol has type `(): Unit` instead of `(): Nothing`. This incorrectly triggers the `box` adaptation in erasure.

Fixes https://github.com/scala/bug/issues/13060

Followup to #10884