### PR TITLE
Fix file handle leak under the non-default classpath mode

### DIFF
--- a/src/reflect/scala/reflect/io/ZipArchive.scala
+++ b/src/reflect/scala/reflect/io/ZipArchive.scala
@@ -276,8 +276,11 @@ final class FileZipArchive(file: JFile, release: Option[String]) extends ZipArch
         }
       }
     } finally {
-      if (!ZipArchive.closeZipFile)
+      if (ZipArchive.closeZipFile) {
+        zipFile.close()
+      } else {
         zipFilePool.release(zipFile)
+      }
     }
     root
   }


### PR DESCRIPTION
Bug introduced in scala/scala@31255c3

The -Dscala.classpath.closeZip mode is enabled in SBT/Zinc straight-to-jar compilation.

Fixes scala/bug#13094