### PR TITLE
Fix `NoClassDefFoundError` when using old zinc version [ci: last-only]

### DIFF
--- a/src/sbt-bridge/scala/tools/xsbt/CallbackGlobal.scala
+++ b/src/sbt-bridge/scala/tools/xsbt/CallbackGlobal.scala
@@ -83,9 +83,15 @@ sealed class ZincCompiler(settings: Settings, dreporter: DelegatingReporter, out
     extends CallbackGlobal(settings, dreporter, output)
     with ZincGlobalCompat {
 
+  // AnalysisCallback3 is a class introduced in recent version of Zinc
+  // Hence when we run Scala Compiler against an old version of Zinc
+  // AnalysisCallback3 is not in classpath
+  // Hence asInstanceOf[AnalysisCallback3] throws a NoClassDefFoundError
+  private lazy val callback3Opt = scala.util.Try(callback.asInstanceOf[AnalysisCallback3]).toOption
+
   override def getSourceFile(f: AbstractFile): BatchSourceFile = {
-    val file = (f, callback) match {
-      case (plainFile: PlainFile, callback3: AnalysisCallback3) =>
+    val file = (f, callback3Opt) match {
+      case (plainFile: PlainFile, Some(callback3)) =>
         AbstractZincFile(callback3.toVirtualFile(plainFile.file.toPath))
       case _ => f
     }


### PR DESCRIPTION
c.c. https://github.com/scala/scala/pull/10905#issuecomment-2557856480

We explicitly catch the exception, as in

https://github.com/scala/scala/blob/1f34012fd80f4bbecb07417885e4ac4ccb2c6b45/src/sbt-bridge/scala/tools/xsbt/CompilerBridge.scala#L158-L160

@SethTisue 