### PR TITLE
Lint dubious overload differs only in implicit [ci: last-only]

### DIFF
--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -661,6 +661,7 @@ object Reporting {
         LintIntDivToFloat,
         LintUniversalMethods,
         LintCloneable,
+        LintOverload,
         LintNumericMethods
       = lint()
 

--- a/src/compiler/scala/tools/nsc/settings/Warnings.scala
+++ b/src/compiler/scala/tools/nsc/settings/Warnings.scala
@@ -229,6 +229,7 @@ trait Warnings {
     val IntDivToFloat          = LintWarning("int-div-to-float",          "Warn when an integer division is converted (widened) to floating point: `(someInt / 2): Double`.")
     val PatternShadow          = LintWarning("pattern-shadow",            "Pattern variable id is also a term in scope.")
     val CloneableObject        = LintWarning("cloneable",                 "Modules (objects) should not be Cloneable.")
+    val DubiousOverload        = LintWarning("overload",                  "Overload differs only in an implicit parameter.")
 
     def allLintWarnings = values.toSeq.asInstanceOf[Seq[LintWarning]]
   }
@@ -267,6 +268,7 @@ trait Warnings {
   def lintIntDivToFloat          = lint.contains(IntDivToFloat)
   def warnPatternShadow          = lint.contains(PatternShadow)
   def warnCloneableObject        = lint.contains(CloneableObject)
+  def warnDubiousOverload        = lint.contains(DubiousOverload)
 
   // The Xlint warning group.
   val lint = MultiChoiceSetting(

--- a/src/library/scala/jdk/DoubleAccumulator.scala
+++ b/src/library/scala/jdk/DoubleAccumulator.scala
@@ -17,6 +17,7 @@ import java.util.Spliterator
 import java.util.function.{Consumer, DoubleConsumer}
 import java.{lang => jl}
 
+import scala.annotation._
 import scala.collection.Stepper.EfficientSplit
 import scala.collection.{AnyStepper, DoubleStepper, Factory, SeqFactory, Stepper, StepperShape, mutable}
 import scala.language.implicitConversions
@@ -236,6 +237,7 @@ final class DoubleAccumulator
   }
 
   /** Copies the elements in this `DoubleAccumulator` into an `Array[Double]` */
+  @nowarn // cat=lint-overload see toArray[B: ClassTag]
   def toArray: Array[Double] = {
     if (totalSize > Int.MaxValue) throw new IllegalArgumentException("Too many elements accumulated for an array: "+totalSize.toString)
     val a = new Array[Double](totalSize.toInt)

--- a/src/library/scala/jdk/IntAccumulator.scala
+++ b/src/library/scala/jdk/IntAccumulator.scala
@@ -17,6 +17,7 @@ import java.util.Spliterator
 import java.util.function.{Consumer, IntConsumer}
 import java.{lang => jl}
 
+import scala.annotation._
 import scala.collection.Stepper.EfficientSplit
 import scala.collection.{AnyStepper, Factory, IntStepper, SeqFactory, Stepper, StepperShape, mutable}
 import scala.language.implicitConversions
@@ -241,6 +242,7 @@ final class IntAccumulator
   }
 
   /** Copies the elements in this `IntAccumulator` into an `Array[Int]` */
+  @nowarn // cat=lint-overload see toArray[B: ClassTag]
   def toArray: Array[Int] = {
     if (totalSize > Int.MaxValue) throw new IllegalArgumentException("Too many elements accumulated for an array: "+totalSize.toString)
     val a = new Array[Int](totalSize.toInt)

--- a/src/library/scala/jdk/LongAccumulator.scala
+++ b/src/library/scala/jdk/LongAccumulator.scala
@@ -17,6 +17,7 @@ import java.util.Spliterator
 import java.util.function.{Consumer, LongConsumer}
 import java.{lang => jl}
 
+import scala.annotation._
 import scala.collection.Stepper.EfficientSplit
 import scala.collection.{AnyStepper, Factory, LongStepper, SeqFactory, Stepper, StepperShape, mutable}
 import scala.language.implicitConversions
@@ -236,6 +237,7 @@ final class LongAccumulator
   }
 
   /** Copies the elements in this `LongAccumulator` into an `Array[Long]` */
+  @nowarn // cat=lint-overload see toArray[B: ClassTag]
   def toArray: Array[Long] = {
     if (totalSize > Int.MaxValue) throw new IllegalArgumentException("Too many elements accumulated for an array: "+totalSize.toString)
     val a = new Array[Long](totalSize.toInt)

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -977,7 +977,7 @@ trait Types
     def load(sym: Symbol): Unit = {}
 
     private def findDecl(name: Name, excludedFlags: Long): Symbol = {
-      var alts: List[Symbol] = List()
+      var alts: List[Symbol] = Nil
       var sym: Symbol = NoSymbol
       var e: ScopeEntry = decls.lookupEntry(name)
       while (e ne null) {
@@ -991,7 +991,7 @@ trait Types
         e = decls.lookupNextEntry(e)
       }
       if (alts.isEmpty) sym
-      else (baseClasses.head.newOverloaded(this, alts))
+      else baseClasses.head.newOverloaded(this, alts)
     }
 
     /** Find all members meeting the flag requirements.
@@ -2930,8 +2930,10 @@ trait Types
 
   object MethodType extends MethodTypeExtractor
 
-  // TODO: rename so it's more appropriate for the type that is for a method without argument lists
-  // ("nullary" erroneously implies it has an argument list with zero arguments, it actually has zero argument lists)
+  /** A method without parameter lists.
+   *
+   *  Note: a MethodType with paramss that is a ListOfNil is called "nilary", to disambiguate.
+   */
   case class NullaryMethodType(override val resultType: Type) extends Type with NullaryMethodTypeApi {
     override def isTrivial = resultType.isTrivial && (resultType eq resultType.withoutAnnotations)
     override def prefix: Type = resultType.prefix
@@ -2952,7 +2954,6 @@ trait Types
       else NullaryMethodType(result1)
     }
     override def foldOver(folder: TypeFolder): Unit = folder(resultType)
-
   }
 
   object NullaryMethodType extends NullaryMethodTypeExtractor

--- a/test/files/neg/t7415.check
+++ b/test/files/neg/t7415.check
@@ -1,0 +1,38 @@
+t7415.scala:10: warning: Calls to parameterless method foo will be easy to mistake for calls to def foo(implicit a: T): Int, which has a single implicit parameter list.
+  def foo = 0 // warn
+      ^
+t7415.scala:14: warning: Usages of value foo will be easy to mistake for calls to def foo(implicit a: T): Int, which has a single implicit parameter list.
+  val foo = 0 // warn
+      ^
+t7415.scala:18: warning: Usages of value foo will be easy to mistake for calls to def foo(implicit a: T): Int, which has a single implicit parameter list.
+  private[this] val foo = 42 // warn
+                    ^
+t7415.scala:31: warning: Calls to parameterless method foo will be easy to mistake for calls to def foo(implicit a: T): Int, which has a single implicit parameter list.
+class Mixed extends Base with T1 // warn here
+      ^
+t7415.scala:41: warning: Usages of value foo will be easy to mistake for calls to overloads which have a single implicit parameter list:
+  def foo(implicit e: String): Int
+  def foo(implicit e: Int): Int
+  val foo = 0 // warn
+      ^
+t7415.scala:54: warning: Usages of value x will be easy to mistake for calls to def x(implicit t: T): Int, which has a single implicit parameter list.
+  def x(implicit t: T) = 27 // warn
+      ^
+t7415.scala:65: warning: Usages of value i will be easy to mistake for calls to def i(implicit t: T): Int, which has a single implicit parameter list.
+class R(val i: Int) extends Q // warn
+            ^
+t7415.scala:66: warning: Usages of value i will be easy to mistake for calls to def i(implicit t: T): Int, which has a single implicit parameter list.
+class S(i: Int) extends R(i) { // warn
+      ^
+t7415.scala:66: warning: Usages of value i will be easy to mistake for calls to def i(implicit t: T): Int, which has a single implicit parameter list.
+class S(i: Int) extends R(i) { // warn
+        ^
+t7415.scala:76: warning: Calls to parameterless method f will be easy to mistake for calls to def f[A](implicit t: T): Int, which has a single implicit parameter list.
+  def f[A] = 27 // warn
+      ^
+t7415.scala:82: warning: Calls to parameterless method foo will be easy to mistake for calls to def foo(implicit a: T): Int, which has a single implicit parameter list.
+  val d1 = new Derived1 {} // warn
+               ^
+error: No warnings can be incurred under -Werror.
+11 warnings
+1 error

--- a/test/files/neg/t7415.scala
+++ b/test/files/neg/t7415.scala
@@ -1,0 +1,88 @@
+//> using options -Werror -Xlint:overload
+
+trait T
+
+trait Base {
+  def foo(implicit a: T) = 0
+}
+
+trait Derived1 extends Base {
+  def foo = 0 // warn
+}
+
+trait Derived2 extends Base {
+  val foo = 0 // warn
+}
+
+class C extends Base {
+  private[this] val foo = 42 // warn
+}
+
+/* private local cannot directly conflict
+class C2 extends Derived2 {
+  private[this] val foo = 42 // weaker access privileges in overriding
+}
+*/
+
+trait T1 {
+  def foo = 0
+}
+
+class Mixed extends Base with T1 // warn here
+
+class D {
+  def foo(a: List[Int])(implicit d: DummyImplicit) = 0
+  def foo(a: List[String]) = 1
+}
+
+class CleverLukas {
+  def foo(implicit e: String) = 1
+  def foo(implicit e: Int) = 2
+  val foo = 0 // warn
+}
+
+class MoreInspiration {
+  def foo(implicit a: T) = 0
+  def foo() = 1 // has parens but Scala 2 allows `foo` with adaptation
+}
+
+class X {
+  val x = 42
+}
+
+class Y extends X {
+  def x(implicit t: T) = 27 // warn
+}
+
+class J(val i: Int)
+class K(i: Int) extends J(i) { // no warn local i shadows member i that is not implicit method
+  def f = i
+}
+
+class Q {
+  def i(implicit t: T) = 42
+}
+class R(val i: Int) extends Q // warn
+class S(i: Int) extends R(i) { // warn
+  def f = i
+}
+
+trait PBase {
+  def f[A](implicit t: T) = 42
+  def g[A](s: String) = s.toInt
+}
+
+trait PDerived extends PBase {
+  def f[A] = 27 // warn
+  def g[A] = f[A] // no warn
+}
+
+object Test extends App {
+  implicit val t: T = new T {}
+  val d1 = new Derived1 {} // warn
+  println(d1.foo) // !
+  val more = new MoreInspiration
+  println(more.foo) // ?
+  val y = new Y
+  println(y.x) // you have been warned!
+}

--- a/test/junit/scala/collection/IteratorTest.scala
+++ b/test/junit/scala/collection/IteratorTest.scala
@@ -10,16 +10,18 @@ import scala.util.chaining._
 
 import java.lang.ref.SoftReference
 
+import mutable.ListBuffer
+
 @RunWith(classOf[JUnit4])
 class IteratorTest {
 
   private def from0 = Iterator.from(0)
 
   private class Counted(limit: Int) extends Iterator[Int] {
-    val max = limit - 1
+    val Max = limit - 1
     var probed, last, i = -1
-    def hasNext = (i < max).tap(_ => probed = i)
-    def next() = { if (i >= max) Iterator.empty.next() else { i += 1 ; i } }.tap(last = _)
+    def hasNext = (i < Max).tap(_ => probed = i)
+    def next() = { if (i >= Max) Iterator.empty.next() else { i += 1 ; i } }.tap(last = _)
   }
   private def counted = new Counted(Int.MaxValue)
   private def limited(n: Int) = new Counted(n)
@@ -397,7 +399,7 @@ class IteratorTest {
   }
 
   @Test def lazyListIsLazy(): Unit = {
-    val results = mutable.ListBuffer.empty[Int]
+    val results = ListBuffer.empty[Int]
     def mkIterator = Range.inclusive(1, 5).iterator map (x => { results += x ; x })
     def mkInfinite = Iterator continually { results += 1 ; 1 }
 
@@ -411,7 +413,7 @@ class IteratorTest {
   // scala/bug#3516
   @deprecated("Tests deprecated Stream", since="2.13")
   @Test def toStreamIsSufficientlyLazy(): Unit = {
-    val results = collection.mutable.ListBuffer.empty[Int]
+    val results = ListBuffer.empty[Int]
     def mkIterator = (1 to 5).iterator map (x => { results += x ; x })
     def mkInfinite = Iterator continually { results += 1 ; 1 }
 
@@ -456,7 +458,7 @@ class IteratorTest {
       def hasNext: Boolean = { counter += 1; parent.hasNext }
     }
     // Iterate separately
-    val res = new mutable.ArrayBuffer[Int]
+    val res = mutable.ArrayBuffer.empty[Int]
     it.foreach(res += _)
     it.foreach(res += _)
     assertSameElements(exp, res)
@@ -780,13 +782,13 @@ class IteratorTest {
 
   // scala/bug#10709
   @Test def `scan is lazy enough`(): Unit = {
-    val results = collection.mutable.ListBuffer.empty[Int]
+    val results = ListBuffer.empty[Int]
     val it = new AbstractIterator[Int] {
       var cur = 1
-      val max = 3
+      val Max = 3
       override def hasNext = {
         results += -cur
-        cur < max
+        cur < Max
       }
       override def next() = {
         val res = cur
@@ -799,7 +801,7 @@ class IteratorTest {
       results += -(sum + x)
       sum + x
     })
-    val scan = collection.mutable.ListBuffer.empty[Int]
+    val scan = ListBuffer.empty[Int]
     for (i <- xy) {
       scan += i
       results += i


### PR DESCRIPTION
Fixes scala/bug#7415

~Tweaks~ Expands upon the truly retro (and pithy) retronym WIP.