### PR TITLE
Add support for Iterable to sizeIs

### DIFF
--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -286,18 +286,27 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
       }
     }
 
-  /** Returns a value class containing operations for comparing the size of this $coll to a test value.
+  /** Returns a value class containing operations for comparing the size of this $coll to a test value or the size of
+   * another collection.
     *
-    * These operations are implemented in terms of [[sizeCompare(Int) `sizeCompare(Int)`]], and
-    * allow the following more readable usages:
+    * These operations are implemented in terms of [[sizeCompare(Int) `sizeCompare(Int)`]] and
+   * [[sizeCompare(Iterable[_]) `sizeCompare(Iterable[_])`]]. They allow the following more readable usages:
     *
     * {{{
-    * this.sizeIs < size     // this.sizeCompare(size) < 0
-    * this.sizeIs <= size    // this.sizeCompare(size) <= 0
-    * this.sizeIs == size    // this.sizeCompare(size) == 0
-    * this.sizeIs != size    // this.sizeCompare(size) != 0
-    * this.sizeIs >= size    // this.sizeCompare(size) >= 0
-    * this.sizeIs > size     // this.sizeCompare(size) > 0
+    * this.sizeIs < size          // this.sizeCompare(size) < 0
+    * this.sizeIs <= size         // this.sizeCompare(size) <= 0
+    * this.sizeIs == size         // this.sizeCompare(size) == 0
+    * this.sizeIs != size         // this.sizeCompare(size) != 0
+    * this.sizeIs >= size         // this.sizeCompare(size) >= 0
+    * this.sizeIs > size          // this.sizeCompare(size) > 0
+    *
+    * this.sizeIs < that.sizeIs   // this.sizeCompare(that) < 0
+    * this.sizeIs <= that.sizeIs  // this.sizeCompare(that) <= 0
+    * this.sizeIs == that.sizeIs  // this.sizeCompare(that) == 0
+    * this.sizeIs != that.sizeIs  // this.sizeCompare(that) != 0
+    * this.sizeIs >= that.sizeIs  // this.sizeCompare(that) >= 0
+    * this.sizeIs > that.sizeIs   // this.sizeCompare(that) > 0
+    * this.sizeIs > that.sizeIs   // this.sizeCompare(that) > 0
     * }}}
     */
   @inline final def sizeIs: IterableOps.SizeCompareOps = new IterableOps.SizeCompareOps(this)
@@ -860,10 +869,11 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
 
 object IterableOps {
 
-  /** Operations for comparing the size of a collection to a test value.
+  /** Operations for comparing the size of a collection to a test value or another collection.
     *
     * These operations are implemented in terms of
-    * [[scala.collection.IterableOps!.sizeCompare(Int):Int* `sizeCompare(Int)`]]
+    * [[scala.collection.IterableOps!.sizeCompare(Int):Int* `sizeCompare(Int)`]] and
+    * [[scala.collection.IterableOps!.sizeCompare(Iterable[_]):Int* `sizeCompare(Iterable[_])`]].
     */
   final class SizeCompareOps private[collection](val it: IterableOps[_, AnyConstr, _]) extends AnyVal {
     /** Tests if the size of the collection is less than some value. */
@@ -878,6 +888,18 @@ object IterableOps {
     @inline def >=(size: Int): Boolean = it.sizeCompare(size) >= 0
     /** Tests if the size of the collection is greater than some value. */
     @inline def >(size: Int): Boolean = it.sizeCompare(size) > 0
+    /** Tests if the size of the collection is less than some other collection. */
+    @inline def <(other: SizeCompareOps): Boolean = it.sizeCompare(other.it.toIterable: @nowarn("cat=deprecation")) < 0
+    /** Tests if the size of the collection is less than or equal to some other collection. */
+    @inline def <=(other: SizeCompareOps): Boolean = it.sizeCompare(other.it.toIterable: @nowarn("cat=deprecation")) <= 0
+    /** Tests if the size of the collection is equal to some other collection. */
+    @inline def ==(other: SizeCompareOps): Boolean = it.sizeCompare(other.it.toIterable: @nowarn("cat=deprecation")) == 0
+    /** Tests if the size of the collection is not equal to some other collection. */
+    @inline def !=(other: SizeCompareOps): Boolean = it.sizeCompare(other.it.toIterable: @nowarn("cat=deprecation")) != 0
+    /** Tests if the size of the collection is greater than or equal to some other collection. */
+    @inline def >=(other: SizeCompareOps): Boolean = it.sizeCompare(other.it.toIterable: @nowarn("cat=deprecation")) >= 0
+    /** Tests if the size of the collection is greater than some other collection. */
+    @inline def >(other: SizeCompareOps): Boolean = it.sizeCompare(other.it.toIterable: @nowarn("cat=deprecation")) > 0
   }
 
   /** A trait that contains just the `map`, `flatMap`, `foreach` and `withFilter` methods

--- a/test/junit/scala/collection/IterableTest.scala
+++ b/test/junit/scala/collection/IterableTest.scala
@@ -94,6 +94,17 @@ class IterableTest {
     check(unknown, unknown)
   }
 
+  @Test
+  def sizeIsIterable(): Unit = {
+    val it = Seq(1, 2, 3)
+    assert(it.sizeIs > Seq(2, 3).sizeIs)
+    assert(it.sizeIs != Seq(2, 3).sizeIs)
+    assert(it.sizeIs >= Seq(2, 3, 4).sizeIs)
+    assert(it.sizeIs == Seq(2, 3, 4).sizeIs)
+    assert(it.sizeIs <= Seq(2, 3, 4).sizeIs)
+    assert(it.sizeIs < Seq(2, 3, 4, 5).sizeIs)
+  }
+
   @Test def copyToArray(): Unit = {
     def check(a: Array[Int], copyToArray: Array[Int] => Int, elemsWritten: Int, start: Int, end: Int) = {
 


### PR DESCRIPTION
This allows the `sizeIs` function to also cover the `sizeCompare(Iterable[_])` variation.

The main motivation for adding this is that `sizeIs` currently returns an unintuitive result when used in the form `col1.sizeIs == col2.sizeIs`. This notation is not documented and likely not intended, but it is valid and it feels intuitive that it should result in comparing the size of the two collections. 

The reason for that is that `col1.sizeIs == 5` is the functional equivalent of `col1.size == 5` and calls `col1.sizeCompare(5) == 0`. Given that `sizeCompare` has a second implementation: `sizeCompare(Iterable[_])`, I would expect that `col1.sizeIs == col2.sizeIs` would be the functional equivalent to `col1.size == col2.size` and call `col1.sizeCompare(col2) == 0`. The problem is that the syntax `col1.sizeIs == col2.sizeIs` is valid, but this is because `col1.sizeIs` returns a value class for col1. This causes the `==` operator to be handled by `Any.==()` which calls the `equals` method for the collections. 

So the result doesn't represent the equality of the sizes of the collections, but the equality of the collections itself. So currently `Seq(1,2).sizeIs == Seq(2,3).sizeIs` results in `false`.