### PR TITLE
correctly fix `NoClassDefFoundError` in sbt bridge

### DIFF
--- a/src/sbt-bridge/scala/tools/xsbt/CallbackGlobal.scala
+++ b/src/sbt-bridge/scala/tools/xsbt/CallbackGlobal.scala
@@ -83,11 +83,13 @@ sealed class ZincCompiler(settings: Settings, dreporter: DelegatingReporter, out
     extends CallbackGlobal(settings, dreporter, output)
     with ZincGlobalCompat {
 
-  // AnalysisCallback3 is a class introduced in recent version of Zinc
-  // Hence when we run Scala Compiler against an old version of Zinc
-  // AnalysisCallback3 is not in classpath
-  // Hence asInstanceOf[AnalysisCallback3] throws a NoClassDefFoundError
-  private lazy val callback3Opt = scala.util.Try(callback.asInstanceOf[AnalysisCallback3]).toOption
+  // AnalysisCallback3 only exists in recent Zinc
+  private lazy val callback3Opt =
+    try Some(callback.asInstanceOf[AnalysisCallback3])
+    catch {
+      case _: NoClassDefFoundError =>
+        None
+    }
 
   override def getSourceFile(f: AbstractFile): BatchSourceFile = {
     val file = (f, callback3Opt) match {

--- a/test/junit/scala/tools/xsbt/TestCallback.scala
+++ b/test/junit/scala/tools/xsbt/TestCallback.scala
@@ -1,7 +1,7 @@
 package scala.tools.xsbt
 
 import xsbti.api.{ClassLike, DependencyContext}
-import xsbti.{Action, AnalysisCallback2, DiagnosticCode, DiagnosticRelatedInformation, Position, Severity, UseScope, VirtualFile, VirtualFileRef}
+import xsbti.{Action, AnalysisCallback3, DiagnosticCode, DiagnosticRelatedInformation, Position, Severity, UseScope, VirtualFile, VirtualFileRef}
 
 import java.io.File
 import java.nio.file.Path
@@ -9,7 +9,7 @@ import java.util
 import java.util.Optional
 import scala.collection.mutable.ArrayBuffer
 
-class TestCallback extends AnalysisCallback2 {
+class TestCallback extends AnalysisCallback3 {
   case class TestUsedName(name: String, scopes: util.EnumSet[UseScope])
 
   val classDependencies = new ArrayBuffer[(String, String, DependencyContext)]
@@ -140,6 +140,12 @@ class TestCallback extends AnalysisCallback2 {
   override def isPickleJava: Boolean = false
 
   override def getPickleJarPair = Optional.empty()
+
+  override def getSourceInfos =
+    throw new UnsupportedOperationException("not expected to be called in tests")
+
+  override def toVirtualFile(path: Path) =
+    throw new UnsupportedOperationException("not expected to be called in tests")
 }
 
 object TestCallback {


### PR DESCRIPTION
adjustment to #10964 cc @Friendseeker 
