### PR TITLE
Move Future.onCompleteWithUnregister out of the Future API

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -43,9 +43,6 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.generic.CommonErrors"),
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.generic.CommonErrors$"),
 
-    // scala/scala#10927
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.concurrent.Future.onCompleteWithUnregister"),
-
     // scala/scala#10937
     ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.immutable.LazyList#LazyBuilder#DeferredState.eval"),
     ProblemFilters.exclude[MissingClassProblem](s"scala.collection.immutable.LazyList$$State"),


### PR DESCRIPTION
This restores compatibility with existing `Future` subclasses. While we're not convinced this method should belong to the Future API, let's keep it internal.

Follow-up for https://github.com/scala/scala/pull/10927
