### PR TITLE
Improve position reporting for infix operations [ci: last-only]

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
@@ -55,11 +55,6 @@ abstract class TreeBuilder {
   def makeSelfDef(name: TermName, tpt: Tree): ValDef =
     ValDef(Modifiers(PRIVATE), name, tpt, EmptyTree)
 
-  /** Tree for `od op`, start is start0 if od.pos is borked. */
-  def makePostfixSelect(start: Int, end: Int, od: Tree, op: Name): Tree = {
-    atPos(r2p(start, end, end + op.length)) { Select(od, op.encode) }.updateAttachment(PostfixAttachment)
-  }
-
   /** Create tree representing a while loop */
   def makeWhile(startPos: Int, cond: Tree, body: Tree): Tree = {
     val lname = freshTermName(nme.WHILE_PREFIX)

--- a/test/files/neg/dotless-targs-a.check
+++ b/test/files/neg/dotless-targs-a.check
@@ -2,15 +2,15 @@ dotless-targs-a.scala:4: error: type application is not allowed for infix operat
 Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or @nowarn to demote them to warnings or suppress.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def fn2 = List apply[Int] 2
-                 ^
+                      ^
 dotless-targs-a.scala:9: error: type application is not allowed for infix operators [quickfixable]
 Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or @nowarn to demote them to warnings or suppress.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
-                ^
+                     ^
 dotless-targs-a.scala:9: error: type application is not allowed for infix operators [quickfixable]
 Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or @nowarn to demote them to warnings or suppress.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
-                                                    ^
+                                                               ^
 3 errors

--- a/test/files/neg/dotless-targs-b.check
+++ b/test/files/neg/dotless-targs-b.check
@@ -2,15 +2,15 @@ dotless-targs-b.scala:4: error: type application is not allowed for infix operat
 Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or @nowarn to demote them to warnings or suppress.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def fn2 = List apply[Int] 2
-                 ^
+                      ^
 dotless-targs-b.scala:9: error: type application is not allowed for infix operators [quickfixable]
 Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or @nowarn to demote them to warnings or suppress.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
-                ^
+                     ^
 dotless-targs-b.scala:9: error: type application is not allowed for infix operators [quickfixable]
 Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or @nowarn to demote them to warnings or suppress.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
-                                                    ^
+                                                               ^
 3 errors

--- a/test/files/neg/dotless-targs-ranged-a.check
+++ b/test/files/neg/dotless-targs-ranged-a.check
@@ -1,18 +1,18 @@
 dotless-targs-ranged-a.scala:4: warning: type application is not allowed for infix operators [quickfixable]
   def fn2 = List apply[Int] 2
-                 ^
+                      ^
 dotless-targs-ranged-a.scala:9: warning: type application is not allowed for infix operators [quickfixable]
   def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
-                ^
+                     ^
 dotless-targs-ranged-a.scala:9: warning: type application is not allowed for infix operators [quickfixable]
   def h1 = List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
-                                                    ^
+                                                               ^
 dotless-targs-ranged-a.scala:13: warning: type application is not allowed for infix operators [quickfixable]
   def eval = 1 ->[Int] 2
-               ^
+                 ^
 dotless-targs-ranged-a.scala:14: warning: type application is not allowed for infix operators [quickfixable]
   def evil = new A() op  [Int,   String     ]  42
-                     ^
+                         ^
 dotless-targs-ranged-a.scala:11: warning: type parameter A defined in method op shadows class A defined in package <empty>. You may want to rename your type parameter, or possibly remove it.
   def op[A, B](i: Int): Int = 2*i
          ^

--- a/test/files/neg/dotless-targs.check
+++ b/test/files/neg/dotless-targs.check
@@ -1,4 +1,4 @@
 dotless-targs.scala:4: error: type application is not allowed for postfix operators
   def f1 = "f1" isInstanceOf[String] // not ok
-                ^
+                            ^
 1 error

--- a/test/files/neg/t12798-migration.check
+++ b/test/files/neg/t12798-migration.check
@@ -33,7 +33,7 @@ t12798-migration.scala:43: error: type application is not allowed for infix oper
 Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or @nowarn to demote them to warnings or suppress.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def f = List(42) map [Int] (_ + 1)
-                   ^
+                       ^
 t12798-migration.scala:46: error: Top-level wildcard is not allowed
 Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or @nowarn to demote them to warnings or suppress.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration

--- a/test/files/neg/t12798.check
+++ b/test/files/neg/t12798.check
@@ -33,7 +33,7 @@ t12798.scala:43: error: type application is not allowed for infix operators [qui
 Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or @nowarn to demote them to warnings or suppress.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def f = List(42) map [Int] (_ + 1)
-                   ^
+                       ^
 t12798.scala:46: error: Top-level wildcard is not allowed
 Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or @nowarn to demote them to warnings or suppress.
 Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration

--- a/test/files/neg/t8182.check
+++ b/test/files/neg/t8182.check
@@ -6,17 +6,17 @@ t8182.scala:7: error: illegal start of simple pattern
 ^
 t8182.scala:6: error: type application is not allowed in pattern
   val a b[B]  // error then continue as for X
-        ^
+         ^
 t8182.scala:10: error: illegal start of simple pattern
     case a b[B] => // bumpy recovery
                 ^
 t8182.scala:10: error: type application is not allowed in pattern
     case a b[B] => // bumpy recovery
-           ^
+            ^
 t8182.scala:11: error: '=>' expected but '}' found.
   }
   ^
 t8182.scala:16: error: type application is not allowed in pattern
     case a B[T] b =>
-           ^
+            ^
 7 errors

--- a/test/files/run/macro-parse-position.check
+++ b/test/files/run/macro-parse-position.check
@@ -1,5 +1,5 @@
 false
-source-<macro>,line-1,offset=4
+RangePosition(<macro>, 0, 4, 7)
 8
 foo bar
 

--- a/test/files/run/t10240.check
+++ b/test/files/run/t10240.check
@@ -1,0 +1,33 @@
+
+List apply 1
+[0:12][0:10]List.apply([11:12]1)
+List apply 1
+
+List apply[Int] 2
+[0:17][0:15][0:10]List.apply[[11:14]Int]([16:17]2)
+List apply[Int] 2
+List apply[Int]
+
+List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
+[0:72][0:63][0:52]List.apply[List[Int]](List(1), List(2)).mapConserve[[53:62][53:57]List[[58:61]Any]]([65:71](([65:66]x) => [70:71]x))
+List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)
+List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]]
+List apply[List[Int]]
+
+1 ->[Int] 2
+[0:11][0:9][0:4]1.$minus$greater[[5:8]Int]([10:11]2)
+1 ->[Int] 2
+1 ->[Int]
+
+new A() op  [Int,   String     ]  42
+[0:36][0:32][0:10]new A().op[[13:16]Int, [20:26]String]([34:36]42)
+new A() op  [Int,   String     ]  42
+new A() op  [Int,   String     ]
+
+42 ::[Int] Nil
+[0:14]{
+  [0:2]final <synthetic> <artifact> val rassoc$1 = [0:2]42;
+  [3:14]<3:14><3:14>Nil.$colon$colon[[6:9]Int]([0]rassoc$1)
+}
+42 ::[Int] Nil
+::[Int] Nil

--- a/test/files/run/t10240.scala
+++ b/test/files/run/t10240.scala
@@ -1,0 +1,35 @@
+object Test extends App {
+  import scala.reflect.internal.util.StringContextStripMarginOps
+  import scala.reflect.runtime._
+  import scala.reflect.runtime.universe._
+  import scala.tools.reflect.ToolBox
+
+  val mirror = universe.runtimeMirror(universe.getClass.getClassLoader)
+  val toolbox = mirror.mkToolBox()
+  def showParsed(code: String) = {
+    val parsed = toolbox.parse(code)
+    def codeOf(pos: Position) = code.substring(pos.start, pos.end)
+    val recovered = codeOf(parsed.pos)
+    val pieces = parsed.collect {
+      case tree @ TypeApply(fun, args) => codeOf(tree.pos)
+    }
+    val display =
+      if (pieces.isEmpty) recovered
+      else
+        sm"""|$recovered
+             |${pieces.mkString("\n")}"""
+    println {
+      sm"""|
+           |$code
+           |${show(parsed, printPositions = true)}
+           |$display"""
+    }
+  }
+  showParsed("List apply 1")
+  showParsed("List apply[Int] 2")
+  showParsed("List apply[List[Int]] (List(1), List(2)) mapConserve[List[Any]] (x => x)")
+  showParsed("1 ->[Int] 2")
+  //def op[A, B](i: Int): Int = 2*i
+  showParsed("new A() op  [Int,   String     ]  42")
+  showParsed("42 ::[Int] Nil")
+}

--- a/test/files/run/t8859.check
+++ b/test/files/run/t8859.check
@@ -1,0 +1,24 @@
+
+x map f
+[0:7][0:5]x.map([6:7]f)
+x map f
+
+x map (f)
+[0:9][0:5]x.map([7:8]f)
+x map (f)
+
+x map ((f))
+[0:11][0:5]x.map([8:9]f)
+x map ((f))
+
+x map {f}
+[0:9][0:5]x.map([7:8]f)
+x map {f}
+
+x map {{f}}
+[0:11][0:5]x.map([8:9]f)
+x map {{f}}
+
+x map {({(f)})}
+[0:15][0:5]x.map([10:11]f)
+x map {({(f)})}

--- a/test/files/run/t8859.scala
+++ b/test/files/run/t8859.scala
@@ -1,0 +1,19 @@
+object Test extends App {
+  import scala.reflect.runtime._
+  import scala.reflect.runtime.universe._
+  import scala.tools.reflect.ToolBox
+
+  val mirror = universe.runtimeMirror(universe.getClass.getClassLoader)
+  val toolbox = mirror.mkToolBox()
+  def showParsed(code: String) = {
+    val parsed = toolbox.parse(code)
+    val recovered = code.substring(parsed.pos.start, parsed.pos.end)
+    println(s"\n$code\n${show(parsed, printPositions = true)}\n$recovered")
+  }
+  showParsed("x map f")
+  showParsed("x map (f)")
+  showParsed("x map ((f))")
+  showParsed("x map {f}")
+  showParsed("x map {{f}}")
+  showParsed("x map {({(f)})}")
+}


### PR DESCRIPTION
Retronym's old-timey test for https://github.com/scala/scala/pull/9761

It says there is still a missing closing infix bracket (!) https://github.com/scala/scala/pull/5787 so fix that even though the syntax is deprecated and sneered at by dotty.

```
List apply[Int] 42
42 ::[Int] Nil
```

Closes https://github.com/scala/bug/issues/8859

Follow-up to https://github.com/scala/scala/pull/5787