### PR TITLE
Tweak partial function doc

### DIFF
--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -99,7 +99,7 @@ object Option {
  *  - [[toList]] — Unary list of optional value, otherwise the empty list
  *
  *  A less-idiomatic way to use $option values is via pattern matching: {{{
- *  val nameMaybe = request getParameter "name"
+ *  val nameMaybe = request.getParameter("name")
  *  nameMaybe match {
  *    case Some(name) =>
  *      println(name.trim.toUppercase)


### PR DESCRIPTION
Martin noted that the Scaladoc for PF doesn't even show an example with arrow syntax.

https://github.com/scala/scala3/issues/21649#issuecomment-2379253444

Another anti-pattern is that the doc shows `val pf: PartialFunction[A, B]` which is not the norm.

This commit tilts the doc toward showing common usage in the context of language support.

It also deletes the combinator example. There is already a caution on the method doc for `andThen`.