### PR TITLE
fix an unreachable-code warning

### DIFF
--- a/src/reflect/scala/reflect/internal/Printers.scala
+++ b/src/reflect/scala/reflect/internal/Printers.scala
@@ -731,7 +731,6 @@ trait Printers extends api.Printers { self: SymbolTable =>
             case _ =>
           }
           printArgss(argss)
-        case _ => super.printTree(tree)
       }
     }
 


### PR DESCRIPTION
` treeInfo.Applied#unapply` has a return type of `Some`, so the unreachable warning we were getting appears to be correct and the dead code can be removed