### PR TITLE
New reference compiler is 2.12.21-M2 (for JDK 25)

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: [8, 11, 17, 21, 24]
+        java: [8, 11, 17, 21, 24, 25-ea]
     runs-on: ${{matrix.os}}
     steps:
       - run: git config --global core.autocrlf false

--- a/versions.properties
+++ b/versions.properties
@@ -1,5 +1,5 @@
 # Scala version used for bootstrapping (see README.md)
-starr.version=2.12.21-M1
+starr.version=2.12.21-M2
 
 # The scala.binary.version determines how modules are resolved. It is set as follows:
 #  - After 2.x.0 is released, the binary version is 2.x


### PR DESCRIPTION
also add JDK 25 (early access) to mergely CI
