### PR TITLE
Fix completions from backticked identifiers

### DIFF
--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -1268,20 +1268,16 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
             typeCompletions(imp, qual, selector.namePos, selector.name)
         }
       case sel@Select(qual, name) =>
-        val qualPos = qual.pos
-        val effectiveQualEnd = if (qualPos.isRange) qualPos.end else qualPos.point - 1
-        def fallback = {
-          effectiveQualEnd + 2
-        }
-        val source = pos.source
-
-        val nameStart: Int = (focus1.pos.end - 1 to effectiveQualEnd by -1).find(p =>
-          source.identFrom(source.position(p)).exists(_.length == 0)
-        ).map(_ + 1).getOrElse(fallback)
+        val rawNameStart: Int = sel.pos.point
+        val hasBackTick = pos.source.content.lift(rawNameStart).contains('`')
+        val nameStart = if (hasBackTick) rawNameStart + 1 else rawNameStart
         typeCompletions(sel, qual, nameStart, name)
-      case Ident(name) =>
+      case ident@Ident(name) =>
         val allMembers = scopeMembers(pos)
-        val positionDelta: Int = pos.start - focus1.pos.start
+        val rawNameStart: Int = ident.pos.point
+        val hasBackTick = pos.source.content.lift(rawNameStart).contains('`')
+        val nameStart = if (hasBackTick) rawNameStart + 1 else rawNameStart
+        val positionDelta: Int = pos.start - nameStart
         val subName = name.subName(0, positionDelta)
         CompletionResult.ScopeMembers(positionDelta, scopeMemberFlatten(allMembers), subName, forImport = false)
       case _ =>

--- a/test/junit/scala/tools/nsc/interpreter/CompletionTest.scala
+++ b/test/junit/scala/tools/nsc/interpreter/CompletionTest.scala
@@ -120,6 +120,16 @@ class CompletionTest {
   }
 
   @Test
+  def backticks(): Unit = {
+    val intp = newIMain()
+    val completer = new ReplCompletion(intp)
+
+    checkExact(completer, "object X { def `Foo Bar` = 0; this.`Foo ", after = "` }")("Foo Bar")
+    checkExact(completer, "val `Foo Bar` = 0; `Foo ", after = "`")("Foo Bar")
+    checkExact(completer, "def foo(`Foo Bar`: Int) { `Foo ", after = "` }")("Foo Bar")
+  }
+
+  @Test
   def annotations(): Unit = {
     val completer = setup()
     checkExact(completer, "def foo[@specialize", " A]")("specialized")


### PR DESCRIPTION
The code detecting the completion prefix of the identifier before the cursor was not accounting for that identifier potentially being backticked.

This manifests both in the REPL where TAB completing inside backticks doesn't work and (what I care about more) in the presentation compiler `completionsAt` API.