### PR TITLE
no more Travis-CI for PR validation, use GitHub Actions

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -40,4 +40,4 @@ jobs:
       - name: Test
         run: |
           STARR=`cat buildcharacter.properties | grep ^maven.version.number | cut -d= -f2` && echo $STARR
-          sbt -Dstarr.version=$STARR setupValidateTest test:compile info testAll
+          sbt -Dstarr.version=$STARR setupValidateTest Test/compile info testAll

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,30 @@
+name: PR validation
+on:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 8
+          cache: sbt
+      - name: Setup SBT
+        uses: sbt/setup-sbt@v1
+      # "mini" bootstrap for PR validation
+      # "mini" in these senses:
+      # - it doesn't use the complicated legacy scripts.
+      # - it doesn't publish to scala-pr-validation-snapshots
+      #   (because we need secrets for that and PRs from forks can't have secrets)
+      # it is still a true bootstrap.
+      - name: Stage 1
+        run: sbt -warn setupPublishCore generateBuildCharacterPropertiesFile headerCheck publishLocal
+      - name: Stage 2
+        run: |
+          STARR=`cat buildcharacter.properties | grep ^maven.version.number | cut -d= -f2` && echo $STARR
+          sbt -Dstarr.version=$STARR -warn setupValidateTest Test/compile info testAll

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ jobs:
 
       # build the spec using jekyll
       - stage: build
+        if: type != pull_request
         dist: focal
         language: ruby
         # ruby 3.x is default, need to upgrade jekyll. using 2.7 for now.
@@ -56,10 +57,10 @@ jobs:
           - bundler --version
           - bundle install
         script:
-        - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then (cd admin && ./init.sh); fi'
+        - '(cd admin && ./init.sh)'
         - bundle exec jekyll build -s spec/ -d build/spec
         after_success:
-        - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ./scripts/travis-publish-spec.sh; fi'
+        - ./scripts/travis-publish-spec.sh
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,20 +30,6 @@ jobs:
           - buildQuick
           - triggerScalaDist
 
-      # pull request validation (w/ mini-bootstrap)
-      # "mini" in these senses:
-      # - it doesn't use the complicated legacy scripts.
-      # - it doesn't publish to scala-pr-validation-snapshots
-      #   (because we need secrets for that and Travis-CI doesn't give PR jobs access to secrets)
-      # it is still a true bootstrap.
-      - stage: build
-        name: "JDK 8 pr validation"
-        if: type = pull_request
-        script:
-          - sbt -warn setupPublishCore generateBuildCharacterPropertiesFile headerCheck publishLocal
-          - STARR=`cat buildcharacter.properties | grep ^maven.version.number | cut -d= -f2` && echo $STARR
-          - sbt -Dstarr.version=$STARR -warn setupValidateTest test:compile info testAll
-
       # build the spec using jekyll
       - stage: build
         if: type != pull_request


### PR DESCRIPTION
also, do not build the spec during PR validation, doing so is overkill and spurious failures have been an ongoing annoyance. nightly ("mergely") is fine for this

this doesn't eliminate Travis-CI entirely. it will still publish nightlies and publish the spec. (for now, anyway.) for context on that, and for why we also keep Jenkins, see https://github.com/scala/scala-dev/issues/751

we could have made this limited change (to PR validation only) ages ago, but it didn't seem like a priority

but
* the contention for the one slot in our Travis-CI free plan has become annoying to me personally, especially around release time
* that same contention is also annoying to all contributors (including ourselves) when there is activity on multiple PRs (usually it's six Som Snytts, hacking away)
* the presence of Travis-CI in PR validation is confusing to contributors
* maybe GitHub Actions will be faster, which all of us would appreciate

and also, it dawned on me today that this might actually be quite easy, so why not just go ahead and try it?

cc @He-Pin who asked about this recently — the question got me thinking