### PR TITLE
Enshrine isPackage

### DIFF
--- a/src/reflect/scala/reflect/api/Symbols.scala
+++ b/src/reflect/scala/reflect/api/Symbols.scala
@@ -442,7 +442,9 @@ trait Symbols { self: Universe =>
     def privateWithin: Symbol
 
     /** Does this symbol represent the definition of a package?
-     *  Known issues: [[https://github.com/scala/bug/issues/6732]].
+     *
+     *  True for term symbols that are packages and for type symbols
+     *  for which `isPackageClass` is true.
      *
      *  @group Tests
      */

--- a/src/reflect/scala/reflect/internal/HasFlags.scala
+++ b/src/reflect/scala/reflect/internal/HasFlags.scala
@@ -121,8 +121,6 @@ trait HasFlags {
   def isOverride            = hasFlag(OVERRIDE)
   def isParamAccessor       = hasFlag(PARAMACCESSOR)
   def isPrivate             = hasFlag(PRIVATE)
-  @deprecated ("use `hasPackageFlag` instead", "2.11.0")
-  def isPackage             = hasFlag(PACKAGE)
   def isPrivateLocal        = hasAllFlags(PrivateLocal)
   def isProtected           = hasFlag(PROTECTED)
   def isProtectedLocal      = hasAllFlags(ProtectedLocal)

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -676,6 +676,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     override def isLabel     = false
 
     /** Package/package object tests */
+    def isPackage              = false
     def isPackageClass         = false
     def isPackageObject        = false
     def isPackageObjectClass   = false
@@ -2968,6 +2969,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     override def isMixinConstructor = rawname == nme.MIXIN_CONSTRUCTOR
     override def isConstructor      = isClassConstructor || isMixinConstructor
 
+    override def isPackage          = hasFlag(PACKAGE)
     override def isPackageObject    = isModule && (rawname == nme.PACKAGE)
 
     override def isExistentiallyBound = this hasFlag EXISTENTIAL
@@ -3388,6 +3390,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     override def isCaseClass               = this hasFlag CASE
     override def isClassLocalToConstructor = this hasFlag INCONSTRUCTOR
     override def isModuleClass             = this hasFlag MODULE
+    override def isPackage                 = hasFlag(PACKAGE) // i.e., isPackageClass
     override def isPackageClass            = this hasFlag PACKAGE
     override def isTrait                   = this hasFlag TRAIT
 


### PR DESCRIPTION
Closes scala/bug#6732

The decision was taken a decade ago to tweak the doc, and the behavior is now out of scope.

Removes the deprecated method and installs it in the Symbol hierarchy, symbolically.

Removing `isPackage` shows one usage in REPL, which uses reflection.