### PR TITLE
Use `toVector` for XML literal sequences

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/MarkupParsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/MarkupParsers.scala
@@ -391,7 +391,7 @@ trait MarkupParsers {
             nextch()
             content_LT(ts)
           } while (charComingAfter(xSpaceOpt()) == '<')
-          handle.makeXMLseq(r2p(start, start, curOffset), ts)
+          handle.makeXMLseq(r2p(start, start, curOffset), ts, toVector = false)
         }
         else {
           assert(ts.length == 1, "Require one tree")

--- a/test/files/run/t3368-b.check
+++ b/test/files/run/t3368-b.check
@@ -25,7 +25,7 @@ package <empty> {
       $buf.$amp$plus(new _root_.scala.xml.Elem(null, "d", _root_.scala.xml.Null, $scope, true));
       $buf.$amp$plus(new _root_.scala.xml.Text("stuff"));
       $buf.$amp$plus(new _root_.scala.xml.PCData("red & black"));
-      $buf
+      $buf.toVector
     }: _*))
   };
   abstract trait Z extends scala.AnyRef {
@@ -43,18 +43,18 @@ package <empty> {
       val $buf = new _root_.scala.xml.NodeBuffer();
       $buf.$amp$plus(new _root_.scala.xml.Text("x"));
       $buf.$amp$plus(new _root_.scala.xml.PCData("hello, world"));
-      $buf
+      $buf.toVector
     }: _*));
     def g = new _root_.scala.xml.Elem(null, "foo", _root_.scala.xml.Null, $scope, false, ({
       val $buf = new _root_.scala.xml.NodeBuffer();
       $buf.$amp$plus(new _root_.scala.xml.PCData("hello, world"));
-      $buf
+      $buf.toVector
     }: _*));
     def h = new _root_.scala.xml.Elem(null, "foo", _root_.scala.xml.Null, $scope, false, ({
       val $buf = new _root_.scala.xml.NodeBuffer();
       $buf.$amp$plus(new _root_.scala.xml.PCData("hello, world"));
       $buf.$amp$plus(new _root_.scala.xml.PCData("hello, world"));
-      $buf
+      $buf.toVector
     }: _*))
   }
 }

--- a/test/files/run/t3368.check
+++ b/test/files/run/t3368.check
@@ -23,7 +23,7 @@ package <empty> {
       $buf.$amp$plus(new _root_.scala.xml.Text("world"));
       $buf.$amp$plus(new _root_.scala.xml.Elem(null, "d", _root_.scala.xml.Null, $scope, true));
       $buf.$amp$plus(new _root_.scala.xml.Text("stuffred & black"));
-      $buf
+      $buf.toVector
     }: _*))
   };
   abstract trait Z extends scala.AnyRef {
@@ -40,17 +40,17 @@ package <empty> {
     def f = new _root_.scala.xml.Elem(null, "foo", _root_.scala.xml.Null, $scope, false, ({
       val $buf = new _root_.scala.xml.NodeBuffer();
       $buf.$amp$plus(new _root_.scala.xml.Text("xhello, world"));
-      $buf
+      $buf.toVector
     }: _*));
     def g = new _root_.scala.xml.Elem(null, "foo", _root_.scala.xml.Null, $scope, false, ({
       val $buf = new _root_.scala.xml.NodeBuffer();
       $buf.$amp$plus(new _root_.scala.xml.Text("hello, world"));
-      $buf
+      $buf.toVector
     }: _*));
     def h = new _root_.scala.xml.Elem(null, "foo", _root_.scala.xml.Null, $scope, false, ({
       val $buf = new _root_.scala.xml.NodeBuffer();
       $buf.$amp$plus(new _root_.scala.xml.Text("hello, worldhello, world"));
-      $buf
+      $buf.toVector
     }: _*))
   }
 }

--- a/test/files/run/t9027/test_2.scala
+++ b/test/files/run/t9027/test_2.scala
@@ -1,11 +1,20 @@
 
 object Test {
-  import scala.xml.NodeBuffer
+  import scala.xml._
 
   def main(args: Array[String]): Unit = {
     val xml =  <hello>world</hello>
     assert(xml.toString == "helloworld")
-    val nodeBuffer: NodeBuffer = <hello/><world/>
-    assert(nodeBuffer.mkString == "helloworld")
+    val nodeSeq: NodeBuffer = <hello/><world/>
+    assert(nodeSeq.mkString == "helloworld")
+    val subSeq: scala.xml.Elem = <a><b/><c/></a>
+    assert(subSeq.child.mkString == "bc")
+    assert(subSeq.child.toString == "Vector(b, c)") // implementation detail
+
+    val attrSeq: Elem = <a foo="txt&entityref;txt"/>
+    assert(attrSeq.attributes.asInstanceOf[UnprefixedAttribute].value.toString == "Vector(txt, &entityref;, txt)")
+
+    val g: Group = <xml:group><a/><b/><c/></xml:group>
+    assert(g.nodes.toString == "Vector(a, b, c)")
   }
 }

--- a/test/files/run/t9027/xml_1.scala
+++ b/test/files/run/t9027/xml_1.scala
@@ -9,7 +9,7 @@ package scala.xml {
     def child: Seq[Node]
     override def toString = label + child.mkString
   }
-  class Elem(prefix: String, val label: String, attributes1: MetaData, scope: NamespaceBinding, minimizeEmpty: Boolean, val child: Node*) extends Node
+  class Elem(prefix: String, val label: String, val attributes: MetaData, scope: NamespaceBinding, minimizeEmpty: Boolean, val child: Node*) extends Node
   class NodeBuffer extends Seq[Node] {
     val nodes = scala.collection.mutable.ArrayBuffer.empty[Node]
     def &+(o: Any): NodeBuffer =
@@ -28,4 +28,11 @@ package scala.xml {
     def label = t.text
     def child = Nil
   }
+  case class UnprefixedAttribute(key: String, value: Seq[Node], next: MetaData) extends MetaData
+  case class EntityRef(entityName: String) extends Node {
+    def label = s"&$entityName;"
+    def child = Nil
+  }
+
+  case class Group(nodes: Seq[Node])
 }


### PR DESCRIPTION
In `<a><b/><c/><a>`, a `NodeBuffer` (which extends `ArrayBuffer`) is used to accumulate the children. The buffer is passed to `new Elem($buf: _*)`, which only works thanks to the implicit `collection.Seq[Node] => NodeSeq` declared in scala-xml.

With `-Vprint:typer`:

```scala
scala> <a><b/></a>
[[syntax trees at end of                     typer]] // <console>

      private[this] val res0: scala.xml.Elem = new scala.xml.Elem(null, "a", scala.xml.Null, scala.xml.TopScope, false, (xml.this.NodeSeq.seqToNodeSeq({
        val $buf: scala.xml.NodeBuffer = new scala.xml.NodeBuffer();
        $buf.&+(new scala.xml.Elem(null, "b", scala.xml.Null, scala.xml.TopScope, true));
        $buf
      }): _*));
```

The implicit was not inserted in 2.12 because the varargs parameter of Elem accepted a `collection.Seq`.


This PR changes the compiler translation to use `toVector`.

Note that there was a related change in scala-xml 2.4.0 to use `immutable.Seq` instead of `collection.Seq` for core parts of the scala-xml API (https://github.com/scala/scala-xml/releases/tag/v2.4.0).