### PR TITLE
Improve unused check of macro expansion

### DIFF
--- a/test/files/pos/t10313a.scala
+++ b/test/files/pos/t10313a.scala
@@ -1,0 +1,14 @@
+//> using options -Werror -Xlint:unused
+//-Vprint:typer -Vmacro
+
+import scala.util.matching.Regex
+
+// guard against regression in reporting constant `esc` unused
+object Naming {
+  private final val esc = "\u001b"
+  private val csi = raw"$esc\[[0-9;]*([\x40-\x7E])"
+  private lazy val cleaner = raw"$csi|([\p{Cntrl}&&[^\p{Space}]]+)|$linePattern".r
+  private def linePattern: String = ""
+  private def clean(m: Regex.Match): Option[String] = None
+  def unmangle(str: String): String = cleaner.replaceSomeIn(str, clean)
+}


### PR DESCRIPTION
Fixes scala/bug#10313

`-Vmacro` shows the shapeless Record expanding the reference to the type alias `X` and then eliminating it, but this commit just improves handling of types in the macro expandee. Some code is refactored out in the main traverser and reused in the `refCollector` (that seeks to collect references but not new definitions from a macro expansion).

Debug output for the example, showing `X` reached from `Y`:
```
AnyRef{type T = shapeless.labelled.FieldType[Symbol @@ String("b"),ex.Foo.X] :: shapeless.HNil} referenced from type Y
shapeless.labelled.FieldType[Symbol @@ String("b"),ex.Foo.X] :: shapeless.HNil referenced from type Y
shapeless.labelled.FieldType[Symbol @@ String("b"),ex.Foo.X] referenced from type Y
Symbol @@ String("b") referenced from type Y
alias ex.Foo.X referenced from type Y
```
(Still needs a standalone test.)