### PR TITLE
Use List.fill instead of range [ci: last-only]

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -528,7 +528,7 @@ abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
       val parentIndex = u2()
       val parentName = if (parentIndex == 0) null else pool.getClassName(parentIndex)
       val ifaceCount = u2()
-      val ifaces = for (_ <- List.range(0, ifaceCount)) yield pool.getSuperClassName(index = u2())
+      val ifaces = List.fill(ifaceCount.toInt)(pool.getSuperClassName(index = u2()))
       val completer = new ClassTypeCompleter(clazz.name, jflags, parentName, ifaces)
 
       enterOwnInnerClasses()

--- a/src/library/scala/collection/Factory.scala
+++ b/src/library/scala/collection/Factory.scala
@@ -146,10 +146,10 @@ trait IterableFactory[+CC[_]] extends Serializable {
   def newBuilder[A]: Builder[A, CC[A]]
 
   /** Produces a $coll containing the results of some element computation a number of times.
-    *  @param   n  the number of elements contained in the $coll.
-    *  @param   elem the element computation
-    *  @return  A $coll that contains the results of `n` evaluations of `elem`.
-    */
+   *  @param   n  the number of elements contained in the $coll.
+   *  @param   elem the element computation
+   *  @return  A $coll that contains the results of `n` evaluations of `elem`.
+   */
   def fill[A](n: Int)(elem: => A): CC[A] = from(new View.Fill(n)(elem))
 
   /** Produces a two-dimensional $coll containing the results of some element computation a number of times.

--- a/src/library/scala/collection/IterableOnce.scala
+++ b/src/library/scala/collection/IterableOnce.scala
@@ -435,6 +435,8 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
    *  @return  a $coll containing the elements greater than or equal to
    *           index `from` extending up to (but not including) index `until`
    *           of this $coll.
+   *  @example
+   *    `List('a', 'b', 'c', 'd', 'e').slice(1, 3) == List('b', 'c')`
    */
   def slice(from: Int, until: Int): C
 
@@ -1241,7 +1243,7 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
    *  @param pf   the partial function
    *  @return     an option value containing pf applied to the first
    *              value for which it is defined, or `None` if none exists.
-   *  @example    `Seq("a", 1, 5L).collectFirst({ case x: Int => x*10 }) = Some(10)`
+   *  @example    `Seq("a", 1, 5L).collectFirst { case x: Int => x*10 } = Some(10)`
    */
   def collectFirst[B](pf: PartialFunction[A, B]): Option[B] = {
     // Presumably the fastest way to get in and out of a partial function is for a sentinel function to return itself

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -186,17 +186,6 @@ sealed abstract class List[+A]
     h
   }
 
-  /** @inheritdoc
-    *
-    *  @example {{{
-    *  // Given a list
-    *  val letters = List('a','b','c','d','e')
-    *
-    *  // `slice` returns all elements beginning at index `from` and afterwards,
-    *  // up until index `until` (excluding index `until`.)
-    *  letters.slice(1,3) // Returns List('b','c')
-    *  }}}
-    */
   override def slice(from: Int, until: Int): List[A] = {
     val lo = scala.math.max(from, 0)
     if (until <= lo || isEmpty) Nil


### PR DESCRIPTION
Follow-up to https://github.com/scala/scala/commit/8c000427aa00f138cfc95c0630b379e9c7980b69

Noticed during https://github.com/scala/scala3/issues/15144 at https://github.com/scala/scala3/blob/main/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala#L383 where it induced an explanatory comment.