### PR TITLE
Prevent NPE in recursive implicit lint

### DIFF
--- a/test/files/neg/t12226.check
+++ b/test/files/neg/t12226.check
@@ -7,9 +7,12 @@ t12226.scala:9: warning: Implicit resolves to enclosing method f; the conversion
 t12226.scala:9: warning: Implicit resolves to enclosing method f
   implicit def f[A](a: A): String = if (a ne null) a else "nope" // warn
                                                    ^
-t12226.scala:21: warning: Implicit resolves to enclosing class StringOps; the enrichment wraps value s
+t12226.scala:13: warning: Implicit resolves to enclosing method f; the conversion adds a member of AnyRef to result of method idt
+  implicit def f[A](a: A): String = if (idt(x = a) ne null) "yup" else "nope" // warn
+                                           ^
+t12226.scala:25: warning: Implicit resolves to enclosing class StringOps; the enrichment wraps value s
     def normal: String = s.crazy.crazy // warn
                          ^
 error: No warnings can be incurred under -Werror.
-4 warnings
+5 warnings
 1 error

--- a/test/files/neg/t12226.scala
+++ b/test/files/neg/t12226.scala
@@ -8,6 +8,10 @@ object X {
 object Y {
   implicit def f[A](a: A): String = if (a ne null) a else "nope" // warn
 }
+object YY {
+  def idt[A](n: Int = 1, x: A): A = x
+  implicit def f[A](a: A): String = if (idt(x = a) ne null) "yup" else "nope" // warn
+}
 object Z {
   implicit class StringOps(val s: String) extends AnyVal {
     def crazy: String = s.reverse
@@ -20,5 +24,20 @@ object ZZ {
     def crazy: String = s.reverse
     def normal: String = s.crazy.crazy // warn
     def join(other: String): String = crazy + other.crazy // nowarn
+  }
+}
+
+object ZZZ {
+  class C { def f: C = this }
+  implicit class E(c: C) {
+    def bar: Int = c.f.bar // nowarn
+  }
+}
+
+object sd893 {
+  case class C(a: Int, b: Int) {
+    implicit class Enrich(c2: C) {
+      def foo: C = c2.copy(b = 0).foo // nowarn
+    }
   }
 }


### PR DESCRIPTION
In `c.copy(y = 10).foo` where `foo` is an extension method, the `tree` is named/default arguments `Block` which doesn't have a symbol.

https://github.com/scala/scala-dev/issues/893#issuecomment-2680514360