### PR TITLE
Warn and remove obsolete constants and backticks

### DIFF
--- a/src/library/scala/collection/StringOps.scala
+++ b/src/library/scala/collection/StringOps.scala
@@ -26,9 +26,7 @@ import scala.util.matching.Regex
 object StringOps {
   // just statics for companion class.
   private final val LF = 0x0A
-  private final val FF = 0x0C
   private final val CR = 0x0D
-  private final val SU = 0x1A
 
   private class StringIterator(private[this] val s: String) extends AbstractIterator[Char] {
     private[this] var pos = 0
@@ -180,14 +178,14 @@ object StringOps {
 final class StringOps(private val s: String) extends AnyVal {
   import StringOps._
 
-  @`inline` def view: StringView = new StringView(s)
+  @inline def view: StringView = new StringView(s)
 
-  @`inline` def size: Int = s.length
+  @inline def size: Int = s.length
 
-  @`inline` def knownSize: Int = s.length
+  @inline def knownSize: Int = s.length
 
   /** Get the char at the specified index. */
-  @`inline` def apply(i: Int): Char = s.charAt(i)
+  @inline def apply(i: Int): Char = s.charAt(i)
 
   def sizeCompare(otherSize: Int): Int = Integer.compare(s.length, otherSize)
 
@@ -344,13 +342,13 @@ final class StringOps(private val s: String) extends AnyVal {
     *  @return       a new string which contains all chars
     *                of this string followed by all chars of `suffix`.
     */
-  @`inline` def concat(suffix: String): String = s + suffix
+  @inline def concat(suffix: String): String = s + suffix
 
   /** Alias for `concat` */
-  @`inline` def ++[B >: Char](suffix: Iterable[B]): immutable.IndexedSeq[B] = concat(suffix)
+  @inline def ++[B >: Char](suffix: Iterable[B]): immutable.IndexedSeq[B] = concat(suffix)
 
   /** Alias for `concat` */
-  @`inline` def ++(suffix: IterableOnce[Char]): String = concat(suffix)
+  @inline def ++(suffix: IterableOnce[Char]): String = concat(suffix)
 
   /** Alias for `concat` */
   def ++(xs: String): String = concat(xs)
@@ -412,14 +410,14 @@ final class StringOps(private val s: String) extends AnyVal {
   }
 
   /** Alias for `prepended` */
-  @`inline` def +: [B >: Char] (elem: B): immutable.IndexedSeq[B] = prepended(elem)
+  @inline def +: [B >: Char] (elem: B): immutable.IndexedSeq[B] = prepended(elem)
 
   /** A copy of the string with an char prepended */
   def prepended(c: Char): String =
     new JStringBuilder(s.length + 1).append(c).append(s).toString
 
   /** Alias for `prepended` */
-  @`inline` def +: (c: Char): String = prepended(c)
+  @inline def +: (c: Char): String = prepended(c)
 
   /** A copy of the string with all elements from a collection prepended */
   def prependedAll[B >: Char](prefix: IterableOnce[B]): immutable.IndexedSeq[B] = {
@@ -432,13 +430,13 @@ final class StringOps(private val s: String) extends AnyVal {
   }
 
   /** Alias for `prependedAll` */
-  @`inline` def ++: [B >: Char] (prefix: IterableOnce[B]): immutable.IndexedSeq[B] = prependedAll(prefix)
+  @inline def ++: [B >: Char] (prefix: IterableOnce[B]): immutable.IndexedSeq[B] = prependedAll(prefix)
 
   /** A copy of the string with another string prepended */
   def prependedAll(prefix: String): String = prefix + s
 
   /** Alias for `prependedAll` */
-  @`inline` def ++: (prefix: String): String = prependedAll(prefix)
+  @inline def ++: (prefix: String): String = prependedAll(prefix)
 
   /** A copy of the string with an element appended */
   def appended[B >: Char](elem: B): immutable.IndexedSeq[B] = {
@@ -450,28 +448,28 @@ final class StringOps(private val s: String) extends AnyVal {
   }
 
   /** Alias for `appended` */
-  @`inline` def :+ [B >: Char](elem: B): immutable.IndexedSeq[B] = appended(elem)
+  @inline def :+ [B >: Char](elem: B): immutable.IndexedSeq[B] = appended(elem)
 
   /** A copy of the string with an element appended */
   def appended(c: Char): String =
     new JStringBuilder(s.length + 1).append(s).append(c).toString
 
   /** Alias for `appended` */
-  @`inline` def :+ (c: Char): String = appended(c)
+  @inline def :+ (c: Char): String = appended(c)
 
   /** A copy of the string with all elements from a collection appended */
-  @`inline` def appendedAll[B >: Char](suffix: IterableOnce[B]): immutable.IndexedSeq[B] =
+  @inline def appendedAll[B >: Char](suffix: IterableOnce[B]): immutable.IndexedSeq[B] =
     concat(suffix)
 
   /** Alias for `appendedAll` */
-  @`inline` def :++ [B >: Char](suffix: IterableOnce[B]): immutable.IndexedSeq[B] =
+  @inline def :++ [B >: Char](suffix: IterableOnce[B]): immutable.IndexedSeq[B] =
     concat(suffix)
 
   /** A copy of the string with another string appended */
-  @`inline` def appendedAll(suffix: String): String = s + suffix
+  @inline def appendedAll(suffix: String): String = s + suffix
 
   /** Alias for `appendedAll` */
-  @`inline` def :++ (suffix: String): String = s + suffix
+  @inline def :++ (suffix: String): String = s + suffix
 
   /** Produces a new collection where a slice of characters in this string is replaced by another collection.
     *
@@ -488,7 +486,7 @@ final class StringOps(private val s: String) extends AnyVal {
     */
   def patch[B >: Char](from: Int, other: IterableOnce[B], replaced: Int): immutable.IndexedSeq[B] = {
     val len = s.length
-    @`inline` def slc(off: Int, length: Int): WrappedString =
+    @inline def slc(off: Int, length: Int): WrappedString =
       new WrappedString(s.substring(off, off+length))
     val b = immutable.IndexedSeq.newBuilder[B]
     val k = other.knownSize
@@ -645,8 +643,8 @@ final class StringOps(private val s: String) extends AnyVal {
 
   // Note: String.repeat is added in JDK 11.
   /** Return the current string concatenated `n` times.
-    */
-  def *(n: Int): String = {
+   */
+  def *(n: Int): String =
     if (n <= 0) {
       ""
     } else {
@@ -658,10 +656,9 @@ final class StringOps(private val s: String) extends AnyVal {
       }
       sb.toString
     }
-  }
 
-  @`inline` private[this] def isLineBreak(c: Char) = c == CR || c == LF
-  @`inline` private[this] def isLineBreak2(c0: Char, c: Char) = c0 == CR && c == LF
+  @inline private def isLineBreak(c: Char) = c == CR || c == LF
+  @inline private def isLineBreak2(c0: Char, c: Char) = c0 == CR && c == LF
 
   /** Strip the trailing line separator from this string if there is one.
    *  The line separator is taken as `"\n"`, `"\r"`, or `"\r\n"`.
@@ -698,7 +695,7 @@ final class StringOps(private val s: String) extends AnyVal {
 
     private[this] val len = s.length
     private[this] var index = 0
-    @`inline` private def done = index >= len
+    @inline private def done = index >= len
     private def advance(): String = {
       val start = index
       while (!done && !isLineBreak(apply(index))) index += 1
@@ -1118,7 +1115,7 @@ final class StringOps(private val s: String) extends AnyVal {
    *   @return        The result of applying `op` to `z` and all chars in this string,
    *                  going left to right. Returns `z` if this string is empty.
    */
-  @`inline` def fold[A1 >: Char](z: A1)(op: (A1, A1) => A1): A1 = foldLeft(z)(op)
+  @inline def fold[A1 >: Char](z: A1)(op: (A1, A1) => A1): A1 = foldLeft(z)(op)
 
   /** Selects the first char of this string.
     *  @return  the first char of this string.
@@ -1158,19 +1155,19 @@ final class StringOps(private val s: String) extends AnyVal {
   /** Stepper can be used with Java 8 Streams. This method is equivalent to a call to
     * [[charStepper]]. See also [[codePointStepper]].
     */
-  @`inline` def stepper: IntStepper with EfficientSplit = charStepper
+  @inline def stepper: IntStepper with EfficientSplit = charStepper
 
   /** Steps over characters in this string. Values are packed in `Int` for efficiency
     * and compatibility with Java 8 Streams which have an efficient specialization for `Int`.
     */
-  @`inline` def charStepper: IntStepper with EfficientSplit = new CharStringStepper(s, 0, s.length)
+  @inline def charStepper: IntStepper with EfficientSplit = new CharStringStepper(s, 0, s.length)
 
   /** Steps over code points in this string.
     */
-  @`inline` def codePointStepper: IntStepper with EfficientSplit = new CodePointStringStepper(s, 0, s.length)
+  @inline def codePointStepper: IntStepper with EfficientSplit = new CodePointStringStepper(s, 0, s.length)
 
   /** Tests whether the string is not empty. */
-  @`inline` def nonEmpty: Boolean = !s.isEmpty
+  @inline def nonEmpty: Boolean = !s.isEmpty
 
   /** Returns new sequence with elements in reversed order.
     * @note $unicodeunaware
@@ -1268,7 +1265,7 @@ final class StringOps(private val s: String) extends AnyVal {
   }
 
   /** Selects all chars of this string which do not satisfy a predicate. */
-  @`inline` def filterNot(pred: Char => Boolean): String = filter(c => !pred(c))
+  @inline def filterNot(pred: Char => Boolean): String = filter(c => !pred(c))
 
   /** Copy chars of this string to an array.
     * Fills the given array `xs` starting at index 0.
@@ -1277,7 +1274,7 @@ final class StringOps(private val s: String) extends AnyVal {
     *
     *  @param  xs     the array to fill.
     */
-  @`inline` def copyToArray(xs: Array[Char]): Int =
+  @inline def copyToArray(xs: Array[Char]): Int =
     copyToArray(xs, 0, Int.MaxValue)
 
   /** Copy chars of this string to an array.
@@ -1288,7 +1285,7 @@ final class StringOps(private val s: String) extends AnyVal {
     *  @param  xs     the array to fill.
     *  @param  start  the starting index.
     */
-  @`inline` def copyToArray(xs: Array[Char], start: Int): Int =
+  @inline def copyToArray(xs: Array[Char], start: Int): Int =
     copyToArray(xs, start, Int.MaxValue)
 
   /** Copy chars of this string to an array.

--- a/src/reflect/scala/reflect/internal/Flags.scala
+++ b/src/reflect/scala/reflect/internal/Flags.scala
@@ -373,7 +373,7 @@ class Flags extends ModifierFlags {
   private final val MODULE_PKL     = (1L << 10)
   private final val INTERFACE_PKL  = (1L << 11)
 
-  private final val PKL_MASK       = 0x00000FFF
+  //private final val PKL_MASK     = 0x00000FFF
 
   /** Pickler correspondence, ordered roughly by frequency of occurrence */
   private def rawPickledCorrespondence = Array[(Long, Long)](

--- a/src/reflect/scala/reflect/internal/util/StripMarginInterpolator.scala
+++ b/src/reflect/scala/reflect/internal/util/StripMarginInterpolator.scala
@@ -41,7 +41,7 @@ trait StripMarginInterpolator {
   final def sm(args: Any*): String = impl('|', args: _*)
 
   private final def impl(sep: Char, args: Any*): String = {
-    def isLineBreak(c: Char) = c == '\n' || c == '\f' // compatible with StringOps#isLineBreak
+    def isLineBreak(c: Char) = c == Chars.LF || c == Chars.FF // compatible with CharArrayReader
     def stripTrailingPart(s: String) = {
       val (pre, post) = s.span(c => !isLineBreak(c))
       pre + post.stripMargin(sep)

--- a/src/testkit/scala/tools/testkit/AssertUtil.scala
+++ b/src/testkit/scala/tools/testkit/AssertUtil.scala
@@ -92,8 +92,6 @@ object AssertUtil {
   def assertNotEqualsAny(message: => String, expected: Any, actual: Any): Unit =
     if (BoxesRunTime.equals(expected, actual)) assertNotEquals(message, expected, actual)
 
-  private final val timeout = 60 * 1000L                 // wait a minute
-
   private implicit class `ref helper`[A <: AnyRef](val r: Reference[A]) extends AnyVal {
     def isEmpty: Boolean  = r.get == null // r.refersTo(null) to avoid influencing collection
     def nonEmpty: Boolean = !isEmpty

--- a/test/files/neg/warn-unused-privates.check
+++ b/test/files/neg/warn-unused-privates.check
@@ -10,6 +10,9 @@ warn-unused-privates.scala:6: warning: private method bippy in class Bippy is ne
 warn-unused-privates.scala:7: warning: private method boop in class Bippy is never used
   private def boop(x: Int)            = x+a+b     // warn
               ^
+warn-unused-privates.scala:8: warning: private val MILLIS1 in class Bippy is never used
+  final private val MILLIS1           = 2000      // now warn, might have been inlined
+                    ^
 warn-unused-privates.scala:9: warning: private val MILLIS2 in class Bippy is never used
   final private val MILLIS2: Int      = 1000      // warn
                     ^
@@ -22,6 +25,9 @@ warn-unused-privates.scala:17: warning: private val BOOL in object Bippy is neve
 warn-unused-privates.scala:41: warning: private val hummer in class Boppy is never used
   private val hummer = "def" // warn
               ^
+warn-unused-privates.scala:43: warning: private val bum in class Boppy is never used
+  private final val bum   = "ghi"       // now warn, might have been (was) inlined
+                    ^
 warn-unused-privates.scala:48: warning: private var v1 in trait Accessors is never used
   private var v1: Int = 0 // warn
               ^
@@ -91,6 +97,9 @@ warn-unused-privates.scala:274: warning: private method f in class recursive ref
 warn-unused-privates.scala:277: warning: private class P in class recursive reference is not a usage is never used
   private class P {
                 ^
+warn-unused-privates.scala:284: warning: private val There in class Constantly is never used
+  private final val There = "there" // warn
+                    ^
 error: No warnings can be incurred under -Werror.
-31 warnings
+34 warnings
 1 error

--- a/test/files/neg/warn-unused-privates.scala
+++ b/test/files/neg/warn-unused-privates.scala
@@ -5,7 +5,7 @@ class Bippy(a: Int, b: Int) {
   private def this(c: Int) = this(c, c)           // warn
   private def bippy(x: Int): Int      = bippy(x)  // warn
   private def boop(x: Int)            = x+a+b     // warn
-  final private val MILLIS1           = 2000      // no warn, might have been inlined
+  final private val MILLIS1           = 2000      // now warn, might have been inlined
   final private val MILLIS2: Int      = 1000      // warn
   final private val HI_COMPANION: Int = 500       // no warn, accessed from companion
   def hi() = Bippy.HI_INSTANCE
@@ -40,7 +40,7 @@ class Boppy extends {
   val dinger = hom
   private val hummer = "def" // warn
 
-  private final val bum   = "ghi"       // no warn, might have been (was) inlined
+  private final val bum   = "ghi"       // now warn, might have been (was) inlined
   final val bum2          = "ghi"       // no warn, same
 }
 
@@ -276,5 +276,35 @@ class `recursive reference is not a usage` {
     else f(i-1)
   private class P {
     def f() = new P()
+  }
+}
+
+class Constantly {
+  private final val Here = "here"
+  private final val There = "there" // warn
+  def bromide = Here + " today, gone tomorrow."
+}
+
+class Annots {
+  import annotation._
+
+  trait T {
+    def value: Int
+  }
+
+  class C {
+    private final val Here = "here"
+    private final val There = "msg=there"
+    def f(implicit @implicitNotFound(Here) t: T) = t.value
+    def x: String @nowarn(There) = ""
+  }
+
+  // cf HashMap#mergeInto which looped on type of new unchecked
+  // case bm: BitmapIndexedMapNode[K, V] @unchecked =>
+  class Weird[K, V] {
+    def f(other: Weird[K, V]) =
+      other match {
+        case weird: Weird[K, V] @unchecked =>
+      }
   }
 }


### PR DESCRIPTION
The remaining constants are not rewritten to `Chars.LF` etc.

The comment at `Chars.LF` is left to a future editor. The ticket mentioned there is still relevant.

`linesIterator` does not respect `FF` because it was aligned with Java.

The interpolator (also in Dotty's `i`) does respect `FF`.

~Perhaps `-Wunused` does not warn for inlined constants? It checks `OriginalTreeAttachment`.~

`-Wunused` warns for inlined constants, and also traverses annotation trees for usages.