### PR TITLE
Fix `BigInt#testBit` to throw `ArithmeticException` when `n` is negative

### DIFF
--- a/src/library/scala/math/BigInt.scala
+++ b/src/library/scala/math/BigInt.scala
@@ -379,7 +379,7 @@ final class BigInt private (private var _bigInteger: BigInteger, private val _lo
       else if (_long < 0) BigInt(-1)
       else BigInt(0) // for _long >= 0
     } else BigInt(this.bigInteger.shiftRight(n))
-  
+
   /** Bitwise and of BigInts
    */
   def &(that: BigInt): BigInt =
@@ -501,7 +501,7 @@ final class BigInt private (private var _bigInteger: BigInteger, private val _lo
         (_long & (1L << n)) != 0
       else
         _long < 0 // give the sign bit
-    } else _bigInteger.testBit(n)
+    } else this.bigInteger.testBit(n)
 
   /** Returns a BigInt whose value is equivalent to this BigInt with the designated bit set.
    */

--- a/test/junit/scala/math/BigIntTest.scala
+++ b/test/junit/scala/math/BigIntTest.scala
@@ -30,7 +30,7 @@ class BigIntTest {
 
   @Test def `/% respects BigInteger`: Unit = assertThrows[ArithmeticException](bigint /% BigInt(0), _.contains("/ by zero"))
 
-  @Test def `testBit respects BigInteger`: Unit = assertThrows[ArithmeticException](bigint.testBit(-3), _.contains("Negative bit address"))
+  @Test def `testBit respects BigInteger`: Unit = assertThrows[ArithmeticException](BigInt(10).testBit(-3), _.contains("Negative bit address"))
 
   @Test def `testBit 0`: Unit = assertFalse(bigint.testBit(0))
 

--- a/test/junit/scala/math/BigIntTest.scala
+++ b/test/junit/scala/math/BigIntTest.scala
@@ -1,14 +1,17 @@
 package scala.math
 
+import java.util.concurrent.atomic.AtomicLong
 import org.junit.Test
 import org.junit.Assert.{assertFalse, assertNull, assertTrue}
 import scala.tools.testkit.AssertUtil.assertThrows
 
 class BigIntTest {
 
-  private val bigint = BigInt(42)
+  private val counter = new AtomicLong(Int.MaxValue)
+  private def bigint = BigInt(counter.getAndIncrement)
+  private def even = BigInt(42)
 
-  @Test def testIsComparable: Unit = assertTrue(BigInt(42).isInstanceOf[java.lang.Comparable[_]])
+  @Test def testIsComparable: Unit = assertTrue(bigint.isInstanceOf[java.lang.Comparable[_]])
 
   @Test def `mod respects BigInteger`: Unit = assertThrows[ArithmeticException](bigint mod BigInt(-3), _.contains("modulus not positive"))
 
@@ -30,9 +33,9 @@ class BigIntTest {
 
   @Test def `/% respects BigInteger`: Unit = assertThrows[ArithmeticException](bigint /% BigInt(0), _.contains("/ by zero"))
 
-  @Test def `testBit respects BigInteger`: Unit = assertThrows[ArithmeticException](BigInt(10).testBit(-3), _.contains("Negative bit address"))
+  @Test def `testBit respects BigInteger`: Unit = assertThrows[ArithmeticException](bigint.testBit(-3), _.contains("Negative bit address"))
 
-  @Test def `testBit 0`: Unit = assertFalse(bigint.testBit(0))
+  @Test def `testBit 0`: Unit = assertFalse(even.testBit(0))
 
   @Test def `BitInteger to BitInt respects null`: Unit = assertNull(null.asInstanceOf[java.math.BigInteger]: BigInt)
 }


### PR DESCRIPTION
The `_bigInteger` field, a mutable value initialized by `BigInt#bigInteger`, is accessed directly by `BigInt#testBit` when the input `n` is negative. As a result, `testBit` currently throws a `NullPointerException`.

The expected behavior is for `testBit` to throw an `ArithmeticException` when `n` is negative, as specified by the underlying `java.math.BigInteger` API: https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/math/BigInteger.html#testBit(int)

This issue was not detected in `BigIntTest` because `_bigInteger` is initialized by earlier tests. Additionally, using `BigInt(42).testBit(-3)` for testing does not reproduce the issue, as `BigInt(42)` uses a cached instance where `_bigInteger` is already initialized.

See:
- https://github.com/scala-native/scala-native/issues/2897
- https://github.com/scala/scala/pull/9628