### PR TITLE
Ensure package objects are opened after namer in interactive

### DIFF
--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -403,8 +403,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
       case unit: RichCompilationUnit => unit.isParsed
       case _                         => true
     })
-    if (isPastNamer) super.openPackageModule(pkgClass, force = true)
-    else analyzer.packageObjects.deferredOpen.add(pkgClass)
+    super.openPackageModule(pkgClass, force = isPastNamer)
   }
 
   // ----------------- Polling ---------------------------------------

--- a/src/interactive/scala/tools/nsc/interactive/tests/InteractiveTest.scala
+++ b/src/interactive/scala/tools/nsc/interactive/tests/InteractiveTest.scala
@@ -86,9 +86,10 @@ abstract class InteractiveTest
         loadSources()
         runDefaultTests()
       }
-    }.linesIterator.map(normalize).foreach(println)
+    }.linesIterator.filterNot(filterOutLines).map(normalize).foreach(println)
   }
 
+  protected def filterOutLines(line: String) = false
   protected def normalize(s: String) = s
 
   /** Load all sources before executing the test. */

--- a/test/files/presentation/package-object-issues.check
+++ b/test/files/presentation/package-object-issues.check
@@ -1,0 +1,42 @@
+reload: Main.scala
+
+askTypeCompletion at Main.scala(7,6)
+================================================================================
+[response] askTypeCompletion at (7,6)
+def +(other: String): String
+def ->[B](y: B): (concurrent.ExecutionException, B)
+def ensuring(cond: Boolean): concurrent.ExecutionException
+def ensuring(cond: Boolean, msg: => Any): concurrent.ExecutionException
+def ensuring(cond: concurrent.ExecutionException => Boolean): concurrent.ExecutionException
+def ensuring(cond: concurrent.ExecutionException => Boolean, msg: => Any): concurrent.ExecutionException
+def equals(x$1: Object): Boolean
+def fillInStackTrace(): Throwable
+def formatted(fmtstr: String): String
+def getCause(): Throwable
+def getLocalizedMessage(): String
+def getMessage(): String
+def getStackTrace(): Array[StackTraceElement]
+def hashCode(): Int
+def initCause(x$1: Throwable): Throwable
+def printStackTrace(): Unit
+def printStackTrace(x$1: java.io.PrintStream): Unit
+def printStackTrace(x$1: java.io.PrintWriter): Unit
+def setStackTrace(x$1: Array[StackTraceElement]): Unit
+def toString(): String
+def →[B](y: B): (concurrent.ExecutionException, B)
+final def !=(x$1: Any): Boolean
+final def ## : Int
+final def ==(x$1: Any): Boolean
+final def addSuppressed(x$1: Throwable): Unit
+final def asInstanceOf[T0]: T0
+final def eq(x$1: AnyRef): Boolean
+final def getSuppressed(): Array[Throwable]
+final def isInstanceOf[T0]: Boolean
+final def ne(x$1: AnyRef): Boolean
+final def notify(): Unit
+final def notifyAll(): Unit
+final def synchronized[T0](x$1: T0): T0
+final def wait(): Unit
+final def wait(x$1: Long): Unit
+final def wait(x$1: Long, x$2: Int): Unit
+================================================================================

--- a/test/files/presentation/package-object-issues/Test.scala
+++ b/test/files/presentation/package-object-issues/Test.scala
@@ -1,0 +1,8 @@
+import scala.tools.nsc.interactive.tests.InteractiveTest
+
+object Test extends InteractiveTest {
+
+  override protected def filterOutLines(line: String) = 
+    line.contains("inaccessible") || line.contains("retrieved ")
+
+}

--- a/test/files/presentation/package-object-issues/src/Main.scala
+++ b/test/files/presentation/package-object-issues/src/Main.scala
@@ -1,0 +1,10 @@
+package scala.concurrent
+
+import scala.concurrent.ExecutionException
+
+object Main extends App {
+  def foo(n: ExecutionException, k: Int): Unit = {
+    n./*!*/
+    k
+  }
+}

--- a/test/files/presentation/package-object-type.check
+++ b/test/files/presentation/package-object-type.check
@@ -1,0 +1,42 @@
+reload: Main.scala
+
+askTypeCompletion at Main.scala(7,6)
+================================================================================
+[response] askTypeCompletion at (7,6)
+def +(other: String): String
+def ->[B](y: B): (concurrent.ExecutionException, B)
+def ensuring(cond: Boolean): concurrent.ExecutionException
+def ensuring(cond: Boolean, msg: => Any): concurrent.ExecutionException
+def ensuring(cond: concurrent.ExecutionException => Boolean): concurrent.ExecutionException
+def ensuring(cond: concurrent.ExecutionException => Boolean, msg: => Any): concurrent.ExecutionException
+def equals(x$1: Object): Boolean
+def fillInStackTrace(): Throwable
+def formatted(fmtstr: String): String
+def getCause(): Throwable
+def getLocalizedMessage(): String
+def getMessage(): String
+def getStackTrace(): Array[StackTraceElement]
+def hashCode(): Int
+def initCause(x$1: Throwable): Throwable
+def printStackTrace(): Unit
+def printStackTrace(x$1: java.io.PrintStream): Unit
+def printStackTrace(x$1: java.io.PrintWriter): Unit
+def setStackTrace(x$1: Array[StackTraceElement]): Unit
+def toString(): String
+def →[B](y: B): (concurrent.ExecutionException, B)
+final def !=(x$1: Any): Boolean
+final def ## : Int
+final def ==(x$1: Any): Boolean
+final def addSuppressed(x$1: Throwable): Unit
+final def asInstanceOf[T0]: T0
+final def eq(x$1: AnyRef): Boolean
+final def getSuppressed(): Array[Throwable]
+final def isInstanceOf[T0]: Boolean
+final def ne(x$1: AnyRef): Boolean
+final def notify(): Unit
+final def notifyAll(): Unit
+final def synchronized[T0](x$1: T0): T0
+final def wait(): Unit
+final def wait(x$1: Long): Unit
+final def wait(x$1: Long, x$2: Int): Unit
+================================================================================

--- a/test/files/presentation/package-object-type/Test.scala
+++ b/test/files/presentation/package-object-type/Test.scala
@@ -1,0 +1,9 @@
+import scala.tools.nsc.interactive.tests.InteractiveTest
+import scala.tools.nsc.util
+
+object Test extends InteractiveTest {
+  
+  override protected def filterOutLines(line: String) = 
+    line.contains("inaccessible") || line.contains("retrieved ")
+
+}

--- a/test/files/presentation/package-object-type/src/Main.scala
+++ b/test/files/presentation/package-object-type/src/Main.scala
@@ -1,0 +1,10 @@
+package example
+
+import scala.concurrent.ExecutionException
+
+object Main extends App {
+  def foo(n: ExecutionException, k: Int): Unit = {
+    n./*!*/
+    k
+  }
+}


### PR DESCRIPTION
Package objects need to be opened during the packageobjects
phase. This was not happening in presentation compilation
because the phase check looks at `globalPhase`, but in presentation
compilation (completion) the code is processed through `compileLate`
which only advances the SymbolTable phase.

Fixes https://github.com/scala/bug/issues/12663