### PR TITLE
remove some stray output in NodePrinters

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/NodePrinters.scala
+++ b/src/compiler/scala/tools/nsc/ast/NodePrinters.scala
@@ -235,7 +235,6 @@ abstract class NodePrinters {
 
         case ld @ LabelDef(name, params, rhs) =>
           printMultiline(tree) {
-            print(showNameAndPos(ld))
             traverseList("()", "params")(params)
             traverse(rhs)
           }


### PR DESCRIPTION
this was introduced between 2.13.14 and 2.13.15 by 8c000427a

the call to `showNameAndPos` was there before that commit but the result was unused. but adding `print` didn't result in sensical output. in my work on a proprietary compiler plugin I'm seeing diffs in the output of `NodePrinters` on `LabelDef` nodes like:

```diff
           LabelDef( // case def case4(): Object, tree.tpe=Object
-            ()
+"case4"            ()
             Apply( // case def matchEnd3(x: Object): Object, tree.tpe=Object
               "matchEnd3" // case def matchEnd3(x: Object): Object, tree.tpe=(x: Object): Object
               Apply( // def box(x: Int): Integer in object Int, tree.tpe=Object
```

which messes up the formatting and doesn't contain useful additional information
