### PR TITLE
fix: complete backticked idents containing `$`

### DIFF
--- a/src/interactive/scala/tools/nsc/interactive/Global.scala
+++ b/src/interactive/scala/tools/nsc/interactive/Global.scala
@@ -1009,7 +1009,7 @@ class Global(settings: Settings, _reporter: Reporter, projectName: String = "") 
     def add(sym: Symbol, pre: Type, implicitlyAdded: Boolean)(toMember: (Symbol, Type) => M): Unit = {
       if ((sym.isGetter || sym.isSetter) && sym.accessed != NoSymbol) {
         add(sym.accessed, pre, implicitlyAdded)(toMember)
-      } else if (!sym.name.decodedName.containsName("$") && !sym.isError && !sym.isArtifact && sym.hasRawInfo) {
+      } else if (!sym.isError && !sym.isArtifact && sym.hasRawInfo && !sym.isDefaultGetter && !sym.isMixinConstructor) {
         val symtpe = pre.memberType(sym) onTypeError ErrorType
         matching(sym, symtpe, this(sym.name)) match {
           case Some(m) =>

--- a/test/files/presentation/callcc-interpreter.check
+++ b/test/files/presentation/callcc-interpreter.check
@@ -3,7 +3,11 @@ reload: CallccInterpreter.scala
 askTypeCompletion at CallccInterpreter.scala(51,34)
 ================================================================================
 [response] askTypeCompletion at (51,34)
-retrieved 66 members
+retrieved 70 members
+[inaccessible] private[this] val self: callccInterpreter.type
+[inaccessible] private[this] val self: callccInterpreter.type
+[inaccessible] private[this] val self: callccInterpreter.type
+[inaccessible] private[this] val self: callccInterpreter.type
 abstract trait Term extends AnyRef
 abstract trait Value extends AnyRef
 case class Add extends callccInterpreter.Term with Product with Serializable

--- a/test/files/presentation/dollar-completion.check
+++ b/test/files/presentation/dollar-completion.check
@@ -1,0 +1,47 @@
+reload: Completions.scala
+
+askScopeCompletion at Completions.scala(5,2)
+================================================================================
+[response] askScopeCompletion at (5,2)
+retrieved 16 members
+abstract trait T extends AnyRef
+case class C1 extends Product with Serializable
+class C2 extends AnyRef
+def <init>(x: Int): test.C1
+def canEqual(x$1: Any): Boolean
+def copy(x: Int): test.C1
+def productArity: Int
+def productElement(x$1: Int): Any
+object C1
+override def equals(x$1: Any): Boolean
+override def hashCode(): Int
+override def productElementName(x$1: Int): String
+override def productIterator: Iterator[Any]
+override def productPrefix: String
+override def toString(): String
+private[this] val x: Int
+================================================================================
+
+askScopeCompletion at Completions.scala(12,2)
+================================================================================
+[response] askScopeCompletion at (12,2)
+retrieved 4 members
+abstract trait T extends AnyRef
+case class C1 extends Product with Serializable
+class C2 extends AnyRef
+object C1
+================================================================================
+
+askScopeCompletion at Completions.scala(21,2)
+================================================================================
+[response] askScopeCompletion at (21,2)
+retrieved 8 members
+abstract trait T extends AnyRef
+case class C1 extends Product with Serializable
+class C2 extends AnyRef
+def $: Int
+def $var: Int
+def <init>(): test.C2
+def dollar$: Int
+object C1
+================================================================================

--- a/test/files/presentation/dollar-completion/Test.scala
+++ b/test/files/presentation/dollar-completion/Test.scala
@@ -1,0 +1,3 @@
+import scala.tools.nsc.interactive.tests.InteractiveTest
+
+object Test extends InteractiveTest

--- a/test/files/presentation/dollar-completion/src/Completions.scala
+++ b/test/files/presentation/dollar-completion/src/Completions.scala
@@ -1,0 +1,22 @@
+package test
+
+case class C1(x: Int) {
+  // Filter out `def copy$default$1: Int`
+  /*_*/
+}
+
+trait T {
+  println("hello")
+
+  // Filter out `$init$`
+  /*_*/
+}
+
+class C2 {
+  def `$` = 1
+  def `dollar$` = 2
+  def `$var` = 3
+
+  // Include explicit dollar methods
+  /*_*/
+}

--- a/test/files/presentation/higher-order-completion.check
+++ b/test/files/presentation/higher-order-completion.check
@@ -3,7 +3,11 @@ reload: Completions.scala
 askTypeCompletion at Completions.scala(12,14)
 ================================================================================
 [response] askTypeCompletion at (12,14)
-retrieved 31 members
+retrieved 35 members
+[inaccessible] private[this] val self: test.Foo
+[inaccessible] private[this] val self: test.Foo
+[inaccessible] private[this] val self: test.Foo
+[inaccessible] private[this] val self: test.Foo
 [inaccessible] protected[package lang] def clone(): Object
 [inaccessible] protected[package lang] def finalize(): Unit
 def +(other: String): String
@@ -37,7 +41,11 @@ final def wait(x$1: Long, x$2: Int): Unit
 askTypeCompletion at Completions.scala(15,13)
 ================================================================================
 [response] askTypeCompletion at (15,13)
-retrieved 31 members
+retrieved 35 members
+[inaccessible] private[this] val self: test.Foo
+[inaccessible] private[this] val self: test.Foo
+[inaccessible] private[this] val self: test.Foo
+[inaccessible] private[this] val self: test.Foo
 [inaccessible] protected[package lang] def clone(): Object
 [inaccessible] protected[package lang] def finalize(): Unit
 def +(other: String): String
@@ -71,7 +79,11 @@ final def wait(x$1: Long, x$2: Int): Unit
 askTypeCompletion at Completions.scala(18,17)
 ================================================================================
 [response] askTypeCompletion at (18,17)
-retrieved 31 members
+retrieved 35 members
+[inaccessible] private[this] val self: test.Foo
+[inaccessible] private[this] val self: test.Foo
+[inaccessible] private[this] val self: test.Foo
+[inaccessible] private[this] val self: test.Foo
 [inaccessible] protected[package lang] def clone(): Object
 [inaccessible] protected[package lang] def finalize(): Unit
 def +(other: String): String
@@ -105,7 +117,11 @@ final def wait(x$1: Long, x$2: Int): Unit
 askTypeCompletion at Completions.scala(21,24)
 ================================================================================
 [response] askTypeCompletion at (21,24)
-retrieved 31 members
+retrieved 35 members
+[inaccessible] private[this] val self: test.Foo
+[inaccessible] private[this] val self: test.Foo
+[inaccessible] private[this] val self: test.Foo
+[inaccessible] private[this] val self: test.Foo
 [inaccessible] protected[package lang] def clone(): Object
 [inaccessible] protected[package lang] def finalize(): Unit
 def +(other: String): String

--- a/test/files/presentation/ide-bug-1000349.check
+++ b/test/files/presentation/ide-bug-1000349.check
@@ -3,7 +3,11 @@ reload: CompletionOnEmptyArgMethod.scala
 askTypeCompletion at CompletionOnEmptyArgMethod.scala(2,17)
 ================================================================================
 [response] askTypeCompletion at (2,17)
-retrieved 30 members
+retrieved 34 members
+[inaccessible] private[this] val self: Foo
+[inaccessible] private[this] val self: Foo
+[inaccessible] private[this] val self: Foo
+[inaccessible] private[this] val self: Foo
 def +(other: String): String
 def ->[B](y: B): (Foo, B)
 def ensuring(cond: Boolean): Foo

--- a/test/files/presentation/ide-bug-1000475.check
+++ b/test/files/presentation/ide-bug-1000475.check
@@ -3,7 +3,11 @@ reload: Foo.scala
 askTypeCompletion at Foo.scala(3,7)
 ================================================================================
 [response] askTypeCompletion at (3,7)
-retrieved 29 members
+retrieved 33 members
+[inaccessible] private[this] val self: Object
+[inaccessible] private[this] val self: Object
+[inaccessible] private[this] val self: Object
+[inaccessible] private[this] val self: Object
 [inaccessible] protected[package lang] def clone(): Object
 [inaccessible] protected[package lang] def finalize(): Unit
 def +(other: String): String
@@ -35,7 +39,11 @@ final def wait(x$1: Long, x$2: Int): Unit
 askTypeCompletion at Foo.scala(6,10)
 ================================================================================
 [response] askTypeCompletion at (6,10)
-retrieved 29 members
+retrieved 33 members
+[inaccessible] private[this] val self: Object
+[inaccessible] private[this] val self: Object
+[inaccessible] private[this] val self: Object
+[inaccessible] private[this] val self: Object
 [inaccessible] protected[package lang] def clone(): Object
 [inaccessible] protected[package lang] def finalize(): Unit
 def +(other: String): String
@@ -67,7 +75,11 @@ final def wait(x$1: Long, x$2: Int): Unit
 askTypeCompletion at Foo.scala(7,7)
 ================================================================================
 [response] askTypeCompletion at (7,7)
-retrieved 29 members
+retrieved 33 members
+[inaccessible] private[this] val self: Object
+[inaccessible] private[this] val self: Object
+[inaccessible] private[this] val self: Object
+[inaccessible] private[this] val self: Object
 [inaccessible] protected[package lang] def clone(): Object
 [inaccessible] protected[package lang] def finalize(): Unit
 def +(other: String): String

--- a/test/files/presentation/ide-bug-1000531.check
+++ b/test/files/presentation/ide-bug-1000531.check
@@ -3,7 +3,11 @@ reload: CrashOnLoad.scala, TestIterable.java
 askTypeCompletion at CrashOnLoad.scala(9,11)
 ================================================================================
 [response] askTypeCompletion at (9,11)
-retrieved 30 members
+retrieved 34 members
+[inaccessible] private[this] val self: other.TestIterator[Nothing]
+[inaccessible] private[this] val self: other.TestIterator[Nothing]
+[inaccessible] private[this] val self: other.TestIterator[Nothing]
+[inaccessible] private[this] val self: other.TestIterator[Nothing]
 [inaccessible] protected[package lang] def clone(): Object
 [inaccessible] protected[package lang] def finalize(): Unit
 def +(other: String): String

--- a/test/files/presentation/implicit-member.check
+++ b/test/files/presentation/implicit-member.check
@@ -3,7 +3,11 @@ reload: ImplicitMember.scala
 askTypeCompletion at ImplicitMember.scala(7,7)
 ================================================================================
 [response] askTypeCompletion at (7,7)
-retrieved 32 members
+retrieved 36 members
+[inaccessible] private[this] val self: Implicit.type
+[inaccessible] private[this] val self: Implicit.type
+[inaccessible] private[this] val self: Implicit.type
+[inaccessible] private[this] val self: Implicit.type
 def +(other: String): String
 def ->[B](y: B): (Implicit.type, B)
 def ensuring(cond: Boolean): Implicit.type

--- a/test/files/presentation/infix-completion.check
+++ b/test/files/presentation/infix-completion.check
@@ -4,10 +4,14 @@ askTypeCompletion at Snippet.scala(1,34)
 ================================================================================
 [response] askTypeCompletion at (1,34)
 #partest !java15+
-retrieved 203 members
+retrieved 207 members
 #partest java15+
-retrieved 205 members
+retrieved 209 members
 #partest
+[inaccessible] private[this] val self: Int
+[inaccessible] private[this] val self: Int
+[inaccessible] private[this] val self: Int
+[inaccessible] private[this] val self: Int
 [inaccessible] protected def num: Fractional[Double]
 [inaccessible] protected def ord: Ordering[Double]
 [inaccessible] protected def unifiedPrimitiveEquals(x: Any): Boolean

--- a/test/files/presentation/infix-completion2.check
+++ b/test/files/presentation/infix-completion2.check
@@ -4,10 +4,14 @@ askTypeCompletion at Snippet.scala(1,34)
 ================================================================================
 [response] askTypeCompletion at (1,34)
 #partest !java15+
-retrieved 203 members
+retrieved 207 members
 #partest java15+
-retrieved 205 members
+retrieved 209 members
 #partest
+[inaccessible] private[this] val self: Int
+[inaccessible] private[this] val self: Int
+[inaccessible] private[this] val self: Int
+[inaccessible] private[this] val self: Int
 [inaccessible] protected def num: Fractional[Double]
 [inaccessible] protected def ord: Ordering[Double]
 [inaccessible] protected def unifiedPrimitiveEquals(x: Any): Boolean

--- a/test/files/presentation/ping-pong.check
+++ b/test/files/presentation/ping-pong.check
@@ -3,8 +3,12 @@ reload: PingPong.scala
 askTypeCompletion at PingPong.scala(10,31)
 ================================================================================
 [response] askTypeCompletion at (10,31)
-retrieved 32 members
+retrieved 36 members
 [inaccessible] private[this] val ping: Ping
+[inaccessible] private[this] val self: Pong
+[inaccessible] private[this] val self: Pong
+[inaccessible] private[this] val self: Pong
+[inaccessible] private[this] val self: Pong
 [inaccessible] protected[package lang] def clone(): Object
 [inaccessible] protected[package lang] def finalize(): Unit
 def +(other: String): String
@@ -38,7 +42,11 @@ private[this] val name: String
 askTypeCompletion at PingPong.scala(19,28)
 ================================================================================
 [response] askTypeCompletion at (19,28)
-retrieved 33 members
+retrieved 37 members
+[inaccessible] private[this] val self: Ping
+[inaccessible] private[this] val self: Ping
+[inaccessible] private[this] val self: Ping
+[inaccessible] private[this] val self: Ping
 [inaccessible] protected[package lang] def clone(): Object
 [inaccessible] protected[package lang] def finalize(): Unit
 def +(other: String): String

--- a/test/files/presentation/t5708.check
+++ b/test/files/presentation/t5708.check
@@ -3,10 +3,14 @@ reload: Completions.scala
 askTypeCompletion at Completions.scala(17,9)
 ================================================================================
 [response] askTypeCompletion at (17,9)
-retrieved 37 members
+retrieved 41 members
 [inaccessible] private def privateM: String
 [inaccessible] private[this] val privateV: String
 [inaccessible] private[this] val protectedV: String
+[inaccessible] private[this] val self: test.Compat.type
+[inaccessible] private[this] val self: test.Compat.type
+[inaccessible] private[this] val self: test.Compat.type
+[inaccessible] private[this] val self: test.Compat.type
 [inaccessible] protected def protectedValM: String
 [inaccessible] protected[package lang] def clone(): Object
 [inaccessible] protected[package lang] def finalize(): Unit

--- a/test/files/presentation/visibility.check
+++ b/test/files/presentation/visibility.check
@@ -3,8 +3,12 @@ reload: Completions.scala
 askTypeCompletion at Completions.scala(14,12)
 ================================================================================
 [response] askTypeCompletion at (14,12)
-retrieved 35 members
+retrieved 39 members
 [inaccessible] private[this] def secretPrivateThis(): Unit
+[inaccessible] private[this] val self: accessibility.Foo
+[inaccessible] private[this] val self: accessibility.Foo
+[inaccessible] private[this] val self: accessibility.Foo
+[inaccessible] private[this] val self: accessibility.Foo
 def +(other: String): String
 def ->[B](y: B): (accessibility.Foo, B)
 def ensuring(cond: Boolean): accessibility.Foo
@@ -41,7 +45,11 @@ protected[package lang] def finalize(): Unit
 askTypeCompletion at Completions.scala(16,11)
 ================================================================================
 [response] askTypeCompletion at (16,11)
-retrieved 35 members
+retrieved 39 members
+[inaccessible] private[this] val self: accessibility.Foo
+[inaccessible] private[this] val self: accessibility.Foo
+[inaccessible] private[this] val self: accessibility.Foo
+[inaccessible] private[this] val self: accessibility.Foo
 def +(other: String): String
 def ->[B](y: B): (accessibility.Foo, B)
 def ensuring(cond: Boolean): accessibility.Foo
@@ -79,7 +87,11 @@ protected[package lang] def finalize(): Unit
 askTypeCompletion at Completions.scala(22,11)
 ================================================================================
 [response] askTypeCompletion at (22,11)
-retrieved 34 members
+retrieved 38 members
+[inaccessible] private[this] val self: accessibility.AccessibilityChecks
+[inaccessible] private[this] val self: accessibility.AccessibilityChecks
+[inaccessible] private[this] val self: accessibility.AccessibilityChecks
+[inaccessible] private[this] val self: accessibility.AccessibilityChecks
 def +(other: String): String
 def ->[B](y: B): (accessibility.AccessibilityChecks, B)
 def ensuring(cond: Boolean): accessibility.AccessibilityChecks
@@ -116,9 +128,13 @@ protected[package lang] def finalize(): Unit
 askTypeCompletion at Completions.scala(28,10)
 ================================================================================
 [response] askTypeCompletion at (28,10)
-retrieved 35 members
+retrieved 39 members
 [inaccessible] private def secretPrivate(): Unit
 [inaccessible] private[this] def secretPrivateThis(): Unit
+[inaccessible] private[this] val self: accessibility.Foo
+[inaccessible] private[this] val self: accessibility.Foo
+[inaccessible] private[this] val self: accessibility.Foo
+[inaccessible] private[this] val self: accessibility.Foo
 [inaccessible] protected def secretProtected(): Unit
 [inaccessible] protected[package lang] def clone(): Object
 [inaccessible] protected[package lang] def finalize(): Unit
@@ -154,9 +170,13 @@ protected[package accessibility] def secretProtectedInPackage(): Unit
 askTypeCompletion at Completions.scala(37,8)
 ================================================================================
 [response] askTypeCompletion at (37,8)
-retrieved 35 members
+retrieved 39 members
 [inaccessible] private def secretPrivate(): Unit
 [inaccessible] private[this] def secretPrivateThis(): Unit
+[inaccessible] private[this] val self: accessibility.Foo
+[inaccessible] private[this] val self: accessibility.Foo
+[inaccessible] private[this] val self: accessibility.Foo
+[inaccessible] private[this] val self: accessibility.Foo
 [inaccessible] protected def secretProtected(): Unit
 [inaccessible] protected[package accessibility] def secretProtectedInPackage(): Unit
 [inaccessible] protected[package lang] def clone(): Object

--- a/test/junit/scala/tools/nsc/interpreter/CompletionTest.scala
+++ b/test/junit/scala/tools/nsc/interpreter/CompletionTest.scala
@@ -127,6 +127,9 @@ class CompletionTest {
     checkExact(completer, "object X { def `Foo Bar` = 0; this.`Foo ", after = "` }")("Foo Bar")
     checkExact(completer, "val `Foo Bar` = 0; `Foo ", after = "`")("Foo Bar")
     checkExact(completer, "def foo(`Foo Bar`: Int) { `Foo ", after = "` }")("Foo Bar")
+    checkExact(completer, "def foo(`Foo Bar!`: Int) { `Foo ", after = "` }")("Foo Bar!")
+    checkExact(completer, "def foo(`Foo Bar$`: Int) { `Foo ", after = "` }")("Foo Bar$")
+    checkExact(completer, "def foo(`$Foo$Bar$`: Int) { `$Foo ", after = "` }")("$Foo$Bar$")
   }
 
   @Test


### PR DESCRIPTION
The previous check around filtering out names whose decoded representation contained `$` was probably written with the idea being that most dollar signs are just encoding artifacts, however it misses the fact that every once in a blue moon, the decoding result might have a `$` that was actually written by the user (as opposed to something synthetic like `MODULE$`)