### PR TITLE
Fix AnnotationInfo when using named/default arguments, support custom annotation subclasses

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -59,6 +59,8 @@ object MimaFilters extends AutoPlugin {
 
     // scala/scala#10976
     ProblemFilters.exclude[MissingClassProblem]("scala.annotation.meta.defaultArg"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.annotation.meta.superArg"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.annotation.meta.superFwdArg"),
   )
 
   override val buildSettings = Seq(

--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -56,6 +56,9 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.immutable.LazyList#LazyBuilder#DeferredState.eval"),
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.LazyList$MidEvaluation$"),
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.LazyList$Uninitialized$"),
+
+    // scala/scala#10976
+    ProblemFilters.exclude[MissingClassProblem]("scala.annotation.meta.defaultArg"),
   )
 
   override val buildSettings = Seq(

--- a/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
@@ -369,7 +369,7 @@ abstract class Pickler extends SubComponent {
       // annotations in Modifiers are removed by the typechecker
       override def traverseModifiers(mods: Modifiers): Unit = if (putEntry(mods)) putEntry(mods.privateWithin)
       override def traverseName(name: Name): Unit           = putEntry(name)
-      override def traverseConstant(const: Constant): Unit  = putEntry(const)
+      override def traverseConstant(const: Constant): Unit  = putConstant(const)
       override def traverse(tree: Tree): Unit               = putTree(tree)
 
       def put(tree: Tree): Unit = {
@@ -418,7 +418,8 @@ abstract class Pickler extends SubComponent {
     private def putAnnotationBody(annot: AnnotationInfo): Unit = {
       def putAnnotArg(arg: Tree): Unit = {
         arg match {
-          case Literal(c) => putConstant(c)
+          // Keep Literal with an AnnotatedType. Used in AnnotationInfo.argIsDefault.
+          case Literal(c) if arg.tpe.isInstanceOf[ConstantType] => putConstant(c)
           case _ => putTree(arg)
         }
       }
@@ -475,7 +476,8 @@ abstract class Pickler extends SubComponent {
     private def writeAnnotation(annot: AnnotationInfo): Unit = {
       def writeAnnotArg(arg: Tree): Unit = {
         arg match {
-          case Literal(c) => writeRef(c)
+          // Keep Literal with an AnnotatedType. Used in AnnotationInfo.argIsDefault.
+          case Literal(c) if arg.tpe.isInstanceOf[ConstantType] => writeRef(c)
           case _ => writeRef(arg)
         }
       }

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2149,6 +2149,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           } else tpt1.tpe
           transformedOrTyped(vdef.rhs, EXPRmode | BYVALmode, tpt2)
         }
+      if (!isPastTyper && sym.hasDefault && sym.owner.isConstructor && sym.enclClass.isNonBottomSubClass(AnnotationClass))
+        sym.addAnnotation(AnnotationInfo(DefaultArgAttr.tpe, List(duplicateAndResetPos.transform(rhs1)), Nil))
       val vdef1 = treeCopy.ValDef(vdef, typedMods, sym.name, tpt1, checkDead(context, rhs1)) setType NoType
       if (sym.isSynthetic && sym.name.startsWith(nme.RIGHT_ASSOC_OP_PREFIX))
         rightAssocValDefs += ((sym, vdef1.rhs))
@@ -4057,6 +4059,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           }
         }
 
+        // Usually, defaults are the default expression ASTs, but only for annotations compiled with a recent compiler
+        // that have `annotation.meta.defaultArg` meta annotations on them.
         def isDefaultArg(tree: Tree) = tree match {
           case treeInfo.Applied(fun, _, _) => fun.symbol != null && fun.symbol.isDefaultGetter
           case _ => false

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4193,17 +4193,11 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         }
         @tailrec
         def annInfo(t: Tree): AnnotationInfo = t match {
+          case Block(Nil, expr) => annInfo(expr)
+
           case Apply(Select(New(tpt), nme.CONSTRUCTOR), args) =>
             // `tpt.tpe` is more precise than `annType`, since it incorporates the types of `args`
             AnnotationInfo(tpt.tpe, args, Nil).setOriginal(typedAnn).setPos(t.pos)
-
-          case Block(_, expr) =>
-            if (!annTypeSym.isNonBottomSubClass(ConstantAnnotationClass))
-              context.warning(t.pos, "Usage of named or default arguments transformed this annotation\n"+
-                                "constructor call into a block. The corresponding AnnotationInfo\n"+
-                                "will contain references to local values and default getters instead\n"+
-                                "of the actual argument trees", WarningCategory.Other)
-            annInfo(expr)
 
           case Apply(fun, args) =>
             context.warning(t.pos, "Implementation limitation: multiple argument lists on annotations are\n"+

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4019,7 +4019,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       def registerNowarn(info: AnnotationInfo): Unit = {
         if (annotee.isDefined && NowarnClass.exists && info.matches(NowarnClass) && !runReporting.suppressionExists(info.pos)) {
           var verbose = false
-          val filters = (info.assocs: @unchecked) match {
+          val filters = (info.assocsForSuper(NowarnClass): @unchecked) match {
             case Nil => List(MessageFilter.Any)
             case (_, LiteralAnnotArg(s)) :: Nil =>
               val str = s.stringValue

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3781,7 +3781,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                     true
                   case _ => false
                 }
-                val (allArgs, missing) = addDefaults(args, qual, targs, previousArgss, params, fun.pos.focus, context)
+                val (allArgs, missing) = addDefaults(args, qual, targs, previousArgss, params, fun.pos.focus, context, mode)
                 val funSym = fun1 match { case Block(_, expr) => expr.symbol case x => throw new MatchError(x) }
                 val lencmp2 = compareLengths(allArgs, formals)
 
@@ -4193,7 +4193,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         val typedAnn: Tree = {
           // local dummy fixes scala/bug#5544
           val localTyper = newTyper(context.make(ann, context.owner.newLocalDummy(ann.pos)))
-          localTyper.typed(ann, mode)
+          localTyper.typed(ann, mode | ANNOTmode)
         }
         @tailrec
         def annInfo(t: Tree): AnnotationInfo = t match {

--- a/src/library/scala/annotation/meta/defaultArg.scala
+++ b/src/library/scala/annotation/meta/defaultArg.scala
@@ -1,0 +1,30 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc. dba Akka
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.annotation
+package meta
+
+/**
+ * This internal meta annotation is used by the compiler to support default annotation arguments.
+ *
+ * For an annotation definition `class ann(x: Int = defaultExpr) extends Annotation`, the compiler adds
+ * `@defaultArg(defaultExpr)` to the parameter `x`. This causes the syntax tree of `defaultExpr` to be
+ * stored in the classfile.
+ *
+ * When using a default annotation argument, the compiler can recover the syntax tree and insert it in the
+ * `AnnotationInfo`.
+ *
+ * For details, see `scala.reflect.internal.AnnotationInfos.AnnotationInfo`.
+ */
+@meta.param class defaultArg(arg: Any) extends StaticAnnotation {
+  def this() = this(null)
+}

--- a/src/library/scala/annotation/meta/superArg.scala
+++ b/src/library/scala/annotation/meta/superArg.scala
@@ -1,0 +1,34 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc. dba Akka
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.annotation
+package meta
+
+/**
+ * This internal annotation encodes arguments passed to annotation superclasses. Example:
+ *
+ * {{{
+ *   class a(x: Int) extends Annotation
+ *   class b extends a(42) // the compiler adds `@superArg("x", 42)` to class b
+ * }}}
+ */
+class superArg(p: String, v: Any) extends StaticAnnotation
+
+/**
+ * This internal annotation encodes arguments passed to annotation superclasses. Example:
+ *
+ * {{{
+ *   class a(x: Int) extends Annotation
+ *   class b(y: Int) extends a(y) // the compiler adds `@superFwdArg("x", "y")` to class b
+ * }}}
+ */
+class superFwdArg(p: String, n: String) extends StaticAnnotation

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1342,6 +1342,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val BeanPropertyAttr           = requiredClass[scala.beans.BeanProperty]
     lazy val BooleanBeanPropertyAttr    = requiredClass[scala.beans.BooleanBeanProperty]
     lazy val CompileTimeOnlyAttr        = getClassIfDefined("scala.annotation.compileTimeOnly")
+    lazy val DefaultArgAttr             = getClassIfDefined("scala.annotation.meta.defaultArg")
     lazy val DeprecatedAttr             = requiredClass[scala.deprecated]
     lazy val DeprecatedNameAttr         = requiredClass[scala.deprecatedName]
     lazy val DeprecatedInheritanceAttr  = requiredClass[scala.deprecatedInheritance]

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1353,6 +1353,8 @@ trait Definitions extends api.StandardDefinitions {
     lazy val SerialVersionUIDAttr       = requiredClass[scala.SerialVersionUID]
     lazy val SerialVersionUIDAnnotation = AnnotationInfo(SerialVersionUIDAttr.tpe, List(), List(nme.value -> LiteralAnnotArg(Constant(0))))
     lazy val SpecializedClass           = requiredClass[scala.specialized]
+    lazy val SuperArgAttr               = getClassIfDefined("scala.annotation.meta.superArg")
+    lazy val SuperFwdArgAttr            = getClassIfDefined("scala.annotation.meta.superFwdArg")
     lazy val ThrowsClass                = requiredClass[scala.throws[_]]
     lazy val TransientAttr              = requiredClass[scala.transient]
     lazy val UncheckedClass             = requiredClass[scala.unchecked]

--- a/src/reflect/scala/reflect/internal/Mode.scala
+++ b/src/reflect/scala/reflect/internal/Mode.scala
@@ -89,8 +89,20 @@ object Mode {
     */
   final val APPSELmode: Mode    = Mode(0x20000)
 
+  /**
+   * Enabled while typing annotations. In this mode, no locals are created for named / default arguments and default
+   * arguments are AST copies of the default expression. Example:
+   *
+   * {{{
+   *   class a(x: Int = xDefault, y: Int) extends Annotation
+   *   @a(y = yExpr) def f = 0 // annotation is typed as `new a(xDefault, yExpr)`
+   *   new a(y = yExpr)        // typed as `{ val x$1 = yExpr; val x$2 = a.init$default$1(); new a(x$2, x$1) }`
+   * }}}
+   */
+  final val ANNOTmode: Mode     = Mode(0x40000)
+
   private val StickyModes: Mode       = EXPRmode | PATTERNmode | TYPEmode
-  private val StickyModesForFun: Mode = StickyModes | SCCmode
+  private val StickyModesForFun: Mode = StickyModes | SCCmode | ANNOTmode
   final val MonoQualifierModes: Mode  = EXPRmode | QUALmode | APPSELmode
   final val PolyQualifierModes: Mode  = MonoQualifierModes | POLYmode
   final val OperatorModes: Mode       = EXPRmode | POLYmode | TAPPmode | FUNmode
@@ -108,7 +120,8 @@ object Mode {
     LHSmode      -> "LHSmode",
     BYVALmode    -> "BYVALmode",
     TYPEPATmode  -> "TYPEPATmode",
-    APPSELmode   -> "APPSELmode"
+    APPSELmode   -> "APPSELmode",
+    ANNOTmode    -> "ANNOTmode",
   )
 
   // Former modes and their values:

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -482,6 +482,8 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.SerialVersionUIDAttr
     definitions.SerialVersionUIDAnnotation
     definitions.SpecializedClass
+    definitions.SuperArgAttr
+    definitions.SuperFwdArgAttr
     definitions.ThrowsClass
     definitions.TransientAttr
     definitions.UncheckedClass

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -471,6 +471,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.BeanPropertyAttr
     definitions.BooleanBeanPropertyAttr
     definitions.CompileTimeOnlyAttr
+    definitions.DefaultArgAttr
     definitions.DeprecatedAttr
     definitions.DeprecatedNameAttr
     definitions.DeprecatedInheritanceAttr

--- a/test/files/neg/annots-constant-neg.check
+++ b/test/files/neg/annots-constant-neg.check
@@ -1,7 +1,7 @@
-Test.scala:12: error: class Ann1 cannot have auxiliary constructors because it extends ConstantAnnotation
+Test.scala:11: error: class Ann1 cannot have auxiliary constructors because it extends ConstantAnnotation
   def this(s: String) = this(0) // err
       ^
-Test.scala:14: error: class Ann2 needs to have exactly one argument list because it extends ConstantAnnotation
+Test.scala:13: error: class Ann2 needs to have exactly one argument list because it extends ConstantAnnotation
 class Ann2(x: Int)(y: Int) extends ConstantAnnotation // err
                                    ^
 Test.scala:27: error: annotation argument needs to be a constant; found: Test.this.nonConst

--- a/test/files/neg/annots-constant-neg/Test.scala
+++ b/test/files/neg/annots-constant-neg/Test.scala
@@ -7,8 +7,7 @@ class Ann(
   b: Class[_] = classOf[String],
   c: Array[Object] = Array()) extends ConstantAnnotation
 
-// non-constant defaults are allowed
-class Ann1(value: Int = Test.nonConst) extends ConstantAnnotation {
+class Ann1(value: Int = 1) extends ConstantAnnotation {
   def this(s: String) = this(0) // err
 }
 class Ann2(x: Int)(y: Int) extends ConstantAnnotation // err
@@ -16,7 +15,8 @@ class Ann3 extends ConstantAnnotation
 class Ann4(x: Int = 0, value: Int) extends ConstantAnnotation
 class Ann5() extends ConstantAnnotation
 class Ann6(x: Int) extends ConstantAnnotation // scala/bug#11724
-class Ann7[T](x: T) extends annotation.ConstantAnnotation // scala/bug#11724
+class Ann7[T](x: T) extends ConstantAnnotation // scala/bug#11724
+class Ann8(x: Int = Test.nonConst) extends ConstantAnnotation // defaults of `ConstantAnnotation` are not enforced to be constants
 
 object Test {
   final val const = 1

--- a/test/files/neg/nowarnRangePos.check
+++ b/test/files/neg/nowarnRangePos.check
@@ -27,6 +27,12 @@ nowarnRangePos.scala:90: warning: a pure expression does nothing in statement po
 Applicable -Wconf / @nowarn filters for this warning: msg=<part of the message>, cat=other-pure-statement, site=C.T13.g
     def g = { 1; 2 }
               ^
+nowarnRangePos.scala:113: warning: method dep in class C is deprecated (since 1.2.3): message
+  @purr def t2 = new C().dep  // warn, plus unused @nowarn
+                         ^
+nowarnRangePos.scala:116: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
+  @nodep def t4 = { 1; 2 } // warn, plus unused @nowarn
+                    ^
 nowarnRangePos.scala:45: warning: I3b has a valid main method (args: Array[String]): Unit,
   but C.I3b will not have an entry point on the JVM.
   Reason: companion is a trait, which means no static forwarder can be generated.
@@ -54,6 +60,12 @@ nowarnRangePos.scala:65: warning: @nowarn annotation does not suppress any warni
 nowarnRangePos.scala:91: warning: @nowarn annotation does not suppress any warnings
     @nowarn("v") def unused = 0
      ^
+nowarnRangePos.scala:113: warning: @nowarn annotation does not suppress any warnings
+  @purr def t2 = new C().dep  // warn, plus unused @nowarn
+   ^
+nowarnRangePos.scala:116: warning: @nowarn annotation does not suppress any warnings
+  @nodep def t4 = { 1; 2 } // warn, plus unused @nowarn
+   ^
 error: No warnings can be incurred under -Werror.
-17 warnings
+21 warnings
 1 error

--- a/test/files/neg/nowarnRangePos.scala
+++ b/test/files/neg/nowarnRangePos.scala
@@ -104,3 +104,14 @@ class Uh {
     def g(c: C) = c.dep
   }
 }
+
+object sd884 {
+  class nodep extends nowarn("cat=deprecation")
+  class purr extends nowarn("msg=pure expression does nothing")
+
+  @nodep def t1 = new C().dep // no warn
+  @purr def t2 = new C().dep  // warn, plus unused @nowarn
+
+  @purr def t3 = { 1; 2 }  // no warn
+  @nodep def t4 = { 1; 2 } // warn, plus unused @nowarn
+}

--- a/test/files/run/sd884.check
+++ b/test/files/run/sd884.check
@@ -1,17 +1,20 @@
 
-scala> import annotation.Annotation
-import annotation.Annotation
+scala> import annotation._
+import annotation._
 
-scala> class ann(x: Int = 0, y: Int = 0) extends Annotation
+scala> class ann(x: Int = 1, y: Int = 2) extends Annotation
 class ann
 
-scala> class naa(x: Int = 0, y: Int = 0) extends Annotation {
+scala> class naa(x: Int = 1, y: Int = 2) extends Annotation {
   def this(s: String) = this(1, 2)
 }
 class naa
 
-scala> class mul(x: Int = 0, y: Int = 0)(z: Int = 0, zz: Int = 0) extends Annotation
+scala> class mul(x: Int = 1, y: Int = 2)(z: Int = 3, zz: Int = 4) extends Annotation
 class mul
+
+scala> class kon(x: Int = 1, y: Int = 2) extends ConstantAnnotation
+class kon
 
 scala> class C {
   val a = 1
@@ -31,6 +34,9 @@ scala> class C {
   @mul(y = b)(a, b) def m8 = 1
   @mul(y = b, x = a)(zz = b) def m9 = 1
   @mul(y = b)(zz = b) def m10 = 1
+
+  @kon(y = 22) def m11 = 1
+  @kon(11) def m12 = 1
 }
          @mul(a, b)(a, b) def m7 = 1
           ^
@@ -43,11 +49,11 @@ On line 16: warning: Implementation limitation: multiple argument lists on annot
          @mul(y = b, x = a)(zz = b) def m9 = 1
           ^
 On line 17: warning: Implementation limitation: multiple argument lists on annotations are
-       currently not supported; ignoring arguments List(mul.<init>$default$3(C.this.a, C.this.b), C.this.b)
+       currently not supported; ignoring arguments List(3, C.this.b)
          @mul(y = b)(zz = b) def m10 = 1
           ^
 On line 18: warning: Implementation limitation: multiple argument lists on annotations are
-       currently not supported; ignoring arguments List(mul.<init>$default$3(mul.<init>$default$1, C.this.b), C.this.b)
+       currently not supported; ignoring arguments List(3, C.this.b)
 class C
 
 scala> :power
@@ -57,20 +63,40 @@ Try :help or completions for vals._ and power._
 
 scala> println(typeOf[C].members.toList.filter(_.name.startsWith("m")).sortBy(_.name).map(_.annotations).mkString("\n"))
 List(ann(C.this.a, C.this.b))
-List(mul($line15.$read.INSTANCE.$iw.mul.<init>$default$1, C.this.b))
-List(ann(C.this.a, $line13.$read.INSTANCE.$iw.ann.<init>$default$2))
-List(ann($line13.$read.INSTANCE.$iw.ann.<init>$default$1, C.this.b))
+List(mul(1, C.this.b))
+List(kon(y = 22))
+List(kon(x = 11))
+List(ann(C.this.a, 2))
+List(ann(1, C.this.b))
 List(naa(C.this.a, C.this.b))
 List(naa(C.this.a, C.this.b))
 List(naa(""))
 List(mul(C.this.a, C.this.b))
-List(mul($line15.$read.INSTANCE.$iw.mul.<init>$default$1, C.this.b))
+List(mul(1, C.this.b))
 List(mul(C.this.a, C.this.b))
 
-scala> val i = typeOf[C].member(TermName("m6")).annotations.head
-val i: $r.intp.global.AnnotationInfo = naa("")
+scala> val i6 = typeOf[C].member(TermName("m6")).annotations.head
+val i6: $r.intp.global.AnnotationInfo = naa("")
 
-scala> i.constructorSymbol(global.typer.typed).paramss
+scala> i6.constructorSymbol(global.typer.typed).paramss
 val res1: List[List[$r.intp.global.Symbol]] = List(List(value s))
+
+scala> val i11 = typeOf[C].member(TermName("m11")).annotations.head
+val i11: $r.intp.global.AnnotationInfo = kon(y = 22)
+
+scala> i11.assocs
+val res2: List[($r.intp.global.Name, $r.intp.global.ClassfileAnnotArg)] = List((y,22))
+
+scala> i11.assocsWithDefaults
+val res3: List[($r.intp.global.Name, $r.intp.global.ClassfileAnnotArg)] = List((x,1), (y,22))
+
+scala> val i3 = typeOf[C].member(TermName("m3")).annotations.head
+val i3: $r.intp.global.AnnotationInfo = ann(1, C.this.b)
+
+scala> i3.args.map(_.tpe)
+val res4: List[$r.intp.global.Type] = List(Int(1) @scala.annotation.meta.defaultArg, Int)
+
+scala> i3.args.map(i3.argIsDefault)
+val res5: List[Boolean] = List(true, false)
 
 scala> :quit

--- a/test/files/run/sd884.check
+++ b/test/files/run/sd884.check
@@ -1,6 +1,7 @@
 
-scala> import annotation._
+scala> import annotation._, scala.util.chaining._
 import annotation._
+import scala.util.chaining._
 
 scala> class ann(x: Int = 1, y: Int = 2) extends Annotation
 class ann
@@ -15,6 +16,9 @@ class mul
 
 scala> class kon(x: Int = 1, y: Int = 2) extends ConstantAnnotation
 class kon
+
+scala> class rann(x: Int = 1.tap(println), y: Int) extends Annotation
+class rann
 
 scala> class C {
   val a = 1
@@ -98,5 +102,24 @@ val res4: List[$r.intp.global.Type] = List(Int(1) @scala.annotation.meta.default
 
 scala> i3.args.map(i3.argIsDefault)
 val res5: List[Boolean] = List(true, false)
+
+scala> // ordinary named/default args when using annotation class in executed code
+
+scala> new rann(y = 2.tap(println)); () // prints 2, then the default 1
+2
+1
+
+scala> @rann(y = {new rann(y = 2.tap(println)); 2}) class r1
+class r1
+
+scala> println(typeOf[r1].typeSymbol.annotations.head.args)
+List(scala.util.`package`.chaining.scalaUtilChainingOps[Int](1).tap[Unit](((x: Any) => scala.Predef.println(x))), {
+  {
+    <artifact> val x$1: Int = scala.util.`package`.chaining.scalaUtilChainingOps[Int](2).tap[Unit](((x: Any) => scala.Predef.println(x)));
+    <artifact> val x$2: Int = $line17.$read.INSTANCE.$iw.rann.<init>$default$1;
+    new $line17.$read.INSTANCE.$iw.rann(x$2, x$1)
+  };
+  2
+})
 
 scala> :quit

--- a/test/files/run/sd884.check
+++ b/test/files/run/sd884.check
@@ -1,0 +1,76 @@
+
+scala> import annotation.Annotation
+import annotation.Annotation
+
+scala> class ann(x: Int = 0, y: Int = 0) extends Annotation
+class ann
+
+scala> class naa(x: Int = 0, y: Int = 0) extends Annotation {
+  def this(s: String) = this(1, 2)
+}
+class naa
+
+scala> class mul(x: Int = 0, y: Int = 0)(z: Int = 0, zz: Int = 0) extends Annotation
+class mul
+
+scala> class C {
+  val a = 1
+  val b = 2
+
+  @ann(y = b, x = a) def m1 = 1
+
+  @ann(x = a) def m2 = 1
+  @ann(y = b) def m3 = 1
+
+  @naa(a, b) def m4 = 1
+  @naa(y = b, x = a) def m5 = 1
+  @naa("") def m6 = 1
+
+  // warn, only first argument list is kept
+  @mul(a, b)(a, b) def m7 = 1
+  @mul(y = b)(a, b) def m8 = 1
+  @mul(y = b, x = a)(zz = b) def m9 = 1
+  @mul(y = b)(zz = b) def m10 = 1
+}
+         @mul(a, b)(a, b) def m7 = 1
+          ^
+On line 15: warning: Implementation limitation: multiple argument lists on annotations are
+       currently not supported; ignoring arguments List(C.this.a, C.this.b)
+         @mul(y = b)(a, b) def m8 = 1
+          ^
+On line 16: warning: Implementation limitation: multiple argument lists on annotations are
+       currently not supported; ignoring arguments List(C.this.a, C.this.b)
+         @mul(y = b, x = a)(zz = b) def m9 = 1
+          ^
+On line 17: warning: Implementation limitation: multiple argument lists on annotations are
+       currently not supported; ignoring arguments List(mul.<init>$default$3(C.this.a, C.this.b), C.this.b)
+         @mul(y = b)(zz = b) def m10 = 1
+          ^
+On line 18: warning: Implementation limitation: multiple argument lists on annotations are
+       currently not supported; ignoring arguments List(mul.<init>$default$3(mul.<init>$default$1, C.this.b), C.this.b)
+class C
+
+scala> :power
+Power mode enabled. :phase is at typer.
+import scala.tools.nsc._, intp.global._, definitions._
+Try :help or completions for vals._ and power._
+
+scala> println(typeOf[C].members.toList.filter(_.name.startsWith("m")).sortBy(_.name).map(_.annotations).mkString("\n"))
+List(ann(C.this.a, C.this.b))
+List(mul($line15.$read.INSTANCE.$iw.mul.<init>$default$1, C.this.b))
+List(ann(C.this.a, $line13.$read.INSTANCE.$iw.ann.<init>$default$2))
+List(ann($line13.$read.INSTANCE.$iw.ann.<init>$default$1, C.this.b))
+List(naa(C.this.a, C.this.b))
+List(naa(C.this.a, C.this.b))
+List(naa(""))
+List(mul(C.this.a, C.this.b))
+List(mul($line15.$read.INSTANCE.$iw.mul.<init>$default$1, C.this.b))
+List(mul(C.this.a, C.this.b))
+
+scala> val i = typeOf[C].member(TermName("m6")).annotations.head
+val i: $r.intp.global.AnnotationInfo = naa("")
+
+scala> i.constructorSymbol(global.typer.typed).paramss
+val res1: List[List[$r.intp.global.Symbol]] = List(List(value s))
+
+scala> :quit

--- a/test/files/run/sd884.check
+++ b/test/files/run/sd884.check
@@ -65,19 +65,19 @@ Power mode enabled. :phase is at typer.
 import scala.tools.nsc._, intp.global._, definitions._
 Try :help or completions for vals._ and power._
 
-scala> println(typeOf[C].members.toList.filter(_.name.startsWith("m")).sortBy(_.name).map(_.annotations).mkString("\n"))
-List(ann(C.this.a, C.this.b))
-List(mul(1, C.this.b))
-List(kon(y = 22))
-List(kon(x = 11))
-List(ann(C.this.a, 2))
-List(ann(1, C.this.b))
-List(naa(C.this.a, C.this.b))
-List(naa(C.this.a, C.this.b))
-List(naa(""))
-List(mul(C.this.a, C.this.b))
-List(mul(1, C.this.b))
-List(mul(C.this.a, C.this.b))
+scala> println(typeOf[C].members.toList.filter(_.name.startsWith("m")).sortBy(_.name).map(_.annotations.head).mkString("\n"))
+ann(C.this.a, C.this.b)
+mul(1, C.this.b)
+kon(y = 22)
+kon(x = 11)
+ann(C.this.a, 2)
+ann(1, C.this.b)
+naa(C.this.a, C.this.b)
+naa(C.this.a, C.this.b)
+naa("")
+mul(C.this.a, C.this.b)
+mul(1, C.this.b)
+mul(C.this.a, C.this.b)
 
 scala> val i6 = typeOf[C].member(TermName("m6")).annotations.head
 val i6: $r.intp.global.AnnotationInfo = naa("")
@@ -121,5 +121,66 @@ List(scala.util.`package`.chaining.scalaUtilChainingOps[Int](1).tap[Unit](((x: A
   };
   2
 })
+
+scala> // subclassing
+
+scala> class sub1(z: Int = 3) extends ann(11, z)
+class sub1
+
+scala> class sub2(z: Int = 3) extends ann(y = z)
+class sub2
+
+scala> class suk(z: Int = 3) extends kon(y = 22)
+class suk
+
+scala> class sum(z: Int) extends mul(11, 22)(z)
+class sum
+
+scala> println(typeOf[sub1].typeSymbol.annotations)
+List(scala.annotation.meta.superArg("x", 11), scala.annotation.meta.superFwdArg("y", "z"))
+
+scala> println(typeOf[sub2].typeSymbol.annotations)
+List(scala.annotation.meta.superArg("x", 1), scala.annotation.meta.superFwdArg("y", "z"))
+
+scala> println(typeOf[suk].typeSymbol.annotations)
+List(scala.annotation.meta.superArg("y", 22))
+
+scala> println(typeOf[sum].typeSymbol.annotations) // none
+List()
+
+scala> class D {
+  val a = 1
+
+  @sub1() def m1 = 1
+  @sub1(a) def m2 = 1
+  @sub2 def m3 = 1
+  @sub2(33) def m4 = 1
+
+  @suk() def k1 = 1
+  @suk(33) def k2 = 1
+}
+class D
+
+scala> val ms = typeOf[D].members.toList.filter(_.name.startsWith("m")).sortBy(_.name).map(_.annotations.head)
+val ms: List[$r.intp.global.AnnotationInfo] = List(sub1(3), sub1(D.this.a), sub2(3), sub2(33))
+
+scala> ms.foreach(m => {println(m.args); println(m.argsForSuper(typeOf[ann].typeSymbol)) })
+List(3)
+List(11, 3)
+List(D.this.a)
+List(11, D.this.a)
+List(3)
+List(1, 3)
+List(33)
+List(1, 33)
+
+scala> val ks = typeOf[D].members.toList.filter(_.name.startsWith("k")).sortBy(_.name).map(_.annotations.head)
+val ks: List[$r.intp.global.AnnotationInfo] = List(suk, suk(z = 33))
+
+scala> ks.foreach(k => {println(k.assocs); println(k.assocsForSuper(typeOf[kon].typeSymbol)) })
+List()
+List((y,22))
+List((z,33))
+List((y,22))
 
 scala> :quit

--- a/test/files/run/sd884.scala
+++ b/test/files/run/sd884.scala
@@ -1,0 +1,35 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  override def code =
+    """import annotation.Annotation
+      |class ann(x: Int = 0, y: Int = 0) extends Annotation
+      |class naa(x: Int = 0, y: Int = 0) extends Annotation {
+      |  def this(s: String) = this(1, 2)
+      |}
+      |class mul(x: Int = 0, y: Int = 0)(z: Int = 0, zz: Int = 0) extends Annotation
+      |class C {
+      |  val a = 1
+      |  val b = 2
+      |
+      |  @ann(y = b, x = a) def m1 = 1
+      |
+      |  @ann(x = a) def m2 = 1
+      |  @ann(y = b) def m3 = 1
+      |
+      |  @naa(a, b) def m4 = 1
+      |  @naa(y = b, x = a) def m5 = 1
+      |  @naa("") def m6 = 1
+      |
+      |  // warn, only first argument list is kept
+      |  @mul(a, b)(a, b) def m7 = 1
+      |  @mul(y = b)(a, b) def m8 = 1
+      |  @mul(y = b, x = a)(zz = b) def m9 = 1
+      |  @mul(y = b)(zz = b) def m10 = 1
+      |}
+      |:power
+      |println(typeOf[C].members.toList.filter(_.name.startsWith("m")).sortBy(_.name).map(_.annotations).mkString("\n"))
+      |val i = typeOf[C].member(TermName("m6")).annotations.head
+      |i.constructorSymbol(global.typer.typed).paramss
+      |""".stripMargin
+}

--- a/test/files/run/sd884.scala
+++ b/test/files/run/sd884.scala
@@ -2,12 +2,13 @@ import scala.tools.partest.ReplTest
 
 object Test extends ReplTest {
   override def code =
-    """import annotation.Annotation
-      |class ann(x: Int = 0, y: Int = 0) extends Annotation
-      |class naa(x: Int = 0, y: Int = 0) extends Annotation {
+    """import annotation._
+      |class ann(x: Int = 1, y: Int = 2) extends Annotation
+      |class naa(x: Int = 1, y: Int = 2) extends Annotation {
       |  def this(s: String) = this(1, 2)
       |}
-      |class mul(x: Int = 0, y: Int = 0)(z: Int = 0, zz: Int = 0) extends Annotation
+      |class mul(x: Int = 1, y: Int = 2)(z: Int = 3, zz: Int = 4) extends Annotation
+      |class kon(x: Int = 1, y: Int = 2) extends ConstantAnnotation
       |class C {
       |  val a = 1
       |  val b = 2
@@ -26,10 +27,19 @@ object Test extends ReplTest {
       |  @mul(y = b)(a, b) def m8 = 1
       |  @mul(y = b, x = a)(zz = b) def m9 = 1
       |  @mul(y = b)(zz = b) def m10 = 1
+      |
+      |  @kon(y = 22) def m11 = 1
+      |  @kon(11) def m12 = 1
       |}
       |:power
       |println(typeOf[C].members.toList.filter(_.name.startsWith("m")).sortBy(_.name).map(_.annotations).mkString("\n"))
-      |val i = typeOf[C].member(TermName("m6")).annotations.head
-      |i.constructorSymbol(global.typer.typed).paramss
+      |val i6 = typeOf[C].member(TermName("m6")).annotations.head
+      |i6.constructorSymbol(global.typer.typed).paramss
+      |val i11 = typeOf[C].member(TermName("m11")).annotations.head
+      |i11.assocs
+      |i11.assocsWithDefaults
+      |val i3 = typeOf[C].member(TermName("m3")).annotations.head
+      |i3.args.map(_.tpe)
+      |i3.args.map(i3.argIsDefault)
       |""".stripMargin
 }

--- a/test/files/run/sd884.scala
+++ b/test/files/run/sd884.scala
@@ -2,13 +2,14 @@ import scala.tools.partest.ReplTest
 
 object Test extends ReplTest {
   override def code =
-    """import annotation._
+    """import annotation._, scala.util.chaining._
       |class ann(x: Int = 1, y: Int = 2) extends Annotation
       |class naa(x: Int = 1, y: Int = 2) extends Annotation {
       |  def this(s: String) = this(1, 2)
       |}
       |class mul(x: Int = 1, y: Int = 2)(z: Int = 3, zz: Int = 4) extends Annotation
       |class kon(x: Int = 1, y: Int = 2) extends ConstantAnnotation
+      |class rann(x: Int = 1.tap(println), y: Int) extends Annotation
       |class C {
       |  val a = 1
       |  val b = 2
@@ -41,5 +42,9 @@ object Test extends ReplTest {
       |val i3 = typeOf[C].member(TermName("m3")).annotations.head
       |i3.args.map(_.tpe)
       |i3.args.map(i3.argIsDefault)
+      |// ordinary named/default args when using annotation class in executed code
+      |new rann(y = 2.tap(println)); () // prints 2, then the default 1
+      |@rann(y = {new rann(y = 2.tap(println)); 2}) class r1
+      |println(typeOf[r1].typeSymbol.annotations.head.args)
       |""".stripMargin
 }

--- a/test/files/run/sd884.scala
+++ b/test/files/run/sd884.scala
@@ -33,7 +33,7 @@ object Test extends ReplTest {
       |  @kon(11) def m12 = 1
       |}
       |:power
-      |println(typeOf[C].members.toList.filter(_.name.startsWith("m")).sortBy(_.name).map(_.annotations).mkString("\n"))
+      |println(typeOf[C].members.toList.filter(_.name.startsWith("m")).sortBy(_.name).map(_.annotations.head).mkString("\n"))
       |val i6 = typeOf[C].member(TermName("m6")).annotations.head
       |i6.constructorSymbol(global.typer.typed).paramss
       |val i11 = typeOf[C].member(TermName("m11")).annotations.head
@@ -46,5 +46,29 @@ object Test extends ReplTest {
       |new rann(y = 2.tap(println)); () // prints 2, then the default 1
       |@rann(y = {new rann(y = 2.tap(println)); 2}) class r1
       |println(typeOf[r1].typeSymbol.annotations.head.args)
+      |// subclassing
+      |class sub1(z: Int = 3) extends ann(11, z)
+      |class sub2(z: Int = 3) extends ann(y = z)
+      |class suk(z: Int = 3) extends kon(y = 22)
+      |class sum(z: Int) extends mul(11, 22)(z)
+      |println(typeOf[sub1].typeSymbol.annotations)
+      |println(typeOf[sub2].typeSymbol.annotations)
+      |println(typeOf[suk].typeSymbol.annotations)
+      |println(typeOf[sum].typeSymbol.annotations) // none
+      |class D {
+      |  val a = 1
+      |
+      |  @sub1() def m1 = 1
+      |  @sub1(a) def m2 = 1
+      |  @sub2 def m3 = 1
+      |  @sub2(33) def m4 = 1
+      |
+      |  @suk() def k1 = 1
+      |  @suk(33) def k2 = 1
+      |}
+      |val ms = typeOf[D].members.toList.filter(_.name.startsWith("m")).sortBy(_.name).map(_.annotations.head)
+      |ms.foreach(m => {println(m.args); println(m.argsForSuper(typeOf[ann].typeSymbol)) })
+      |val ks = typeOf[D].members.toList.filter(_.name.startsWith("k")).sortBy(_.name).map(_.annotations.head)
+      |ks.foreach(k => {println(k.assocs); println(k.assocsForSuper(typeOf[kon].typeSymbol)) })
       |""".stripMargin
 }

--- a/test/files/run/sd884b.check
+++ b/test/files/run/sd884b.check
@@ -1,0 +1,54 @@
+
+scala> class B {
+  @ann(x = 11) def m1 = 1
+  @ann(y = 22) def m2 = 1
+
+  @kon(x = 11) def k1 = 1
+  @kon(y = 22) def k2 = 1
+}
+class B
+
+scala> :power
+Power mode enabled. :phase is at typer.
+import scala.tools.nsc._, intp.global._, definitions._
+Try :help or completions for vals._ and power._
+
+scala> def t(tp: Type) = {
+  val ms = tp.members.toList.filter(_.name.startsWith("m")).sortBy(_.name)
+  for (m <- ms) {
+    val i = m.annotations.head
+    println(i)
+    println(i.args.map(_.tpe))
+    println(i.args.map(i.argIsDefault))
+  }
+  val ks = tp.members.toList.filter(_.name.startsWith("k")).sortBy(_.name)
+  ks.foreach(k => println(k.annotations.head))
+  ks.foreach(k => println(k.annotations.head.assocsWithDefaults))
+}
+def t(tp: $r.intp.global.Type): Unit
+
+scala> t(typeOf[A])
+ann(11, T.i)
+List(Int, Int @scala.annotation.meta.defaultArg)
+List(false, true)
+ann(1, 22)
+List(Int(1) @scala.annotation.meta.defaultArg, Int)
+List(true, false)
+kon(x = 11)
+kon(y = 22)
+List((x,11), (y,2))
+List((x,1), (y,22))
+
+scala> t(typeOf[B])
+ann(11, T.i)
+List(Int(11), Int @scala.annotation.meta.defaultArg)
+List(false, true)
+ann(1, 22)
+List(Int @scala.annotation.meta.defaultArg, Int(22))
+List(true, false)
+kon(x = 11)
+kon(y = 22)
+List((x,11), (y,2))
+List((x,1), (y,22))
+
+scala> :quit

--- a/test/files/run/sd884b/A.scala
+++ b/test/files/run/sd884b/A.scala
@@ -1,0 +1,12 @@
+class ann(x: Int = 1, y: Int = T.i) extends annotation.StaticAnnotation
+class kon(x: Int = 1, y: Int = 2) extends annotation.ConstantAnnotation
+
+object T { def i = 0 }
+
+class A {
+  @ann(x = 11) def m1 = 1
+  @ann(y = 22) def m2 = 1
+
+  @kon(x = 11) def k1 = 1
+  @kon(y = 22) def k2 = 1
+}

--- a/test/files/run/sd884b/Test_1.scala
+++ b/test/files/run/sd884b/Test_1.scala
@@ -1,0 +1,28 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  override def code =
+    """class B {
+      |  @ann(x = 11) def m1 = 1
+      |  @ann(y = 22) def m2 = 1
+      |
+      |  @kon(x = 11) def k1 = 1
+      |  @kon(y = 22) def k2 = 1
+      |}
+      |:power
+      |def t(tp: Type) = {
+      |  val ms = tp.members.toList.filter(_.name.startsWith("m")).sortBy(_.name)
+      |  for (m <- ms) {
+      |    val i = m.annotations.head
+      |    println(i)
+      |    println(i.args.map(_.tpe))
+      |    println(i.args.map(i.argIsDefault))
+      |  }
+      |  val ks = tp.members.toList.filter(_.name.startsWith("k")).sortBy(_.name)
+      |  ks.foreach(k => println(k.annotations.head))
+      |  ks.foreach(k => println(k.annotations.head.assocsWithDefaults))
+      |}
+      |t(typeOf[A])
+      |t(typeOf[B])
+      |""".stripMargin
+}


### PR DESCRIPTION
In an ordinary application `f(y = b, x = a)`, the compiler needs to create a block with local variables

```scala
{
  val x$1 = b
  val x$2 = a
  f(x$2, x$1)
}
```

in order to preserve evaluation order (`b` before `a`).

## Avoid named / default args transformation

For annotations `@ann(y = b, x = a)` this is not needed, and it makes annotation processing more difficult / impossible.

This PR disables the named / default arguments transformation for annotations.

## Inline default argument values (syntax trees)

Furthermore, when an annotation uses a default argument, the compiler inserts a copy of the default expression AST to the `AnnotationInfo` (instaead of a call to the `annot$init$default$1` method):

```scala
scala> :power
scala> class ann(x: Int = 1, y: Int = 2) extends annotation.Annotation
scala> @ann(y = 22) class C
scala> val i = typeOf[C].typeSymbol.annotations.head
val i: $r.intp.global.AnnotationInfo = ann(1, 22)
```

The `argIsDefault` method identifies which annotation arguments are defaults inserted by the compiler

```scala
scala> i.args.map(a => i.argIsDefault(a))
  List(true, false)
```

<details>
<summary><b>Details</b></summary>

The default expression ASTs are stored in meta-annotations so that they can be recovered later when using an annotation:


```scala
scala> typeOf[ann].typeSymbol.primaryConstructor.paramss.flatten.map(p => (p, p.annotations))
  List((value x,List(scala.annotation.meta.defaultArg(1))), (value y,List(scala.annotation.meta.defaultArg(2))))
```

The behavior with defaults differes betwen Java/ConstantAnnotation and other annotations.

In 2.13.15:
  - missing arguments for a Java/ConstantAnnotation are simply not present in `annotationInfo.assocs`
  - missing args for other annotations are present in `args` as `annot.init$default$1` method call ASTs

In order to remain mostly compatible, in this PR:
  - `assocs` still returns only explicit arguments, the new `annotationInfo.assocsWithDefaults` method extends `assocs` with the default values
  - default arguments in `args` are now an AST corresponding to the default expression.

Internally, default annotation arguments inserted by the compiler have the `arg.tpe` tagged with an `@defaultArg`:

```scala
scala> class ann(x: Int = 1) extends annotation.Annotation
scala> @ann() class K

scala> :power

scala> val info = typeOf[K].typeSymbol.annotations.head
val info: $r.intp.global.AnnotationInfo = ann(1)

scala> info.args.head.tpe
val res1: $r.intp.global.Type = Int(1) @scala.annotation.meta.defaultArg

scala> info.argIsDefault(info.args.head)
val res2: Boolean = true
```
</details>

## Support user-defined annotation subclasses

This PR also adds support for user-defined annotation subclasses. The `annotationInfo.argsForSuper` method returns the corresponding annotation arguments:

```scala
scala> class sub(z: Int) extends ann(11, z)
scala> @sub(z = 33) class D

scala> val info = typeOf[D].typeSymbol.annotations.head
val info: $r.intp.global.AnnotationInfo = sub(33)

scala> info.argsForSuper(typeOf[ann].typeSymbol)
val res5: List[$r.intp.global.Tree] = List(11, 33)
```

<details>
<summary><b>Details</b></summary>
Arguments passed to the super annotation are encoded in yet more meta annotations:

```scala
scala> typeOf[sub].typeSymbol.annotations
val res6: List[$r.intp.global.AnnotationInfo] = List(scala.annotation.meta.superArg("x", 11), scala.annotation.meta.superFwdArg(p = "y", n = "z"))
```
</details>

## Custom `@nowarn` subclasses

Finally, this PR adds support for custom `@nowarn` subclasses

```scala
scala> class nodep extends annotation.nowarn("cat=deprecation")
scala> @nodep def f = Map().mapValues(identity)
def f: scala.collection.MapView[Nothing,Nothing]
```

-----

Fixes https://github.com/scala/scala-dev/issues/884, https://github.com/scala/bug/issues/7656, https://github.com/scala/bug/issues/9612, https://github.com/scala/bug/issues/12367

Ticket for Scala 3 forward port: https://github.com/scala/scala3/discussions/22414