### PR TITLE
bump copyright year to 2025

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,6 @@
 Scala
-Copyright (c) 2002-2024 EPFL
-Copyright (c) 2011-2024 Lightbend, Inc. dba Akka
+Copyright (c) 2002-2025 EPFL
+Copyright (c) 2011-2025 Lightbend, Inc. dba Akka
 
 Scala includes software developed at
 LAMP/EPFL (https://lamp.epfl.ch/) and

--- a/doc/LICENSE.md
+++ b/doc/LICENSE.md
@@ -2,9 +2,9 @@ Scala is licensed under the [Apache License Version 2.0](https://www.apache.org/
 
 ## Scala License
 
-Copyright (c) 2002-2024 EPFL
+Copyright (c) 2002-2025 EPFL
 
-Copyright (c) 2011-2024 Lightbend, Inc. dba Akka
+Copyright (c) 2011-2025 Lightbend, Inc. dba Akka
 
 All rights reserved.
 

--- a/doc/License.rtf
+++ b/doc/License.rtf
@@ -23,8 +23,8 @@ Scala is licensed under the\'a0{\field{\*\fldinst{HYPERLINK "https://www.apache.
 \fs48 \cf2 Scala License\
 \pard\pardeftab720\sl360\sa320\partightenfactor0
 
-\f0\b0\fs28 \cf2 Copyright (c) 2002-2024 EPFL\
-Copyright (c) 2011-2024 Lightbend, Inc. dba Akka\
+\f0\b0\fs28 \cf2 Copyright (c) 2002-2025 EPFL\
+Copyright (c) 2011-2025 Lightbend, Inc. dba Akka\
 All rights reserved.\
 \pard\pardeftab720\sl360\sa320\partightenfactor0
 \cf2 \cb4 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at {\field{\*\fldinst{HYPERLINK "http://www.apache.org/licenses/LICENSE-2.0"}}{\fldrslt http://www.apache.org/licenses/LICENSE-2.0}}.\

--- a/project/VersionUtil.scala
+++ b/project/VersionUtil.scala
@@ -30,7 +30,7 @@ object VersionUtil {
   )
 
   lazy val generatePropertiesFileSettings = Seq[Setting[_]](
-    copyrightString := "Copyright 2002-2024, LAMP/EPFL and Lightbend, Inc. dba Akka",
+    copyrightString := "Copyright 2002-2025, LAMP/EPFL and Lightbend, Inc. dba Akka",
     shellWelcomeString := """
       |     ________ ___   / /  ___
       |    / __/ __// _ | / /  / _ |

--- a/src/library/scala/util/Properties.scala
+++ b/src/library/scala/util/Properties.scala
@@ -108,7 +108,7 @@ private[scala] trait PropertiesTrait {
    *  or "version (unknown)" if it cannot be determined.
    */
   val versionString         = "version " + scalaPropOrElse("version.number", "(unknown)")
-  val copyrightString       = scalaPropOrElse("copyright.string", "Copyright 2002-2024, LAMP/EPFL and Lightbend, Inc. dba Akka")
+  val copyrightString       = scalaPropOrElse("copyright.string", "Copyright 2002-2025, LAMP/EPFL and Lightbend, Inc. dba Akka")
 
   /** This is the encoding to use reading in source files, overridden with -encoding.
    *  Note that it uses "prop" i.e. looks in the scala jar, not the system properties.

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
@@ -407,7 +407,7 @@ trait EntityPage extends HtmlPage {
 
       {
         if (Set("epfl", "EPFL").contains(tpl.universe.settings.docfooter.value))
-          <div id="footer">Scala programming documentation. Copyright (c) 2002-2024 <a href="http://www.epfl.ch" target="_top">EPFL</a>, with contributions from <a href="https://akka.io" target="_top">Akka</a>.</div>
+          <div id="footer">Scala programming documentation. Copyright (c) 2002-2025 <a href="http://www.epfl.ch" target="_top">EPFL</a>, with contributions from <a href="https://akka.io" target="_top">Akka</a>.</div>
         else
           <div id="footer"> { tpl.universe.settings.docfooter.value } </div>
       }

--- a/src/scalap/decoder.properties
+++ b/src/scalap/decoder.properties
@@ -1,2 +1,2 @@
 version.number=2.0.1
-copyright.string=(c) 2002-2024 LAMP/EPFL
+copyright.string=(c) 2002-2025 LAMP/EPFL


### PR DESCRIPTION
in the usual places. based on 567412d, and verified with `git grep -w 2024`

I'll merge it forward onto 2.13.x in time for 2.13.16, too