### PR TITLE
Judicious shadowing of implicits from scope

### DIFF
--- a/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BCodeHelpers.scala
@@ -842,7 +842,10 @@ abstract class BCodeHelpers extends BCodeIdiomatic {
       // * Using `exitingUncurry` (not `enteringErasure`) because erasure enters bridges in traversal,
       //   not in the InfoTransform, so it actually modifies the type from the previous phase.
       //   Uncurry adds java varargs, which need to be included in the mirror class.
-      val members = exitingUncurry(moduleClass.info.membersBasedOnFlags(BCodeHelpers.ExcludedForwarderFlags, symtab.Flags.METHOD))
+      val members = exitingUncurry {
+        moduleClass.info
+          .membersBasedOnFlags(excluded = BCodeHelpers.ExcludedForwarderFlags, required = symtab.Flags.METHOD)
+      }
       for (m <- members) {
         val excl = m.isDeferred || m.isConstructor || m.hasAccessBoundary ||
           { val o = m.owner; (o eq ObjectClass) || (o eq AnyRefClass) || (o eq AnyClass) } ||

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -1445,7 +1445,7 @@ abstract class Erasure extends InfoTransform
   final def isJvmAccessible(cls: Symbol, context: Context): Boolean = {
     // Phase travel necessary, isAccessible is too lax after erasure for Java-defined members, see
     // comment in its implementation.
-    !cls.isJavaDefined || enteringErasure(context.isAccessible(cls, cls.owner.thisType))
+    !cls.isJavaDefined || enteringErasure(context.isAccessible(cls, cls.owner.thisType, superAccess = false))
   }
 
   /**

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -462,7 +462,7 @@ trait ContextErrors extends splain.SplainErrors {
                     !nme.isLocalName(sym.name) &&
                     isEncodedComparison(sym.name) == nameIsComparison &&
                     sym.name != nme.EQ && sym.name != nme.NE &&
-                    cx.isAccessible(sym, target))
+                    cx.isAccessible(sym, target, superAccess = false))
                   .map(_.name.decode)
                   .filter { n =>
                     math.abs(n.length - x.length) <= editThreshold &&

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -14,7 +14,7 @@ package scala.tools.nsc
 package typechecker
 
 import scala.annotation.tailrec
-import scala.collection.mutable
+import scala.collection.mutable, mutable.ListBuffer
 import scala.reflect.internal.util.{CodeAction, ReusableInstance, shortClassOfInstance, ListOfNil, SomeOfNil}
 import scala.tools.nsc.Reporting.WarningCategory
 import scala.util.chaining._
@@ -873,7 +873,7 @@ trait Contexts { self: Analyzer with ImportTracking =>
     }
 
     /** Is `sym` accessible as a member of `pre` in current context? */
-    def isAccessible(sym: Symbol, pre: Type, superAccess: Boolean = false): Boolean = {
+    def isAccessible(sym: Symbol, pre: Type, superAccess: Boolean): Boolean = {
       lastAccessCheckDetails = ""
       // Console.println("isAccessible(%s, %s, %s)".format(sym, pre, superAccess))
 
@@ -1016,17 +1016,10 @@ trait Contexts { self: Analyzer with ImportTracking =>
       if (outer != null && outer != this) outer.resetCache()
     }
 
-    /** A symbol `sym` qualifies as an implicit if it has the IMPLICIT flag set,
-     *  it is accessible, and if it is imported there is not already a local symbol
-     *  with the same names. Local symbols override imported ones. This fixes #2866.
+    /** A symbol `sym` qualifies as an implicit if it has the IMPLICIT flag set and is accessible.
      */
-    private def isQualifyingImplicit(name: Name, sym: Symbol, pre: Type, imported: Boolean) =
-      sym.isImplicit &&
-      isAccessible(sym, pre) &&
-      !(imported && {
-        val e = scope.lookupEntry(name)
-        (e ne null) && (e.owner == scope) && e.sym.exists
-      })
+    private def isQualifyingImplicit(sym: Symbol, pre: Type) =
+      sym.isImplicit && isAccessible(sym, pre, superAccess = false)
 
     /** Do something with the symbols with name `name` imported via the import in `imp`,
      *  if any such symbol is accessible from this context and is a qualifying implicit.
@@ -1035,31 +1028,30 @@ trait Contexts { self: Analyzer with ImportTracking =>
       val imported = importedAccessibleSymbol(imp, imp.importedSymbol(name))
       if (imported.isOverloaded) {
         for (sym <- imported.alternatives)
-          if (isQualifyingImplicit(name, sym, pre, imported = true))
+          if (isQualifyingImplicit(sym, pre))
             f(sym)
       }
-      else if (isQualifyingImplicit(name, imported, pre, imported = true))
+      else if (isQualifyingImplicit(imported, pre))
         f(imported)
     }
 
     private def collectImplicits(syms: Scope, pre: Type): List[ImplicitInfo] =
-      for (sym <- syms.toList if isQualifyingImplicit(sym.name, sym, pre, imported = false))
+      for (sym <- syms.toList if isQualifyingImplicit(sym, pre))
       yield new ImplicitInfo(sym.name, pre, sym, inPackagePrefix = false)
 
-    private def collectImplicitImports(imp: ImportInfo): List[ImplicitInfo] = if (isExcludedRootImport(imp)) List() else {
+    private def collectImplicitImports(imp: ImportInfo): List[ImplicitInfo] =
+    if (isExcludedRootImport(imp)) Nil
+    else {
       val qual = imp.qual
-
       val pre = qual.tpe
       def collect(sels: List[ImportSelector]): List[ImplicitInfo] = sels match {
-        case List() =>
-          List()
         case sel :: _ if sel.isWildcard || sel.isGiven =>
           // Using pre.implicitMembers seems to exposes a problem with out-dated symbols in the IDE,
           // see the example in https://www.assembla.com/spaces/scala-ide/tickets/1002552#/activity/ticket
           // I haven't been able to boil that down the an automated test yet.
           // Looking up implicit members in the package, rather than package object, here is at least
           // consistent with what is done just below for named imports.
-          for (sym <- qual.tpe.implicitMembers.toList if isQualifyingImplicit(sym.name, sym, pre, imported = true))
+          for (sym <- qual.tpe.implicitMembers.toList if isQualifyingImplicit(sym, pre))
           yield new ImplicitInfo(sym.name, pre, sym, importInfo = imp, importSelector = sel)
         case (sel @ ImportSelector(from, _, to, _)) :: sels1 =>
           var impls = collect(sels1).filter(_.name != from)
@@ -1068,6 +1060,7 @@ trait Contexts { self: Analyzer with ImportTracking =>
               impls = new ImplicitInfo(to, pre, sym, importInfo = imp, importSelector = sel) :: impls
             }
           impls
+        case _ => Nil
       }
       //debuglog("collect implicit imports " + imp + "=" + collect(imp.tree.selectors))//DEBUG
       collect(imp.tree.selectors)
@@ -1081,7 +1074,7 @@ trait Contexts { self: Analyzer with ImportTracking =>
      */
     final def implicitss: List[List[ImplicitInfo]] = implicitssImpl(NoSymbol)
 
-    private def implicitssImpl(skipClass: Symbol): List[List[ImplicitInfo]] = {
+    private def implicitssImpl(skipClass: Symbol): List[List[ImplicitInfo]] =
       if (this == NoContext) Nil
       else if (owner == skipClass) outer.implicitssImpl(NoSymbol)
       else {
@@ -1099,7 +1092,8 @@ trait Contexts { self: Analyzer with ImportTracking =>
         if (implicitsRunId == CycleMarker) {
           debuglog(s"cycle while collecting implicits at owner ${owner}, probably due to an implicit without an explicit return type. Continuing with implicits from enclosing contexts.")
           withOuter(Nil)
-        } else if (implicitsRunId != currentRunId) {
+        }
+        else if (implicitsRunId != currentRunId) {
           implicitsRunId = CycleMarker
           implicits match {
             case None =>
@@ -1107,38 +1101,54 @@ trait Contexts { self: Analyzer with ImportTracking =>
               withOuter(Nil)
             case Some(is) =>
               implicitsRunId = currentRunId
-              implicitsCache = is
-              withOuter(is)
+              val terms = is.filter(_.sym.isTerm)
+              implicitsCache = terms
+              withOuter(terms)
           }
         }
         else withOuter(implicitsCache)
       }
-    }
 
-    /** @return None if a cycle is detected, or Some(infos) containing the in-scope implicits at this context */
+    /** Optionally collect the implicits at this context.
+     *
+     *  This method picks a scope from which implicits are extracted. That can be class members,
+     *  local scope, an import, or a package object.
+     *
+     *  Some contexts are skipped by implicitssImpl, see above.
+     *
+     *  @return None if a cycle is detected, or Some(infos) containing the in-scope implicits at this context
+     */
     private def implicits: Option[List[ImplicitInfo]] = {
-      val firstImport = this.firstImport
       if (unit.isJava) SomeOfNil
       else if (owner != outer.owner && owner.isClass && !owner.isPackageClass) {
         if (!owner.isInitialized) None
         else savingEnclClass(this) {
-          // !!! In the body of `class C(implicit a: A) { }`, `implicitss` returns `List(List(a), List(a), List(<predef..)))`
-          //     it handled correctly by implicit search, which considers the second `a` to be shadowed, but should be
-          //     remedied nonetheless.
           Some(collectImplicits(owner.thisType.implicitMembers, owner.thisType))
+            .tap(res => debuglog(s"collect implicits in ${owner.thisType} from ${owner.thisType.implicitMembers.toList} owner $owner"))
         }
       } else if (scope != outer.scope && !owner.isPackageClass) {
-        debuglog("collect local implicits " + scope.toList)//DEBUG
-        Some(collectImplicits(scope, NoPrefix))
-      } else if (firstImport != outer.firstImport) {
-        if (isDeveloper)
-          assert(imports.tail.headOption == outer.firstImport, (imports, outer.imports))
-        Some(collectImplicitImports(firstImport.get))
-      } else if (owner.isPackageClass) {
-        // the corresponding package object may contain implicit members.
-        val pre = owner.packageObject.typeOfThis
-        Some(collectImplicits(pre.implicitMembers, pre))
-      } else SomeOfNil
+        if (scope.reverseIterator.forall(_.owner == enclClass.owner)) {
+          debuglog(s"omit implicit class-owned members in ${scope.toList}")
+          SomeOfNil
+        }
+        else
+          Some(collectImplicits(scope, NoPrefix))
+            .tap(res => debuglog(s"collect local implicits from ${scope.toList}"))
+      } else {
+        val firstImport = this.firstImport
+        if (firstImport != outer.firstImport) {
+          if (isDeveloper)
+            assert(imports.tail.headOption == outer.firstImport, (imports, outer.imports))
+          Some(collectImplicitImports(firstImport.get))
+            .tap(res => debuglog(s"collect implicits from import at $firstImport: $res"))
+        } else if (owner.isPackageClass) {
+          // the corresponding package object may contain implicit members.
+          val pre = owner.packageObject.typeOfThis
+          Some(collectImplicits(pre.implicitMembers, pre))
+            .tap(res => debuglog(s"collect implicits in package object $pre: $res"))
+        } else
+          SomeOfNil
+      }
     }
 
     //
@@ -1227,7 +1237,7 @@ trait Contexts { self: Analyzer with ImportTracking =>
       else pkg.hasPackageFlag && sym.owner != pkg && requiresQualifier(sym)
     }
 
-    def isNameInScope(name: Name) = lookupSymbol(name, _ => true).isSuccess
+    //def isNameInScope(name: Name) = lookupSymbol(name, _ => true).isSuccess
 
     def lookupSymbol(name: Name, qualifies: Symbol => Boolean): NameLookup =
       symbolLookupCache.using(_(this, name)(qualifies))
@@ -1415,12 +1425,12 @@ trait Contexts { self: Analyzer with ImportTracking =>
         } else {
           val e1 = e
           val e1Sym = e.sym
-          var syms: mutable.ListBuffer[Symbol] = null
+          var syms: ListBuffer[Symbol] = null
           e = scope.lookupNextEntry(e)
           while (e ne null) {
             if (e.depth == e1.depth && e.sym != e1Sym && qualifies(e.sym)) {
               if (syms eq null) {
-                syms = new mutable.ListBuffer[Symbol]
+                syms = ListBuffer.empty[Symbol]
                 syms += e1Sym
               }
               syms += e.sym

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -22,7 +22,7 @@ package typechecker
 import scala.annotation.{nowarn, tailrec}
 import scala.collection.mutable, mutable.{LinkedHashMap, ListBuffer}
 import scala.language.implicitConversions
-import scala.reflect.internal.util.{ReusableInstance, Statistics, TriState}
+import scala.reflect.internal.util.{Statistics, TriState}
 import scala.reflect.internal.TypesStats
 import scala.tools.nsc.Reporting.WarningCategory.{Scala3Migration, WFlagSelfImplicit}
 import symtab.Flags._
@@ -88,11 +88,10 @@ trait Implicits extends splain.SplainData {
    */
   def inferImplicit(tree: Tree, pt: Type, reportAmbiguous: Boolean, isView: Boolean, context: Context, saveAmbiguousDivergent: Boolean, pos: Position): SearchResult = {
     currentRun.profiler.beforeImplicitSearch(pt)
-    try {
+    try
       inferImplicit1(tree, pt, reportAmbiguous, isView, context, saveAmbiguousDivergent, pos)
-    } finally {
+    finally
       currentRun.profiler.afterImplicitSearch(pt)
-    }
   }
 
   private def inferImplicit1(tree: Tree, pt: Type, reportAmbiguous: Boolean, isView: Boolean, context: Context, saveAmbiguousDivergent: Boolean, pos: Position): SearchResult = {
@@ -239,7 +238,6 @@ trait Implicits extends splain.SplainData {
   private val improvesCache = perRunCaches.newMap[(ImplicitInfo, ImplicitInfo), Boolean]()
   private val implicitSearchId = { var id = 1 ; () => try id finally id += 1 }
 
-  private val shadowerUseOldImplementation = java.lang.Boolean.getBoolean("scalac.implicit.shadow.old")
   def resetImplicits(): Unit = {
     implicitsCache.clear()
     infoMapCache.clear()
@@ -815,7 +813,9 @@ trait Implicits extends splain.SplainData {
         case _                          => (if (fast) isPlausiblySubType(tp, pt) else tp <:< pt) && {
           pt match {
             case RefinedType(_, syms) if !syms.isEmpty =>
-              syms.reverseIterator.exists(x => context.isAccessible(tp.nonPrivateMember(x.name), tp))
+              syms.reverseIterator.exists { x =>
+                context.isAccessible(tp.nonPrivateMember(x.name), tp, superAccess = false)
+              }
             case _ =>
               true
           }
@@ -943,8 +943,7 @@ trait Implicits extends splain.SplainData {
         else if (itree3.isErroneous)
           fail("error typechecking implicit candidate")
         else if (isLocalToCallsite && !hasMatchingSymbol(itree2))
-          fail("candidate implicit %s is shadowed by %s".format(
-            info.sym.fullLocationString, itree2.symbol.fullLocationString))
+          fail(s"candidate implicit ${info.sym.fullLocationString} is shadowed by ${itree2.symbol.fullLocationString}")
         else {
           val tvars = undetParams map freshVar
           val ptInstantiated = pt.instantiateTypeParams(undetParams, tvars)
@@ -1035,7 +1034,8 @@ trait Implicits extends splain.SplainData {
      *   - the symbol's type is initialized
      *   - the symbol comes from a classfile
      *   - the symbol comes from a different sourcefile than the current one
-     *   - the symbol and the accessed symbol's definitions come before, and do not contain the closest enclosing definition, // see #3373
+     *   - the symbol comes earlier in the source file but is not an enclosing definition
+     *   - ditto for the accessed of an accessor (#3373)
      *   - the symbol's definition is a val, var, or def with an explicit result type
      *  The aim of this method is to prevent premature cyclic reference errors
      *  by computing the types of only those implicits for which one of these
@@ -1055,21 +1055,27 @@ trait Implicits extends splain.SplainData {
       }
       def comesBefore(sym: Symbol, owner: Symbol) = {
         val ownerPos = owner.pos.pointOrElse(Int.MaxValue)
+        val res =
         sym.pos.pointOrElse(0) < ownerPos && (
           if (sym.hasAccessorFlag) {
             val symAcc = sym.accessed // #3373
             symAcc.pos.pointOrElse(0) < ownerPos &&
-            !(owner.ownerChain exists (o => (o eq sym) || (o eq symAcc))) // probably faster to iterate only once, don't feel like duplicating hasTransOwner for this case
-          } else !(owner hasTransOwner sym)) // faster than owner.ownerChain contains sym
+            !owner.ownerChain.exists(o => (o eq sym) || (o eq symAcc))
+              // probably faster to iterate only once, avoid duplicating hasTransOwner for this case
+              // TODO hasTransOwner has an override
+          }
+          else !owner.hasTransOwner(sym) // faster than owner.ownerChain contains sym
+        )
+        res
       }
-
-      sym.isInitialized || {
-        val sourceFile = sym.sourceFile
-        sourceFile == null ||
-        (sourceFile ne context.unit.source.file) ||
-        hasExplicitResultType(sym) ||
-        comesBefore(sym, context.owner)
-      }
+      (    sym.isInitialized
+        || hasExplicitResultType(sym)
+        || (sym.sourceFile match {
+             case null => true
+             case sourceFile => sourceFile ne context.unit.source.file
+           })
+        || comesBefore(sym, context.owner)
+      )
     }
 
     /** Prune ImplicitInfos down to either all the eligible ones or the best one.
@@ -1088,19 +1094,18 @@ trait Implicits extends splain.SplainData {
         || (!context.macrosEnabled && info.sym.isTermMacro)
       )
 
-      /** True if a given ImplicitInfo (already known isValid) is eligible.
+      /** True if a given ImplicitInfo that isValid is not ineligible and matches the expected type.
        */
       @nowarn("cat=lint-inaccessible")
-      def survives(info: ImplicitInfo, shadower: Shadower) = (
+      def survives(info: ImplicitInfo) = (
            !isIneligible(info)                      // cyclic, erroneous, shadowed, or specially excluded
         && isPlausiblyCompatible(info.tpe, wildPt)  // optimization to avoid matchesPt
-        && !shadower.isShadowed(info.name)          // OPT rare, only check for plausible candidates
         && matchesPt(info)                          // stable and matches expected type
       )
       /** The implicits that are not valid because they come later in the source and
        *  lack an explicit result type. Used for error diagnostics only.
        */
-      val invalidImplicits = new ListBuffer[Symbol]
+      val invalidImplicits = ListBuffer.empty[Symbol]
 
       /** Tests for validity and updates invalidImplicits by side effect when false.
        */
@@ -1145,88 +1150,10 @@ trait Implicits extends splain.SplainData {
         }
       }
 
-      /** Sorted list of eligible implicits.
-       */
-      private def eligibleOld = Shadower.using(isLocalToCallsite) { shadower =>
-        iss flatMap { is =>
-          val result = is filter (info => checkValid(info.sym) && survives(info, shadower))
-          shadower addInfos is
-          result
-        }
-      }
+      val eligibleValidMatching: List[ImplicitInfo] =
+        iss.flatMap(_.filter(info => checkValid(info.sym) && survives(info)))
 
-      /** Sorted list of eligible implicits.
-       */
-      private def eligibleNew = {
-        final case class Candidate(info: ImplicitInfo, level: Int)
-        var matches: java.util.ArrayList[Candidate] = null
-        var matchesNames: java.util.HashSet[Name] = null
-
-        var maxCandidateLevel = 0
-
-        {
-          var i = 0
-          // Collect candidates, the level at which each was found and build a set of their names
-          var iss = this.iss
-          while (!iss.isEmpty) {
-            var is = iss.head
-            while (!is.isEmpty) {
-              val info = is.head
-              if (checkValid(info.sym) && survives(info, NoShadower)) {
-                if (matches == null) {
-                  matches = new java.util.ArrayList(16)
-                  matchesNames = new java.util.HashSet(16)
-                }
-                matches.add(Candidate(info, i))
-                matchesNames.add(info.name)
-                maxCandidateLevel = i
-              }
-              is = is.tail
-            }
-            iss = iss.tail
-            i += 1
-          }
-        }
-
-        if (matches == null)
-          Nil // OPT common case: no candidates
-        else {
-          if (isLocalToCallsite) {
-            // A second pass to filter out results that are shadowed by implicits in inner scopes.
-            var i = 0
-            var removed = false
-            var iss = this.iss
-            while (!iss.isEmpty && i < maxCandidateLevel) {
-              var is = iss.head
-              while (!is.isEmpty) {
-                val info = is.head
-                if (matchesNames.contains(info.name)) {
-                  var j = 0
-                  val numMatches = matches.size()
-                  while (j < numMatches) {
-                    val matchInfo = matches.get(j)
-                    if (matchInfo != null && matchInfo.info.name == info.name && matchInfo.level > i) {
-                      // Shadowed. For now set to null, so as not to mess up the indexing our current loop.
-                      matches.set(j, null)
-                      removed = true
-                    }
-                    j += 1
-                  }
-                }
-                is = is.tail
-              }
-              iss = iss.tail
-              i += 1
-            }
-            if (removed) matches.removeIf(_ == null) // remove for real now.
-          }
-          val result = new ListBuffer[ImplicitInfo]
-          matches.forEach(x => result += x.info)
-          result.toList
-        }
-      }
-
-      val eligible: List[ImplicitInfo] = if (shadowerUseOldImplementation) eligibleOld else eligibleNew
+      val eligible: List[ImplicitInfo] = eligibleValidMatching
       if (eligible.nonEmpty)
         printTyping(tree, s"${eligible.size} eligible for pt=$pt at ${fullSiteString(context)}")
 
@@ -1270,8 +1197,9 @@ trait Implicits extends splain.SplainData {
               foreach2(undetParams, savedInfos){ (up, si) => up.setInfo(si) }
             }
           }
+          // Don't accumulate constraints from typechecking or type error message creation for failed candidates
           if (typedFirstPending.isFailure)
-            undoLog.undoTo(mark) // Don't accumulate constraints from typechecking or type error message creation for failed candidates
+            undoLog.undoTo(mark)
 
           // Pass the errors to `DivergentImplicitRecovery` so that it can note
           // the first `DivergentImplicitTypeError` that is being propagated
@@ -1302,13 +1230,13 @@ trait Implicits extends splain.SplainData {
         // earlier elems may improve on later ones, but not the other way.
         // So if there is any element not improved upon by the first it is an error.
         rankImplicits(eligible, Nil) match {
-          case Nil            => ()
+          case Nil =>
           case (chosenResult, chosenInfo) :: rest =>
-            rest find { case (_, alt) => !improves(chosenInfo, alt) } match {
-              case Some((competingResult, competingInfo))  =>
+            rest.find { case (_, alt) => !improves(chosenInfo, alt) } match {
+              case Some((competingResult, competingInfo)) =>
                 AmbiguousImplicitError(chosenInfo, chosenResult.tree, competingInfo, competingResult.tree, "both", "and", "")(isView, pt, tree)(context)
                 return AmbiguousSearchFailure // Stop the search once ambiguity is encountered, see t4457_2.scala
-              case _                =>
+              case _ =>
                 if (isView) chosenInfo.useCountView += 1
                 else chosenInfo.useCountArg += 1
             }
@@ -1482,8 +1410,14 @@ trait Implicits extends splain.SplainData {
       }
       emptyInfos.foreach(infoMap.remove)
       if (infoMap.nonEmpty)
-        printTyping(tree, "" + infoMap.size + " implicits in companion scope")
-
+        printTyping(tree, s"${infoMap.size} implicits in companion scope")
+      /*
+      if (settings.debug.value)
+        infoMap.foreachEntry { (sym, iis) =>
+          for (ii <- iis)
+            printTyping(tree, s"$sym -> ${ii.name} ${ii.pre} ${ii.sym}")
+        }
+      */
       infoMap
     }
 
@@ -1757,15 +1691,42 @@ trait Implicits extends splain.SplainData {
       val failstart = if (stats) statistics.startTimer(inscopeFailNanos) else null
       val succstart = if (stats) statistics.startTimer(inscopeSucceedNanos) else null
 
-      var result = searchImplicit(context.implicitss, isLocalToCallsite = true)
+      // looking up a "candidate" implicit from this context must yield the candidate if not shadowed
+      // note that isAccessible is checked by isQualifyingImplicit //&& isAccessible(ii.sym, ii.pre)
+      // if lookup fails, it's a stale symbol problem, not our problem (pos/t5639)
+      def shadowed(ii: ImplicitInfo): Boolean = {
+        def shadowed = context.lookupSymbol(ii.name, _ => true) match {
+          case LookupSucceeded(qualifier, symbol) =>
+            // ii.pre or skipPackageObject
+            val pre = if (ii.pre.typeSymbol.isPackageObjectClass) ii.pre.typeSymbol.owner.module.info else ii.pre
+            val ok = (
+                 symbol.alternatives.exists(_ == ii.sym)
+              && (qualifier.isEmpty || qualifier.tpe =:= pre)
+            )
+            if (!ok && settings.isDebug) {
+              val pretext = if (ii.pre != NoType) s" in ${ii.pre}" else ""
+              val qualtext = if (!qualifier.isEmpty) s" in ${qualifier.tpe}" else ""
+              debuglog(s"Drop shadowed implicit ${ii.sym.fullLocationString}${pretext} for ${
+                symbol.fullLocationString}${qualtext}")
+            }
+            !ok
+          case failure =>
+            debuglog(s"Not dropping implicit $ii or ${ii.sym.fullLocationString} on bad lookup $failure in ${
+              context.owner}")
+            false
+        }
+        try shadowed
+        catch { case _: TypeError => false }
+      }
+      val implicitss = context.implicitss.map(_.filterNot(shadowed)).filter(!_.isEmpty)
+      var result = searchImplicit(implicitss, isLocalToCallsite = true)
 
-      if (stats) {
+      if (stats)
         if (result.isFailure) statistics.stopTimer(inscopeFailNanos, failstart)
         else {
           statistics.stopTimer(inscopeSucceedNanos, succstart)
           statistics.incCounter(inscopeImplicitHits)
         }
-      }
 
       if (result.isFailure) {
         val failstart = if (stats) statistics.startTimer(oftypeFailNanos) else null
@@ -1973,37 +1934,6 @@ trait Implicits extends splain.SplainData {
           Some(s"The type parameter$ess ${unboundNames mkString ", "} referenced in the message of the @$annotationName annotation $bee not $where.")
       }
     }
-  }
-
-  private abstract class Shadower {
-    def addInfos(infos: Infos): Unit
-    def isShadowed(name: Name): Boolean
-  }
-  object Shadower {
-    private[this] val localShadowerCache = ReusableInstance[LocalShadower](new LocalShadower, enabled = isCompilerUniverse)
-
-    def using[T](local: Boolean)(f: Shadower => T): T =
-      if (local) localShadowerCache.using { shadower =>
-        shadower.clear()
-        f(shadower)
-      }
-      else f(NoShadower)
-  }
-
-  /** Used for exclude implicits from outer scopes that are shadowed by same-named implicits */
-  private final class LocalShadower extends Shadower {
-    // OPT: using j.l.HashSet as that retains the internal array on clear(), which makes it worth caching.
-    val shadowed = new java.util.HashSet[Name](512)
-    def addInfos(infos: Infos): Unit = {
-      infos.foreach(i => shadowed.add(i.name))
-    }
-    def isShadowed(name: Name) = shadowed.contains(name)
-    def clear(): Unit = shadowed.clear()
-  }
-  /** Used for the implicits of expected type, when no shadowing checks are needed. */
-  private object NoShadower extends Shadower {
-    def addInfos(infos: Infos): Unit = {}
-    def isShadowed(name: Name) = false
   }
 }
 

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -363,22 +363,6 @@ trait Namers extends MethodSynthesis {
       }
     }
 
-    private def enterClassSymbol(@unused tree: ClassDef, clazz: ClassSymbol): Symbol = {
-      var sourceFile = clazz.sourceFile
-      if (sourceFile != null && sourceFile != contextFile)
-        devWarning(s"Source file mismatch in $clazz: ${sourceFile} vs. $contextFile")
-
-      clazz.associatedFile = contextFile
-      sourceFile = clazz.sourceFile
-      if (sourceFile != null) {
-        assert(currentRun.canRedefine(clazz) || sourceFile == currentRun.symSource(clazz), sourceFile)
-        currentRun.symSource(clazz) = sourceFile
-      }
-      registerTopLevelSym(clazz)
-      assert(clazz.name.toString.indexOf('(') < 0, clazz.name)  // )
-      clazz
-    }
-
     def enterClassSymbol(tree: ClassDef): Symbol = {
       val existing = context.scope.lookup(tree.name)
       val isRedefinition = (
@@ -397,9 +381,25 @@ trait Namers extends MethodSynthesis {
         else enterInScope(assignMemberSymbol(tree)) setFlag inConstructorFlag
       }
       clazz match {
-        case csym: ClassSymbol if csym.isTopLevel => enterClassSymbol(tree, csym)
-        case _                                    => clazz
+        case clazz: ClassSymbol if clazz.isTopLevel =>
+          clazz.sourceFile match {
+            case null =>
+            case sourceFile =>
+              if (sourceFile != contextFile)
+                devWarning(s"Source file mismatch in $clazz: ${sourceFile} vs. $contextFile")
+          }
+          clazz.associatedFile = contextFile
+          clazz.sourceFile match {
+            case null =>
+            case sourceFile =>
+              assert(currentRun.canRedefine(clazz) || sourceFile == currentRun.symSource(clazz), sourceFile)
+              currentRun.symSource(clazz) = sourceFile
+          }
+          registerTopLevelSym(clazz)
+          assert(!clazz.name.containsChar('('), clazz.name)  // )
+        case _ =>
       }
+      clazz
     }
 
     /** Given a ClassDef or ModuleDef, verifies there isn't a companion which

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -163,8 +163,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
      */
     def applyImplicitArgs(fun: Tree): Tree = fun.tpe match {
       case MethodType(params, _) =>
-        val argResultsBuff = new ListBuffer[SearchResult]()
-        val argBuff = new ListBuffer[Tree]()
+        val argResultsBuff = ListBuffer.empty[SearchResult]
+        val argBuff = ListBuffer.empty[Tree]
         // paramFailed cannot be initialized with params.exists(_.tpe.isError) because that would
         // hide some valid errors for params preceding the erroneous one.
         var paramFailed = false
@@ -174,9 +174,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         //
         // apply the substitutions (undet type param -> type) that were determined
         // by implicit resolution of implicit arguments on the left of this argument
-        for(param <- params) {
+        for (param <- params) {
           var paramTp = param.tpe
-          for(ar <- argResultsBuff)
+          for (ar <- argResultsBuff)
             paramTp = paramTp.subst(ar.subst.from, ar.subst.to)
 
           val res =
@@ -187,7 +187,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           if (res.isSuccess) {
             argBuff += mkArg(param.name, res.tree)
           } else {
-            mkArg = gen.mkNamedArg // don't pass the default argument (if any) here, but start emitting named arguments for the following args
+            // don't pass the default argument (if any) here, but start emitting named arguments for the following args
+            mkArg = gen.mkNamedArg
             if (!param.hasDefault && !paramFailed) {
               context.reporter.reportFirstDivergentError(fun, param, paramTp)(context)
               paramFailed = true

--- a/src/partest/scala/tools/partest/nest/AbstractRunner.scala
+++ b/src/partest/scala/tools/partest/nest/AbstractRunner.scala
@@ -115,6 +115,9 @@ class AbstractRunner(val config: RunnerSpec.Config, protected final val testSour
     } else {
       echo(statusLine(state, durationMs))
       if (!state.isOk) errInfo.foreach(echo)
+      else if (config.optShowLog && info.logFile.canRead)
+        List(bold(cyan(s"##### Log file '${info.logFile}' from successful test #####\n")), info.logFile.fileContents)
+          .foreach(echo)
       Nil
     }
   }

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1054,7 +1054,7 @@ trait Definitions extends api.StandardDefinitions {
             //    Scopes()
             // must filter out "universal" members (getClass is deferred for some reason)
             val deferredMembers =
-              tpSym.info.membersBasedOnFlags(excludedFlags = BridgeAndPrivateFlags, requiredFlags = METHOD)
+              tpSym.info.membersBasedOnFlags(excluded = BridgeAndPrivateFlags, required = METHOD)
               .toList
               .filter(mem => mem.isDeferred && !isUniversalMember(mem))
 

--- a/src/reflect/scala/reflect/internal/Scopes.scala
+++ b/src/reflect/scala/reflect/internal/Scopes.scala
@@ -30,11 +30,16 @@ trait Scopes extends api.Scopes { self: SymbolTable =>
 
   /** An ADT to represent the results of symbol name lookups.
    */
-  sealed trait NameLookup { def symbol: Symbol ; def isSuccess = false }
-  case class LookupSucceeded(qualifier: Tree, symbol: Symbol) extends NameLookup { override def isSuccess = true }
-  case class LookupAmbiguous(msg: String) extends NameLookup { def symbol = NoSymbol }
-  case class LookupInaccessible(symbol: Symbol, msg: String) extends NameLookup
-  case object LookupNotFound extends NameLookup { def symbol = NoSymbol }
+  sealed trait NameLookup {
+    def symbol: Symbol = NoSymbol
+    def isSuccess: Boolean = false
+  }
+  case class LookupSucceeded(qualifier: Tree, override val symbol: Symbol) extends NameLookup {
+    override def isSuccess = true
+  }
+  case class LookupAmbiguous(msg: String) extends NameLookup
+  case class LookupInaccessible(override val symbol: Symbol, msg: String) extends NameLookup
+  case object LookupNotFound extends NameLookup
 
   class ScopeEntry(var sym: Symbol, val owner: Scope) {
     /** the next entry in the hash bucket

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -3569,7 +3569,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     def implicitMembers: Scope = {
       val tp = info
       if ((implicitMembersCacheKey1 ne tp) || (implicitMembersCacheKey2 ne tp.decls.elems)) {
-        implicitMembersCacheValue = tp.membersBasedOnFlags(BridgeFlags, IMPLICIT)
+        implicitMembersCacheValue = tp.membersBasedOnFlags(excluded = BridgeFlags, required = IMPLICIT)
         implicitMembersCacheKey1 = tp
         implicitMembersCacheKey2 = tp.decls.elems
       }

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -404,7 +404,8 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     final def newOverloaded(pre: Type, alternatives: List[Symbol]): TermSymbol = {
       val triedCookingFlag = if (alternatives.forall(_.hasFlag(TRIEDCOOKING))) TRIEDCOOKING else 0L
 
-      newTermSymbol(alternatives.head.name.toTermName, alternatives.head.pos, OVERLOADED | triedCookingFlag) setInfo OverloadedType(pre, alternatives)
+      newTermSymbol(alternatives.head.name.toTermName, alternatives.head.pos, OVERLOADED | triedCookingFlag)
+        .setInfo(OverloadedType(pre, alternatives))
     }
 
     final def newErrorValue(name: TermName): TermSymbol =
@@ -2310,7 +2311,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
      *
      *  class C {
      *    def <init> = { ... }
-     *    val x = { def g() = ...; g() } }
+     *    val x = { def g() = ...; g() }
      *  }
      *
      *  In this case the owner chain of `g` is `x`, followed by `C` but
@@ -2655,7 +2656,8 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
         (file eq NoAbstractFile) || {
           val path = file.path
           path.endsWith(".class") || path.endsWith(".sig") || path.endsWith(".tasty")
-        }) null else file
+        }) null
+      else file
     }
 
     /** Overridden in ModuleSymbols to delegate to the module class.
@@ -3448,6 +3450,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
         else _associatedFile
       }
     )
+    // assert isTopLevel
     override def associatedFile_=(f: AbstractFile): Unit = { _associatedFile = f }
 
     override def reset(completer: Type): this.type = {

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -593,26 +593,27 @@ trait Types
      *  Members appear in linearization order of their owners.
      *  Members with the same owner appear in reverse order of their declarations.
      */
-    def members: Scope = membersBasedOnFlags(0, 0)
+    def members: Scope = membersBasedOnFlags(excluded = 0, required = 0)
 
     /** A list of all non-private members of this type (defined or inherited) */
-    def nonPrivateMembers: Scope = membersBasedOnFlags(BridgeAndPrivateFlags, 0)
+    def nonPrivateMembers: Scope = membersBasedOnFlags(excluded = BridgeAndPrivateFlags, required = 0)
 
     /** A list of all non-private members of this type  (defined or inherited),
      *  admitting members with given flags `admit`
      */
-    def nonPrivateMembersAdmitting(admit: Long): Scope = membersBasedOnFlags(BridgeAndPrivateFlags & ~admit, 0)
+    def nonPrivateMembersAdmitting(admit: Long): Scope =
+      membersBasedOnFlags(excluded = BridgeAndPrivateFlags & ~admit, required = 0)
 
     /** A list of all implicit symbols of this type  (defined or inherited) */
     def implicitMembers: Scope = {
       typeSymbolDirect match {
         case sym: ModuleClassSymbol => sym.implicitMembers
-        case _ => membersBasedOnFlags(BridgeFlags, IMPLICIT)
+        case _ => membersBasedOnFlags(excluded = BridgeFlags, required = IMPLICIT)
       }
     }
 
     /** A list of all deferred symbols of this type  (defined or inherited) */
-    def deferredMembers: Scope = membersBasedOnFlags(BridgeFlags, DEFERRED)
+    def deferredMembers: Scope = membersBasedOnFlags(excluded = BridgeFlags, required = DEFERRED)
 
     /** The member with given name,
      *  an OverloadedSymbol if several exist, NoSymbol if none exist */
@@ -649,8 +650,8 @@ trait Types
     /** Members excluding and requiring the given flags.
      *  Note: unfortunately it doesn't work to exclude DEFERRED this way.
      */
-    def membersBasedOnFlags(excludedFlags: Long, requiredFlags: Long): Scope =
-      findMembers(excludedFlags, requiredFlags)
+    def membersBasedOnFlags(excluded: Long, required: Long): Scope =
+      findMembers(excludedFlags = excluded, requiredFlags = required)
 
     def memberBasedOnName(name: Name, excludedFlags: Long): Symbol =
       findMember(name, excludedFlags, 0, stableOnly = false)

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -1001,10 +1001,11 @@ trait Types
      *    you won't get deferred members (whether they have an overriding concrete member or not)
      *
      * Thus, findMember requiring DEFERRED flags yields deferred members,
-     * while `findMember(excludedFlags = 0, requiredFlags = 0).filter(_.isDeferred)` may not (if there's a corresponding concrete member)
+     * while `findMember(excludedFlags = 0, requiredFlags = 0).filter(_.isDeferred)` may not
+     * (if there's a corresponding concrete member)
      *
-     * Requirements take precedence over exclusions, so requiring and excluding DEFERRED will yield a DEFERRED member (if there is one).
-     *
+     * Requirements take precedence over exclusions, so requiring and excluding DEFERRED will yield a DEFERRED member
+     * (if there is one).
      */
     def findMembers(excludedFlags: Long, requiredFlags: Long): Scope = {
       def findMembersInternal = new FindMembers(this, excludedFlags, requiredFlags).apply()
@@ -1012,9 +1013,8 @@ trait Types
       else suspendingTypeVars(typeVarsInTypeRev(this))(findMembersInternal)
     }
 
-    /**
-     *  Find member(s) in this type. If several members matching criteria are found, they are
-     *  returned in an OverloadedSymbol
+    /** Find member(s) in this type. If several members matching criteria are found, they are
+     *  returned in an OverloadedSymbol.
      *
      *  @param name           The member's name
      *  @param excludedFlags  Returned members do not have these flags

--- a/test/files/neg/t12351.check
+++ b/test/files/neg/t12351.check
@@ -1,0 +1,4 @@
+t12351.scala:8: error: could not find implicit value for parameter e: T
+  def g(t: String): T = implicitly[T]
+                                  ^
+1 error

--- a/test/files/neg/t12351.scala
+++ b/test/files/neg/t12351.scala
@@ -1,0 +1,9 @@
+///> using options -Vdebug -Vlog:typer -Werror
+
+trait T
+
+class C(implicit t: T) {
+  def f: T = implicitly[T]
+
+  def g(t: String): T = implicitly[T]
+}

--- a/test/files/neg/t2509-2.check
+++ b/test/files/neg/t2509-2.check
@@ -1,6 +1,6 @@
 t2509-2.scala:27: error: ambiguous implicit values:
- both value xb in object Test of type X[B,Int]
- and value xa in object Test of type X[A,Boolean]
+ both value xa in object Test of type X[A,Boolean]
+ and value xb in object Test of type X[B,Int]
  match expected type X[B,U]
   val fb = f(new B)
             ^

--- a/test/files/neg/t712.check
+++ b/test/files/neg/t712.check
@@ -1,11 +1,14 @@
-t712.scala:10: error: overloaded method coerce needs result type
+t712.scala:12: error: overloaded method coerce needs result type
   implicit def coerce(p : ParentImpl) = p.self;
                                           ^
-t712.scala:3: warning: Implicit definition should have explicit type (inferred A.this.Node) [quickfixable]
+t712.scala:20: error: value scope is not a member of B.this.Symbol
+  val s_scope = s.scope;
+                  ^
+t712.scala:5: warning: Implicit definition should have explicit type (inferred A.this.Node) [quickfixable]
   implicit def coerce(n : NodeImpl) = n.self;
                ^
-t712.scala:10: warning: Implicit definition should have explicit type [quickfixable]
+t712.scala:12: warning: Implicit definition should have explicit type [quickfixable]
   implicit def coerce(p : ParentImpl) = p.self;
                ^
 2 warnings
-1 error
+2 errors

--- a/test/files/neg/t712.scala
+++ b/test/files/neg/t712.scala
@@ -1,3 +1,5 @@
+import language.implicitConversions
+
 trait A {
   type Node <: NodeImpl;
   implicit def coerce(n : NodeImpl) = n.self;

--- a/test/files/neg/t729.check
+++ b/test/files/neg/t729.check
@@ -1,13 +1,12 @@
-t729.scala:20: error: type mismatch;
- found   : ScalaParserAutoEdit.this.NodeImpl(in trait Parser)
- required: ScalaParserAutoEdit.this.NodeImpl(in trait ScalaParserAutoEdit)
-      val yyy : NodeImpl = link.from;
-                                ^
-t729.scala:3: warning: Implicit definition should have explicit type (inferred Parser.this.Node) [quickfixable]
-  implicit def coerce(n : NodeImpl) = n.self;
+t729.scala:6: warning: Implicit definition should have explicit type (inferred Parser.this.Node) [quickfixable]
+  implicit def coerce(n : NodeImpl)/*: Node*/ = n.self;
                ^
-t729.scala:14: warning: Implicit definition should have explicit type (inferred ScalaParserAutoEdit.this.Node) [quickfixable]
-  implicit def coerce(node : NodeImpl) = node.self;
+t729.scala:17: warning: Implicit definition should have explicit type (inferred ScalaParserAutoEdit.this.Node) [quickfixable]
+  implicit def coerce(node : NodeImpl)/*: Node*/ = node.self;
                ^
-2 warnings
+t729.scala:18: warning: shadowing a nested class of a parent is deprecated but trait NodeImpl shadows trait NodeImpl defined in trait Parser; rename the class to something else
+  trait NodeImpl extends super[Parser].NodeImpl {
+        ^
+error: No warnings can be incurred under -Werror.
+3 warnings
 1 error

--- a/test/files/neg/t729.scala
+++ b/test/files/neg/t729.scala
@@ -1,6 +1,9 @@
+//> using options -Werror -deprecation -feature
+import language.implicitConversions
+
 trait Parser {
   type Node <: NodeImpl;
-  implicit def coerce(n : NodeImpl) = n.self;
+  implicit def coerce(n : NodeImpl)/*: Node*/ = n.self;
   trait NodeImpl {
     def self : Node;
   }
@@ -11,13 +14,13 @@ trait Parser {
 
 trait ScalaParserAutoEdit extends Parser {
   type Node <: NodeImpl;
-  implicit def coerce(node : NodeImpl) = node.self;
+  implicit def coerce(node : NodeImpl)/*: Node*/ = node.self;
   trait NodeImpl extends super[Parser].NodeImpl {
     def self : Node;
     def foo = {
       var link : Link = null;
       val xxx : NodeImpl = coerce(link.from);
-      val yyy : NodeImpl = link.from;
+      val yyy : NodeImpl = link.from
     }
   }
 }

--- a/test/files/pos/t12351.scala
+++ b/test/files/pos/t12351.scala
@@ -1,0 +1,25 @@
+import scala.concurrent._
+
+trait TestModule {
+  implicit def ec: ExecutionContext
+}
+
+class ClassA()(implicit ec: ExecutionContext)
+
+trait Trait1 {
+  this: TestModule =>
+
+  implicit def ec: ExecutionContext
+  def a: ClassA = new ClassA()
+  def b = new ClassA()
+}
+
+class K extends Trait1 with TestModule {
+  override implicit def ec: ExecutionContext = ???
+}
+
+object Test extends App {
+  println {
+    new K().a
+  }
+}

--- a/test/files/pos/t9208.scala
+++ b/test/files/pos/t9208.scala
@@ -1,0 +1,8 @@
+object X { implicit def x: Int = 42 }
+
+trait T { implicit def x: Int = 27 }
+
+object Y extends T {
+  import X._
+  def f: Int = implicitly[Int]
+}

--- a/test/files/run/t11860.scala
+++ b/test/files/run/t11860.scala
@@ -1,0 +1,33 @@
+
+trait Writer[A] {
+  def write(value: A): String
+}
+
+object Writer {
+  implicit val stringWriter: Writer[String] = new Writer[String] {
+    override def write(value: String): String = value
+  }
+}
+
+object Foo {
+  implicit val string2foo: Writer[String] = new Writer[String] {
+    override def write(value: String): String = "foo"
+  }
+}
+
+object Test extends App {
+  import Foo._
+
+  implicit class WriterOps[A](value: A) {
+    def toWrappedString(implicit w: Writer[A]): String = w.write(value)
+  }
+
+ //object Foo has the implicit with the same name
+  implicit val string2foo: Writer[String] = new Writer[String] {
+    override def write(value: String): String = "foo"
+  }
+
+  val foo = "Hello".toWrappedString
+  assert(foo == "foo") //prints "foo"
+  assert("Hello".toWrappedString == "foo") //prints "Hello"
+}

--- a/test/files/run/virtpatmat_typetag.scala
+++ b/test/files/run/virtpatmat_typetag.scala
@@ -1,5 +1,5 @@
-//> using options -Xfatal-warnings
-//
+//> using options -Werror
+
 import reflect.{ClassTag, classTag}
 
 trait Extractors {


### PR DESCRIPTION
Fixes scala/bug#12351
Fixes scala/bug#9208

Retire both the old and new "implicit shadowing" mechanisms in favor of using `ctx.lookupSymbol`.

Tweak when `ctx.implicitss` collects implicits from a class by waiting to use `owner.thisType.implicitMembers`.

A notable improvement in correctness is that overloaded implicits are handled correctly (see `neg/t729.scala`). The spec for lexically scoped implicits is that the value must be "accessible without a prefix". (Probably a member was seen once in a nested context and then again as an overload in the class type, which was taken as shadowed.)

The shadowing test in `isQualifyingImplicit` is removed; further clean-up of removed code is still needed after more testing.

There are two test tweaks to address which are due to existing cyclic error handling: in one case (`t712`), where one implicit member causes a cycle, the other implicit member is not collected; in the other case (`virtpatmat_typetag`), an explicit type is spuriously required for a class tag, also due to an existing cyclic error.

Also 2509 switched order when reporting ambiguous, which is supposed to have "winner" first. Maybe benign or progress.