### PR TITLE
Reduce memory footprint of evaluated elements in LazyList

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -45,6 +45,17 @@ object MimaFilters extends AutoPlugin {
 
     // scala/scala#10927
     ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.concurrent.Future.onCompleteWithUnregister"),
+
+    // scala/scala#10937
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.immutable.LazyList#LazyBuilder#DeferredState.eval"),
+    ProblemFilters.exclude[MissingClassProblem](s"scala.collection.immutable.LazyList$$State"),
+    ProblemFilters.exclude[MissingClassProblem](s"scala.collection.immutable.LazyList$$State$$"),
+    ProblemFilters.exclude[MissingClassProblem](s"scala.collection.immutable.LazyList$$State$$Cons"),
+    ProblemFilters.exclude[MissingClassProblem](s"scala.collection.immutable.LazyList$$State$$Empty$$"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.LazyList$EmptyMarker$"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.immutable.LazyList#LazyBuilder#DeferredState.eval"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.LazyList$MidEvaluation$"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.LazyList$Uninitialized$"),
   )
 
   override val buildSettings = Seq(

--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -1372,7 +1372,7 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
     if (it.hasNext) {
       jsb.append(it.next())
       while (it.hasNext) {
-        jsb.append(sep)
+        if (sep.length != 0) jsb.append(sep)
         jsb.append(it.next())
       }
     }

--- a/test/junit/scala/collection/Sizes.scala
+++ b/test/junit/scala/collection/Sizes.scala
@@ -1,8 +1,11 @@
 package scala.collection
 
 import org.junit._
+
 import scala.collection.mutable.ListBuffer
 import org.openjdk.jol.info.GraphLayout
+
+import scala.annotation.nowarn
 
 object Sizes {
   def list: Int = 24
@@ -41,6 +44,27 @@ class Sizes {
     val wrapped = Array[String]("")
     assertTotalSize(16, JOL.netLayout(mutable.ArraySeq.make[String](wrapped), wrapped))
     assertTotalSize(16, JOL.netLayout(immutable.ArraySeq.unsafeWrapArray[String](wrapped), wrapped))
+  }
+
+  @Test
+  def stream(): Unit = {
+    def next = new Object
+    @nowarn("cat=deprecation")
+    val st = Stream.continually(next).take(100)
+    locally(st.mkString) // force 100 elements
+    val l = JOL.netLayout(st)
+    // println(l.toFootprint)
+    assertTotalSize(4016, l)
+  }
+
+  @Test
+  def lazyList(): Unit = {
+    def next = new Object
+    val ll = LazyList.continually(next).take(100)
+    locally(ll.mkString) // force 100 elements
+    val l = JOL.netLayout(ll)
+    // println(l.toFootprint)
+    assertTotalSize(4024, l)
   }
 }
 

--- a/test/junit/scala/collection/immutable/LazyListGCTest.scala
+++ b/test/junit/scala/collection/immutable/LazyListGCTest.scala
@@ -116,4 +116,10 @@ class LazyListGCTest {
   def tails_zipWithIndex_foreach_allowsGC(): Unit = {
     assertLazyListOpAllowsGC((ll, check) => ll.tails.zipWithIndex.foreach { case (_, i) => check(i) }, _ => ())
   }
+
+  @Test
+  def foldLeft(): Unit = {
+    // fails when using `/:` instead of `foldLeft`
+    assertLazyListOpAllowsGC((ll, check) => ll.foldLeft(0){ case (s, x) => check(x); s + x}, _ => ())
+  }
 }


### PR DESCRIPTION
The LazyList implementation uses two objects per evaluated value,
a LazyList and one State instance. So the overhead for evaluated
values is 2x compared to Stream.

This PR reduces the overhead to one LazyList instance with two
fields (head and tail) per evaluated value.

Thread safety is implemented through checking the volatile `head`
field and synchronizing on `this` for initialization. This is
the equivalent to the previous implementation which uses a `lazy val`.

### Breaking change

Serialization is not compatible. Non-evaluated (tails of) lazy lists are
serialized using plain object serialization. The internals are
different and serialization is incompatible in both directions.

Fixes https://github.com/scala/bug/issues/13062