### PR TITLE
Tighter condition for nowarn a single patvar

### DIFF
--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -632,7 +632,8 @@ trait Trees extends api.Trees {
   case class UnApply(fun: Tree, args: List[Tree])
        extends TermTree with UnApplyApi {
     override def transform(transformer: Transformer): Tree =
-      transformer.treeCopy.UnApply(this, transformer.transform(fun), transformer.transformTrees(args)) // bq: see test/.../unapplyContexts2.scala
+      transformer.treeCopy.UnApply(this, transformer.transform(fun), transformer.transformTrees(args))
+        // bq: see test/.../unapplyContexts2.scala
     override def traverse(traverser: Traverser): Unit = {
       traverser.traverse(fun)
       traverser.traverseTrees(args)

--- a/test/files/neg/t13095.check
+++ b/test/files/neg/t13095.check
@@ -4,6 +4,18 @@ t13095.scala:12: warning: pattern var z in object Main is never used
 t13095.scala:13: warning: pattern var r in object Main is never used
   private[this] val A(q, r) = A(42, 27) // warn
                          ^
+t13095.scala:42: warning: pattern var s in method spam is never used
+      case email(s, addr) => // warn // warn each, multiple extraction
+                 ^
+t13095.scala:42: warning: pattern var addr in method spam is never used
+      case email(s, addr) => // warn // warn each, multiple extraction
+                    ^
+t13095.scala:52: warning: pattern var v in method scala-dev#902 is never used
+      case (i, v @ (_, _)) => i // warn multiple patvars
+               ^
+t13095.scala:52: warning: a pure expression does nothing in statement position
+      case (i, v @ (_, _)) => i // warn multiple patvars
+                              ^
 error: No warnings can be incurred under -Werror.
-2 warnings
+6 warnings
 1 error

--- a/test/files/neg/t13095.scala
+++ b/test/files/neg/t13095.scala
@@ -26,6 +26,31 @@ class C {
       case x: String => // nowarn because x is not a new reference but an alias
       case _ =>
     }
+  def s(x: Option[String]) =
+    x match {
+      case x: Some[String] => // nowarn because x is not a new reference but an alias
+      case _ =>
+    }
+  def t(x: Option[String]) =
+    x match {
+      case Some(x) => // nowarn because x is not a new reference but an alias of sorts
+      case _ =>
+    }
+  val email = "(.*)@(.*)".r
+  def spam(s: String) =
+    s match {
+      case email(s, addr) => // warn // warn each, multiple extraction
+      case _ =>
+    }
+  def border(s: String) =
+    s match {
+      case email(s, _) => // nowarn only one patvar
+      case _ =>
+    }
+  def `scala-dev#902`(v: (Int, (Boolean, String))): Unit =
+    v match {
+      case (i, v @ (_, _)) => i // warn multiple patvars
+    }
 }
 
 final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {


### PR DESCRIPTION
Address the question how liberal the exclusion for unused patvars should be.

This commit proposes: a single patvar named after the selector is always OK.

That is analogous to "narrow a var via a type pattern", `(x: Option[_]) match { case x: Some[_] => }`.

This "ergonomics" respects "cut and paste" where patterns that don't have a "canonical" patvar name may represent "extract a canonically narrower value". It still requires the patvar name to "align" with the selector name.

```Scala
person match {
  case PreferredName(person) =>
  case _ => // no preference
}
```
The patvar is unused, but the match expression is allowed as something cut and pasted, so it's annoying to require "fixing up" just to pass a lint. The previous allowance is for case class element names, `case Person(firstName, lastName) =>`.

At a `case`, it's not necessary to walk the pattern twice: it will process `Apply` before recursing into children, so child `Bind` will see the attachment.

Fixes scala/scala-dev#902