### PR TITLE
Select symbol overload in tree unpickling

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
@@ -418,8 +418,9 @@ abstract class Pickler extends SubComponent {
     private def putAnnotationBody(annot: AnnotationInfo): Unit = {
       def putAnnotArg(arg: Tree): Unit = {
         arg match {
-          // Keep Literal with an AnnotatedType. Used in AnnotationInfo.argIsDefault.
-          case Literal(c) if arg.tpe.isInstanceOf[ConstantType] => putConstant(c)
+          // Keep Literal with an AnnotatedType. Used in AnnotationInfo.argIsDefault. Allow `null` to prevent NPEs:
+          // Literal(Constant(v)) is used eg in compiler plugins, it produces a tree with `tpe == null`.
+          case Literal(c) if arg.tpe == null || arg.tpe.isInstanceOf[ConstantType] => putConstant(c)
           case _ => putTree(arg)
         }
       }
@@ -476,8 +477,9 @@ abstract class Pickler extends SubComponent {
     private def writeAnnotation(annot: AnnotationInfo): Unit = {
       def writeAnnotArg(arg: Tree): Unit = {
         arg match {
-          // Keep Literal with an AnnotatedType. Used in AnnotationInfo.argIsDefault.
-          case Literal(c) if arg.tpe.isInstanceOf[ConstantType] => writeRef(c)
+          // Keep Literal with an AnnotatedType. Used in AnnotationInfo.argIsDefault. Allow `null` to prevent NPEs:
+          // Literal(Constant(v)) is used eg in compiler plugins, it produces a tree with `tpe == null`.
+          case Literal(c) if arg.tpe == null || arg.tpe.isInstanceOf[ConstantType] => writeRef(c)
           case _ => writeRef(arg)
         }
       }

--- a/test/files/run/t13087.check
+++ b/test/files/run/t13087.check
@@ -1,0 +1,43 @@
+
+scala> :power
+Power mode enabled. :phase is at typer.
+import scala.tools.nsc._, intp.global._, definitions._
+Try :help or completions for vals._ and power._
+
+scala> @ann class K
+class K
+
+scala> typeOf[K]
+val res0: $r.intp.global.Type = K
+
+scala> val arg = typeOf[K].typeSymbol.annotations.head.args.head
+val arg: $r.intp.global.Tree = kux.f.+(new O[Int]().a(1))
+
+scala> val plusSel = arg.asInstanceOf[Apply].fun
+val plusSel: $r.intp.global.Tree = kux.f.+
+
+scala> plusSel.tpe
+val res1: $r.intp.global.Type = (x: Int): Int
+
+scala> plusSel.symbol.tpe
+val res2: $r.intp.global.Type = (x: Int): Int
+
+scala> val fSel = plusSel.asInstanceOf[Select].qualifier
+val fSel: $r.intp.global.Tree = kux.f
+
+scala> fSel.tpe
+val res3: $r.intp.global.Type = Int
+
+scala> fSel.symbol.tpe
+val res4: $r.intp.global.Type = Int
+
+scala> val aSel = arg.asInstanceOf[Apply].args.head.asInstanceOf[Apply].fun
+val aSel: $r.intp.global.Tree = new O[Int]().a
+
+scala> aSel.tpe
+val res5: $r.intp.global.Type = (t: Int): Int
+
+scala> aSel.symbol.tpe
+val res6: $r.intp.global.Type = (t: T): T
+
+scala> :quit

--- a/test/files/run/t13087/A.scala
+++ b/test/files/run/t13087/A.scala
@@ -1,0 +1,10 @@
+class ann(key: Int = kux.f + new O[Int].a(1)) extends annotation.StaticAnnotation
+
+object kux {
+  def f = 1
+  def f(x: Int) = 2
+}
+class O[T] {
+  def a(t: T): T = t
+  def a(s: String): String = s
+}

--- a/test/files/run/t13087/Test_1.scala
+++ b/test/files/run/t13087/Test_1.scala
@@ -1,0 +1,19 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  override def code =
+    """:power
+      |@ann class K
+      |typeOf[K]
+      |val arg = typeOf[K].typeSymbol.annotations.head.args.head
+      |val plusSel = arg.asInstanceOf[Apply].fun
+      |plusSel.tpe
+      |plusSel.symbol.tpe
+      |val fSel = plusSel.asInstanceOf[Select].qualifier
+      |fSel.tpe
+      |fSel.symbol.tpe
+      |val aSel = arg.asInstanceOf[Apply].args.head.asInstanceOf[Apply].fun
+      |aSel.tpe
+      |aSel.symbol.tpe
+      |""".stripMargin
+}


### PR DESCRIPTION
References to external symbols are pickled as owner + name, so overloads cannot be resolved. This only affects tree unpickling, i.e., only annotation arguments.

At some point in history, the unpickler was using
`Infer.inferMethodAlternative`, but not anymore since fff93cd049.

This commit performs overloading resolution based on the Select tree's type instead: when unpickling `t.f`, the `tpe` of the tree is unpickled. This type can be used to select the correct overload.

Fixes https://github.com/scala/bug/issues/13087