### PR TITLE
REPL completion for idents starting with number [ci: last-only]

### DIFF
--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -21,7 +21,6 @@ import scala.collection.mutable
 import scala.collection.mutable.{HashSet, LinkedHashMap}
 import scala.jdk.javaapi.CollectionConverters
 import scala.language.implicitConversions
-import scala.reflect.internal.Chars.isIdentifierStart
 import scala.reflect.internal.util.SourceFile
 import scala.tools.nsc.io.AbstractFile
 import scala.tools.nsc.reporters.Reporter
@@ -1191,7 +1190,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
       results.filter { (member: Member) =>
         val symbol = member.sym
         def isStable = member.tpe.isStable || member.sym.isStable || member.sym.getterIn(member.sym.owner).isStable
-        def isJunk = !symbol.exists || symbol.name.isEmpty || !isIdentifierStart(member.sym.name.charAt(0)) // e.g. <byname>
+        def isJunk = !symbol.exists || symbol.name.isEmpty || symbol.encodedName.charAt(0) == '<' // e.g. <byname>
         def nameTypeOk: Boolean = {
           forImport || // Completing an import: keep terms and types.
             symbol.name.isTermName == name.isTermName || // Keep names of the same type
@@ -1202,7 +1201,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
           matcher(member.aliasInfo.map(_.sym.name).getOrElse(NoSymbol.name)) && !forImport && symbol.name.isTermName == name.isTermName
         }
         
-        !isJunk && member.accessible && !symbol.isConstructor && (name.isEmpty || (matcher(member.sym.name) || aliasTypeOk)
+        !isJunk && member.accessible && (name.isEmpty || (matcher(member.sym.name) || aliasTypeOk)
           && nameTypeOk)
 
       }

--- a/test/junit/scala/tools/nsc/interpreter/CompletionTest.scala
+++ b/test/junit/scala/tools/nsc/interpreter/CompletionTest.scala
@@ -94,6 +94,9 @@ class CompletionTest {
     checkExact(completer, "object O { private def x_y_z = 1; x_y", "}")("x_y_z")
     checkExact(completer, "object x_y_z; import x_y")("x_y_z")
 
+    checkExact(completer, "object O { def `1 thing` = 1 }; O.")("1 thing")
+    checkExact(completer, "object O { def `<x>` = 1 }; O.")("<x>")
+
     checkExact(completer, "object x_y_z { def a_b_c }; import x_y_z.a_b")("a_b_c")
 
     checkExact(completer, "object X { private[this] def definition = 0; def")("definition")


### PR DESCRIPTION
This relaxes some of the completion result filtering to allow backticked identifiers such as the following to show up in completion results.

     object Test {
       def `1 world` = ""
     }

The pathological builtin names to guard against all start with `<`, even in their encoded forms (backticked `<` would start with a `$`).

Fixes scala/bug#13076