### PR TITLE
Collect nowarn symbols instead of skipping them

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -197,6 +197,8 @@ lazy val commonSettings = instanceSettings ++ clearSourceAndResourceDirectories 
   run / fork := true,
   run / connectInput := true,
   Compile / scalacOptions ++= Seq("-feature", "-Xlint",
+    //"-Wunused:patvars",
+    //"-Wunused:params",
     //"-Vprint",
     //"-Xmaxerrs", "5", "-Xmaxwarns", "5", // uncomment for ease of development while breaking things
     // work around https://github.com/scala/bug/issues/11534
@@ -451,6 +453,7 @@ lazy val library = configureAsSubproject(project)
     name := "scala-library",
     description := "Scala Standard Library",
     Compile / scalacOptions ++= Seq("-sourcepath", (Compile / scalaSource).value.toString),
+    Compile / scalacOptions ++= Seq("-Wconf:msg=method box|method anyValClass:s"), // unused params in patched src
     Compile / doc / scalacOptions ++= {
       val libraryAuxDir = (ThisBuild / baseDirectory).value / "src/library-aux"
       Seq(

--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -124,16 +124,16 @@ object Array {
     * @see `java.util.Arrays#copyOf`
     */
   def copyOf[A](original: Array[A], newLength: Int): Array[A] = ((original: @unchecked) match {
-    case x: Array[BoxedUnit]  => newUnitArray(newLength).asInstanceOf[Array[A]]
-    case x: Array[AnyRef]     => java.util.Arrays.copyOf(x, newLength)
-    case x: Array[Int]        => java.util.Arrays.copyOf(x, newLength)
-    case x: Array[Double]     => java.util.Arrays.copyOf(x, newLength)
-    case x: Array[Long]       => java.util.Arrays.copyOf(x, newLength)
-    case x: Array[Float]      => java.util.Arrays.copyOf(x, newLength)
-    case x: Array[Char]       => java.util.Arrays.copyOf(x, newLength)
-    case x: Array[Byte]       => java.util.Arrays.copyOf(x, newLength)
-    case x: Array[Short]      => java.util.Arrays.copyOf(x, newLength)
-    case x: Array[Boolean]    => java.util.Arrays.copyOf(x, newLength)
+    case original: Array[BoxedUnit]  => newUnitArray(newLength).asInstanceOf[Array[A]]
+    case original: Array[AnyRef]     => java.util.Arrays.copyOf(original, newLength)
+    case original: Array[Int]        => java.util.Arrays.copyOf(original, newLength)
+    case original: Array[Double]     => java.util.Arrays.copyOf(original, newLength)
+    case original: Array[Long]       => java.util.Arrays.copyOf(original, newLength)
+    case original: Array[Float]      => java.util.Arrays.copyOf(original, newLength)
+    case original: Array[Char]       => java.util.Arrays.copyOf(original, newLength)
+    case original: Array[Byte]       => java.util.Arrays.copyOf(original, newLength)
+    case original: Array[Short]      => java.util.Arrays.copyOf(original, newLength)
+    case original: Array[Boolean]    => java.util.Arrays.copyOf(original, newLength)
   }).asInstanceOf[Array[A]]
 
   /** Copy one array to another, truncating or padding with default values (if

--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -725,10 +725,12 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
    *  @return       a new $coll which contains all elements
    *                of this $coll followed by all elements of `suffix`.
    */
-  def concat[B >: A](suffix: IterableOnce[B]): CC[B] = iterableFactory.from(suffix match {
-    case xs: Iterable[B] => new View.Concat(this, xs)
-    case xs => iterator ++ suffix.iterator
-  })
+  def concat[B >: A](suffix: IterableOnce[B]): CC[B] = iterableFactory.from {
+    suffix match {
+      case suffix: Iterable[B] => new View.Concat(this, suffix)
+      case suffix => iterator ++ suffix.iterator
+    }
+  }
 
   /** Alias for `concat` */
   @inline final def ++ [B >: A](suffix: IterableOnce[B]): CC[B] = concat(suffix)

--- a/src/reflect/scala/reflect/internal/Printers.scala
+++ b/src/reflect/scala/reflect/internal/Printers.scala
@@ -850,7 +850,7 @@ trait Printers extends api.Printers { self: SymbolTable =>
           if (name.startsWith(nme.WHILE_PREFIX)) {
             val If(cond, thenp, _) = rhs: @unchecked
             print("while (", cond, ") ")
-            val Block(list, wh) = thenp: @unchecked
+            val Block(list, _) = thenp: @unchecked
             printColumn(list, "", ";", "")
           } else if (name.startsWith(nme.DO_WHILE_PREFIX)) {
             val Block(bodyList, If(cond, _, _)) = rhs: @unchecked

--- a/src/reflect/scala/reflect/internal/util/WeakHashSet.scala
+++ b/src/reflect/scala/reflect/internal/util/WeakHashSet.scala
@@ -424,7 +424,8 @@ object WeakHashSet {
   val defaultInitialCapacity = 16
   val defaultLoadFactor = .75
 
-  def apply[A <: AnyRef](initialCapacity: Int = WeakHashSet.defaultInitialCapacity, loadFactor: Double = WeakHashSet.defaultLoadFactor) = new WeakHashSet[A](initialCapacity, defaultLoadFactor)
+  def apply[A <: AnyRef](initialCapacity: Int = defaultInitialCapacity, loadFactor: Double = defaultLoadFactor) =
+    new WeakHashSet[A](initialCapacity, loadFactor)
 
   def empty[A <: AnyRef]: WeakHashSet[A] = new WeakHashSet[A]()
 }

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
@@ -687,10 +687,10 @@ trait EntityPage extends HtmlPage {
         val exceptions: Elems =
           orEmpty(comment.throws) {
             dt("Exceptions thrown") ::
-            Dd(elems= {
+            Dd(elems = {
               val exceptionsXml: List[Elems] =
-                for((name, body) <- comment.throws.toList.sortBy(_._1) ) yield
-                  Span(`class`= "cmt", elems= bodyToHtml(body)) :: NoElems
+                for ((name@_, body) <- comment.throws.toList.sortBy(_._1))
+                yield Span(`class` = "cmt", elems = bodyToHtml(body)) :: NoElems
               exceptionsXml.reduceLeft(_ ++ Txt("") ++ _)
             })
           }
@@ -698,8 +698,10 @@ trait EntityPage extends HtmlPage {
         val todo: Elems =
           orEmpty(comment.todo) {
             dt("To do") ::
-            Dd(elems= {
-              val todoXml: List[Elems] = for(todo <- comment.todo ) yield Span(`class`= "cmt", elems= bodyToHtml(todo)) :: NoElems
+            Dd(elems = {
+              val todoXml: List[Elems] =
+                for (todo <- comment.todo)
+                yield Span(`class` = "cmt", elems = bodyToHtml(todo)) :: NoElems
               todoXml.reduceLeft(_ ++ _)
             })
           }

--- a/test/files/neg/prefix-unary-nilary-removal.check
+++ b/test/files/neg/prefix-unary-nilary-removal.check
@@ -1,19 +1,19 @@
-prefix-unary-nilary-removal.scala:4: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_~ : Foo = this` [quickfixable]
-  def unary_~() : Foo = this
+prefix-unary-nilary-removal.scala:4: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_~ : Foo = Foo()` [quickfixable]
+  def unary_~(): Foo = Foo()
       ^
-prefix-unary-nilary-removal.scala:5: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_-(implicit pos: Long) = this` [quickfixable]
-  def unary_-()(implicit pos: Long) = this
+prefix-unary-nilary-removal.scala:5: warning: unary prefix operator definition with empty parameter list is deprecated: instead, remove () to declare as `def unary_-(implicit pos: Long) = Foo()` [quickfixable]
+  def unary_-()(implicit pos: Long) = Foo()
       ^
-prefix-unary-nilary-removal.scala:12: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method unary_~,
+prefix-unary-nilary-removal.scala:15: warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method unary_~,
 or remove the empty argument list from its definition (Java-defined methods are exempt).
 In Scala 3, an unapplied method like this will be eta-expanded into a function. [quickfixable]
   val f2 = ~f
            ^
 prefix-unary-nilary-removal.scala:5: warning: parameter pos in method unary_- is never used
-  def unary_-()(implicit pos: Long) = this
+  def unary_-()(implicit pos: Long) = Foo()
                          ^
 prefix-unary-nilary-removal.scala:8: warning: parameter pos in method unary_+ is never used
-  def unary_+(implicit pos: Long) = this // ok
+  def unary_+(implicit pos: Long) = Foo() // ok
                        ^
 error: No warnings can be incurred under -Werror.
 5 warnings

--- a/test/files/neg/prefix-unary-nilary-removal.scala
+++ b/test/files/neg/prefix-unary-nilary-removal.scala
@@ -1,13 +1,16 @@
 //> using options -Werror -Xlint
 //
 class Foo {
-  def unary_~() : Foo = this
-  def unary_-()(implicit pos: Long) = this
+  def unary_~(): Foo = Foo()
+  def unary_-()(implicit pos: Long) = Foo()
 
-  def unary_! : Foo = this // ok
-  def unary_+(implicit pos: Long) = this // ok
+  def `unary_!`: Foo = Foo() // ok
+  def unary_+(implicit pos: Long) = Foo() // ok
+}
+object Foo {
+  def apply() = new Foo
 }
 object Test {
-  val f = new Foo
+  val f = Foo()
   val f2 = ~f
 }

--- a/test/files/neg/t10790.check
+++ b/test/files/neg/t10790.check
@@ -4,7 +4,7 @@ t10790.scala:8: warning: parameter x in method control is never used
 t10790.scala:10: warning: private class C in class X is never used
   private class C                  // warn
                 ^
-t10790.scala:13: warning: private val y in class X is never used
+t10790.scala:13: warning: pattern var y in class X is never used
   private val Some(y) = Option(answer) // warn
                    ^
 error: No warnings can be incurred under -Werror.

--- a/test/files/neg/t10790.scala
+++ b/test/files/neg/t10790.scala
@@ -11,7 +11,7 @@ class X {
   @unused private class D          // no warn
 
   private val Some(y) = Option(answer) // warn
-  @unused private val Some(z) = Option(answer) // no warn
+  private val Some(z @ _) = Option(answer) // no warn
 
   @unused("not updated") private var i = answer       // no warn
   def g = i

--- a/test/files/neg/t13070.check
+++ b/test/files/neg/t13070.check
@@ -7,6 +7,12 @@ t13070.scala:7: warning: pattern var j in value $anonfun is never used
 t13070.scala:16: warning: pattern var j in value $anonfun is never used
       (i, j) = ns // warn
           ^
+t13070.scala:23: warning: pattern var i in object pat vardef are patvars is never used
+  private var (i, j) = (42, 27) // warn // warn
+               ^
+t13070.scala:23: warning: pattern var j in object pat vardef are patvars is never used
+  private var (i, j) = (42, 27) // warn // warn
+                  ^
 error: No warnings can be incurred under -Werror.
-3 warnings
+5 warnings
 1 error

--- a/test/files/neg/t13070.scala
+++ b/test/files/neg/t13070.scala
@@ -18,7 +18,7 @@ class D {
   }
 }
 
-// the following do not warn under -Wunused:patvars in Scala 2 (but Scala 3 does)
+// previously, the following do not warn under -Wunused:patvars in Scala 2 (but Scala 3 does)
 object `pat vardef are patvars` {
   private var (i, j) = (42, 27) // warn // warn
 }

--- a/test/files/neg/t13095.check
+++ b/test/files/neg/t13095.check
@@ -1,0 +1,9 @@
+t13095.scala:12: warning: pattern var z in object Main is never used
+  private val A(w, z) = A(42, 27) // warn
+                   ^
+t13095.scala:13: warning: pattern var r in object Main is never used
+  private[this] val A(q, r) = A(42, 27) // warn
+                         ^
+error: No warnings can be incurred under -Werror.
+2 warnings
+1 error

--- a/test/files/neg/t13095.scala
+++ b/test/files/neg/t13095.scala
@@ -1,0 +1,40 @@
+//> using options -Wunused:patvars -Werror
+
+case class A(x: Int, y: Int)
+
+object Main {
+  for {
+    a <- List.empty[A]
+    A(x, y) = a
+  } yield x + y
+
+  private val A(x, y) = A(42, 27) // nowarn for canonical name
+  private val A(w, z) = A(42, 27) // warn
+  private[this] val A(q, r) = A(42, 27) // warn
+  def W = w
+  def Q = q
+}
+
+class C {
+  def f(x: Any) =
+    x match {
+      case x: String => // nowarn because x is not a new reference but an alias
+      case _ =>
+    }
+  def g(x: Any) =
+    (x: @unchecked) match {
+      case x: String => // nowarn because x is not a new reference but an alias
+      case _ =>
+    }
+}
+
+final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
+  def f =
+    (xs: Array[_]) match {
+      case xs =>
+    }
+}
+
+class Publix {
+  val A(w, z) = A(42, 27) // nowarn if an accessor is neither private nor local
+}

--- a/test/files/neg/warn-unused-params.scala
+++ b/test/files/neg/warn-unused-params.scala
@@ -151,3 +151,9 @@ object END
 class Nested {
   @annotation.unused private def actuallyNotUsed(fresh: Int, stale: Int) = fresh
 }
+
+class Annie(value: String) extends annotation.StaticAnnotation // no warn for annotation
+
+class Selfie {
+  def f(i: Int, j: Int) = this // no warn this is trivial
+}

--- a/test/files/neg/warn-unused-patvars.check
+++ b/test/files/neg/warn-unused-patvars.check
@@ -1,5 +1,5 @@
-warn-unused-patvars.scala:11: warning: private val x in trait Boundings is never used
-  private val x = 42                      // warn, sanity check
+warn-unused-patvars.scala:10: warning: private val x in trait Boundings is never used
+  private val x = 42                      // warn, to ensure that warnings are enabled
               ^
 error: No warnings can be incurred under -Werror.
 1 warning

--- a/test/files/neg/warn-unused-patvars.scala
+++ b/test/files/neg/warn-unused-patvars.scala
@@ -1,14 +1,13 @@
-//> using options -Ywarn-unused:-patvars,_ -Xfatal-warnings
-//
+//> using options -Wunused:-patvars,_ -Werror
 
-// verify no warning when -Ywarn-unused:-patvars
+// verify NO warning when -Wunused:-patvars
 
 case class C(a: Int, b: String, c: Option[String])
 case class D(a: Int)
 
 trait Boundings {
 
-  private val x = 42                      // warn, sanity check
+  private val x = 42                      // warn, to ensure that warnings are enabled
 
   def c = C(42, "hello", Some("world"))
   def d = D(42)


### PR DESCRIPTION
Associated patvars must be processed together: a patvar is unused if no associated symbol is used. Therefore a patvar can't be skipped if it is marked `@nowarn`. Instead, collect those symbols; then, a patvar is warnable if no associated symbol is marked nowarn.

Fixes scala/bug#13095