### PR TITLE
Print import given which is never a rename

### DIFF
--- a/src/reflect/scala/reflect/internal/Printers.scala
+++ b/src/reflect/scala/reflect/internal/Printers.scala
@@ -31,7 +31,7 @@ trait Printers extends api.Printers { self: SymbolTable =>
   def quotedName(name: Name, decode: Boolean): String = {
     val s = if (decode) name.decode else name.toString
     val term = name.toTermName
-    if (nme.keywords(term) && term != nme.USCOREkw) "`%s`" format s
+    if (nme.keywords(term) && term != nme.USCOREkw) s"`$s`"
     else s
   }
   def quotedName(name: Name): String = quotedName(name, decode = false)
@@ -272,9 +272,9 @@ trait Printers extends api.Printers { self: SymbolTable =>
 
       def selectorToString(s: ImportSelector): String = {
         def selectorName(n: Name): String = if (s.isWildcard) nme.WILDCARD.decoded else quotedName(n)
-        val from = selectorName(s.name)
-        if (s.isRename || s.isMask) from + "=>" + selectorName(s.rename)
-        else from
+        if (s.isGiven) s.rename.decoded
+        else if (s.isRename || s.isMask) s"${selectorName(s.name)}=>${selectorName(s.rename)}"
+        else selectorName(s.name)
       }
       print("import ", resSelect, ".")
       selectors match {

--- a/test/files/pos/import-future.scala
+++ b/test/files/pos/import-future.scala
@@ -44,3 +44,17 @@ object X {
   import T.given
   def g = T.f[Int] // was given is not a member
 }
+
+class status_quo {
+  import scala.util.chaining._
+  import scala.concurrent.duration._
+  def f = 42.tap(println)
+  def g = 42.seconds
+}
+
+class givenly {
+  import scala.util.chaining.given
+  import scala.concurrent.duration.given
+  def f = 42.tap(println)
+  def g = 42.seconds
+}

--- a/test/files/run/t13038.check
+++ b/test/files/run/t13038.check
@@ -1,0 +1,9 @@
+
+scala> import scala.util.chaining.given
+import scala.util.chaining.given
+
+scala> 42.tap(println)
+42
+val res0: Int = 42
+
+scala> :quit

--- a/test/files/run/t13038.scala
+++ b/test/files/run/t13038.scala
@@ -1,0 +1,6 @@
+
+import scala.tools.partest.SessionTest
+
+object Test extends SessionTest {
+  override def extraSettings = s"${super.extraSettings} -Xsource:3"
+}


### PR DESCRIPTION
Fixes scala/bug#13038

Stringly REPL relies on correct printing.