### PR TITLE
REPL: on Windows, allow default `-Dscala.color=auto` to show colors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -635,7 +635,6 @@ lazy val replFrontend = configureAsSubproject(project, srcdir = Some("repl-front
   )
   .settings(
     run := (Compile / run).partialInput(" -usejavacp").evaluated, // so `replFrontend/run` works
-    Compile / run / javaOptions += s"-Dscala.color=${!scala.util.Properties.isWin}",
     Compile / run / javaOptions += "-Dorg.jline.terminal.output=forced-out",
   )
   .dependsOn(repl)

--- a/src/library/scala/util/Properties.scala
+++ b/src/library/scala/util/Properties.scala
@@ -142,7 +142,7 @@ private[scala] trait PropertiesTrait {
   private[scala] lazy val isAvian = javaVmName.contains("Avian")
 
   private[scala] def coloredOutputEnabled: Boolean = propOrElse("scala.color", "auto") match {
-    case "auto" => !isWin && consoleIsTerminal
+    case "auto" => consoleIsTerminal
     case s      => "" == s || "true".equalsIgnoreCase(s)
   }
 


### PR DESCRIPTION
This brings the behavior on Windows in line with other platforms.

To disable the colors if necessary, use `-Dscala.color=false`.

## Notes

This implements the change proposed in [bug/issues/13077]( https://github.com/scala/bug/issues/13077).
It addresses this `scala-cli` bug : [scala-cli/issues/#3394](https://github.com/VirtusLab/scala-cli/issues/3394)

The change was manually verified by confirming color is enabled by default:

- Command Prompt session in Windows Terminal
![image](https://github.com/user-attachments/assets/21407155-d429-4924-8331-ab4aaf1de5d4)

- `CMD.EXE` session 
![image](https://github.com/user-attachments/assets/ebf53d15-58ef-4d21-9252-a0e2ca8cf308)

- MSYS64 bash shell
![image](https://github.com/user-attachments/assets/47686f67-5791-4035-bda8-c41aabdd1934)

- CYGWIN session running in Windows Terminal
![image](https://github.com/user-attachments/assets/875fa369-4fa7-4e6e-8bd4-dbc3d3cbd30b)

- CYGWIN session in MINTTY console
![image](https://github.com/user-attachments/assets/875f8a23-669c-43f3-ac5c-5a545dd51256)

- Git Bash session in Windows Terminal
![image](https://github.com/user-attachments/assets/dc3cbacb-1181-4901-899d-730573a12a3c)

- MINGW64 in Windows Terminal
![image](https://github.com/user-attachments/assets/b8ee80b1-25c3-4b84-bb9f-a958a4446e12)

- WSL2 Ubuntu Linux session
![image](https://github.com/user-attachments/assets/18ed7541-0eec-4403-af08-14db91f95ea5)

Verified that color can be disabled on the command line:
![image](https://github.com/user-attachments/assets/83ecbf52-86ca-4323-b89d-13752e0b4c6f)

