### PR TITLE
bugfix: Try and avoid potential race condition in compiler

### DIFF
--- a/src/compiler/scala/tools/nsc/classpath/ZipAndJarFileLookupFactory.scala
+++ b/src/compiler/scala/tools/nsc/classpath/ZipAndJarFileLookupFactory.scala
@@ -18,6 +18,7 @@ import java.nio.file.Files
 import java.nio.file.attribute.{BasicFileAttributes, FileTime}
 import java.util.{Timer, TimerTask}
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicBoolean
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.reflect.io.{AbstractFile, FileZipArchive, ManifestResources}
@@ -212,10 +213,9 @@ final class FileBasedCache[K, T] {
     e.cancelTimer()
 
     new Closeable {
-      var closed = false
+      val closed = new AtomicBoolean(false)
       override def close(): Unit = {
-        if (!closed) {
-          closed = true
+        if (closed.compareAndSet(false, true)) {
           val count = e.referenceCount.decrementAndGet()
           if (count == 0) {
             e.t match {


### PR DESCRIPTION
Most likely related to https://github.com/scalameta/metals/issues/7591

My guess is that we are running close twice somehow, maybe two compiler restarts close to each other.