### PR TITLE
Show nowarn / Wconf filters for a warning with  `@nowarn("verbose")`

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -40,8 +40,8 @@ trait Warnings {
          |Syntax: -Wconf:<filters>:<action>,<filters>:<action>,...
          |multiple <filters> are combined with &, i.e., <filter>&...&<filter>
          |
-         |Note: Run with `-Wconf:any:warning-verbose` to print warnings with their category, site,
-         |and (for deprecations) origin and since-version.
+         |Use the `@nowarn("verbose")` / `@nowarn("v")` annotation or `-Wconf:any:warning-verbose`
+         |to print applicable message filters with every warning.
          |
          |<filter>
          |  - Any message: any

--- a/src/library/scala/annotation/nowarn.scala
+++ b/src/library/scala/annotation/nowarn.scala
@@ -14,14 +14,20 @@ package scala.annotation
 
 /** An annotation for local warning suppression.
   *
-  * The optional `value` parameter allows selectively silencing messages, see `scalac -Wconf:help`
-  * for help. Examples:
+  * The optional `value` parameter allows selectively silencing messages. See `-Wconf:help` for help
+  * writing a message filter expression, or use `@nowarn("verbose")` / `@nowarn("v")` to display message
+  * filters applicable to a specific warning.
+  *
+  * Examples:
   *
   * {{{
   *   def f = {
   *     1: @nowarn // don't warn "a pure expression does nothing in statement position"
   *     2
   *   }
+  *
+  *   // show the warning, plus the applicable @nowarn / Wconf filters ("cat=other-pure-statement", ...)
+  *   @nowarn("v") def f = { 1; 2 }
   *
   *   @nowarn def f = { 1; deprecated() } // don't warn
   *

--- a/test/files/neg/nowarnRangePos.check
+++ b/test/files/neg/nowarnRangePos.check
@@ -1,3 +1,7 @@
+nowarnRangePos.scala:84: warning: A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.
+Applicable -Wconf / @nowarn filters for this warning: msg=<part of the message>, cat=other, site=C.T12.f
+    @nowarn("v") def f = try 1
+                         ^
 nowarnRangePos.scala:11: warning: method dep in class C is deprecated (since 1.2.3): message
   @nowarn @ann(dep) def t2 = 0          // deprecation warning, @nowarn unused
                ^
@@ -19,6 +23,10 @@ nowarnRangePos.scala:75: warning: a pure expression does nothing in statement po
 nowarnRangePos.scala:80: warning: method dep in class C is deprecated (since 1.2.3): message
     a + dep
         ^
+nowarnRangePos.scala:90: warning: a pure expression does nothing in statement position; multiline expressions might require enclosing parentheses
+Applicable -Wconf / @nowarn filters for this warning: msg=<part of the message>, cat=other-pure-statement, site=C.T13.g
+    def g = { 1; 2 }
+              ^
 nowarnRangePos.scala:45: warning: I3b has a valid main method (args: Array[String]): Unit,
   but C.I3b will not have an entry point on the JVM.
   Reason: companion is a trait, which means no static forwarder can be generated.
@@ -43,6 +51,9 @@ nowarnRangePos.scala:24: warning: @nowarn annotation does not suppress any warni
 nowarnRangePos.scala:65: warning: @nowarn annotation does not suppress any warnings
   @nowarn("msg=something else") // unused
    ^
+nowarnRangePos.scala:91: warning: @nowarn annotation does not suppress any warnings
+    @nowarn("v") def unused = 0
+     ^
 error: No warnings can be incurred under -Werror.
-14 warnings
+17 warnings
 1 error

--- a/test/files/neg/nowarnRangePos.scala
+++ b/test/files/neg/nowarnRangePos.scala
@@ -79,6 +79,17 @@ class C {
     val a = dep: @nowarn
     a + dep
   }
+
+  @nowarn object T12 {
+    @nowarn("v") def f = try 1
+    def g = { 1; 2 }
+  }
+
+  @nowarn("verbose") object T13 {
+    @nowarn def f = try 1
+    def g = { 1; 2 }
+    @nowarn("v") def unused = 0
+  }
 }
 
 trait T {


### PR DESCRIPTION
This is a practical method to find out what filter can be applied to silence a warning, no need to modify the compiler flags in the build configuration.

Same as already implemented in Scala 3.

```scala
scala> @nowarn("v") def f = try 1
                            ^
       warning: A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.
       Applicable -Wconf / @nowarn filters for this warning: msg=<part of the message>, cat=other, site=f
def f: Int
```

(https://hachyderm.io/@spills/112831541923471812)