### PR TITLE
JDK 25 support in optimizer (new reference compiler includes ASM upgrade)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: [8, 11, 17, 21, 24]
+        java: [8, 11, 17, 21, 24, 25-ea]
     runs-on: ${{matrix.os}}
     steps:
       - run: git config --global core.autocrlf false

--- a/versions.properties
+++ b/versions.properties
@@ -1,5 +1,5 @@
 # Scala version used for bootstrapping (see README.md)
-starr.version=2.13.16
+starr.version=2.13.17-M1
 
 # These are the versions of the modules that go with this release.
 # Artifact dependencies:


### PR DESCRIPTION
re-STARR on 2.13.17-M1 (for ASM 9.8 upgrade) and add 25-ea to mergely CI

the CI addition won't get tested in PR validation but I'll ensure the mergely goes green (reference: https://github.com/scala/scala-dev/issues/900)