### PR TITLE
Add MiMa filter for new mixin forwarders on JDK 25

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -32,6 +32,13 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.Predef#ArrayCharSequence.isEmpty"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.ArrayCharSequence.isEmpty"),
 
+    // new jdk 25 method in CharSequence => mixin forwarders
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.Predef#ArrayCharSequence.getChars"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.Predef#SeqCharSequence.getChars"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.mutable.StringBuilder.getChars"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.ArrayCharSequence.getChars"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.SeqCharSequence.getChars"),
+
   )
 
   override val buildSettings = Seq(


### PR DESCRIPTION
A new method was added to CharSequence in JDK 25, which leads to new mixin forwarders flagged by MiMa.

Build failure seen in https://github.com/scala/scala/actions/runs/15013871709/job/42194847921

https://github.com/openjdk/jdk/commit/7642556a5a131e9104033ad7d7abfdb4be5012cf