### PR TITLE
Port `summonIgnoring` from 3.7 as `c.inferImplicitValueIgnoring`

### DIFF
--- a/src/compiler/scala/reflect/macros/contexts/Typers.scala
+++ b/src/compiler/scala/reflect/macros/contexts/Typers.scala
@@ -56,6 +56,11 @@ trait Typers {
     universe.analyzer.inferImplicit(universe.EmptyTree, pt, isView = false, callsiteTyper.context, silent, withMacrosDisabled, pos, (pos, msg) => throw TypecheckException(pos, msg))
   }
 
+  def inferImplicitValueIgnoring(pt: Type, silent: Boolean = true, withMacrosDisabled: Boolean = false, pos: Position = enclosingPosition)(ignoredSymbols: Symbol*): Tree = {
+    macroLogVerbose(s"inferring implicit value of type $pt, macros = ${!withMacrosDisabled}, ignored symbols = ${ignoredSymbols.mkString(", ")}")
+    universe.analyzer.inferImplicitIgnoring(universe.EmptyTree, pt, isView = false, callsiteTyper.context, silent, withMacrosDisabled, pos, (pos, msg) => throw TypecheckException(pos, msg), ignoredSymbols.toSet)
+  }
+
   def inferImplicitView(tree: Tree, from: Type, to: Type, silent: Boolean = true, withMacrosDisabled: Boolean = false, pos: Position = enclosingPosition): Tree = {
     macroLogVerbose(s"inferring implicit view from $from to $to for $tree, macros = ${!withMacrosDisabled}")
     val viewTpe = universe.appliedType(universe.definitions.FunctionClass(1).toTypeConstructor, List(from, to))

--- a/src/reflect/scala/reflect/macros/Typers.scala
+++ b/src/reflect/scala/reflect/macros/Typers.scala
@@ -98,6 +98,12 @@ trait Typers {
    */
   def inferImplicitValue(pt: Type, silent: Boolean = true, withMacrosDisabled: Boolean = false, pos: Position = enclosingPosition): Tree
 
+  /** A sibling to [[inferImplicitValue]] that allows to ignore certain symbols during the implicit search.
+   *
+   *  @throws scala.reflect.macros.TypecheckException
+   */
+  def inferImplicitValueIgnoring(pt: Type, silent: Boolean = true, withMacrosDisabled: Boolean = false, pos: Position = enclosingPosition)(ignoredSymbols: Symbol*): Tree
+
   /** Infers an implicit view from the provided tree `tree` of the type `from` to the type `to` in the macro callsite context.
    *  Optional `pos` parameter provides a position that will be associated with the implicit search.
    *

--- a/test/files/run/macro-implicit-ignoring.check
+++ b/test/files/run/macro-implicit-ignoring.check
@@ -1,0 +1,4 @@
+implicit-in-companion
+ignoring-implicit-in-companion
+not-ignoring-user-provided-implicit
+not-ignoring-user-provided-implicit

--- a/test/files/run/macro-implicit-ignoring/Macros_1.scala
+++ b/test/files/run/macro-implicit-ignoring/Macros_1.scala
@@ -1,0 +1,31 @@
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox
+
+trait TypeClass[A] {
+
+  def value: A
+}
+
+object TypeClass {
+  
+  implicit val defaultString: TypeClass[String] = new TypeClass[String] {
+    def value: String = "implicit-in-companion"
+  }
+
+  def ignoreDefault[A]: A = macro ignoreDefaultImpl[A]
+
+  def ignoreDefaultImpl[A](c: blackbox.Context)(implicit tt: c.WeakTypeTag[A]): c.Expr[A] = {
+    import c.universe._
+
+    val defaultStringSymbol = c.weakTypeOf[TypeClass.type].decl(TermName("defaultString"))
+
+    scala.util
+      .Try(c.inferImplicitValueIgnoring(weakTypeOf[TypeClass[A]], silent = true, withMacrosDisabled = false)(defaultStringSymbol))
+      .toOption
+      .filterNot(_ == EmptyTree) match {
+        case Some(default) => c.Expr[A](q"$default.value")
+        case None if weakTypeOf[A] <:< weakTypeOf[String] => c.Expr[A](q""" "ignoring-implicit-in-companion" """)
+        case None => c.abort(c.enclosingPosition, "No implicit value found")
+      }
+  }
+}

--- a/test/files/run/macro-implicit-ignoring/Test_2.scala
+++ b/test/files/run/macro-implicit-ignoring/Test_2.scala
@@ -1,0 +1,12 @@
+object Test extends App {
+
+  println(implicitly[TypeClass[String]].value)
+  println(TypeClass.ignoreDefault[String])
+  locally {
+    implicit val overridenDefaultString: TypeClass[String] = new TypeClass[String] {
+      def value: String = "not-ignoring-user-provided-implicit"
+    }
+    println(implicitly[TypeClass[String]].value)
+    println(TypeClass.ignoreDefault[String])
+  }
+}


### PR DESCRIPTION
This PR backports [`Expr.summonIgnoring`](https://github.com/scala/scala3/discussions/21909#discussioncomment-11283363) that was introduced in [3.7.0](https://github.com/scala/scala3/releases/tag/3.7.0).

On 3.7.0 it allowed:

 - faster recursive derivation of type classes with more performant code (vide [presentation](https://www.youtube.com/watch?v=M54ux51H6Fo))
 - without fragile type-level tricks that got broken by change to 3.7.0 givens

However, it increased the maintenance burden on such libraries since they need to implement 2 different hierarchies to keep the behavior consistent. It might also burden users who would like to use such libraries and cross-compile their codebases.

By adding just 1 public macro method - and keeping the behavior and signatures of all the other methods unchanged - libraries that use such solutions to improve the QoL of their users could have once again align how the code looks and behaves, preventing unnecessary friction during the 2->3 migration process.