### PR TITLE
Deregister stale callbacks in `Future.firstCompletedOf` (prevents memory leaks)

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -41,7 +41,10 @@ object MimaFilters extends AutoPlugin {
 
     // KEEP: the CommonErrors object is not a public API
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.generic.CommonErrors"),
-    ProblemFilters.exclude[MissingClassProblem]("scala.collection.generic.CommonErrors$")
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.generic.CommonErrors$"),
+
+    // scala/scala#10927
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.concurrent.Future.onCompleteWithUnregister"),
   )
 
   override val buildSettings = Seq(


### PR DESCRIPTION
`Future.firstCompletedOf` registers an `onComplete` handler on each argument future. After the first future is completed, all remaining handler become no-ops. Remvoing them from the futures can prevent memory leaks.

Fixes https://github.com/scala/bug/issues/13058

This PR was later amended by #10994 to avoid changing the public API of `Future`