### PR TITLE
Macro bundle fails more cleanly

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Macros.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Macros.scala
@@ -758,19 +758,21 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
     expander(expandee)
   }
 
-  sealed abstract class MacroStatus(val result: Tree)
-  case class Success(expanded: Tree) extends MacroStatus(expanded)
-  case class Fallback(fallback: Tree) extends MacroStatus(fallback) { runReporting.seenMacroExpansionsFallingBack = true }
-  case class Delayed(delayed: Tree) extends MacroStatus(delayed)
-  case class Skipped(skipped: Tree) extends MacroStatus(skipped)
-  case class Failure(failure: Tree) extends MacroStatus(failure)
-  def Delay(expanded: Tree) = Delayed(expanded)
-  def Skip(expanded: Tree) = Skipped(expanded)
+  private sealed abstract class MacroStatus(val result: Tree)
+  private case class Success(expanded: Tree) extends MacroStatus(expanded)
+  private case class Fallback(fallback: Tree) extends MacroStatus(fallback) {
+    runReporting.seenMacroExpansionsFallingBack = true
+  }
+  private case class Delayed(delayed: Tree) extends MacroStatus(delayed)
+  private case class Skipped(skipped: Tree) extends MacroStatus(skipped)
+  private case class Failure(failure: Tree) extends MacroStatus(failure)
+  private def Delay(expanded: Tree) = Delayed(expanded)
+  private def Skip(expanded: Tree) = Skipped(expanded)
 
   /** Expands a macro when a runtime (i.e. the macro implementation) can be successfully loaded
    *  Meant for internal use within the macro infrastructure, don't use it elsewhere.
    */
-  def macroExpandWithRuntime(typer: Typer, expandee: Tree, runtime: MacroRuntime): MacroStatus = {
+  private def macroExpandWithRuntime(typer: Typer, expandee: Tree, runtime: MacroRuntime): MacroStatus = {
     val wasDelayed  = isDelayed(expandee)
     val undetparams = calculateUndetparams(expandee)
     val nowDelayed  = !typer.context.macrosEnabled || undetparams.nonEmpty
@@ -830,7 +832,7 @@ trait Macros extends MacroRuntimes with Traces with Helpers {
   /** Expands a macro when a runtime (i.e. the macro implementation) cannot be loaded
    *  Meant for internal use within the macro infrastructure, don't use it elsewhere.
    */
-  def macroExpandWithoutRuntime(typer: Typer, expandee: Tree): MacroStatus = {
+  private def macroExpandWithoutRuntime(typer: Typer, expandee: Tree): MacroStatus = {
     import typer.TyperErrorGen._
     val fallbackSym = expandee.symbol.nextOverriddenSymbol orElse MacroImplementationNotFoundError(expandee)
     macroLogLite(s"falling back to: $fallbackSym")

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -79,10 +79,10 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     @inline final def filter(p: T => Boolean): SilentResult[T] = this match {
       case SilentResultValue(value) if !p(value) => SilentTypeError(TypeErrorWrapper(new TypeError(NoPosition, "!p")))
       case _                                     => this
-  }
+    }
     @inline final def orElse[T1 >: T](f: Seq[AbsTypeError] => T1): T1 = this match {
       case SilentResultValue(value) => value
-      case s : SilentTypeError      => f(s.reportableErrors)
+      case s: SilentTypeError       => f(s.reportableErrors)
     }
   }
   class SilentTypeError private(val errors: List[AbsTypeError], val warnings: List[ContextWarning]) extends SilentResult[Nothing] {

--- a/src/reflect/scala/reflect/internal/TreeInfo.scala
+++ b/src/reflect/scala/reflect/internal/TreeInfo.scala
@@ -1014,8 +1014,8 @@ abstract class TreeInfo {
       case _ => EmptyTree
     }
 
-    def unapply(tree: Tree) = refPart(tree) match {
-      case ref: RefTree => {
+    def unapply(tree: Tree): Option[(Boolean, Boolean, Symbol, Symbol, List[Tree])] = refPart(tree) match {
+      case ref: RefTree =>
         val qual = ref.qualifier
         val isBundle = definitions.isMacroBundleType(qual.tpe)
         val isBlackbox =
@@ -1031,8 +1031,7 @@ abstract class TreeInfo {
             if (qualSym.isModule) qualSym.moduleClass else qualSym
           }
         Some((isBundle, isBlackbox, owner, ref.symbol, dissectApplied(tree).targs))
-      }
-      case _  => None
+      case _ => None
     }
   }
 

--- a/test/files/pos/macro-bounds-check/MacroImpl_1.scala
+++ b/test/files/pos/macro-bounds-check/MacroImpl_1.scala
@@ -28,6 +28,7 @@ class DerivationMacros(val c: whitebox.Context) {
       q"""
         {
           def e(a: $R): Object = a
+          println("encode hlist")
           Predef.???
         }
         """
@@ -39,7 +40,7 @@ class DerivationMacros(val c: whitebox.Context) {
       q"""
         {
           def e(a: $R): Object = a
-
+          println("encode coproduct")
           Predef.???
         }
         """

--- a/test/files/pos/t9107.scala
+++ b/test/files/pos/t9107.scala
@@ -1,0 +1,12 @@
+//> using options -Werror -deprecation
+
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox.Context
+
+class qqq(count: Int) {
+  def macroTransform(annottees: Any*): Any = macro qqq.qqqImpl
+}
+
+object qqq {
+  def qqqImpl(c: Context)(annottees: c.Expr[Any]*): c.Expr[Any] = ???
+}


### PR DESCRIPTION
The problem diagnosed on the ticket is that "macro bundles" are compiled `new C(null).m`, so that if the class takes a primitive, the compiler issues the "subpar message" that null can't be converted. That error is emitted while searching for the conversion, with `reportAmbiguous` turned (back) on, under which it is always reported.

There is a comment (Adriaan?) somewhere to the effect that it would nice to nuance that behavior. (Not attempted here.)

It would also be nice if `macros.compiler` accumulated errors and then decided what to emit when failing, similar to `reportMostAppropriateFailure`. (Also not attempted here, see first item.)

The typecheck in `reportMostAppropriateFailure` is now tried before the construction of the bundle, so that the parameter can be checked in advance.

Note that it always  tries both unbundled def macro and bundle, accepting whichever succeeds, or failing if both succeed.

Fixes scala/bug#9107