### PR TITLE
Allow optimizer use within Bazel (don't attempt inlining methods without instructions)

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BackendReporting.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BackendReporting.scala
@@ -203,6 +203,9 @@ object BackendReporting {
         case SynchronizedMethod(_, _, _, _) =>
           s"Method $calleeMethodSig cannot be inlined because it is synchronized."
 
+        case _: NoBytecode =>
+          s"Method $calleeMethodSig cannot be inlined because it does not have any instructions, even though it is not abstract. The class may come from a signature jar file (such as a Bazel 'hjar')."
+
         case StrictfpMismatch(_, _, _, _, callsiteClass, callsiteName, callsiteDesc) =>
           s"""The callsite method ${BackendReporting.methodSignature(callsiteClass, callsiteName, callsiteDesc)}
              |does not have the same strictfp mode as the callee $calleeMethodSig.
@@ -229,6 +232,7 @@ object BackendReporting {
   final case class MethodWithHandlerCalledOnNonEmptyStack(calleeDeclarationClass: InternalName, name: String, descriptor: String, annotatedInline: Boolean,
                                                     callsiteClass: InternalName, callsiteName: String, callsiteDesc: String) extends CannotInlineWarning
   final case class SynchronizedMethod(calleeDeclarationClass: InternalName, name: String, descriptor: String, annotatedInline: Boolean) extends CannotInlineWarning
+  final case class NoBytecode(calleeDeclarationClass: InternalName, name: String, descriptor: String, annotatedInline: Boolean) extends CannotInlineWarning
   final case class StrictfpMismatch(calleeDeclarationClass: InternalName, name: String, descriptor: String, annotatedInline: Boolean,
                               callsiteClass: InternalName, callsiteName: String, callsiteDesc: String) extends CannotInlineWarning
   case class ResultingMethodTooLarge(calleeDeclarationClass: InternalName, name: String, descriptor: String, annotatedInline: Boolean,

--- a/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/opt/Inliner.scala
@@ -1010,6 +1010,8 @@ abstract class Inliner {
       Some(StrictfpMismatch(
         calleeDeclarationClass.internalName, callee.name, callee.desc, callsite.isInlineAnnotated,
         callsiteClass.internalName, callsiteMethod.name, callsiteMethod.desc))
+    } else if (callee.instructions.size == 0) {
+      Some(NoBytecode(calleeDeclarationClass.internalName, callee.name, callee.desc, callsite.isInlineAnnotated))
     } else
       None
   }


### PR DESCRIPTION
Bazel sometimes puts jar files where method bodies are removed on the classpath (hjars). This broke an assumption in the backend.

Fixes https://github.com/scala/bug/issues/13097

References https://github.com/bazelbuild/rules_scala/issues/1717