### PR TITLE
When parsing Java sources, skip JDK 21+’s JEP 445 compact compilation units

### DIFF
--- a/test/files/neg/i20026.check
+++ b/test/files/neg/i20026.check
@@ -1,4 +1,7 @@
-JTest.java:3: error: illegal start of type declaration
+JTest.java:3: error: illegal start of type
 import java.util.*;
-       ^
-1 error
+^
+JTest.java:3: error: identifier expected but `;` found.
+import java.util.*;
+                  ^
+2 errors

--- a/test/files/neg/t12878.check
+++ b/test/files/neg/t12878.check
@@ -1,0 +1,7 @@
+Test.scala:3: error: not found: type H
+  new H()
+      ^
+Test.scala:4: error: not found: value T
+  new T.H()
+      ^
+2 errors

--- a/test/files/neg/t12878/T.java
+++ b/test/files/neg/t12878/T.java
@@ -1,0 +1,9 @@
+//> using jvm 25+
+
+int k = 0;
+File f = null;
+java.io.File g = f;
+@Deprecated void main() { return; }
+public record Person(String name, int age) { }
+public class H { }
+public static int k() { return 1; }

--- a/test/files/neg/t12878/Test.scala
+++ b/test/files/neg/t12878/Test.scala
@@ -1,0 +1,5 @@
+class Test {
+  new U
+  new H()
+  new T.H()
+}

--- a/test/files/neg/t12878/U.java
+++ b/test/files/neg/t12878/U.java
@@ -1,0 +1,1 @@
+public class U { }

--- a/test/files/pos/t12878/T.java
+++ b/test/files/pos/t12878/T.java
@@ -1,0 +1,9 @@
+//> using jvm 25+
+
+int k = 0;
+File f = null;
+java.io.File g = f;
+@Deprecated void main() { return; }
+public record Person(String name, int age) { }
+public class H { }
+public static int k() { return 1; }

--- a/test/files/pos/t12878/Test.scala
+++ b/test/files/pos/t12878/Test.scala
@@ -1,0 +1,3 @@
+class Test {
+  new U
+}

--- a/test/files/pos/t12878/U.java
+++ b/test/files/pos/t12878/U.java
@@ -1,0 +1,1 @@
+public class U { }


### PR DESCRIPTION
Compact compilation units are not referenceable, so we can skip over them.

Fixes https://github.com/scala/bug/issues/12878