### PR TITLE
Reduce allocations in Typer

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -149,8 +149,6 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     // requiring both the ACCESSOR and the SYNTHETIC bits to trigger the exemption
     private def isSyntheticAccessor(sym: Symbol) = sym.isAccessor && (!sym.isLazy || isPastTyper)
 
-    private def isFixable(name: Name) = name == nme.tupled || name == nme.curried
-
     // when type checking during erasure, generate erased types in spots that aren't transformed by erasure
     // (it erases in TypeTrees, but not in, e.g., the type a Function node)
     def phasedAppliedType(sym: Symbol, args: List[Type]) = {
@@ -5436,7 +5434,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         }
 
       // If they try C.tupled, make it (C.apply _).tupled
-      def fixUpCaseTupled(tree: Tree, qual: Tree, name: Name, mode: Mode): Tree =
+      def fixUpCaseTupled(tree: Tree, qual: Tree, name: Name, mode: Mode): Tree = {
+        def isFixable(name: Name) = name == nme.tupled || name == nme.curried
+
         if (!isPastTyper && qual.symbol != null && qual.symbol.isModule && qual.symbol.companion.isCase &&
             context.undetparams.isEmpty && isFixable(name)) {
           val t2 = {
@@ -5452,6 +5452,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           else EmptyTree
         }
         else EmptyTree
+      }
 
       /* Attribute a selection where `tree` is `qual.name`.
        * `qual` is already attributed.

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -149,7 +149,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     // requiring both the ACCESSOR and the SYNTHETIC bits to trigger the exemption
     private def isSyntheticAccessor(sym: Symbol) = sym.isAccessor && (!sym.isLazy || isPastTyper)
 
-    private val fixableFunctionMembers = List(nme.tupled, TermName("curried"))
+    private def isFixable(name: Name) = name == nme.tupled || name == nme.curried
 
     // when type checking during erasure, generate erased types in spots that aren't transformed by erasure
     // (it erases in TypeTrees, but not in, e.g., the type a Function node)
@@ -5438,7 +5438,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
       // If they try C.tupled, make it (C.apply _).tupled
       def fixUpCaseTupled(tree: Tree, qual: Tree, name: Name, mode: Mode): Tree =
         if (!isPastTyper && qual.symbol != null && qual.symbol.isModule && qual.symbol.companion.isCase &&
-            context.undetparams.isEmpty && fixableFunctionMembers.contains(name)) {
+            context.undetparams.isEmpty && isFixable(name)) {
           val t2 = {
             val t = atPos(tree.pos)(Select(qual, nme.apply))
             val t1 = typedSelect(t, qual, nme.apply)

--- a/src/reflect/scala/reflect/internal/StdNames.scala
+++ b/src/reflect/scala/reflect/internal/StdNames.scala
@@ -774,6 +774,7 @@ trait StdNames {
     val copy: NameType                 = nameType("copy")
     val create: NameType               = nameType("create")
     val currentMirror: NameType        = nameType("currentMirror")
+    val curried: NameType              = nameType("curried")
     val delayedInit: NameType          = nameType("delayedInit")
     val delayedInitArg: NameType       = nameType("delayedInit$body")
     val dollarScope: NameType          = nameType("$scope")


### PR DESCRIPTION
Prefer a pre-interned name to Name("literalString")

Avoid adding fields and constructor allocations to Typer which is frequently allocated during descent of the AST.