### PR TITLE
Extract common IndexOutOfBoundsException error message

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -39,6 +39,9 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.concurrent.impl.FutureConvertersImpl#P.accept"),
     ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.concurrent.impl.FutureConvertersImpl#P.andThen"),
 
+    // KEEP: the CommonErrors object is not a public API
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.generic.CommonErrors"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.generic.CommonErrors$")
   )
 
   override val buildSettings = Seq(

--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -44,6 +44,7 @@ import scala.Predef.{ // unimport all array-related implicit conversions to avoi
   _
 }
 import scala.collection.Stepper.EfficientSplit
+import scala.collection.generic.CommonErrors
 import scala.collection.immutable.Range
 import scala.collection.mutable.ArrayBuilder
 import scala.math.Ordering
@@ -1545,7 +1546,8 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     *  @throws IndexOutOfBoundsException if `index` does not satisfy `0 <= index < length`.
     */
   def updated[B >: A : ClassTag](index: Int, elem: B): Array[B] = {
-    if(index < 0 || index >= xs.length) throw new IndexOutOfBoundsException(s"$index is out of bounds (min 0, max ${xs.length-1})")
+    if(index < 0 || index >= xs.length)
+      throw CommonErrors.indexOutOfBounds(index = index, max = xs.length-1)
     val dest = toArray[B]
     dest(index) = elem
     dest

--- a/src/library/scala/collection/SeqView.scala
+++ b/src/library/scala/collection/SeqView.scala
@@ -14,6 +14,7 @@ package scala
 package collection
 
 import scala.annotation.nowarn
+import scala.collection.generic.CommonErrors
 
 
 trait SeqView[+A] extends SeqOps[A, View, View[A]] with View[A] {
@@ -95,7 +96,10 @@ object SeqView {
     def apply(idx: Int): A = if (idx < n) {
       underlying(idx)
     } else {
-      throw new IndexOutOfBoundsException(s"$idx is out of bounds (min 0, max ${if (underlying.knownSize >= 0) knownSize - 1 else "unknown"})")
+      throw (
+        if (underlying.knownSize >= 0) CommonErrors.indexOutOfBounds(index = idx, max = knownSize - 1)
+        else CommonErrors.indexOutOfBounds(index = idx)
+      )
     }
     def length: Int = underlying.length min normN
   }

--- a/src/library/scala/collection/generic/CommonErrors.scala
+++ b/src/library/scala/collection/generic/CommonErrors.scala
@@ -1,0 +1,29 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection
+package generic
+
+
+/** Some precomputed common errors to reduce the generated code size.
+  */
+private[collection] object CommonErrors {
+  /** IndexOutOfBounds exception with a known max index */
+  @noinline
+  def indexOutOfBounds(index: Int, max: Int): IndexOutOfBoundsException = 
+    new IndexOutOfBoundsException(s"$index is out of bounds (min 0, max ${max})")
+
+  /** IndexOutOfBounds exception with an unknown max index. */
+  @noinline
+  def indexOutOfBounds(index: Int): IndexOutOfBoundsException = 
+    new IndexOutOfBoundsException(s"$index is out of bounds (min 0, max unknown)")
+}

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -17,7 +17,7 @@ package immutable
 import scala.annotation.unchecked.uncheckedVariance
 import scala.annotation.tailrec
 import mutable.{Builder, ListBuffer}
-import scala.collection.generic.DefaultSerializable
+import scala.collection.generic.{CommonErrors, DefaultSerializable}
 import scala.runtime.Statics.releaseFence
 
 /** A class for immutable linked lists representing ordered collections
@@ -238,7 +238,7 @@ sealed abstract class List[+A]
     if (i == index && current.nonEmpty) {
       prefix.prependToList(elem :: current.tail)
     } else {
-      throw new IndexOutOfBoundsException(s"$index is out of bounds (min 0, max ${length-1})")
+      throw CommonErrors.indexOutOfBounds(index = index, max = length - 1)
     }
   }
 

--- a/src/library/scala/collection/immutable/NumericRange.scala
+++ b/src/library/scala/collection/immutable/NumericRange.scala
@@ -14,6 +14,7 @@ package scala.collection.immutable
 
 import scala.collection.Stepper.EfficientSplit
 import scala.collection.{AbstractIterator, AnyStepper, IterableFactoryDefaults, Iterator, Stepper, StepperShape}
+import scala.collection.generic.CommonErrors
 
 /** `NumericRange` is a more generic version of the
   *  `Range` class which works with arbitrary types.
@@ -104,7 +105,8 @@ sealed class NumericRange[T](
 
   @throws[IndexOutOfBoundsException]
   def apply(idx: Int): T = {
-    if (idx < 0 || idx >= length) throw new IndexOutOfBoundsException(s"$idx is out of bounds (min 0, max ${length - 1})")
+    if (idx < 0 || idx >= length)
+      throw CommonErrors.indexOutOfBounds(index = idx, max = length - 1)
     else locationAfterN(idx)
   }
 

--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -15,6 +15,7 @@ package collection.immutable
 
 import scala.collection.Stepper.EfficientSplit
 import scala.collection.convert.impl.RangeStepper
+import scala.collection.generic.CommonErrors
 import scala.collection.{AbstractIterator, AnyStepper, IterableFactoryDefaults, Iterator, Stepper, StepperShape}
 import scala.util.hashing.MurmurHash3
 
@@ -177,7 +178,8 @@ sealed abstract class Range(
   @throws[IndexOutOfBoundsException]
   final def apply(idx: Int): Int = {
     validateMaxLength()
-    if (idx < 0 || idx >= numRangeElements) throw new IndexOutOfBoundsException(s"$idx is out of bounds (min 0, max ${numRangeElements-1})")
+    if (idx < 0 || idx >= numRangeElements)
+      throw CommonErrors.indexOutOfBounds(index = idx, max = numRangeElements - 1)
     else start + (step * idx)
   }
 

--- a/src/library/scala/collection/immutable/StrictOptimizedSeqOps.scala
+++ b/src/library/scala/collection/immutable/StrictOptimizedSeqOps.scala
@@ -14,6 +14,8 @@ package scala
 package collection
 package immutable
 
+import scala.collection.generic.CommonErrors
+
 /** Trait that overrides operations to take advantage of strict builders.
  */
 trait StrictOptimizedSeqOps[+A, +CC[_], +C]
@@ -38,7 +40,11 @@ trait StrictOptimizedSeqOps[+A, +CC[_], +C]
   }
 
   override def updated[B >: A](index: Int, elem: B): CC[B] = {
-    if (index < 0) throw new IndexOutOfBoundsException(s"$index is out of bounds (min 0, max ${if (knownSize>=0) knownSize else "unknown"})")
+    if (index < 0)
+      throw (
+        if (knownSize >= 0) CommonErrors.indexOutOfBounds(index = index, max = knownSize)
+        else CommonErrors.indexOutOfBounds(index = index)
+      )
     val b = iterableFactory.newBuilder[B]
     b.sizeHint(this)
     var i = 0
@@ -47,7 +53,8 @@ trait StrictOptimizedSeqOps[+A, +CC[_], +C]
       b += it.next()
       i += 1
     }
-    if (!it.hasNext) throw new IndexOutOfBoundsException(s"$index is out of bounds (min 0, max ${i-1})")
+    if (!it.hasNext)
+      throw CommonErrors.indexOutOfBounds(index = index, max = i - 1)
     b += elem
     it.next()
     while (it.hasNext) b += it.next()

--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -20,7 +20,7 @@ import java.util.{Arrays, Spliterator}
 import scala.annotation.switch
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.Stepper.EfficientSplit
-import scala.collection.generic.DefaultSerializable
+import scala.collection.generic.{CommonErrors, DefaultSerializable}
 import scala.collection.immutable.VectorInline._
 import scala.collection.immutable.VectorStatics._
 import scala.collection.mutable.ReusableBuilder
@@ -283,7 +283,7 @@ sealed abstract class Vector[+A] private[immutable] (private[immutable] final va
   }
 
   protected[this] def ioob(index: Int): IndexOutOfBoundsException =
-    new IndexOutOfBoundsException(s"$index is out of bounds (min 0, max ${length-1})")
+    CommonErrors.indexOutOfBounds(index = index, max = length - 1)
 
   override final def head: A =
     if (prefix1.length == 0) throw new NoSuchElementException("empty.head")

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -17,7 +17,7 @@ package mutable
 import java.util.Arrays
 import scala.annotation.{nowarn, tailrec}
 import scala.collection.Stepper.EfficientSplit
-import scala.collection.generic.DefaultSerializable
+import scala.collection.generic.{CommonErrors, DefaultSerializable}
 import scala.runtime.PStatics.VM_MaxArraySize
 
 /** An implementation of the `Buffer` class using an array to
@@ -99,8 +99,8 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
     array = ArrayBuffer.downsize(array, requiredLength)
 
   @inline private def checkWithinBounds(lo: Int, hi: Int) = {
-    if (lo < 0) throw new IndexOutOfBoundsException(s"$lo is out of bounds (min 0, max ${size0 - 1})")
-    if (hi > size0) throw new IndexOutOfBoundsException(s"${hi - 1} is out of bounds (min 0, max ${size0 - 1})")
+    if (lo < 0) throw CommonErrors.indexOutOfBounds(index = lo, max = size0 - 1)
+    if (hi > size0) throw CommonErrors.indexOutOfBounds(index = hi - 1, max = size0 - 1)
   }
 
   def apply(n: Int): A = {

--- a/src/library/scala/collection/mutable/ArrayDeque.scala
+++ b/src/library/scala/collection/mutable/ArrayDeque.scala
@@ -16,7 +16,7 @@ package mutable
 
 import scala.annotation.nowarn
 import scala.collection.Stepper.EfficientSplit
-import scala.collection.generic.DefaultSerializable
+import scala.collection.generic.{CommonErrors, DefaultSerializable}
 import scala.reflect.ClassTag
 
 /** An implementation of a double-ended queue that internally uses a resizable circular buffer.
@@ -580,7 +580,8 @@ trait ArrayDequeOps[A, +CC[_], +C <: AnyRef] extends StrictOptimizedSeqOps[A, CC
   protected def start_+(idx: Int): Int
 
   @inline protected final def requireBounds(idx: Int, until: Int = length): Unit =
-    if (idx < 0 || idx >= until) throw new IndexOutOfBoundsException(s"$idx is out of bounds (min 0, max ${until-1})")
+    if (idx < 0 || idx >= until)
+      throw CommonErrors.indexOutOfBounds(index = idx, max = until - 1)
 
   /**
     * This is a more general version of copyToArray - this also accepts a srcStart unlike copyToArray

--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -14,6 +14,7 @@ package scala.collection
 package mutable
 
 import scala.annotation.{nowarn, tailrec}
+import scala.collection.generic.CommonErrors
 import scala.collection.immutable.{::, List, Nil}
 import java.lang.{IllegalArgumentException, IndexOutOfBoundsException}
 
@@ -203,7 +204,7 @@ class ListBuffer[A]
 
   def update(idx: Int, elem: A): Unit = {
     ensureUnaliased()
-    if (idx < 0 || idx >= len) throw new IndexOutOfBoundsException(s"$idx is out of bounds (min 0, max ${len-1})")
+    if (idx < 0 || idx >= len) throw CommonErrors.indexOutOfBounds(index = idx, max = len - 1)
     if (idx == 0) {
       val newElem = new :: (elem, first.tail)
       if (last0 eq first) {
@@ -223,7 +224,7 @@ class ListBuffer[A]
 
   def insert(idx: Int, elem: A): Unit = {
     ensureUnaliased()
-    if (idx < 0 || idx > len) throw new IndexOutOfBoundsException(s"$idx is out of bounds (min 0, max ${len-1})")
+    if (idx < 0 || idx > len) throw CommonErrors.indexOutOfBounds(index = idx, max = len - 1)
     if (idx == len) addOne(elem)
     else {
       val p = locate(idx)
@@ -250,7 +251,7 @@ class ListBuffer[A]
   }
 
   def insertAll(idx: Int, elems: IterableOnce[A]): Unit = {
-    if (idx < 0 || idx > len) throw new IndexOutOfBoundsException(s"$idx is out of bounds (min 0, max ${len-1})")
+    if (idx < 0 || idx > len) throw CommonErrors.indexOutOfBounds(index = idx, max = len - 1)
     val it = elems.iterator
     if (it.hasNext) {
       if (idx == len) addAll(it)
@@ -264,7 +265,7 @@ class ListBuffer[A]
 
   def remove(idx: Int): A = {
     ensureUnaliased()
-    if (idx < 0 || idx >= len) throw new IndexOutOfBoundsException(s"$idx is out of bounds (min 0, max ${len-1})")
+    if (idx < 0 || idx >= len) throw CommonErrors.indexOutOfBounds(index = idx, max = len - 1)
     val p = locate(idx)
     val nx = getNext(p)
     if(p eq null) {
@@ -281,7 +282,7 @@ class ListBuffer[A]
   def remove(idx: Int, count: Int): Unit =
     if (count > 0) {
       ensureUnaliased()
-      if (idx < 0 || idx + count > len) throw new IndexOutOfBoundsException(s"$idx to ${idx + count} is out of bounds (min 0, max ${len-1})")
+      if (idx < 0 || idx + count > len) throw new IndexOutOfBoundsException(s"$idx to ${idx + count} is out of bounds (min 0, max ${len - 1})")
       removeAfter(locate(idx), count)
     } else if (count < 0) {
       throw new IllegalArgumentException("removing negative number of elements: " + count)

--- a/src/library/scala/collection/mutable/UnrolledBuffer.scala
+++ b/src/library/scala/collection/mutable/UnrolledBuffer.scala
@@ -14,7 +14,7 @@ package scala.collection
 package mutable
 
 import scala.annotation.tailrec
-import scala.collection.generic.DefaultSerializable
+import scala.collection.generic.{CommonErrors, DefaultSerializable}
 import scala.reflect.ClassTag
 import scala.collection.immutable.Nil
 
@@ -158,11 +158,11 @@ sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
 
   def apply(idx: Int) =
     if (idx >= 0 && idx < sz) headptr(idx)
-    else throw new IndexOutOfBoundsException(s"$idx is out of bounds (min 0, max ${sz-1})")
+    else throw CommonErrors.indexOutOfBounds(index = idx, max = sz - 1)
 
   def update(idx: Int, newelem: T) =
     if (idx >= 0 && idx < sz) headptr(idx) = newelem
-    else throw new IndexOutOfBoundsException(s"$idx is out of bounds (min 0, max ${sz-1})")
+    else throw CommonErrors.indexOutOfBounds(index = idx, max = sz - 1)
 
   /** Replace the contents of this $coll with the mapped result.
    *
@@ -178,7 +178,7 @@ sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
     if (idx >= 0 && idx < sz) {
       sz -= 1
       headptr.remove(idx, this)
-    } else throw new IndexOutOfBoundsException(s"$idx is out of bounds (min 0, max ${sz-1})")
+    } else throw CommonErrors.indexOutOfBounds(index = idx, max = sz - 1)
 
   @tailrec final def remove(idx: Int, count: Int): Unit =
     if (count > 0) {
@@ -198,7 +198,7 @@ sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
   def insertAll(idx: Int, elems: IterableOnce[T]): Unit =
     if (idx >= 0 && idx <= sz) {
       sz += headptr.insertAll(idx, elems, this)
-    } else throw new IndexOutOfBoundsException(s"$idx is out of bounds (min 0, max ${sz-1})")
+    } else throw CommonErrors.indexOutOfBounds(index = idx, max = sz - 1)
 
   override def subtractOne(elem: T): this.type = {
     if (headptr.subtractOne(elem, this)) {


### PR DESCRIPTION
A lot of places in the collections library share a similar `IndexOutOfBoundsException` error message.
This PR extracts it to a common place in the package object as a private method.

The reasoning for this is actually to try to reduce the code size of some methods (similarly to what's done in https://github.com/scala/scala/blob/a9078fb4fd4d1bf5c3a9f1eb0b5f277ec048a42f/src/library/scala/runtime/Statics.java#L190-L197).

One method where the code size is particularly problematic is `ArrayBuffer#checkWithinBounds`: https://github.com/scala/scala/blob/a9078fb4fd4d1bf5c3a9f1eb0b5f277ec048a42f/src/library/scala/collection/mutable/ArrayBuffer.scala#L101-L104

While this method is marked as `@inline`, Scala Native's Interflow is not able to inline this due to code size (See https://github.com/scala-native/scala-native/issues/4040#issuecomment-2389431329). I'm not entirely sure if this change is enough to make the code inlineable or if it needs further refactoring, but I believe the changes on this PR should improve the status quo.

Also, I only focused on the collections, but this same issue also happens in `Product`. I'm not sure if that's much of a problem, though.

Godbolt example: https://godbolt.org/z/Ts46TEn3K