### PR TITLE
ArrayBuilder of Unit needs addAll forwarded

### DIFF
--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -1310,7 +1310,7 @@ private final class BitmapIndexedMapNode[K, +V](
         }
       }
     case _: HashCollisionMapNode[_, _] =>
-      throw new Exception("Cannot merge BitmapIndexedMapNode with HashCollisionMapNode")
+      throw new RuntimeException("Cannot merge BitmapIndexedMapNode with HashCollisionMapNode")
   }
 
   override def equals(that: Any): Boolean =
@@ -2061,7 +2061,7 @@ private final class HashCollisionMapNode[K, +V ](
         i += 1
       }
     case _: BitmapIndexedMapNode[K, V1] =>
-      throw new Exception("Cannot merge HashCollisionMapNode with BitmapIndexedMapNode")
+      throw new RuntimeException("Cannot merge HashCollisionMapNode with BitmapIndexedMapNode")
 
   }
 

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -317,9 +317,9 @@ object ArrayBuffer extends StrictOptimizedSeqFactory[ArrayBuffer] {
    *   - Throws an exception if `targetLen` exceeds `VM_MaxArraySize` or is negative (overflow).
    */
   private[mutable] def resizeUp(arrayLen: Int, targetLen: Int): Int =
-    if (targetLen < 0) throw new Exception(s"Overflow while resizing array of array-backed collection. Requested length: $targetLen; current length: $arrayLen; increase: ${targetLen - arrayLen}")
+    if (targetLen < 0) throw new RuntimeException(s"Overflow while resizing array of array-backed collection. Requested length: $targetLen; current length: $arrayLen; increase: ${targetLen - arrayLen}")
     else if (targetLen <= arrayLen) -1
-    else if (targetLen > VM_MaxArraySize) throw new Exception(s"Array of array-backed collection exceeds VM length limit of $VM_MaxArraySize. Requested length: $targetLen; current length: $arrayLen")
+    else if (targetLen > VM_MaxArraySize) throw new RuntimeException(s"Array of array-backed collection exceeds VM length limit of $VM_MaxArraySize. Requested length: $targetLen; current length: $arrayLen")
     else if (arrayLen > VM_MaxArraySize / 2) VM_MaxArraySize
     else math.max(targetLen, math.max(arrayLen * 2, DefaultInitialSize))
 

--- a/src/library/scala/collection/mutable/ArrayBuilder.scala
+++ b/src/library/scala/collection/mutable/ArrayBuilder.scala
@@ -46,7 +46,7 @@ sealed abstract class ArrayBuilder[T]
   protected[this] def resize(size: Int): Unit
 
   /** Add all elements of an array. */
-  def addAll(xs: Array[_ <: T]): this.type = doAddAll(xs, 0, xs.length)
+  def addAll(xs: Array[_ <: T]): this.type = addAll(xs, 0, xs.length)
 
   /** Add a slice of an array. */
   def addAll(xs: Array[_ <: T], offset: Int, length: Int): this.type = {

--- a/test/junit/scala/collection/mutable/ArrayBuilderTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBuilderTest.scala
@@ -30,7 +30,7 @@ class ArrayBuilderTest {
     assertThrows[Exception](ab.addAll(arr.iterator), _.endsWith("Requested length: -2147483645; current length: 2147483639; increase: 12"))
 
     // expect an exception when trying to grow larger than maximum size by addAll(array)
-    assertThrows[Exception](ab.addAll(arr))
+    assertThrows[Exception](ab.addAll(arr), _.startsWith("Overflow while resizing"))
   }
 
   // avoid allocating "default size" for empty, and especially avoid doubling capacity for empty

--- a/test/junit/scala/collection/mutable/ArrayBuilderTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBuilderTest.scala
@@ -1,8 +1,9 @@
 package scala.collection.mutable
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.{assertEquals, assertTrue}
 import org.junit.Test
 
+import scala.annotation._
 import scala.runtime.PStatics.VM_MaxArraySize
 import scala.tools.testkit.AssertUtil.assertThrows
 
@@ -45,5 +46,6 @@ class ArrayBuilderTest {
     val arr = Array[Unit]((), (), (), (), (), (), (), (), (), (), (), ())
     ab.addAll(arr)
     assertEquals(arr.length, ab.result().length)
+    assertTrue(ab.result().forall(_ == ())): @nowarn
   }
 }

--- a/test/junit/scala/collection/mutable/ArrayBuilderTest.scala
+++ b/test/junit/scala/collection/mutable/ArrayBuilderTest.scala
@@ -39,4 +39,11 @@ class ArrayBuilderTest {
     (1 to 100).foreach(_ => builder.addAll(Array.empty[String]))
     assertEquals(0, builder.knownSize)
   }
+
+  @Test def `t13068 addAll of array`: Unit = {
+    val ab: ArrayBuilder[Unit] = ArrayBuilder.make[Unit]
+    val arr = Array[Unit]((), (), (), (), (), (), (), (), (), (), (), ())
+    ab.addAll(arr)
+    assertEquals(arr.length, ab.result().length)
+  }
 }


### PR DESCRIPTION
Fixes scala/bug#13068

Follow-up to previous changes for resizing.

One `addAll` used to forward to the other. That changed just to avoid redundant range checks.