### PR TITLE
Pull `argIsDefault` up into reflect.AnnotationApi

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -54,6 +54,12 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.LazyList$MidEvaluation$"),
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.LazyList$Uninitialized$"),
 
+    // scala/scala#11004
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.api.Annotations#AnnotationApi.argIsDefault"),
+    // A new abstract trait method is not binary compatible in principle, but `AnnotationApi` is only implemented by
+    // `AnnotationInfo`, both of which are in scala-reflect.jar. So this should never leak.
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.reflect.api.Annotations#AnnotationApi.argIsDefault"),
+
     // scala/scala#10976
     ProblemFilters.exclude[MissingClassProblem]("scala.annotation.meta.defaultArg"),
     ProblemFilters.exclude[MissingClassProblem]("scala.annotation.meta.superArg"),

--- a/src/reflect/scala/reflect/api/Annotations.scala
+++ b/src/reflect/scala/reflect/api/Annotations.scala
@@ -91,6 +91,20 @@ trait Annotations { self: Universe =>
     @deprecated("use `tree.children.tail` instead", "2.11.0")
     def scalaArgs: List[Tree]
 
+    /** For arguments in [[scalaArgs]], this method returns `true` if the argument AST is a default inserted
+     *  by the compiler, not an explicit argument passed in source code.
+     *
+     *  Since Scala 2.13.17, the defaults are ASTs of the default expression in the annotation definition.
+     *  Example:
+     *  {{{
+     *    class ann(x: Int = 42) extends Annotation
+     *    @ann class C
+     *  }}}
+     *  The `annotation.scalaArgs.head` is an AST `Literal(Constant(42))` for which the `argIsDefault` method
+     *  returns `true`.
+     */
+    def argIsDefault(tree: Tree): Boolean
+
     /** Payload of the Java annotation: a list of name-value pairs.
      *  Empty for Scala annotations.
      */


### PR DESCRIPTION
So macros can easily identify default annotation arguments inserted by the compiler.

Follow-up for https://github.com/scala/scala/pull/10976, as discussed in https://github.com/scala/scala-dev/issues/893#issuecomment-2680233233