### PR TITLE
Warn implicit is wrapper of enclosing class [ci: last-only]

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -223,7 +223,7 @@ trait Warnings {
     val RecurseWithDefault     = LintWarning("recurse-with-default",      "Recursive call used default argument.")
     val UnitSpecialization     = LintWarning("unit-special",              "Warn for specialization of Unit in parameter position.")
     val ImplicitRecursion      = LintWarning("implicit-recursion",        "Implicit resolves to an enclosing definition.")
-    val UniversalMethods       = LintWarning("universal-methods",         "Require arg to is/asInstanceOf. No Unit receiver.")
+    val UniversalMethods       = LintWarning("universal-methods",         "Dubious usage of member of `Any` or `AnyRef`.")
     val NumericMethods         = LintWarning("numeric-methods",           "Dubious usages, such as `42.isNaN`.")
     val ArgDiscard             = LintWarning("arg-discard",               "-Wvalue-discard for adapted arguments.")
     val IntDivToFloat          = LintWarning("int-div-to-float",          "Warn when an integer division is converted (widened) to floating point: `(someInt / 2): Double`.")

--- a/src/compiler/scala/tools/nsc/tasty/bridge/FlagOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/FlagOps.scala
@@ -71,10 +71,10 @@ trait FlagOps { self: TastyUniverse =>
     def is(mask: TastyFlagSet)(implicit ctx: Context): Boolean =
       sym.hasAllFlags(unsafeEncodeTastyFlagSet(mask, ctx.isJava))
     def is(mask: TastyFlagSet, butNot: TastyFlagSet)(implicit ctx: Context): Boolean =
-      if (!butNot)
-        sym.is(mask)
+      if (butNot.hasFlags)
+        is(mask) && not(butNot)
       else
-        sym.is(mask) && sym.not(butNot)
+        is(mask)
     def not(mask: TastyFlagSet)(implicit ctx: Context): Boolean =
       sym.hasNoFlags(unsafeEncodeTastyFlagSet(mask, ctx.isJava))
   }

--- a/src/compiler/scala/tools/nsc/tasty/bridge/SymbolOps.scala
+++ b/src/compiler/scala/tools/nsc/tasty/bridge/SymbolOps.scala
@@ -74,7 +74,7 @@ trait SymbolOps { self: TastyUniverse =>
     def isTraitParamAccessor: Boolean = sym.owner.isTrait && repr.tflags.is(FieldAccessor|ParamSetter)
 
     def isParamGetter: Boolean =
-      sym.isMethod && sym.repr.tflags.is(FlagSets.ParamGetter)
+      sym.isMethod && repr.tflags.is(FlagSets.ParamGetter)
 
     /** A computed property that should only be called on a symbol which is known to have been initialised by the
      *  Tasty Unpickler and is not yet completed.

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -24,8 +24,9 @@ import scala.collection.mutable, mutable.{LinkedHashMap, ListBuffer}
 import scala.language.implicitConversions
 import scala.reflect.internal.util.{ReusableInstance, Statistics, TriState}
 import scala.reflect.internal.TypesStats
-import scala.tools.nsc.Reporting.WarningCategory
+import scala.tools.nsc.Reporting.WarningCategory.{Scala3Migration, WFlagSelfImplicit}
 import symtab.Flags._
+import PartialFunction.cond
 
 /** This trait provides methods to find various kinds of implicits.
  *
@@ -135,15 +136,32 @@ trait Implicits extends splain.SplainData {
         }
       }
       if (settings.lintImplicitRecursion) {
-        val s = if (rts.isAccessor) rts.accessed else if (rts.isModule) rts.moduleClass else rts
-        if (s != NoSymbol && context.owner.hasTransOwner(s))
-          context.warning(result.tree.pos, s"Implicit resolves to enclosing $rts", WarningCategory.WFlagSelfImplicit)
+        val s =
+          if (rts.isAccessor) rts.accessed
+          else if (rts.isModule) rts.moduleClass
+          else rts
+        val rtsIsImplicitWrapper = isView && rts.isMethod && rts.isSynthetic && rts.isImplicit
+        def isSelfEnrichment(encl: Symbol): Boolean =
+          tree.symbol.isParamAccessor && tree.symbol.owner == encl && !encl.isDerivedValueClass
+        def targetsUniversalMember(encl: Symbol): Boolean = cond(pt) {
+          case TypeRef(pre, sym, _ :: RefinedType(WildcardType :: Nil, decls) :: Nil) =>
+            sym == FunctionClass(1) &&
+            decls.exists(d => d.isMethod && d.info == WildcardType && isUniversalMember(encl.info.member(d.name)))
+        }
+        if (s != NoSymbol)
+          context.owner.ownersIterator
+           .find(encl => encl == s || rtsIsImplicitWrapper &&
+              encl.owner == rts.owner && encl.isClass && encl.isImplicit && encl.name == rts.name.toTypeName) match {
+            case Some(encl) if !encl.isClass || encl.isModuleClass || isSelfEnrichment(encl) || targetsUniversalMember(encl) =>
+              context.warning(result.tree.pos, s"Implicit resolves to enclosing $encl", WFlagSelfImplicit)
+            case _ =>
+          }
       }
       if (result.inPackagePrefix && currentRun.isScala3) {
         val msg =
           s"""Implicit $rts was found in a package prefix of the required type, which is not part of the implicit scope in Scala 3 (or with -Xsource-features:package-prefix-implicits).
              |For migration, add `import ${rts.fullNameString}`.""".stripMargin
-        context.warning(result.tree.pos, msg, WarningCategory.Scala3Migration)
+        context.warning(result.tree.pos, msg, Scala3Migration)
       }
     }
     implicitSearchContext.emitImplicitDictionary(result)

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -152,29 +152,28 @@ trait Implicits extends splain.SplainData {
           encl.owner == rts.owner && encl.isClass && encl.isImplicit && encl.name == rts.name.toTypeName
         if (target != NoSymbol)
           context.owner.ownersIterator
-          .find(encl => encl == target || rtsIsImplicitWrapper && targetsImplicitWrapper(encl)) match {
-            case Some(encl) =>
-              var doWarn = false
-              var help = ""
-              if (!encl.isClass) {
-                doWarn = true
-                if (encl.isMethod && targetsUniversalMember(encl.info.finalResultType))
-                  help = s"; the conversion adds a member of AnyRef to ${tree.symbol}"
-              }
-              else if (encl.isModuleClass) {
-                doWarn = true
-              }
-              else if (isSelfEnrichment(encl)) {
-                doWarn = true
-                help = s"; the enrichment wraps ${tree.symbol}"
-              }
-              else if (targetsUniversalMember(encl.info)) {
-                doWarn = true
+          .find(encl => encl == target || rtsIsImplicitWrapper && targetsImplicitWrapper(encl))
+          .foreach { encl =>
+            var doWarn = false
+            var help = ""
+            if (!encl.isClass) {
+              doWarn = true
+              if (encl.isMethod && targetsUniversalMember(encl.info.finalResultType))
                 help = s"; the conversion adds a member of AnyRef to ${tree.symbol}"
-              }
-              if (doWarn)
-                context.warning(result.tree.pos, s"Implicit resolves to enclosing $encl$help", WFlagSelfImplicit)
-            case _ =>
+            }
+            else if (encl.isModuleClass) {
+              doWarn = true
+            }
+            else if (isSelfEnrichment(encl)) {
+              doWarn = true
+              help = s"; the enrichment wraps ${tree.symbol}"
+            }
+            else if (targetsUniversalMember(encl.info)) {
+              doWarn = true
+              help = s"; the conversion adds a member of AnyRef to ${tree.symbol}"
+            }
+            if (doWarn)
+              context.warning(result.tree.pos, s"Implicit resolves to enclosing $encl$help", WFlagSelfImplicit)
           }
       }
       if (result.inPackagePrefix && currentRun.isScala3) {

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1332,10 +1332,30 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           case coercion  =>
             if (settings.logImplicitConv.value)
               context.echo(qual.pos, s"applied implicit conversion from ${qual.tpe} to ${searchTemplate} = ${coercion.symbol.defString}")
-
             if (currentRun.isScala3 && coercion.symbol == currentRun.runDefinitions.Predef_any2stringaddMethod)
               if (!currentRun.sourceFeatures.any2StringAdd)
                 runReporting.warning(qual.pos, s"Converting to String for concatenation is not supported in Scala 3 (or with -Xsource-features:any2stringadd).", Scala3Migration, coercion.symbol)
+            if (settings.lintUniversalMethods) {
+              def targetsUniversalMember(target: => Type): Option[Symbol] = searchTemplate match {
+                case HasMethodMatching(name, argtpes, restpe) =>
+                  target.member(name)
+                   .alternatives
+                   .find { m =>
+                      def argsOK = m.paramLists match {
+                        case h :: _ => argtpes.corresponds(h.map(_.info))(_ <:< _)
+                        case nil    => argtpes.isEmpty
+                      }
+                      isUniversalMember(m) && argsOK
+                   }
+                case RefinedType(WildcardType :: Nil, decls) =>
+                  decls.find(d => d.isMethod && d.info == WildcardType && isUniversalMember(target.member(d.name)))
+                case _ =>
+                  None
+              }
+              for (target <- targetsUniversalMember(coercion.symbol.info.finalResultType))
+                context.warning(qual.pos, s"conversion ${coercion.symbol.nameString} adds universal member $target to ${qual.tpe.typeSymbol}",
+                  WarningCategory.LintUniversalMethods)
+            }
             typedQualifier(atPos(qual.pos)(new ApplyImplicitView(coercion, List(qual))))
         }
       }

--- a/test/files/neg/adapt-to-any-member.check
+++ b/test/files/neg/adapt-to-any-member.check
@@ -1,0 +1,6 @@
+adapt-to-any-member.scala:6: warning: conversion Elvis adds universal member method eq to type A
+  def f[A](x: A) = if (x eq null) 0 else 1 // warn
+                       ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/adapt-to-any-member.scala
+++ b/test/files/neg/adapt-to-any-member.scala
@@ -1,0 +1,14 @@
+
+//> using options -Werror -Xlint:universal-methods
+
+class C {
+  import C._
+  def f[A](x: A) = if (x eq null) 0 else 1 // warn
+  def g[A](x: A) = if (x.hashCode(0) == 0) 0 else 1 // nowarn
+}
+object C {
+  implicit class Elvis[A](alt: => A) {
+    def ?:(a: A): A = if (a.asInstanceOf[AnyRef] ne null) a else alt
+    def hashCode(seed: Int): Int = seed
+  }
+}

--- a/test/files/neg/i17266.check
+++ b/test/files/neg/i17266.check
@@ -10,9 +10,18 @@ i17266.scala:32: warning: notify not selected from this instance
 i17266.scala:33: warning: notifyAll not selected from this instance
   def `maybe notifyAll`(): Unit = notifyAll()
                                   ^
+i17266.scala:53: warning: conversion int2Integer adds universal member method synchronized to class Int
+    1.synchronized { // warn
+    ^
+i17266.scala:165: warning: conversion int2Integer adds universal member method wait to class Int
+    1.wait() // not an error (should be?)
+    ^
+i17266.scala:183: warning: conversion int2Integer adds universal member method wait to class Int
+    1.wait(10) // not an error (should be?)
+    ^
 i17266.scala:53: warning: Suspicious `synchronized` call involving boxed primitive `Integer`
     1.synchronized { // warn
       ^
 error: No warnings can be incurred under -Werror.
-5 warnings
+8 warnings
 1 error

--- a/test/files/neg/t12226.check
+++ b/test/files/neg/t12226.check
@@ -1,13 +1,13 @@
-t12226.scala:6: warning: Implicit resolves to enclosing class Elvis
+t12226.scala:6: warning: Implicit resolves to enclosing class Elvis; the conversion adds a member of AnyRef to value a
   implicit class Elvis[A](alt: => A) { def ?:(a: A): A = if (a ne null) a else alt } // warn
                                                              ^
-t12226.scala:9: warning: Implicit resolves to enclosing method f
+t12226.scala:9: warning: Implicit resolves to enclosing method f; the conversion adds a member of AnyRef to value a
   implicit def f[A](a: A): String = if (a ne null) a else "nope" // warn
                                         ^
 t12226.scala:9: warning: Implicit resolves to enclosing method f
   implicit def f[A](a: A): String = if (a ne null) a else "nope" // warn
                                                    ^
-t12226.scala:21: warning: Implicit resolves to enclosing class StringOps
+t12226.scala:21: warning: Implicit resolves to enclosing class StringOps; the enrichment wraps value s
     def normal: String = s.crazy.crazy // warn
                          ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t12226.check
+++ b/test/files/neg/t12226.check
@@ -1,0 +1,15 @@
+t12226.scala:6: warning: Implicit resolves to enclosing class Elvis
+  implicit class Elvis[A](alt: => A) { def ?:(a: A): A = if (a ne null) a else alt } // warn
+                                                             ^
+t12226.scala:9: warning: Implicit resolves to enclosing method f
+  implicit def f[A](a: A): String = if (a ne null) a else "nope" // warn
+                                        ^
+t12226.scala:9: warning: Implicit resolves to enclosing method f
+  implicit def f[A](a: A): String = if (a ne null) a else "nope" // warn
+                                                   ^
+t12226.scala:21: warning: Implicit resolves to enclosing class StringOps
+    def normal: String = s.crazy.crazy // warn
+                         ^
+error: No warnings can be incurred under -Werror.
+4 warnings
+1 error

--- a/test/files/neg/t12226.scala
+++ b/test/files/neg/t12226.scala
@@ -1,0 +1,24 @@
+//> using options -Xlint:implicit-recursion -Werror
+
+import language.implicitConversions
+
+object X {
+  implicit class Elvis[A](alt: => A) { def ?:(a: A): A = if (a ne null) a else alt } // warn
+}
+object Y {
+  implicit def f[A](a: A): String = if (a ne null) a else "nope" // warn
+}
+object Z {
+  implicit class StringOps(val s: String) extends AnyVal {
+    def crazy: String = s.reverse
+    def normal: String = s.crazy.crazy // nowarn value class
+    def join(other: String): String = crazy + other.crazy // nowarn
+  }
+}
+object ZZ {
+  implicit class StringOps(s: String) {
+    def crazy: String = s.reverse
+    def normal: String = s.crazy.crazy // warn
+    def join(other: String): String = crazy + other.crazy // nowarn
+  }
+}


### PR DESCRIPTION
Fixes scala/bug#12226

Also take Lukas's idea of linting when a conversion adds a universal method.