### PR TITLE
No dealias of type ctor in typedNew

### DIFF
--- a/test/files/neg/t6779.check
+++ b/test/files/neg/t6779.check
@@ -1,0 +1,12 @@
+t6779.scala:9: warning: class Annotee is deprecated
+  def f = new Annotee // error
+              ^
+t6779.scala:15: warning: type TR in class C is deprecated
+  final def g: String = if (b) g else "" // error
+            ^
+t6779.scala:17: warning: type TR in class C is deprecated
+  def h = new TR // error
+              ^
+error: No warnings can be incurred under -Werror.
+3 warnings
+1 error

--- a/test/files/neg/t6779.scala
+++ b/test/files/neg/t6779.scala
@@ -1,0 +1,18 @@
+//> using options -deprecation -Werror
+
+@Deprecated
+class Annotee
+
+class C {
+  def b = true
+
+  def f = new Annotee // error
+
+  @deprecated
+  type TR = annotation.tailrec
+
+  @TR
+  final def g: String = if (b) g else "" // error
+
+  def h = new TR // error
+}

--- a/test/files/pos/t11387.scala
+++ b/test/files/pos/t11387.scala
@@ -1,0 +1,7 @@
+//> using options -Werror -Wunused:privates
+
+class Foo
+object Foo {
+  private type Alias = Foo
+  def x: Foo = new Alias
+}

--- a/test/files/run/t4535.check
+++ b/test/files/run/t4535.check
@@ -1,3 +1,6 @@
+t4535.scala:8: warning: type ArrayStack in package mutable is deprecated (since 2.13.0): Use Stack instead of ArrayStack; it now uses an array-based implementation
+    val as = new mutable.ArrayStack[Int]
+                         ^
 Stack(1, 2, 3)
 Stack(1, 2, 3, 4, 5, 6)
 Stack(6, 5, 4, 3, 2, 1)

--- a/test/files/run/t4535.scala
+++ b/test/files/run/t4535.scala
@@ -1,3 +1,4 @@
+//> using options -deprecation
 import collection._
 
 // #4535


### PR DESCRIPTION
Fixes scala/bug#11387
Fixes scala/bug#6779

Dealiasing in `typedNew` was added while tightening screws all around, but now it seems to be more conservative than necessary.

Dotty keeps the type member selection until erasure.
