### PR TITLE
Correctly report unused variables introduced by patterns in value definitions in for comprehensions

### DIFF
--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -742,7 +742,7 @@ abstract class TreeGen {
         )
         val untupled = {
           val allpats = (pat :: pats).map(_.duplicate)
-          atPos(wrappingPos(allpats))(mkTuple(allpats))
+          atPos(wrappingPos(allpats))(mkTuple(allpats).updateAttachment(ForAttachment))
         }
         val pos1 =
           if (t.pos == NoPosition) NoPosition
@@ -816,7 +816,7 @@ abstract class TreeGen {
           rhs1,
           List(
             atPos(pat1.pos) {
-              CaseDef(pat1, EmptyTree, mkTuple(vars map (_._1) map Ident.apply))
+              CaseDef(pat1, EmptyTree, mkTuple(vars.map(_._1).map(Ident.apply)).updateAttachment(ForAttachment))
             }
           ))
       }

--- a/test/files/neg/t13070.check
+++ b/test/files/neg/t13070.check
@@ -1,0 +1,12 @@
+t13070.scala:7: warning: pattern var i in value $anonfun is never used
+      (i, j) = ns // warn // warn
+       ^
+t13070.scala:7: warning: pattern var j in value $anonfun is never used
+      (i, j) = ns // warn // warn
+          ^
+t13070.scala:16: warning: pattern var j in value $anonfun is never used
+      (i, j) = ns // warn
+          ^
+error: No warnings can be incurred under -Werror.
+3 warnings
+1 error

--- a/test/files/neg/t13070.scala
+++ b/test/files/neg/t13070.scala
@@ -1,0 +1,59 @@
+//> using options -Wunused:patvars -Werror
+class C {
+  def g = {
+    val t = Option((27, 42))
+    for {
+      ns <- t
+      (i, j) = ns // warn // warn
+    } yield 42
+  }
+}
+class D {
+  def g = {
+    val t = Option((27, 42))
+    for {
+      ns <- t
+      (i, j) = ns // warn
+    } yield 42 + i
+  }
+}
+
+// the following do not warn under -Wunused:patvars in Scala 2 (but Scala 3 does)
+object `pat vardef are patvars` {
+  private var (i, j) = (42, 27) // warn // warn
+}
+
+object `patvar is assignable` {
+  var (i, j) = (42, 27) // no warn nonprivate
+  j += 1
+  println((i, j))
+}
+
+object `privy patvar is assignable` {
+  private var (i, j) = (42, 27) // warn
+  j += 1
+  println((i, j))
+}
+
+object `local patvar is assignable` {
+  def f() = {
+    var (i, j) = (42, 27) // warn
+    j += 1
+    println((i, j))
+  }
+}
+
+object `mutable patvar in for` {
+  def f(xs: List[Int]) = {
+    for (x <- xs; y = x + 1 if y > 10)
+    yield {
+      var z :: Nil = y :: Nil: @unchecked // warn
+      z + 10
+    }
+  }
+}
+
+class `unset var requires -Wunused` {
+  private var i = 0 // no warn as we didn't ask for it
+  def f = println(i)
+}


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/13070