### PR TITLE
Handle `RefinementClassSymbol` in `checkSensibleEquals`

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1019,6 +1019,8 @@ abstract class RefChecks extends Transform {
       def underlyingClass(tp: Type): Symbol = {
         val sym = tp.widen.typeSymbol
         if (sym.isAbstractType) underlyingClass(sym.info.upperBound)
+        // could be smarter than picking the first parent, but refined / intersection types are not that common
+        else if (sym.isRefinementClass) sym.parentSymbols.headOption.getOrElse(AnyClass)
         else sym
       }
       val actual   = underlyingClass(other.tpe)

--- a/test/files/neg/t13089.check
+++ b/test/files/neg/t13089.check
@@ -1,0 +1,6 @@
+t13089.scala:8: warning: comparing values of types String and T with java.io.Serializable using `==` will always yield false
+  def t2 = "" == a // warn
+              ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/t13089.scala
+++ b/test/files/neg/t13089.scala
@@ -1,0 +1,10 @@
+//> using options -Werror
+
+class T {
+  def t1 = "" == Some("").getOrElse(None) // used to warn incorrectly, because a RefinementClassSymbol is unrelated to String
+
+  def a: T with Serializable = null
+  def b: Serializable with T = null
+  def t2 = "" == a // warn
+  def t3 = "" == b // no warn; on intersection types, the implementation currently picks the first parent
+}


### PR DESCRIPTION
A `RefinementClassSymbol` is unrelated to a class like `String`, which lead to false positive warnings.

Fixes https://github.com/scala/bug/issues/13089