### PR TITLE
Make ClassfileParser robust for directly reading Java inner classes

### DIFF
--- a/test/files/run/t9152.check
+++ b/test/files/run/t9152.check
@@ -1,0 +1,42 @@
+
+scala> :power
+Power mode enabled. :phase is at typer.
+import scala.tools.nsc._, intp.global._, definitions._
+Try :help or completions for vals._ and power._
+
+scala> import rootMirror._
+import rootMirror._
+
+scala> getClassIfDefined("p.C1$I").info
+val res0: $r.intp.global.Type =
+p.C1 {
+  private[package p] def <init>(): p.C1$I
+}
+
+scala> getClassIfDefined("p.C2$I").info
+val res1: $r.intp.global.Type =
+Object {
+  private[package p] def <init>(): p.C2$I
+  private[package p] def foo(): p.C2[_]
+}
+
+scala> getClassIfDefined("p.C1$I") // symbol unlinked after reading C1
+val res2: $r.intp.global.Symbol = <none>
+
+scala> getClassIfDefined("p.C2$I") // symbol unlinked after reading C2
+val res3: $r.intp.global.Symbol = <none>
+
+scala> getClassIfDefined("p.C1").info.member(TypeName("I")).info
+val res4: $r.intp.global.Type =
+p.C1[X] {
+  private[package p] def <init>(): C1.this.I
+}
+
+scala> getClassIfDefined("p.C2").info.member(TypeName("I")).info
+val res5: $r.intp.global.Type =
+Object {
+  private[package p] def <init>(): C2.this.I
+  private[package p] def foo(): p.C2[X]
+}
+
+scala> :quit

--- a/test/files/run/t9152/C_1.java
+++ b/test/files/run/t9152/C_1.java
@@ -1,0 +1,11 @@
+package p;
+
+class C1<X> {
+  class I extends C1<X> { }
+}
+
+class C2<X> {
+  class I {
+    C2<X> foo() { return null; }
+  }
+}

--- a/test/files/run/t9152/Test.scala
+++ b/test/files/run/t9152/Test.scala
@@ -1,0 +1,17 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  // before java 21, nested classes have a `this$0` accessor
+  override def eval(): Iterator[String] = super.eval().filterNot(_.contains("val this$0"))
+
+  def code = """
+    |:power
+    |import rootMirror._
+    |getClassIfDefined("p.C1$I").info
+    |getClassIfDefined("p.C2$I").info
+    |getClassIfDefined("p.C1$I") // symbol unlinked after reading C1
+    |getClassIfDefined("p.C2$I") // symbol unlinked after reading C2
+    |getClassIfDefined("p.C1").info.member(TypeName("I")).info
+    |getClassIfDefined("p.C2").info.member(TypeName("I")).info
+  """.stripMargin
+}


### PR DESCRIPTION
Usually when the ClassfileParser reads a classfile for a Java inner class, the entry point is the outer class, the inner symbol is created in `enterOwnInnerClasses`.

But when scanning the classpath, a Symbol is also created because of the presence of the `C$I.class` classfile. (This symbol is later unlinked and marked invalid.) When invoking the classfile parser on this symbol directly, reading generic signatures can fail because they may refer to type variables defined in the outer class:

```
class C1<X> {
  // signature: Lp/C1<TX;>; -- `TX;` references outer `X`
  class I extends C1<X> { }
}
```

Fixes https://github.com/scala/bug/issues/9152