### PR TITLE
Make `Position.copyRange` public

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/DocComments.scala
+++ b/src/compiler/scala/tools/nsc/ast/DocComments.scala
@@ -421,7 +421,7 @@ trait DocComments { self: Global =>
       else {
         val start1 = pos.start + start
         val end1 = pos.start + end
-        pos withStart start1 withPoint start1 withEnd end1
+        pos.copyRange(start1, start1, end1)
       }
 
     def defineVariables(sym: Symbol) = {

--- a/src/compiler/scala/tools/nsc/typechecker/ImportTracking.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ImportTracking.scala
@@ -139,7 +139,7 @@ trait ImportTracking { self: Analyzer =>
                   if (n > 1 && i == n - 1) {
                     val prev = existing.lastIndexWhere(!deleting.contains(_))
                     val prevPos = existing(prev).tree.pos
-                    val commaPos = prevPos.withStart(prevPos.end).withEnd(existing(prev + 1).tree.pos.start)
+                    val commaPos = prevPos.copyRange(start = prevPos.end, end = existing(prev + 1).tree.pos.start)
                     delete(commaPos) ++ delete(editPos)
                   }
                   else delete(editPos)
@@ -167,15 +167,15 @@ trait ImportTracking { self: Analyzer =>
                   toEmit.foreach { case culled @ (selector, (_, _, _)) =>
                     if (selector != last) {
                       val index = selectors.indexWhere(_ == selector)
-                      val editPos = infoPos.withStart(selector.namePos).withEnd(selectors(index + 1).namePos)
+                      val editPos = infoPos.copyRange(start = selector.namePos, end = selectors(index + 1).namePos)
                       emit(culled, delete(editPos))
                     }
                     else {
                       // info.tree.pos.end is one char after rbrace
                       val prev = selectors.lastIndexWhere(remaining.contains(_))
                       val comma = content.indexWhere(_ == ',', from = selectors(prev).namePos)
-                      val commaPos = infoPos.withStart(comma).withEnd(selectors(prev + 1).namePos)
-                      val editPos = infoPos.withStart(selector.namePos).withEnd(info.tree.pos.end - 1)
+                      val commaPos = infoPos.copyRange(start = comma, end = selectors(prev + 1).namePos)
+                      val editPos = infoPos.copyRange(start = selector.namePos, end = info.tree.pos.end - 1)
                       emit(culled, delete(commaPos) ++ delete(editPos))
                     }
                   }

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -545,7 +545,7 @@ trait Trees extends api.Trees {
       if (start >= 0 && selectors.contains(sel)) {
         val hasRename = sel.rename != null && sel.renamePos >= 0 // !sel.isWildcard
         val end = if (hasRename) sel.renamePos + sel.rename.length else start + sel.name.length
-        pos0.withStart(start).withEnd(end) ^ start
+        pos0.copyRange(start, start, end)
       }
       else pos0
     }

--- a/src/reflect/scala/reflect/internal/util/Position.scala
+++ b/src/reflect/scala/reflect/internal/util/Position.scala
@@ -133,13 +133,16 @@ private[util] trait InternalPositionImpl {
   final def makeTransparentIf(cond: Boolean): Position =
     if (cond && isOpaqueRange) Position.transparent(source, start, point, end) else this
 
-  /** Copy a range position with a changed value.
-   */
+  /* Copy a range position with a changed value. */
+  /* Note: the result is validated (start <= end), use `copyRange` to update both at the same time. */
   def withStart(start: Int): Position          = copyRange(start = start)
   def withPoint(point: Int): Position          = if (isRange) copyRange(point = point) else Position.offset(source, point)
   def withEnd(end: Int): Position              = copyRange(end = end)
   def withSource(source: SourceFile): Position = copyRange(source = source)
   def withShift(shift: Int): Position          = Position.range(source, start + shift, point + shift, end + shift)
+
+  def copyRange(start: Int = start, point: Int = point, end: Int = end, source: SourceFile = source) =
+    Position.range(source, start, point, end)
 
   /** Convert a range position to a simple offset.
    */
@@ -233,8 +236,6 @@ private[util] trait InternalPositionImpl {
     that.isDefined && this.point == that.point && this.source.file == that.source.file
 
   private def asOffset(point: Int): Position = Position.offset(source, point)
-  private def copyRange(source: SourceFile = source, start: Int = start, point: Int = point, end: Int = end): Position =
-    Position.range(source, start, point, end)
   private def hasSource                      = source ne NoSourceFile
   private def bothRanges(that: Position)     = isRange && that.isRange
   private def bothDefined(that: Position)    = isDefined && that.isDefined

--- a/test/files/presentation/t13083.check
+++ b/test/files/presentation/t13083.check
@@ -1,0 +1,7 @@
+reload: CompleteLocalImport.scala
+
+askTypeCompletion at CompleteLocalImport.scala(2,14)
+================================================================================
+[response] askTypeCompletion at (2,14)
+retrieved 14 members
+================================================================================

--- a/test/files/presentation/t13083/Runner.scala
+++ b/test/files/presentation/t13083/Runner.scala
@@ -1,0 +1,5 @@
+import scala.tools.nsc.interactive.tests._
+
+object Test extends InteractiveTest {
+  override protected def filterOutLines(line: String) = line.contains("package")
+}

--- a/test/files/presentation/t13083/src/CompleteLocalImport.scala
+++ b/test/files/presentation/t13083/src/CompleteLocalImport.scala
@@ -1,0 +1,3 @@
+object Autocompletewrapper {
+  import java./*!*/
+}


### PR DESCRIPTION
Allow updating start and end at the same time, which prevents intermediate (potentially failing) validataion after changing only one value.

Fixes https://github.com/scala/bug/issues/13083