### PR TITLE
doc: remove 2.10 references in library docs

### DIFF
--- a/src/library-aux/scala/Any.scala
+++ b/src/library-aux/scala/Any.scala
@@ -15,7 +15,6 @@ package scala
 /** Class `Any` is the root of the Scala class hierarchy.  Every class in a Scala
  *  execution environment inherits directly or indirectly from this class.
  *
- * Starting with Scala 2.10 it is possible to directly extend `Any` using ''universal traits''.
  * A ''universal trait'' is a trait that extends `Any`, only has `def`s as members, and does no initialization.
  *
  * The main use case for universal traits is to allow basic inheritance of methods for [[scala.AnyVal value classes]].

--- a/src/library/scala/AnyVal.scala
+++ b/src/library/scala/AnyVal.scala
@@ -29,9 +29,8 @@ package scala
  *   - The ''integer types'' include the subrange types as well as [[scala.Int]] and [[scala.Long]].
  *   - The ''floating point types'' are [[scala.Float]] and [[scala.Double]].
  *
- * Prior to Scala 2.10, `AnyVal` was a sealed trait. Beginning with Scala 2.10,
- * however, it is possible to define a subclass of `AnyVal` called a ''user-defined value class''
- * which is treated specially by the compiler. Properly-defined user value classes provide a way
+ * A subclass of `AnyVal` is called a ''user-defined value class''
+ * and is treated specially by the compiler. Properly-defined user value classes provide a way
  * to improve performance on user-defined types by avoiding object allocation at runtime, and by
  * replacing virtual method invocations with static method invocations.
  *

--- a/src/library/scala/Dynamic.scala
+++ b/src/library/scala/Dynamic.scala
@@ -30,7 +30,7 @@ package scala
  *  foo.arr(10)         ~~> foo.applyDynamic("arr")(10)
  *  }}}
  *
- *  As of Scala 2.10, defining direct or indirect subclasses of this trait
+ *  Defining direct or indirect subclasses of this trait
  *  is only possible if the language feature `dynamics` is enabled.
  */
 trait Dynamic extends Any

--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -382,8 +382,15 @@ object Ordering extends LowPriorityOrderingImplicits {
 
   /** `Ordering`s for `Float`s.
     *
-    * The behavior of the comparison operations provided by the default (implicit)
-    * ordering on `Float` changed in 2.10.0 and 2.13.0.
+    * The default extends `Ordering.Float.TotalOrdering`.
+    *
+    * `Ordering.Float.TotalOrdering` uses the `java.lang.Float.compare` semantics for all operations.
+    * Scala also provides the `Ordering.Float.IeeeOrdering` semantics. Which uses the IEEE 754 semantics
+    * for float ordering.
+    *
+    * Historically: `IeeeOrdering` was used in Scala from 2.10.x through 2.12.x. This changed in 2.13.0
+    * to `TotalOrdering`.
+    *
     * Prior to Scala 2.10.0, the `Ordering` instance used semantics
     * consistent with `java.lang.Float.compare`.
     *
@@ -394,11 +401,6 @@ object Ordering extends LowPriorityOrderingImplicits {
     * `false` thus `0.0F < Float.NaN`, `0.0F > Float.NaN`, and
     * `Float.NaN == Float.NaN` all yield `false`, analogous `None` in `flatMap`.
     *
-    * Recognizing the limitation of the IEEE 754 semantics in terms of ordering,
-    * Scala 2.13.0 created two instances: `Ordering.Float.IeeeOrdering`, which retains
-    * the IEEE 754 semantics from Scala 2.12.x, and `Ordering.Float.TotalOrdering`,
-    * which brings back the `java.lang.Float.compare` semantics for all operations.
-    * The default extends `TotalOrdering`.
     *
     *  {{{
     *  List(0.0F, 1.0F, 0.0F / 0.0F, -1.0F / 0.0F).sorted      // List(-Infinity, 0.0, 1.0, NaN)

--- a/test/scaladoc/resources/doc-root/Any.scala
+++ b/test/scaladoc/resources/doc-root/Any.scala
@@ -15,7 +15,6 @@ package scala
 /** Class `Any` is the root of the Scala class hierarchy.  Every class in a Scala
  *  execution environment inherits directly or indirectly from this class.
  *
- * Starting with Scala 2.10 it is possible to directly extend `Any` using ''universal traits''.
  * A ''universal trait'' is a trait that extends `Any`, only has `def`s as members, and does no initialization.
  *
  * The main use case for universal traits is to allow basic inheritance of methods for [[scala.AnyVal value classes]].


### PR DESCRIPTION
Goal is to focus the docs on current usage.