### PR TITLE
improvement (?): Allow for clearing JrtClassPath caches

### DIFF
--- a/src/compiler/scala/tools/nsc/classpath/DirectoryClassPath.scala
+++ b/src/compiler/scala/tools/nsc/classpath/DirectoryClassPath.scala
@@ -140,6 +140,10 @@ trait JFileDirectoryLookup[FileEntryType <: ClassRepresentation] extends Directo
 object JrtClassPath {
   private val jrtClassPathCache = new FileBasedCache[Option[String], JrtClassPath]()
   private val ctSymClassPathCache = new FileBasedCache[String, CtSymClassPath]()
+  def clearCaches(): Unit = {
+    jrtClassPathCache.clear()     
+    ctSymClassPathCache.clear()
+  }
   def apply(release: Option[String], systemPath: Option[String], unsafe: Option[List[String]], closeableRegistry: CloseableRegistry): List[ClassPath] =
     if (!isJavaAtLeast("9")) Nil
     else {

--- a/src/compiler/scala/tools/nsc/classpath/ZipAndJarFileLookupFactory.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ZipAndJarFileLookupFactory.scala
@@ -203,6 +203,12 @@ final class FileBasedCache[K, T] {
         case null =>
         case task => task.cancel()
       }
+    def close(): Unit = {
+      t match {
+        case cl: Closeable => cl.close()
+        case _ =>
+      }
+    }
   }
   private val cache = collection.mutable.Map.empty[(K, Seq[Path]), Entry]
 
@@ -311,7 +317,7 @@ final class FileBasedCache[K, T] {
 
   def clear(): Unit = cache.synchronized {
     // TODO support closing
-    // cache.valuesIterator.foreach(_.close())
+    cache.valuesIterator.foreach(_.close())
     cache.clear()
   }
 }


### PR DESCRIPTION
In long running sessions of presentation compiler it seem like these caches can easily get corrupted and we longer can use the compiler within the current JVM or classloader.

I couldn't find the exact problem, but this is the only difference with Scala 2.12 and Scala 3, where those caches are not present. We don'tget those issues there.

I added a workaround in Metals for this, but it uses reflection quite heavily.

**Alternatively, maybe this caching is not needed? I see that it's created only in Global once, so maybe we could cache it in Global instead?**

The workaround with reflection is in https://github.com/scalameta/metals/pull/7541/files

Should help with https://github.com/scala/bug/issues/13045