### PR TITLE
Independent attachment to enforce Match desugaring

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchOptimization.scala
@@ -208,7 +208,7 @@ trait MatchOptimization extends MatchTreeMaking with MatchApproximation {
   trait SwitchEmission extends TreeMakers with MatchMonadInterface {
     import treeInfo.isGuardedCase
 
-    def inAsync: Boolean
+    def inForceDesugar: Boolean
 
     abstract class SwitchMaker {
       abstract class SwitchableTreeMakerExtractor { def unapply(x: TreeMaker): Option[Tree] }
@@ -502,7 +502,7 @@ trait MatchOptimization extends MatchTreeMaking with MatchApproximation {
     class RegularSwitchMaker(scrutSym: Symbol, matchFailGenOverride: Option[Tree => Tree], val unchecked: Boolean) extends SwitchMaker { import CODE._
       val switchableTpe = Set(ByteTpe, ShortTpe, IntTpe, CharTpe, StringTpe)
       val alternativesSupported = true
-      val canJump = !inAsync
+      val canJump = !inForceDesugar
 
       // Constant folding sets the type of a constant tree to `ConstantType(Constant(folded))`
       // The tree itself can be a literal, an ident, a selection, ...

--- a/src/reflect/scala/reflect/internal/StdAttachments.scala
+++ b/src/reflect/scala/reflect/internal/StdAttachments.scala
@@ -183,4 +183,7 @@ trait StdAttachments {
   case object DiscardedExpr extends PlainAttachment
   /** Anonymous parameter of `if (_)` may be inferred as Boolean. */
   case object BooleanParameterType extends PlainAttachment
+
+  /** Force desugaring Match trees, don't emit switches. Attach to DefDef trees or their symbol. */
+  case object ForceMatchDesugar extends PlainAttachment
 }

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -91,6 +91,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.DiscardedValue
     this.DiscardedExpr
     this.BooleanParameterType
+    this.ForceMatchDesugar
     this.noPrint
     this.typeDebug
     // inaccessible: this.posAssigner


### PR DESCRIPTION
Follow-up for a recent change (https://github.com/scala/scala/pull/10775) where Match desugaring is enforced (to avoid emitting switches) in methods later transformed by async.

This PR adds a separate attachment to enforce desugaring instead of relying on the `AsyncAttachment`. That makes it easier for compiler plugins to also enforce the desugaring (the `AsyncAttachment` is not public, and adding it has the effect of enabling the async transformation).