### PR TITLE
perf: avoid double checking `value0` Future.

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -43,6 +43,9 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.generic.CommonErrors"),
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.generic.CommonErrors$"),
 
+    //scala/scala#10972
+    ProblemFilters.exclude[MissingClassProblem]("scala.concurrent.Await$FutureValue$"),
+
     // scala/scala#10937
     ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.immutable.LazyList#LazyBuilder#DeferredState.eval"),
     ProblemFilters.exclude[MissingClassProblem](s"scala.collection.immutable.LazyList$$State"),

--- a/src/library/scala/concurrent/impl/Promise.scala
+++ b/src/library/scala/concurrent/impl/Promise.scala
@@ -255,9 +255,9 @@ private[concurrent] object Promise {
               l.result
             }
           if (r ne null) r
-          else throw new TimeoutException("Future timed out after [" + atMost + "]")
+          else Future.timeoutError(atMost)
         }
-      } else throw new IllegalArgumentException("Cannot wait for Undefined duration of time")
+      } else Future.waitUndefinedError()
 
     @throws(classOf[TimeoutException])
     @throws(classOf[InterruptedException])

--- a/src/library/scala/concurrent/package.scala
+++ b/src/library/scala/concurrent/package.scala
@@ -12,8 +12,9 @@
 
 package scala
 
-import scala.concurrent.duration.Duration
 import scala.annotation.implicitNotFound
+import scala.concurrent.duration.Duration
+import scala.util.Try
 
 /** This package object contains primitives for concurrent and parallel programming.
  *
@@ -170,8 +171,11 @@ package concurrent {
     @throws(classOf[TimeoutException])
     @throws(classOf[InterruptedException])
     final def ready[T](awaitable: Awaitable[T], atMost: Duration): awaitable.type = awaitable match {
-      case f: Future[T] if f.isCompleted => awaitable.ready(atMost)(AwaitPermission)
-      case _ => blocking(awaitable.ready(atMost)(AwaitPermission))
+      case f: Future[T] if f.isCompleted =>
+        if (atMost eq Duration.Undefined) Future.waitUndefinedError() // preserve semantics, see scala/scala#10972
+        else awaitable
+      case _ =>
+        blocking(awaitable.ready(atMost)(AwaitPermission))
     }
 
     /**
@@ -197,8 +201,18 @@ package concurrent {
     @throws(classOf[TimeoutException])
     @throws(classOf[InterruptedException])
     final def result[T](awaitable: Awaitable[T], atMost: Duration): T = awaitable match {
-      case f: Future[T] if f.isCompleted => f.result(atMost)(AwaitPermission)
-      case _ => blocking(awaitable.result(atMost)(AwaitPermission))
+      case FutureValue(v) =>
+        if (atMost eq Duration.Undefined) Future.waitUndefinedError() // preserve semantics, see scala/scala#10972
+        else v.get
+      case _ =>
+        blocking(awaitable.result(atMost)(AwaitPermission))
+    }
+
+    private object FutureValue {
+      def unapply[T](a: Awaitable[T]): Option[Try[T]] = a match {
+        case f: Future[T] => f.value
+        case _ => None
+      }
     }
   }
 }

--- a/test/junit/scala/concurrent/FutureTest.scala
+++ b/test/junit/scala/concurrent/FutureTest.scala
@@ -6,7 +6,7 @@ import org.junit.Test
 
 import scala.tools.testkit.AssertUtil._
 import scala.util.{Success, Try}
-import duration.Duration.Inf
+import duration.Duration.{Inf, Undefined}
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.impl.Promise.DefaultPromise
 import scala.util.chaining._
@@ -197,5 +197,10 @@ class FutureTest {
       println(b.mkString)
       assert(b.mkString == "b4a4")
     }
+  }
+
+  @Test def completedWaitUndefined(): Unit = {
+    assertThrows[IllegalArgumentException](Await.result(Future.successful(1), Undefined))
+    assertThrows[IllegalArgumentException](Await.ready(Future.successful(1), Undefined))
   }
 }


### PR DESCRIPTION
Motivation:

The current `Future.isComplete` check the `value0` once, and then it will checked it again to extract the value.

Modification:

Use `.value` to extract the value at the same time.

Result:
Better performance when the future is already completed.

```
[info] Benchmark                                                 (pool)  (recursion)  (threads)   Mode  Cnt        Score        Error   Units
[info] CompleteFutureBenchmark.success                              fix         1024          1  thrpt    5   990403.006 ±   6431.624  ops/ms
[info] CompleteFutureBenchmark.success:gc.alloc.rate                fix         1024          1  thrpt    5        0.001 ±      0.001  MB/sec
[info] CompleteFutureBenchmark.success:gc.alloc.rate.norm           fix         1024          1  thrpt    5       ≈ 10⁻⁶                 B/op
[info] CompleteFutureBenchmark.success:gc.count                     fix         1024          1  thrpt    5          ≈ 0               counts
[info] CompleteFutureBenchmark.successOption                        fix         1024          1  thrpt    5  1265272.145 ± 336165.695  ops/ms
[info] CompleteFutureBenchmark.successOption:gc.alloc.rate          fix         1024          1  thrpt    5        0.001 ±      0.001  MB/sec
[info] CompleteFutureBenchmark.successOption:gc.alloc.rate.norm     fix         1024          1  thrpt    5       ≈ 10⁻⁶                 B/op
[info] CompleteFutureBenchmark.successOption:gc.count               fix         1024          1  thrpt    5          ≈ 0               counts
[info] CompleteFutureBenchmark.successUnwrap                        fix         1024          1  thrpt    5  1322735.278 ±  25844.808  ops/ms
[info] CompleteFutureBenchmark.successUnwrap:gc.alloc.rate          fix         1024          1  thrpt    5        0.001 ±      0.001  MB/sec
[info] CompleteFutureBenchmark.successUnwrap:gc.alloc.rate.norm     fix         1024          1  thrpt    5       ≈ 10⁻⁶                 B/op
[info] CompleteFutureBenchmark.successUnwrap:gc.count               fix         1024          1  thrpt    5          ≈ 0               counts`
```

The result if `successOption` with this modification.

I still checked adding an `Future#unwrap = value0()` method  to avoid the lifting to `Some/None` ,but seems not help much.