### PR TITLE
Add method type help to missing arg list message [ci: last-only]

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -815,17 +815,24 @@ trait ContextErrors extends splain.SplainErrors {
       //adapt
       def MissingArgsForMethodTpeError(tree: Tree, meth: Symbol) = {
         val f = meth.name.decoded
-        val paf = s"$f(${ meth.asMethod.paramLists map (_ map (_ => "_") mkString ",") mkString ")(" })"
+        val paf = s"$f(${ meth.asMethod.paramLists.map(_.map(_ => "_").mkString(",")).mkString(")(") })"
+        val feature = if (!currentRun.isScala3) "" else
+          sm"""|
+               |Use -Xsource-features:eta-expand-always to convert even if the expected type is not a function type."""
         val advice =
           if (meth.isConstructor || meth.info.params.lengthIs > definitions.MaxFunctionArity) ""
-          else s"""
-            |Unapplied methods are only converted to functions when a function type is expected.${
-              if (!currentRun.isScala3) "" else """
-            |Use -Xsource-features:eta-expand-always to convert even if the expected type is not a function type."""}
-            |You can make this conversion explicit by writing `$f _` or `$paf` instead of `$f`.""".stripMargin
+          else
+            sm"""|
+                 |Unapplied methods are only converted to functions when a function type is expected.$feature
+                 |You can make this conversion explicit by writing `$f _` or `$paf` instead of `$f`."""
+        val help = tree match {
+          case Select(qualifier, name) => qualifier.tpe.memberType(meth)
+          case treeInfo.Applied(Select(qualifier, _), _, _) => qualifier.tpe.memberType(meth)
+          case _ => meth.info
+        }
         val message =
           if (meth.isMacro) MacroTooFewArgumentListsMessage
-          else s"""missing argument list for ${meth.fullLocationString}$advice"""
+          else s"""missing argument list for ${meth.fullLocationString} of type ${help}${advice}"""
         issueNormalTypeError(tree, message)
         setError(tree)
       }
@@ -1150,18 +1157,20 @@ trait ContextErrors extends splain.SplainErrors {
         val ambiguousBuffered = !context.ambiguousErrors
         if (validTargets || ambiguousBuffered)
           context.issueAmbiguousError(
-            if (sym1.hasDefault && sym2.hasDefault && sym1.enclClass == sym2.enclClass) {
-              val methodName = nme.defaultGetterToMethod(sym1.name)
+            if (sym1.hasDefault && sym2.hasDefault && sym1.enclClass == sym2.enclClass)
               AmbiguousTypeError(sym1.enclClass.pos,
-                s"in ${sym1.enclClass}, multiple overloaded alternatives of $methodName define default arguments")
-
-            } else {
+                s"in ${sym1.enclClass}, multiple overloaded alternatives of ${
+                  nme.defaultGetterToMethod(sym1.name)
+                } define default arguments"
+              )
+            else
               AmbiguousTypeError(pos,
-                 "ambiguous reference to overloaded definition,\n" +
-                s"both ${sym1.fullLocationString} of type ${pre.memberType(sym1)}\n" +
-                s"and  ${sym2.fullLocationString} of type ${pre.memberType(sym2)}\n" +
-                s"match $rest")
-            })
+              sm"""|ambiguous reference to overloaded definition,
+                   |both ${sym1.fullLocationString} of type ${pre.memberType(sym1)}
+                   |and  ${sym2.fullLocationString} of type ${pre.memberType(sym2)}
+                   |match $rest"""
+              )
+          )
       }
 
       def AccessError(tree: Tree, sym: Symbol, ctx: Context, explanation: String): AbsTypeError =

--- a/test/files/neg/annots-constant-neg.check
+++ b/test/files/neg/annots-constant-neg.check
@@ -89,7 +89,7 @@ Test.scala:79: error: not enough arguments for constructor Ann2: (x: Int)(y: Int
 Unspecified value parameter x.
   @Ann2 def v7 = 0 // err
    ^
-Test.scala:80: error: missing argument list for constructor Ann2 in class Ann2
+Test.scala:80: error: missing argument list for constructor Ann2 in class Ann2 of type (x: Int)(y: Int): Ann2
   @Ann2(x = 0) def v8 = 0 // err
    ^
 Test.scala:83: error: no arguments allowed for nullary constructor Ann3: (): Ann3

--- a/test/files/neg/macro-invalidshape.check
+++ b/test/files/neg/macro-invalidshape.check
@@ -8,7 +8,7 @@ macro [<static object>].<method name>[[<type args>]] or
 macro [<macro bundle>].<method name>[[<type args>]]
   def foo2(x: Any) = macro Impls.foo(null)(null)
                                  ^
-Macros_Test_2.scala:5: error: missing argument list for method foo in object Impls
+Macros_Test_2.scala:5: error: missing argument list for method foo in object Impls of type (c: scala.reflect.macros.blackbox.Context)(x: c.Expr[Any]): Nothing
 Unapplied methods are only converted to functions when a function type is expected.
 You can make this conversion explicit by writing `foo _` or `foo(_)(_)` instead of `foo`.
   def foo3(x: Any) = macro {2; Impls.foo}

--- a/test/files/neg/missing-arg-list.check
+++ b/test/files/neg/missing-arg-list.check
@@ -1,24 +1,24 @@
-missing-arg-list.scala:9: error: missing argument list for method id in trait T
+missing-arg-list.scala:9: error: missing argument list for method id in trait T of type (i: Int): Int
 Unapplied methods are only converted to functions when a function type is expected.
 You can make this conversion explicit by writing `id _` or `id(_)` instead of `id`.
   val w = id
           ^
-missing-arg-list.scala:10: error: missing argument list for method f in trait T
+missing-arg-list.scala:10: error: missing argument list for method f in trait T of type (i: Int)(j: Int): Int
 Unapplied methods are only converted to functions when a function type is expected.
 You can make this conversion explicit by writing `f _` or `f(_)(_)` instead of `f`.
   val x = f
           ^
-missing-arg-list.scala:11: error: missing argument list for method g in trait T
+missing-arg-list.scala:11: error: missing argument list for method g in trait T of type (i: Int, j: Int, k: Int): Int
 Unapplied methods are only converted to functions when a function type is expected.
 You can make this conversion explicit by writing `g _` or `g(_,_,_)` instead of `g`.
   val y = g
           ^
-missing-arg-list.scala:12: error: missing argument list for method h in trait T
+missing-arg-list.scala:12: error: missing argument list for method h in trait T of type (i: Int, j: Int, k: Int)(implicit s: String): String
 Unapplied methods are only converted to functions when a function type is expected.
 You can make this conversion explicit by writing `h _` or `h(_,_,_)(_)` instead of `h`.
   val z = h
           ^
-missing-arg-list.scala:15: error: missing argument list for method + in trait T
+missing-arg-list.scala:15: error: missing argument list for method + in trait T of type (i: Int): Int
 Unapplied methods are only converted to functions when a function type is expected.
 You can make this conversion explicit by writing `+ _` or `+(_)` instead of `+`.
   val p = +

--- a/test/files/neg/t12843.check
+++ b/test/files/neg/t12843.check
@@ -9,4 +9,13 @@ Unapplied methods are only converted to functions when a function type is expect
 You can make this conversion explicit by writing `update _` or `update(_,_)` instead of `update`.
   def g = b.update
             ^
-2 errors
+t12843.scala:10: error: missing argument list for method map in class BitSet
+with overloaded members in scala.collection.immutable.BitSet
+  (f: Int => Int): scala.collection.immutable.BitSet
+  [B](f: Int => B)(implicit ev: Ordering[B]): scala.collection.immutable.SortedSet[B]
+  [B](f: Int => B): scala.collection.immutable.Set[B]
+Unapplied methods are only converted to functions when a function type is expected.
+You can make this conversion explicit by writing `map _` or `map(_)` instead of `map`.
+  def f = c.map
+            ^
+3 errors

--- a/test/files/neg/t12843.check
+++ b/test/files/neg/t12843.check
@@ -1,0 +1,12 @@
+t12843.scala:4: error: ambiguous reference to overloaded definition,
+both method remove in class ListBuffer of type (idx: Int, count: Int): Unit
+and  method remove in class ListBuffer of type (idx: Int): Int
+match expected type ?
+  def f = b.remove
+            ^
+t12843.scala:5: error: missing argument list for method update in class ListBuffer of type (idx: Int, elem: Int): Unit
+Unapplied methods are only converted to functions when a function type is expected.
+You can make this conversion explicit by writing `update _` or `update(_,_)` instead of `update`.
+  def g = b.update
+            ^
+2 errors

--- a/test/files/neg/t12843.scala
+++ b/test/files/neg/t12843.scala
@@ -4,3 +4,8 @@ class C {
   def f = b.remove
   def g = b.update
 }
+
+class D {
+  val c = collection.immutable.BitSet(1, 2, 3)
+  def f = c.map
+}

--- a/test/files/neg/t12843.scala
+++ b/test/files/neg/t12843.scala
@@ -1,0 +1,6 @@
+
+class C {
+  val b = collection.mutable.ListBuffer.empty[Int]
+  def f = b.remove
+  def g = b.update
+}

--- a/test/files/neg/t13055.check
+++ b/test/files/neg/t13055.check
@@ -1,4 +1,7 @@
-t13055.scala:15: error: missing argument list for method forAll in object Main of type [T1, P](g: Main.Gen[T1])(f: T1 => P)(implicit p: P => Main.Prop): Main.Prop
+t13055.scala:15: error: missing argument list for method forAll in object Main
+with overloaded members in Main.type
+  [A1, P](f: A1 => P)(implicit p: P => Main.Prop): Main.Prop
+  [T1, P](g: Main.Gen[T1])(f: T1 => P)(implicit p: P => Main.Prop): Main.Prop
 Unapplied methods are only converted to functions when a function type is expected.
 Use -Xsource-features:eta-expand-always to convert even if the expected type is not a function type.
 You can make this conversion explicit by writing `forAll _` or `forAll(_)(_)(_)` instead of `forAll`.

--- a/test/files/neg/t13055.check
+++ b/test/files/neg/t13055.check
@@ -1,4 +1,4 @@
-t13055.scala:15: error: missing argument list for method forAll in object Main
+t13055.scala:15: error: missing argument list for method forAll in object Main of type [T1, P](g: Main.Gen[T1])(f: T1 => P)(implicit p: P => Main.Prop): Main.Prop
 Unapplied methods are only converted to functions when a function type is expected.
 Use -Xsource-features:eta-expand-always to convert even if the expected type is not a function type.
 You can make this conversion explicit by writing `forAll _` or `forAll(_)(_)(_)` instead of `forAll`.

--- a/test/files/neg/t7187.check
+++ b/test/files/neg/t7187.check
@@ -17,7 +17,7 @@ Unspecified value parameter i.
 t7187.scala:29: error: _ must follow method; cannot follow String
   val t3d: Any       = baz() _ // error: _ must follow method
                           ^
-t7187.scala:38: error: missing argument list for method zup in class EtaExpandZeroArg
+t7187.scala:38: error: missing argument list for method zup in class EtaExpandZeroArg of type (x: Int): Int
 Unapplied methods are only converted to functions when a function type is expected.
 You can make this conversion explicit by writing `zup _` or `zup(_)` instead of `zup`.
   val t5a = zup // error in 2.13, eta-expansion in 3.0

--- a/test/files/neg/t9093.check
+++ b/test/files/neg/t9093.check
@@ -1,4 +1,4 @@
-t9093.scala:3: error: missing argument list for method apply2 in object Main
+t9093.scala:3: error: missing argument list for method apply2 in object Main of type [C](fa: Any)(f: C): Null
 Unapplied methods are only converted to functions when a function type is expected.
 You can make this conversion explicit by writing `apply2 _` or `apply2(_)(_)` instead of `apply2`.
   val x: Unit = apply2(0)/*(0)*/

--- a/test/files/run/t12720.check
+++ b/test/files/run/t12720.check
@@ -1,4 +1,7 @@
-newSource1.scala:14: error: missing argument list for method f*** in class D*** of type (x***: String***): String***
+newSource1.scala:14: error: missing argument list for method f*** in class D***
+with overloaded members in D***
+  (x***: Int***): String***
+  (x***: String***): String***
 Unapplied methods are only converted to functions when a function type is expected.
 You can make this conversion explicit by writing `f _` or `f(_)` instead of `f`.
   def f = d.f

--- a/test/files/run/t12720.check
+++ b/test/files/run/t12720.check
@@ -1,4 +1,4 @@
-newSource1.scala:14: error: missing argument list for method f*** in class D***
+newSource1.scala:14: error: missing argument list for method f*** in class D*** of type (x***: String***): String***
 Unapplied methods are only converted to functions when a function type is expected.
 You can make this conversion explicit by writing `f _` or `f(_)` instead of `f`.
   def f = d.f


### PR DESCRIPTION
Fixes scala/bug#12843

The completion part of the ticket is deemed fixed, so this commit just adds help to the error message.