### PR TITLE
Always type body of default case in switch translation

### DIFF
--- a/test/files/pos/t13060.scala
+++ b/test/files/pos/t13060.scala
@@ -8,3 +8,19 @@ class C {
     println()
   }
 }
+
+class D {
+  def foo(): Unit = ()
+  def b: Boolean = false
+
+  def bug(x: Int): Unit = {
+    (x: @annotation.switch) match {
+      case 2 if b =>
+        foo()
+      case _ if b =>
+        foo()
+      case _ =>
+        foo()
+    }
+  }
+}


### PR DESCRIPTION
In case there are multiple `_` cases (with guards), switch translation combines them into if-then-else.

This AST needs to be typed in order to assign the correct type to the `default:` label.

yolo-up to https://github.com/scala/scala/pull/10926 (which is itself a followup to #10884)