### PR TITLE
Simplify the run-time wrappers of arrays for use in varargs.

### DIFF
--- a/project/TestJarSize.scala
+++ b/project/TestJarSize.scala
@@ -6,7 +6,7 @@ object TestJarSize {
   final private case class JarSize(currentBytes: Long, errorThreshold: Double, warnThreshold: Double)
 
   private val libraryJarSize = JarSize(5926587L, 1.03, 1.015)
-  private val reflectJarSize = JarSize(3702957L, 1.03, 1.015)
+  private val reflectJarSize = JarSize(3814060L, 1.03, 1.015)
 
   val testJarSizeImpl: Def.Initialize[Task[Unit]] = Def.task {
     Def.unit(testJarSize1("library", libraryJarSize).value)

--- a/src/library/scala/runtime/ScalaRunTime.scala
+++ b/src/library/scala/runtime/ScalaRunTime.scala
@@ -274,22 +274,20 @@ object ScalaRunTime {
       case s => s + "\n"
     }
 
-  // Convert arrays to immutable.ArraySeq for use with Java varargs:
-  def genericWrapArray[T](xs: Array[T]): ArraySeq[T] =
-    if (xs eq null) null
-    else ArraySeq.unsafeWrapArray(xs)
-  def wrapRefArray[T <: AnyRef](xs: Array[T]): ArraySeq[T] = {
-    if (xs eq null) null
-    else if (xs.length == 0) ArraySeq.empty[AnyRef].asInstanceOf[ArraySeq[T]]
-    else new ArraySeq.ofRef[T](xs)
-  }
-  def wrapIntArray(xs: Array[Int]): ArraySeq[Int] = if (xs ne null) new ArraySeq.ofInt(xs) else null
-  def wrapDoubleArray(xs: Array[Double]): ArraySeq[Double] = if (xs ne null) new ArraySeq.ofDouble(xs) else null
-  def wrapLongArray(xs: Array[Long]): ArraySeq[Long] = if (xs ne null) new ArraySeq.ofLong(xs) else null
-  def wrapFloatArray(xs: Array[Float]): ArraySeq[Float] = if (xs ne null) new ArraySeq.ofFloat(xs) else null
-  def wrapCharArray(xs: Array[Char]): ArraySeq[Char] = if (xs ne null) new ArraySeq.ofChar(xs) else null
-  def wrapByteArray(xs: Array[Byte]): ArraySeq[Byte] = if (xs ne null) new ArraySeq.ofByte(xs) else null
-  def wrapShortArray(xs: Array[Short]): ArraySeq[Short] = if (xs ne null) new ArraySeq.ofShort(xs) else null
-  def wrapBooleanArray(xs: Array[Boolean]): ArraySeq[Boolean] = if (xs ne null) new ArraySeq.ofBoolean(xs) else null
-  def wrapUnitArray(xs: Array[Unit]): ArraySeq[Unit] = if (xs ne null) new ArraySeq.ofUnit(xs) else null
+  // Convert arrays to immutable.ArraySeq for use with Scala varargs.
+  // By construction, calls to these methods always receive a fresh (and non-null), non-empty array.
+  // In cases where an empty array would appear, the compiler uses a direct reference to Nil instead.
+  // Synthetic Java varargs forwarders (@annotation.varargs or varargs bridges when overriding) may pass
+  // `null` to these methods; but returning `null` or `ArraySeq(null)` makes little difference in practice.
+  def genericWrapArray[T](xs: Array[T]): ArraySeq[T] = ArraySeq.unsafeWrapArray(xs)
+  def wrapRefArray[T <: AnyRef](xs: Array[T]): ArraySeq[T] = new ArraySeq.ofRef[T](xs)
+  def wrapIntArray(xs: Array[Int]): ArraySeq[Int] = new ArraySeq.ofInt(xs)
+  def wrapDoubleArray(xs: Array[Double]): ArraySeq[Double] = new ArraySeq.ofDouble(xs)
+  def wrapLongArray(xs: Array[Long]): ArraySeq[Long] = new ArraySeq.ofLong(xs)
+  def wrapFloatArray(xs: Array[Float]): ArraySeq[Float] = new ArraySeq.ofFloat(xs)
+  def wrapCharArray(xs: Array[Char]): ArraySeq[Char] = new ArraySeq.ofChar(xs)
+  def wrapByteArray(xs: Array[Byte]): ArraySeq[Byte] = new ArraySeq.ofByte(xs)
+  def wrapShortArray(xs: Array[Short]): ArraySeq[Short] = new ArraySeq.ofShort(xs)
+  def wrapBooleanArray(xs: Array[Boolean]): ArraySeq[Boolean] = new ArraySeq.ofBoolean(xs)
+  def wrapUnitArray(xs: Array[Unit]): ArraySeq[Unit] = new ArraySeq.ofUnit(xs)
 }


### PR DESCRIPTION
The `ScalaRunTime.wrap*Array` methods are exclusively used by the codegen for varargs. They are always called with fresh (hence non-null) arrays that are non-empty. Therefore, the various code paths handling `null`s and empty arrays were dead code.

This commit removes those code paths to simplify those methods and streamline varargs call sites.