### PR TITLE
collections Scaladoc: fix an awkward wording

### DIFF
--- a/src/library/scala/jdk/CollectionConverters.scala
+++ b/src/library/scala/jdk/CollectionConverters.scala
@@ -28,7 +28,7 @@ import scala.collection.convert.{AsJavaExtensions, AsScalaExtensions}
   * }}}
   *
   * The conversions return adapters for the corresponding API, i.e., the collections are wrapped,
-  * not converted. Changes to the original collection are reflected in the view, and vice versa:
+  * not copied. Changes to the original collection are reflected in the view, and vice versa:
   *
   * {{{
   *   scala> import scala.jdk.CollectionConverters._

--- a/src/library/scala/jdk/javaapi/CollectionConverters.scala
+++ b/src/library/scala/jdk/javaapi/CollectionConverters.scala
@@ -34,7 +34,7 @@ import scala.collection.convert.{AsJavaConverters, AsScalaConverters}
   * }}}
   *
   * The conversions return adapters for the corresponding API, i.e., the collections are wrapped,
-  * not converted. Changes to the original collection are reflected in the view, and vice versa.
+  * not copied. Changes to the original collection are reflected in the view, and vice versa.
   *
   * The following conversions are supported via `asScala` and `asJava`:
   *


### PR DESCRIPTION
a class called "Converters" said that its inputs are "not converted" 😬 😄 