### PR TITLE
Remove scaladoc CSS ruleset making inherited text white on light background

### DIFF
--- a/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.css
+++ b/src/scaladoc/scala/tools/nsc/doc/html/resource/lib/template.css
@@ -321,10 +321,6 @@ dl.attributes > dd {
   font-style: italic;
 }
 
-#inheritedMembers > div.parent > h3 * {
-  color: white;
-}
-
 #inheritedMembers > div.conversion > h3 {
   height: 2em;
   padding: 1em;


### PR DESCRIPTION
I found myself annoyed by the fact that when I switch scaladoc to "By Inheritance" order, the name of the classes appears white on the light background making them difficult to see.

**chromium**
![chromium](https://github.com/user-attachments/assets/7e6ef5dc-9184-4fd7-a32e-54568e551d28)
**firefox**
![firefox](https://github.com/user-attachments/assets/829f4bba-ab24-412b-8b68-97f15c9f6ba5)


I have removed a ruleset that, as far as I know, only affects this text.

**result**
![image](https://github.com/user-attachments/assets/71b0a737-7e28-456e-ab2b-67e9e0ca61a0)

