### PR TITLE
Improve `scala.util.Using` suppression order (NonFatal suppresses ControlThrowable)

### DIFF
--- a/src/library/scala/util/Using.scala
+++ b/src/library/scala/util/Using.scala
@@ -125,8 +125,8 @@ import scala.util.control.{ControlThrowable, NonFatal}
   *   - `java.lang.LinkageError`
   *   - `java.lang.InterruptedException` and `java.lang.ThreadDeath`
   *   - [[scala.util.control.NonFatal fatal exceptions]], excluding `scala.util.control.ControlThrowable`
+  *   - all other exceptions, excluding `scala.util.control.ControlThrowable`
   *   - `scala.util.control.ControlThrowable`
-  *   - all other exceptions
   *
   * When more than two exceptions are thrown, the first two are combined and
   * re-thrown as described above, and each successive exception thrown is combined
@@ -265,9 +265,9 @@ object Using {
       case _: VirtualMachineError                   => 4
       case _: LinkageError                          => 3
       case _: InterruptedException | _: ThreadDeath => 2
-      case _: ControlThrowable                      => 0
+      case _: ControlThrowable                      => -1 // below everything
       case e if !NonFatal(e)                        => 1 // in case this method gets out of sync with NonFatal
-      case _                                        => -1
+      case _                                        => 0
     }
     @inline def suppress(t: Throwable, suppressed: Throwable): Throwable = { t.addSuppressed(suppressed); t }
 


### PR DESCRIPTION
In `scala.util.Using`, when two exceptions are thrown, one is attached to the other using `addSuppressed`
according to a specified order.

Change that order to have `scala.util.control.ControlThrowable` suppressed by non-fatal exceptions (`scala.util.control.NonFatal`).

Fixes scala/bug#13088

Users of scala-collection-compat can upgrade to [2.14.0](https://github.com/scala/scala-collection-compat/releases/tag/v2.14.0) to get the same behavior change
 
If you use `Using` in a project that crossbuilds to Scala 3, you may wish to wait for a Scala 3 release that includes the 2.13.17 standard library, or use a dependency override to force the upgrade in your build
                                                                                                    
