### PR TITLE
Adjust caret in error message

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -2197,13 +2197,10 @@ self =>
        */
       def pattern1(): Tree = pattern2() match {
         case p @ Ident(name) if in.token == COLON =>
-          if (nme.isVariableName(name)) {
-            p.removeAttachment[BackquotedIdentifierAttachment.type]
-            atPos(p.pos.start, in.skipToken())(Typed(p, compoundType()))
-          } else {
-            syntaxError(in.offset, "Pattern variables must start with a lower-case letter. (SLS 8.1.1.)")
-            p
-          }
+          if (!nme.isVariableName(name))
+            syntaxError(p.pos.point, "Pattern variables must start with a lower-case letter. (SLS 8.1.1.)")
+          p.removeAttachment[BackquotedIdentifierAttachment.type]
+          atPos(p.pos.start, in.skipToken())(Typed(p, compoundType()))
         case p => p
       }
 

--- a/test/files/neg/t5357.check
+++ b/test/files/neg/t5357.check
@@ -1,4 +1,4 @@
 t5357.scala:5: error: Pattern variables must start with a lower-case letter. (SLS 8.1.1.)
     case A: N => 1
-          ^
+         ^
 1 error

--- a/test/files/neg/t8044-b.check
+++ b/test/files/neg/t8044-b.check
@@ -1,4 +1,4 @@
 t8044-b.scala:3: error: Pattern variables must start with a lower-case letter. (SLS 8.1.1.)
   def g = 42 match { case `Oops` : Int => }  // must be varish
-                                 ^
+                          ^
 1 error


### PR DESCRIPTION
Re-improves the previous improvement at https://github.com/scala/scala/commit/3192048a4bfb59966f93bb87a3c4f6b7ccfc80b2

where Paul said
```
That's uggo!
```
and which we may justly echo.

Noticed while commenting smugly on Dotty.

https://github.com/scala/scala3/pull/23088#discussion_r2074967252

Scala 2 doesn't accept that syntax.