### PR TITLE
Make `Iterator.empty` also be `i.Iterable`

### DIFF
--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -985,7 +985,7 @@ object Iterator extends IterableFactory[Iterator] {
   override def from[A](source: IterableOnce[A]): Iterator[A] = source.iterator
 
   /** The iterator which produces no values. */
-  @`inline` final def empty[T]: Iterator[T] = _empty
+  @`inline` final def empty[A]: Iterator[A] with immutable.Iterable[A] = _empty
 
   def single[A](a: A): Iterator[A] = new AbstractIterator[A] {
     private[this] var consumed: Boolean = false

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -968,12 +968,13 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
 @SerialVersionUID(3L)
 object Iterator extends IterableFactory[Iterator] {
 
-  private[this] val _empty: Iterator[Nothing] = new AbstractIterator[Nothing] {
-    def hasNext = false
-    def next() = throw new NoSuchElementException("next on empty iterator")
-    override def knownSize: Int = 0
-    override protected def sliceIterator(from: Int, until: Int): AbstractIterator[Nothing] = this
-  }
+  private[this] val _empty: Iterator[Nothing] with immutable.Iterable[Nothing] =
+    new AbstractIterator[Nothing] with immutable.Iterable[Nothing] {
+      def hasNext = false
+      def next() = throw new NoSuchElementException("next on empty iterator")
+      override def knownSize: Int = 0
+      override protected def sliceIterator(from: Int, until: Int): AbstractIterator[Nothing] = this
+    }
 
   /** Creates a target $coll from an existing source collection
     *


### PR DESCRIPTION
I noticed that `Iterator.empty` is by definition both immutable and repeatedly iterable, so I decided its type may as well reflect that.

If folks dislike changing the typing of the public method, I'm happy to remove the second commit