### PR TITLE
Multivar definitions get transparent positions [ci: last-only]

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2922,7 +2922,9 @@ self =>
      */
     def patDefOrDcl(start: Int, mods: Modifiers): List[Tree] = {
       def mkDefs(mods: Modifiers, pat: Tree, tp: Tree, rhs: Tree, rhsPos: Position, defPos: Position): List[Tree] = {
-        val pat1 = if (tp.isEmpty) pat else Typed(pat, tp).setPos(pat.pos | tp.pos)
+        val pat1 =
+          if (tp.isEmpty) pat
+          else Typed(pat, tp).setPos((pat.pos | tp.pos).makeTransparent) // pos may extend over other patterns
         val trees = makePatDef(mods, pat1, rhs, rhsPos)
         val defs = if (trees.lengthCompare(1) == 0) trees else trees.tail
         defs.foreach(d => d.setPos(defPos.withPoint(d.pos.start).makeTransparent))
@@ -2968,7 +2970,7 @@ self =>
       // each valdef gets transparent defPos with point at name and NamePos
       val lhsPos = wrappingPos(lhs)
       val defPos = {
-        if (lhsPos.isRange) lhsPos.withStart(start).withEnd(in.lastOffset)
+        if (lhsPos.isRange) lhsPos.copyRange(start = start, end = in.lastOffset)
         else o2p(start)
       }
       def expandPatDefs(lhs: List[Tree], expansion: List[Tree]): List[Tree] =

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -1758,7 +1758,7 @@ trait Namers extends MethodSynthesis {
         patchSymInfo(pt)
 
         if (vdef.hasAttachment[MultiDefAttachment.type])
-          vdef.symbol.updateAttachment(MultiDefAttachment)
+          vdef.symbol.updateAttachment[MultiDefAttachment.type](MultiDefAttachment)
 
         // derives the val's result type from type checking its rhs under the expected type `pt`
         // vdef.tpt is mutated, and `vdef.tpt.tpe` is `assignTypeToTree`'s result

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2152,10 +2152,13 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       val vdef1 = treeCopy.ValDef(vdef, typedMods, sym.name, tpt1, checkDead(context, rhs1)) setType NoType
       if (sym.isSynthetic && sym.name.startsWith(nme.RIGHT_ASSOC_OP_PREFIX))
         rightAssocValDefs += ((sym, vdef1.rhs))
-      if (vdef.hasAttachment[PatVarDefAttachment.type])
+      if (vdef.hasAttachment[PatVarDefAttachment.type]) {
         sym.updateAttachment(PatVarDefAttachment)
-      if (sym.isSynthetic && sym.owner.isClass && (tpt1.tpe eq UnitTpe) && vdef.hasAttachment[PatVarDefAttachment.type] && sym.isPrivateThis && vdef.mods.isPrivateLocal && !sym.enclClassChain.exists(_.isInterpreterWrapper)) {
-        context.warning(vdef.pos, s"Pattern definition introduces Unit-valued member of ${sym.owner.name}; consider wrapping it in `locally { ... }`.", WarningCategory.OtherMatchAnalysis)
+        if (sym.isSynthetic && sym.owner.isClass && (tpt1.tpe eq UnitTpe))
+          if (sym.isPrivateThis && vdef.mods.isPrivateLocal && !sym.enclClassChain.exists(_.isInterpreterWrapper))
+            context.warning(vdef.pos,
+              s"Pattern definition introduces Unit-valued member of ${sym.owner.name}; consider wrapping it in `locally { ... }`.",
+              WarningCategory.OtherMatchAnalysis)
       }
       vdef1
     }

--- a/src/partest/scala/tools/partest/CompilerTest.scala
+++ b/src/partest/scala/tools/partest/CompilerTest.scala
@@ -31,11 +31,12 @@ abstract class CompilerTest extends DirectTest {
   def check(source: String, unit: global.CompilationUnit): Unit
 
   lazy val global: Global = newCompiler()
-  lazy val units: List[global.CompilationUnit] = compilationUnits(global)(sources: _ *)
+  lazy val computedSources = sources
+  lazy val units: List[global.CompilationUnit] = compilationUnits(global)(computedSources: _ *)
   import global._
   import definitions.compilerTypeFromTag
 
-  def show() = sources.lazyZip(units).foreach(check)
+  def show() = computedSources.lazyZip(units).foreach(check)
 
   // Override at least one of these...
   def code = ""

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -776,10 +776,16 @@ abstract class TreeGen {
     case Some((name, tpt)) =>
       atPos(pat.pos | rhsPos) {
         ValDef(mods, name.toTermName, tpt, rhs)
-          .updateAttachment(NamePos(pat.pos))
-          .tap(vd =>
-              if (forFor) propagatePatVarDefAttachments(pat, vd)
-              else propagateNoWarnAttachment(pat, vd))
+          .tap { vd =>
+            val namePos = pat match {
+              case id @ Ident(_) => id.pos
+              case Typed(id @ Ident(_), _) => id.pos
+              case pat => pat.pos
+            }
+            vd.updateAttachment(NamePos(namePos))
+            if (forFor) propagatePatVarDefAttachments(pat, vd)
+            else propagateNoWarnAttachment(pat, vd)
+          }
       } :: Nil
 
     case None =>

--- a/src/reflect/scala/reflect/macros/Attachments.scala
+++ b/src/reflect/scala/reflect/macros/Attachments.scala
@@ -133,9 +133,11 @@ private final class SingleAttachment[P >: Null](override val pos: P, val att: An
   override def all = Set.empty[Any] + att
   override def contains[T](implicit tt: ClassTag[T]) = tt.runtimeClass.isInstance(att)
   override def get[T](implicit tt: ClassTag[T]) = if (contains(tt)) Some(att.asInstanceOf[T]) else None
-  override def update[T](newAtt: T)(implicit tt: ClassTag[T]) =
+  override def update[T](newAtt: T)(implicit tt: ClassTag[T]) = {
+    //assert(tt ne classTag[Any])
     if (contains(tt)) new SingleAttachment[P](pos, newAtt)
     else new NonemptyAttachments[P](pos, Set.empty[Any] + att + newAtt)
+  }
   override def remove[T](implicit tt: ClassTag[T]) =
     if (contains(tt)) pos.asInstanceOf[Attachments { type Pos = P }] else this
   override def toString = s"SingleAttachment at $pos: $att"

--- a/test/files/neg/not-found.check
+++ b/test/files/neg/not-found.check
@@ -23,8 +23,4 @@ not-found.scala:21: error: not found: value X
 Identifiers that begin with uppercase are not pattern variables but match the value in scope.
   val X :: Nil = List(42)
       ^
-not-found.scala:21: warning: Pattern definition introduces Unit-valued member of T; consider wrapping it in `locally { ... }`.
-  val X :: Nil = List(42)
-        ^
-1 warning
 7 errors

--- a/test/files/neg/t10474.check
+++ b/test/files/neg/t10474.check
@@ -4,8 +4,4 @@ t10474.scala:8: error: stable identifier required, but Test.this.Foo found.
 t10474.scala:15: error: stable identifier required, but hrhino.this.Foo found.
   val Foo.Crash = ???
       ^
-t10474.scala:15: warning: Pattern definition introduces Unit-valued member of hrhino; consider wrapping it in `locally { ... }`.
-  val Foo.Crash = ???
-          ^
-1 warning
 2 errors

--- a/test/files/neg/t10731.check
+++ b/test/files/neg/t10731.check
@@ -1,8 +1,4 @@
 t10731.scala:3: error: stable identifier required, but C.this.eq found.
   val eq.a = 1
       ^
-t10731.scala:3: warning: Pattern definition introduces Unit-valued member of C; consider wrapping it in `locally { ... }`.
-  val eq.a = 1
-         ^
-1 warning
 1 error

--- a/test/files/neg/t10790.check
+++ b/test/files/neg/t10790.check
@@ -6,7 +6,7 @@ t10790.scala:10: warning: private class C in class X is never used
                 ^
 t10790.scala:13: warning: private val y in class X is never used
   private val Some(y) = Option(answer) // warn
-                  ^
+                   ^
 error: No warnings can be incurred under -Werror.
 3 warnings
 1 error

--- a/test/files/neg/t11374b.check
+++ b/test/files/neg/t11374b.check
@@ -8,6 +8,6 @@ Identifiers enclosed in backticks are not pattern variables but match the value 
              ^
 t11374b.scala:3: warning: Pattern definition introduces Unit-valued member of C; consider wrapping it in `locally { ... }`.
   val Some(`_`) = Option(42)  // was crashola
-          ^
+      ^
 1 warning
 2 errors

--- a/test/files/neg/t11618.check
+++ b/test/files/neg/t11618.check
@@ -18,19 +18,19 @@ t11618.scala:7: warning: Pattern definition introduces Unit-valued member of C; 
       ^
 t11618.scala:8: warning: Pattern definition introduces Unit-valued member of C; consider wrapping it in `locally { ... }`.
   val Some(_) = Option(42)
-          ^
+      ^
 t11618.scala:9: warning: Pattern definition introduces Unit-valued member of C; consider wrapping it in `locally { ... }`.
   implicit val _ = 42
                ^
 t11618.scala:10: warning: Pattern definition introduces Unit-valued member of C; consider wrapping it in `locally { ... }`.
   implicit val Some(_) = Option(42)
-                   ^
+               ^
 t11618.scala:23: warning: Pattern definition introduces Unit-valued member of C; consider wrapping it in `locally { ... }`.
   val Some(_) = Option(42)
-          ^
+      ^
 t11618.scala:24: warning: Pattern definition introduces Unit-valued member of C; consider wrapping it in `locally { ... }`.
   implicit val Some(_) = Option(42)
-                   ^
+               ^
 error: No warnings can be incurred under -Werror.
 11 warnings
 1 error

--- a/test/files/run/position-val-def.check
+++ b/test/files/run/position-val-def.check
@@ -2,12 +2,12 @@ newSource8.scala:1: warning: Pattern definition introduces Unit-valued member of
 class C7 { val Some(_) = Option(42) }
                ^
 class C0 { val x = 42 }
-[15:16] <11:21> [NoPosition]   -> private[this] val x: Int = _
+[15:16] [11:21] [NoPosition]   -> private[this] val x: Int = _
 [15]    [15]    [15]           -> <stable> <accessor> def x(): Int = C0.this.x
 [15:16] [19:21]                -> C0.this.x = 42
 --
 class C1 { var x = 42 }
-[15:16] <11:21> [NoPosition]   -> private[this] var x: Int = _
+[15:16] [11:21] [NoPosition]   -> private[this] var x: Int = _
 [15]    [15]    [15]           -> <accessor> def x(): Int = C1.this.x
 [15]    [15]    [15]           -> <accessor> def x_=(x$1: Int): Unit = C1.this.x = x$1
 [15]    [15]                   -> C1.this.x = x$1
@@ -71,18 +71,18 @@ class C5 { val (x, y), (w, z) = (42, 27) }
 [27:28] [27]                   -> C5.this.z = C5.this.x$2._2$mcI$sp()
 --
 class C6 { val x, y, z: String = "hello, worlds" }
-[15:24] <11:48> [NoPosition]   -> private[this] val x: String = _
+[15:16] <11:48> [NoPosition]   -> private[this] val x: String = _
 [15]    [15]    [15]           -> <stable> <accessor> def x(): String = C6.this.x
-[18:24] <11:48> [NoPosition]   -> private[this] val y: String = _
+[18:19] <11:48> [NoPosition]   -> private[this] val y: String = _
 [18]    [18]    [18]           -> <stable> <accessor> def y(): String = C6.this.y
-[21:30] <11:48> [NoPosition]   -> private[this] val z: String = _
+[21:22] <11:48> [NoPosition]   -> private[this] val z: String = _
 [21]    [21]    [21]           -> <stable> <accessor> def z(): String = C6.this.z
-[15:24] [33]                   -> C6.this.x = "hello, worlds"
-[18:24] [33]                   -> C6.this.y = "hello, worlds"
-[21:30] [33:48]                -> C6.this.z = "hello, worlds"
+[15:16] [33]                   -> C6.this.x = "hello, worlds"
+[18:19] [33]                   -> C6.this.y = "hello, worlds"
+[21:22] [33:48]                -> C6.this.z = "hello, worlds"
 --
 class C7 { val Some(_) = Option(42) }
-<11:35> <11:35> [NoPosition]   -> <synthetic> <artifact> private[this] val x$1: scala.runtime.BoxedUnit = _
-<11:35> [25:35]                -> C7.this.x$1 = {...
+[11:35] [11:35] [NoPosition]   -> <synthetic> <artifact> private[this] val x$1: scala.runtime.BoxedUnit = _
+[11:35] [25:35]                -> C7.this.x$1 = {...
 [25:35] [25:35] [25:35]        -> case <synthetic> val x1: Option = (scala.Option.apply(scala.Int.box(42)): Option)
 --

--- a/test/files/run/position-val-def.check
+++ b/test/files/run/position-val-def.check
@@ -1,3 +1,6 @@
+newSource8.scala:1: warning: Pattern definition introduces Unit-valued member of C7; consider wrapping it in `locally { ... }`.
+class C7 { val Some(_) = Option(42) }
+               ^
 class C0 { val x = 42 }
 [15:16] <11:21> [NoPosition]   -> private[this] val x: Int = _
 [15]    [15]    [15]           -> <stable> <accessor> def x(): Int = C0.this.x
@@ -77,4 +80,9 @@ class C6 { val x, y, z: String = "hello, worlds" }
 [15:24] [33]                   -> C6.this.x = "hello, worlds"
 [18:24] [33]                   -> C6.this.y = "hello, worlds"
 [21:30] [33:48]                -> C6.this.z = "hello, worlds"
+--
+class C7 { val Some(_) = Option(42) }
+<11:35> <11:35> [NoPosition]   -> <synthetic> <artifact> private[this] val x$1: scala.runtime.BoxedUnit = _
+<11:35> [25:35]                -> C7.this.x$1 = {...
+[25:35] [25:35] [25:35]        -> case <synthetic> val x1: Option = (scala.Option.apply(scala.Int.box(42)): Option)
 --

--- a/test/files/run/position-val-def.check
+++ b/test/files/run/position-val-def.check
@@ -1,30 +1,80 @@
-val x = 0
-[0:9]val x = [8:9]0
-
-var x = 0
-[0:9]var x = [8:9]0
-
-val x, y = 0
-[NoPosition]{
-  [4]val x = [11]0;
-  [7:12]val y = [11:12]0;
-  [NoPosition]()
-}
-
-var x, y = 0
-[NoPosition]{
-  [4]var x = [11]0;
-  [7:12]var y = [11:12]0;
-  [NoPosition]()
-}
-
-val (x, y) = 0
-[NoPosition]{
-  <0:14><synthetic> <artifact> private[this] val x$1 = <4:14>[13:14][13:14]0: @[13]scala.unchecked match {
-    <4:10>case <4:10>[4]scala.Tuple2(<5:6>(x @ [5]_), <8:9>(y @ [8]_)) => <4:10><4:10>scala.Tuple2(<4:10>x, <4:10>y)
-  };
-  [5:6]val x = [5]x$1._1;
-  [8:9]val y = [8]x$1._2;
-  [NoPosition]()
-}
-
+class C0 { val x = 42 }
+[15:16] <11:21> [NoPosition]   -> private[this] val x: Int = _
+[15]    [15]    [15]           -> <stable> <accessor> def x(): Int = C0.this.x
+[15:16] [19:21]                -> C0.this.x = 42
+--
+class C1 { var x = 42 }
+[15:16] <11:21> [NoPosition]   -> private[this] var x: Int = _
+[15]    [15]    [15]           -> <accessor> def x(): Int = C1.this.x
+[15]    [15]    [15]           -> <accessor> def x_=(x$1: Int): Unit = C1.this.x = x$1
+[15]    [15]                   -> C1.this.x = x$1
+[15:16] [19:21]                -> C1.this.x = 42
+--
+class C2 { val x, y = 42 }
+[15:16] <11:24> [NoPosition]   -> private[this] val x: Int = _
+[15]    [15]    [15]           -> <stable> <accessor> def x(): Int = C2.this.x
+[18:19] <11:24> [NoPosition]   -> private[this] val y: Int = _
+[18]    [18]    [18]           -> <stable> <accessor> def y(): Int = C2.this.y
+[15:16] [22]                   -> C2.this.x = 42
+[18:19] [22:24]                -> C2.this.y = 42
+--
+class C3 { var x, y = 42 }
+[15:16] <11:24> [NoPosition]   -> private[this] var x: Int = _
+[15]    [15]    [15]           -> <accessor> def x(): Int = C3.this.x
+[15]    [15]    [15]           -> <accessor> def x_=(x$1: Int): Unit = C3.this.x = x$1
+[15]    [15]                   -> C3.this.x = x$1
+[18:19] <11:24> [NoPosition]   -> private[this] var y: Int = _
+[18]    [18]    [18]           -> <accessor> def y(): Int = C3.this.y
+[18]    [18]    [18]           -> <accessor> def y_=(x$1: Int): Unit = C3.this.y = x$1
+[18]    [18]                   -> C3.this.y = x$1
+[15:16] [22]                   -> C3.this.x = 42
+[18:19] [22:24]                -> C3.this.y = 42
+--
+class C4 { val (x, y) = (42, 27) }
+<15:32> <15:32> [NoPosition]   -> <synthetic> <artifact> private[this] val x$1: Tuple2 = _
+[16:17] <11:32> [NoPosition]   -> private[this] val x: Int = _
+[16]    [16]    [16]           -> <stable> <accessor> def x(): Int = C4.this.x
+[19:20] <11:32> [NoPosition]   -> private[this] val y: Int = _
+[19]    [19]    [19]           -> <stable> <accessor> def y(): Int = C4.this.y
+<15:32> [24:32]                -> C4.this.x$1 = {...
+[24:32] [24:32] [24:32]        -> case <synthetic> val x1: Tuple2 = (new Tuple2$mcII$sp(42, 27): Tuple2)
+<16:17> <16:17> <16:17>        -> val x: Int = x1._1$mcI$sp()
+<19:20> <19:20> <19:20>        -> val y: Int = x1._2$mcI$sp()
+[16:17] [16]                   -> C4.this.x = C4.this.x$1._1$mcI$sp()
+[19:20] [19]                   -> C4.this.y = C4.this.x$1._2$mcI$sp()
+--
+class C5 { val (x, y), (w, z) = (42, 27) }
+<15:40> <15:40> [NoPosition]   -> <synthetic> <artifact> private[this] val x$1: Tuple2 = _
+[16:17] <11:40> [NoPosition]   -> private[this] val x: Int = _
+[16]    [16]    [16]           -> <stable> <accessor> def x(): Int = C5.this.x
+[19:20] <11:40> [NoPosition]   -> private[this] val y: Int = _
+[19]    [19]    [19]           -> <stable> <accessor> def y(): Int = C5.this.y
+<23:40> <23:40> [NoPosition]   -> <synthetic> <artifact> private[this] val x$2: Tuple2 = _
+[24:25] <11:40> [NoPosition]   -> private[this] val w: Int = _
+[24]    [24]    [24]           -> <stable> <accessor> def w(): Int = C5.this.w
+[27:28] <11:40> [NoPosition]   -> private[this] val z: Int = _
+[27]    [27]    [27]           -> <stable> <accessor> def z(): Int = C5.this.z
+<15:40> [32]                   -> C5.this.x$1 = {...
+[32]    [32]    [32]           -> case <synthetic> val x1: Tuple2 = (new Tuple2$mcII$sp(42, 27): Tuple2)
+<16:17> <16:17> <16:17>        -> val x: Int = x1._1$mcI$sp()
+<19:20> <19:20> <19:20>        -> val y: Int = x1._2$mcI$sp()
+[16:17] [16]                   -> C5.this.x = C5.this.x$1._1$mcI$sp()
+[19:20] [19]                   -> C5.this.y = C5.this.x$1._2$mcI$sp()
+<23:40> [32:40]                -> C5.this.x$2 = {...
+[32:40] [32:40] [32:40]        -> case <synthetic> val x1: Tuple2 = (new Tuple2$mcII$sp(42, 27): Tuple2)
+<24:25> <24:25> <24:25>        -> val w: Int = x1._1$mcI$sp()
+<27:28> <27:28> <27:28>        -> val z: Int = x1._2$mcI$sp()
+[24:25] [24]                   -> C5.this.w = C5.this.x$2._1$mcI$sp()
+[27:28] [27]                   -> C5.this.z = C5.this.x$2._2$mcI$sp()
+--
+class C6 { val x, y, z: String = "hello, worlds" }
+[15:24] <11:48> [NoPosition]   -> private[this] val x: String = _
+[15]    [15]    [15]           -> <stable> <accessor> def x(): String = C6.this.x
+[18:24] <11:48> [NoPosition]   -> private[this] val y: String = _
+[18]    [18]    [18]           -> <stable> <accessor> def y(): String = C6.this.y
+[21:30] <11:48> [NoPosition]   -> private[this] val z: String = _
+[21]    [21]    [21]           -> <stable> <accessor> def z(): String = C6.this.z
+[15:24] [33]                   -> C6.this.x = "hello, worlds"
+[18:24] [33]                   -> C6.this.y = "hello, worlds"
+[21:30] [33:48]                -> C6.this.z = "hello, worlds"
+--

--- a/test/files/run/position-val-def.scala
+++ b/test/files/run/position-val-def.scala
@@ -18,6 +18,7 @@ object Test extends CompilerTest {
     val (x, y) = (42, 27)
     val (x, y), (w, z) = (42, 27)
     val x, y, z: String = "hello, worlds"
+    val Some(_) = Option(42)
     """.linesIterator.map(_.trim).filter(_.nonEmpty)
        .map(s => s"class C${counter.getAndIncrement} { $s }")
        .toList

--- a/test/files/run/position-val-def.scala
+++ b/test/files/run/position-val-def.scala
@@ -1,26 +1,46 @@
-import scala.reflect.runtime.universe._
-import scala.reflect.runtime.{universe => ru}
-import scala.reflect.runtime.{currentMirror => cm}
-import scala.tools.reflect.ToolBox
+//> using options -Xsource:3-cross
 
-object Test {
-  val toolbox = cm.mkToolBox()
+import scala.reflect.internal.util.StringContextStripMarginOps
+import scala.tools.partest.CompilerTest
+import java.util.concurrent.atomic.AtomicInteger
 
-  def main(args: Array[String]): Unit = {
-    def test(expr: String): Unit = {
-      val t = toolbox.parse(expr)
-      println(expr)
-      println(show(t, printPositions = true))
-      println()
+object Test extends CompilerTest {
+  import global.{show as tshow, *}
+
+  val counter = new AtomicInteger
+
+  override def sources =
+    sm"""
+    val x = 42
+    var x = 42
+    val x, y = 42
+    var x, y = 42
+    val (x, y) = (42, 27)
+    val (x, y), (w, z) = (42, 27)
+    val x, y, z: String = "hello, worlds"
+    """.linesIterator.map(_.trim).filter(_.nonEmpty)
+       .map(s => s"class C${counter.getAndIncrement} { $s }")
+       .toList
+
+  def check(source: String, unit: CompilationUnit): Unit = {
+    println(source)
+    //println("--")
+    //println(tshow(unit.body))
+    //println("--")
+    unit.body.foreach {
+      case t: ValOrDefDef if !t.symbol.isConstructor && !t.symbol.isParameter =>
+        println(f"${tshow(t.namePos)}%-8s${tshow(t.pos)}%-8s${tshow(t.rhs.pos)}%-14s -> ${tshow(t).clipped}")
+      case t: Assign =>
+        println(f"${tshow(t.pos)}%-8s${tshow(t.rhs.pos)}%-22s -> ${tshow(t).clipped}")
+      case _ =>
     }
-    val tests = """
-    val x = 0
-    var x = 0
-    val x, y = 0
-    var x, y = 0
-    val (x, y) = 0
-    """
-    for (line <- tests.linesIterator; expr = line.trim if !expr.isEmpty)
-      test(expr)
+    println("--")
+  }
+  implicit class Clippy(val s: String) extends AnyVal {
+    def clipped = {
+      val it = s.linesIterator
+      val t = it.next()
+      if (it.hasNext) s"$t..." else t
+    }
   }
 }

--- a/test/files/run/position-val-def.scala
+++ b/test/files/run/position-val-def.scala
@@ -20,7 +20,7 @@ object Test {
     var x, y = 0
     val (x, y) = 0
     """
-    val exprs = tests.split("\\n").map(_.trim).filterNot(_.isEmpty)
-    exprs foreach test
+    for (line <- tests.linesIterator; expr = line.trim if !expr.isEmpty)
+      test(expr)
   }
 }


### PR DESCRIPTION
Fixes scala/bug#13067

In `var x, y: Int = 42`, the trees span the text, with point at the name. The symbol pos is the name pos.

In `patDefOrDecl`, `mkDefs` is refactored for clarity; the recursion in `expandPatDefs` is easier to read.

`NamePos` handling is pushed into `makePatDef`, resulting in better positions, reflected in updated check files. (A few warnings are now hidden by errors at the same position.)

In the multivar def, only `y: Int` may be an opaque position. (That nuance is probably not relevant.) Otherwise, the spans of the trees are transparent. 

The test shows the `valdef.namePos` and `valdef.pos` for various single and multi defs.
