### PR TITLE
Merge 2.12 to 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -451,7 +451,7 @@ lazy val compilerOptionsExporter = Project("compilerOptionsExporter", file(".") 
   .settings(disablePublishing)
   .settings(
     libraryDependencies ++= {
-      val jacksonVersion = "2.18.3"
+      val jacksonVersion = "2.19.0"
       Seq(
         "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
         "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -41,4 +41,4 @@ addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")
 
-addSbtPlugin("com.gradle" % "sbt-develocity" % "1.2")
+addSbtPlugin("com.gradle" % "sbt-develocity" % "1.2.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -41,4 +41,4 @@ addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")
 
-addSbtPlugin("com.gradle" % "sbt-develocity" % "1.1.2")
+addSbtPlugin("com.gradle" % "sbt-develocity" % "1.2")


### PR DESCRIPTION
The `jackson-module-scala` dep is no longer there in 2.13 https://github.com/scala/scala/commit/c0eb517868