### PR TITLE
fix: error location for aliased import selector

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -519,7 +519,7 @@ trait ContextErrors extends splain.SplainErrors {
         }
         sel match {
           case tree: Import => // selector name is unique; use it to improve position
-            tree.selectors.find(_.introduces(name)) match {
+            tree.selectors.find(_.hasName(name)) match {
               case Some(badsel) => issueTypeError(PosAndMsgTypeError(tree.posOf(badsel), errMsg))
               case _ => issueNormalTypeError(sel, errMsg)
             }

--- a/test/files/neg/t6340.check
+++ b/test/files/neg/t6340.check
@@ -1,13 +1,16 @@
 t6340.scala:11: error: value D is not a member of object Foo
-  import Foo.{ A, B, C, D, E, X, Y, Z }
+  import Foo.{ A, B, C, D, E, F => G, X, Y, Z }
                         ^
 t6340.scala:11: error: value E is not a member of object Foo
-  import Foo.{ A, B, C, D, E, X, Y, Z }
+  import Foo.{ A, B, C, D, E, F => G, X, Y, Z }
                            ^
+t6340.scala:11: error: value F is not a member of object Foo
+  import Foo.{ A, B, C, D, E, F => G, X, Y, Z }
+                              ^
 t6340.scala:16: error: not found: type D
   val d = new D
               ^
 t6340.scala:17: error: not found: type W
   val w = new W
               ^
-4 errors
+5 errors

--- a/test/files/neg/t6340.scala
+++ b/test/files/neg/t6340.scala
@@ -8,7 +8,7 @@ object Foo {
 }
 
 object Test {
-  import Foo.{ A, B, C, D, E, X, Y, Z }
+  import Foo.{ A, B, C, D, E, F => G, X, Y, Z }
 
   val a = new A
   val b = new B


### PR DESCRIPTION
In the case of something like `import foo.{DoesntExist => Bar}`, the error location should be on `DoesntExist`. The previous check in error message construction for whether the name is introduced by a selector is not quite right - really we just care about whether the name is _used_ by the selector (though in the non-rename case this is the same thing).