### PR TITLE
Improve Array.copy performance

### DIFF
--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -106,7 +106,9 @@ object Array {
    */
   def copy(src: AnyRef, srcPos: Int, dest: AnyRef, destPos: Int, length: Int): Unit = {
     val srcClass = src.getClass
-    if (srcClass.isArray && dest.getClass.isAssignableFrom(srcClass))
+    val destClass = dest.getClass
+    if (srcClass.isArray && ((destClass eq srcClass) ||
+        (destClass.isArray && !srcClass.getComponentType.isPrimitive && !destClass.getComponentType.isPrimitive)))
       java.lang.System.arraycopy(src, srcPos, dest, destPos, length)
     else
       slowcopy(src, srcPos, dest, destPos, length)

--- a/test/benchmarks/src/main/scala/scala/collection/mutable/ArrayBufferBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/mutable/ArrayBufferBenchmark.scala
@@ -45,6 +45,17 @@ class ArrayBufferBenchmark {
     bh.consume(b)
   }
 
+  @Benchmark def toObjArrayTagged(bh:Blackhole):Unit = {
+    val res = ref.asInstanceOf[ArrayBuffer[Integer]].toArray
+    bh.consume(res)
+  }
+
+  @Benchmark def toObjArrayUntagged(bh:Blackhole):Unit = {
+    val res = ref.asInstanceOf[ArrayBuffer[AnyRef]].toArray
+    bh.consume(res)
+  }
+
+
   @Benchmark def update(bh: Blackhole): Unit = {
     val b = ref.clone()
     var i = 0


### PR DESCRIPTION
If source and dest are both non-primitive array types, then we can always use System.arraycopy and avoid the slowcopy branch. ArrayBuffer.toArray is added to the benchmark suite in order to avoid regressions and demonstrate the performance impact.


============================
We found that while debugging some performance issues in our product. I'm new to contributing to scala-core, is anything more needed from us? We're actually on scala3, but as far as I understood the stdlib is shared? Or do we need to submit a separate PR to dotty?

cc @mpollmeier

Benchmark results:
```
before:
[info] # JMH version: 1.37
[info] # VM version: JDK 21.0.5, OpenJDK 64-Bit Server VM, 21.0.5+11
[info] Benchmark                                (size)  Mode  Cnt      Score      Error  Units
[info] ArrayBufferBenchmark.toObjArrayTagged        10  avgt    3     22.612 ±    0.777  ns/op
[info] ArrayBufferBenchmark.toObjArrayTagged       100  avgt    3    138.671 ±    6.337  ns/op
[info] ArrayBufferBenchmark.toObjArrayTagged      1000  avgt    3   1481.954 ±   23.427  ns/op
[info] ArrayBufferBenchmark.toObjArrayTagged     10000  avgt    3  20339.480 ± 4783.063  ns/op
[info] ArrayBufferBenchmark.toObjArrayUntagged      10  avgt    3     12.081 ±    0.857  ns/op
[info] ArrayBufferBenchmark.toObjArrayUntagged     100  avgt    3     27.387 ±    1.870  ns/op
[info] ArrayBufferBenchmark.toObjArrayUntagged    1000  avgt    3    268.906 ±    0.578  ns/op
[info] ArrayBufferBenchmark.toObjArrayUntagged   10000  avgt    3   3275.216 ±  191.143  ns/op

after:
[info] Benchmark                                (size)  Mode  Cnt     Score      Error  Units
[info] ArrayBufferBenchmark.toObjArrayTagged        10  avgt    3    24.527 ±    2.174  ns/op
[info] ArrayBufferBenchmark.toObjArrayTagged       100  avgt    3    89.477 ±    5.532  ns/op
[info] ArrayBufferBenchmark.toObjArrayTagged      1000  avgt    3   967.160 ±   16.491  ns/op
[info] ArrayBufferBenchmark.toObjArrayTagged     10000  avgt    3  9293.766 ±  631.164  ns/op
[info] ArrayBufferBenchmark.toObjArrayUntagged      10  avgt    3    11.202 ±    0.234  ns/op
[info] ArrayBufferBenchmark.toObjArrayUntagged     100  avgt    3    27.401 ±    0.115  ns/op
[info] ArrayBufferBenchmark.toObjArrayUntagged    1000  avgt    3   273.243 ±   23.052  ns/op
[info] ArrayBufferBenchmark.toObjArrayUntagged   10000  avgt    3  3375.853 ± 2073.324  ns/op
```