### PR TITLE
Set pos of args in tupling for patvar def

### DIFF
--- a/test/files/run/position-val-def.check
+++ b/test/files/run/position-val-def.check
@@ -41,8 +41,16 @@ class C4 { val (x, y) = (42, 27) }
 [19]    [19]    [19]           -> <stable> <accessor> def y(): Int = C4.this.y
 <15:32> [24:32]                -> C4.this.x$1 = {...
 [24:32] [24:32] [24:32]        -> case <synthetic> val x1: Tuple2 = (new Tuple2$mcII$sp(42, 27): Tuple2)
+[24:32]                        -> new Tuple2$mcII$sp(42, 27)
+  [25:27]                      -> 42
+  [29:31]                      -> 27
+<15:21>                        -> x1.ne(null)
+  <15:21>                      -> null
 <16:17> <16:17> <16:17>        -> val x: Int = x1._1$mcI$sp()
 <19:20> <19:20> <19:20>        -> val y: Int = x1._2$mcI$sp()
+<15:21>                        -> new Tuple2$mcII$sp(x, y)
+  <16:17>                      -> x
+  <19:20>                      -> y
 [16:17] [16]                   -> C4.this.x = C4.this.x$1._1$mcI$sp()
 [19:20] [19]                   -> C4.this.y = C4.this.x$1._2$mcI$sp()
 --
@@ -59,14 +67,27 @@ class C5 { val (x, y), (w, z) = (42, 27) }
 [27]    [27]    [27]           -> <stable> <accessor> def z(): Int = C5.this.z
 <15:40> [32]                   -> C5.this.x$1 = {...
 [32]    [32]    [32]           -> case <synthetic> val x1: Tuple2 = (new Tuple2$mcII$sp(42, 27): Tuple2)
+<15:21>                        -> x1.ne(null)
+  <15:21>                      -> null
 <16:17> <16:17> <16:17>        -> val x: Int = x1._1$mcI$sp()
 <19:20> <19:20> <19:20>        -> val y: Int = x1._2$mcI$sp()
+<15:21>                        -> new Tuple2$mcII$sp(x, y)
+  <16:17>                      -> x
+  <19:20>                      -> y
 [16:17] [16]                   -> C5.this.x = C5.this.x$1._1$mcI$sp()
 [19:20] [19]                   -> C5.this.y = C5.this.x$1._2$mcI$sp()
 <23:40> [32:40]                -> C5.this.x$2 = {...
 [32:40] [32:40] [32:40]        -> case <synthetic> val x1: Tuple2 = (new Tuple2$mcII$sp(42, 27): Tuple2)
+[32:40]                        -> new Tuple2$mcII$sp(42, 27)
+  [33:35]                      -> 42
+  [37:39]                      -> 27
+<23:29>                        -> x1.ne(null)
+  <23:29>                      -> null
 <24:25> <24:25> <24:25>        -> val w: Int = x1._1$mcI$sp()
 <27:28> <27:28> <27:28>        -> val z: Int = x1._2$mcI$sp()
+<23:29>                        -> new Tuple2$mcII$sp(w, z)
+  <24:25>                      -> w
+  <27:28>                      -> z
 [24:25] [24]                   -> C5.this.w = C5.this.x$2._1$mcI$sp()
 [27:28] [27]                   -> C5.this.z = C5.this.x$2._2$mcI$sp()
 --
@@ -85,4 +106,8 @@ class C7 { val Some(_) = Option(42) }
 [11:35] [11:35] [NoPosition]   -> <synthetic> <artifact> private[this] val x$1: scala.runtime.BoxedUnit = _
 [11:35] [25:35]                -> C7.this.x$1 = {...
 [25:35] [25:35] [25:35]        -> case <synthetic> val x1: Option = (scala.Option.apply(scala.Int.box(42)): Option)
+[25:35]                        -> scala.Option.apply(scala.Int.box(42))
+  [32:34]                      -> scala.Int.box(42)
+[32:34]                        -> scala.Int.box(42)
+  [32:34]                      -> 42
 --

--- a/test/files/run/position-val-def.scala
+++ b/test/files/run/position-val-def.scala
@@ -33,6 +33,16 @@ object Test extends CompilerTest {
         println(f"${tshow(t.namePos)}%-8s${tshow(t.pos)}%-8s${tshow(t.rhs.pos)}%-14s -> ${tshow(t).clipped}")
       case t: Assign =>
         println(f"${tshow(t.pos)}%-8s${tshow(t.rhs.pos)}%-22s -> ${tshow(t).clipped}")
+      case t @ treeInfo.Application(fun, _, argss)
+      if !t.pos.isZeroExtent
+      && argss.exists(_.nonEmpty)
+      && !fun.symbol.isLabel
+      && fun.symbol.owner != definitions.MatchErrorClass
+      && !treeInfo.isSuperConstrCall(t)
+      =>
+        println(f"${tshow(t.pos)}%-30s -> ${tshow(t).clipped}")
+        for (args <- argss; arg <- args)
+          println(f"  ${tshow(arg.pos)}%-28s -> ${tshow(arg).clipped}")
       case _ =>
     }
     println("--")
@@ -43,5 +53,9 @@ object Test extends CompilerTest {
       val t = it.next()
       if (it.hasNext) s"$t..." else t
     }
+  }
+  implicit class Positional(val pos: Position) extends AnyVal {
+    def isZeroExtent =
+      !pos.isRange || pos.start == pos.end
   }
 }


### PR DESCRIPTION
Fixes scala/bug#13078

More precise position of args to tuple in "destructuring" match. That is, just the position of each variable (albeit transparent).

Note that `Bind` should get a `NamePos` in parser so it's always easy to locate the name (i.e., the variable). The position of the tree includes `x @ p`. Maybe it's worth reviewing focusing of position in `PatVarTransformer`, which converts `x` to `x @ _`, or `makeValue` which is used for the same tupling in a `for`.

Edit: I left `-Yvalidate-pos` turned on in a previous test for this reason.

Since the expectation on the ticket is for a transparent range, that is supplied instead of an opaque offset (as seen in `for`).

`-Wunused:patvars` relies just on finding one var with an opaque non-empty range. Otherwise, it seems more useful to have a transparent range than an opaque offset. An opaque offset might best represent a desugaring expansion in place? Otherwise, `NamePos` is a workaround for "show the thing"; an offset point is sufficient for the one-caret case only. Multiple trees and symbol could have identical name pos, as it does not represent anything structural. Structural position is useful for `@nowarn`, for example.