### PR TITLE
Improve javaBootClassPath to lazily evaluate searchForBootClasspath

### DIFF
--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -72,7 +72,8 @@ object PathResolver {
      */
     def sourcePathEnv       = envOrElse("SOURCEPATH", "")
 
-    def javaBootClassPath   = propOrElse("sun.boot.class.path", searchForBootClasspath)
+    //using propOrNone/getOrElse instead of propOrElse so that searchForBootClasspath is lazy evaluated
+    def javaBootClassPath   = propOrNone("sun.boot.class.path") getOrElse searchForBootClasspath
     def javaExtDirs         = propOrEmpty("java.ext.dirs")
     def scalaHome           = propOrEmpty("scala.home")
     def scalaExtDirs        = propOrEmpty("scala.ext.dirs")


### PR DESCRIPTION
As implemented in https://github.com/scala/scala3/pull/22180/commits/31690d45237fb6aab7e0474ee115d7bdfe8a0892