### PR TITLE
improve ArrayBuffer.addOne performance

### DIFF
--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -140,9 +140,9 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
   def addOne(elem: A): this.type = {
     mutationCount += 1
     val newSize = size0 + 1
-    ensureSize(newSize)
+    if(array.length <= newSize - 1) ensureSize(newSize)
     size0 = newSize
-    this(size0 - 1) = elem
+    array(newSize - 1) = elem.asInstanceOf[AnyRef]
     this
   }
 

--- a/test/benchmarks/src/main/scala/scala/collection/mutable/ArrayBufferBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/mutable/ArrayBufferBenchmark.scala
@@ -63,6 +63,20 @@ class ArrayBufferBenchmark {
     bh.consume(b1)
   }
 
+  //addOne
+  @Benchmark def addOneArrayBuffer(bh:Blackhole):Unit = {
+    val res = ArrayBuffer[Object]()
+    ref.asInstanceOf[ArrayBuffer[Object]].foreach(res.addOne)
+    bh.consume(res)
+  }
+
+  //addOne comparison
+  @Benchmark def addOneArrayList(bh:Blackhole):Unit = {
+    val res = new java.util.ArrayList[Object]()
+    ref.asInstanceOf[ArrayBuffer[Object]].foreach(res.add)
+    bh.consume(res)
+  }
+
   // append `Iterable` with known size
   @Benchmark def addAll2(bh: Blackhole): Unit = {
     val b = ref.clone()


### PR DESCRIPTION
This improves ArrayBuffer.addOne performance.

The performance improvement is because actually growing the underlying array is rare, so it pays a lot to encourage a situation where the fastpath is inlined, and the actual resizing is not inlined.

This comes with two changes: First, we can identify the good fastpath and avoid calling ensureSize, and second we don't need to update mutationCount twice.

Tested with
```
sbt:scala2> bench/Jmh/run scala.collection.mutable.ArrayBufferBenchmark.addOne* -i 3 -wi 1 -f1 -t1
```
Before:
```
[info] # JMH version: 1.37
[info] # VM version: JDK 21.0.5, OpenJDK 64-Bit Server VM, 21.0.5+11
[info] Benchmark                               (size)  Mode  Cnt      Score       Error  Units
[info] ArrayBufferBenchmark.addOneArrayBuffer      10  avgt    3     84.099 ±     2.883  ns/op
[info] ArrayBufferBenchmark.addOneArrayBuffer     100  avgt    3    778.368 ±    46.573  ns/op
[info] ArrayBufferBenchmark.addOneArrayBuffer    1000  avgt    3   5501.210 ±   287.987  ns/op
[info] ArrayBufferBenchmark.addOneArrayBuffer   10000  avgt    3  58386.443 ±  2288.640  ns/op
[info] ArrayBufferBenchmark.addOneArrayList        10  avgt    3     46.995 ±    12.254  ns/op
[info] ArrayBufferBenchmark.addOneArrayList       100  avgt    3    573.067 ±     4.742  ns/op
[info] ArrayBufferBenchmark.addOneArrayList      1000  avgt    3   4813.111 ±  3534.428  ns/op
[info] ArrayBufferBenchmark.addOneArrayList     10000  avgt    3  51735.758 ± 62955.018  ns/op
```
After:
```
[info] Benchmark                               (size)  Mode  Cnt      Score       Error  Units
[info] ArrayBufferBenchmark.addOneArrayBuffer      10  avgt    3     60.318 ±     2.618  ns/op
[info] ArrayBufferBenchmark.addOneArrayBuffer     100  avgt    3    544.034 ±    17.179  ns/op
[info] ArrayBufferBenchmark.addOneArrayBuffer    1000  avgt    3   4627.398 ±   464.332  ns/op
[info] ArrayBufferBenchmark.addOneArrayBuffer   10000  avgt    3  47260.816 ± 36998.515  ns/op
[info] ArrayBufferBenchmark.addOneArrayList        10  avgt    3     47.173 ±    12.243  ns/op
[info] ArrayBufferBenchmark.addOneArrayList       100  avgt    3    574.507 ±    24.936  ns/op
[info] ArrayBufferBenchmark.addOneArrayList      1000  avgt    3   4833.217 ±  3415.794  ns/op
[info] ArrayBufferBenchmark.addOneArrayList     10000  avgt    3  51487.699 ± 63914.819  ns/op
```

cc @mpollmeier , to discourage switching ArrayBuffer for java.util.ArrayList in our code ;)

Generally speaking, I like the java.util.ArrayList logic more than the ArrayBuffer logic on two fronts:
1. A growth rate of 1.5 (newSize = oldSize + (oldSize>>1)) is imo more appropriate than our growth rate of 2
2. ArrayList has very nice logic to initialize new ArrayLists with a global (shared) zero-element array. This kind of lazy initialization saves much memory if people create a lot of empty ArrayLists that are never used (and people do that! representing an empty ArrayBuffer with a null-pointer gets annoying very fast!)

On the other hand, our eager initialization leads to a situation where the ArrayList object and the initial backing array tend to be directly adjacent in memory, and ideally sit on the same cache-line. So our approach should win out for small ArrayLists.

If it was up to me I'd copy java's lazy initialization. If there is interest, I could prepare a PR?
