### PR TITLE
Fix ArraySeq.ofFloat/ofDouble.equals for floating point

### DIFF
--- a/src/library/scala/collection/immutable/ArraySeq.scala
+++ b/src/library/scala/collection/immutable/ArraySeq.scala
@@ -575,7 +575,14 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
     def apply(i: Int): Float = unsafeArray(i)
     override def hashCode = MurmurHash3.arraySeqHash(unsafeArray)
     override def equals(that: Any) = that match {
-      case that: ofFloat => Arrays.equals(unsafeArray, that.unsafeArray)
+      case that: ofFloat =>
+        val array = unsafeArray
+        val thatArray = that.unsafeArray
+        (array eq thatArray) || array.length == thatArray.length && {
+          var i = 0
+          while (i < array.length && array(i) == thatArray(i)) i += 1
+          i >= array.length
+        }
       case _ => super.equals(that)
     }
     override def iterator: Iterator[Float] = new ArrayOps.ArrayIterator[Float](unsafeArray)
@@ -610,7 +617,14 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
     def apply(i: Int): Double = unsafeArray(i)
     override def hashCode = MurmurHash3.arraySeqHash(unsafeArray)
     override def equals(that: Any) = that match {
-      case that: ofDouble => Arrays.equals(unsafeArray, that.unsafeArray)
+      case that: ofDouble =>
+        val array = unsafeArray
+        val thatArray = that.unsafeArray
+        (array eq thatArray) || array.length == thatArray.length && {
+          var i = 0
+          while (i < array.length && array(i) == thatArray(i)) i += 1
+          i >= array.length
+        }
       case _ => super.equals(that)
     }
     override def iterator: Iterator[Double] = new ArrayOps.ArrayIterator[Double](unsafeArray)

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -286,7 +286,13 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
     def update(index: Int, elem: Float): Unit = { array(index) = elem }
     override def hashCode = MurmurHash3.arraySeqHash(array)
     override def equals(that: Any) = that match {
-      case that: ofFloat => Arrays.equals(array, that.array)
+      case that: ofFloat =>
+        val thatArray = that.array
+        (array eq thatArray) || array.length == thatArray.length && {
+          var i = 0
+          while (i < array.length && array(i) == thatArray(i)) i += 1
+          i >= array.length
+        }
       case _ => super.equals(that)
     }
     override def iterator: Iterator[Float] = new ArrayOps.ArrayIterator[Float](array)
@@ -306,7 +312,13 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
     def update(index: Int, elem: Double): Unit = { array(index) = elem }
     override def hashCode = MurmurHash3.arraySeqHash(array)
     override def equals(that: Any) = that match {
-      case that: ofDouble => Arrays.equals(array, that.array)
+      case that: ofDouble =>
+        val thatArray = that.array
+        (array eq thatArray) || array.length == thatArray.length && {
+          var i = 0
+          while (i < array.length && array(i) == thatArray(i)) i += 1
+          i >= array.length
+        }
       case _ => super.equals(that)
     }
     override def iterator: Iterator[Double] = new ArrayOps.ArrayIterator[Double](array)

--- a/test/junit/scala/collection/immutable/ArraySeqTest.scala
+++ b/test/junit/scala/collection/immutable/ArraySeqTest.scala
@@ -209,4 +209,25 @@ class ArraySeqTest {
       assertEquals(a ++: b, expect)
     }
   }
+
+  @Test
+  def t13108(): Unit = {
+    def checkBoth[A: ClassTag](check: (ArraySeq[A], ArraySeq[A]) => Unit, a: ArraySeq[A], b: ArraySeq[A]): Unit = {
+      check(a, b)
+      check(a.map(identity), b)
+      check(a, b.map(identity))
+      check(a.map(identity), b.map(identity))
+    }
+    def checkEquals[A: ClassTag](a: ArraySeq[A], b: ArraySeq[A]): Unit = checkBoth(assertEquals, a, b)
+    def checkNotEquals[A: ClassTag](a: ArraySeq[A], b: ArraySeq[A]): Unit = checkBoth(assertNotEquals, a, b)
+
+    checkEquals(ArraySeq(1, 2, 3), ArraySeq(1, 2, 3))
+    checkNotEquals(ArraySeq(1, 2, 3), ArraySeq(1, 2))
+    checkNotEquals(ArraySeq(1, 2, 3), ArraySeq(1, 2, 4))
+    checkNotEquals(ArraySeq(1, 2, 3), ArraySeq(1, 2, 3, 4))
+    checkEquals(ArraySeq(-0.0f), ArraySeq(0.0f))
+    checkEquals(ArraySeq(-0.0), ArraySeq(0.0))
+    checkNotEquals(ArraySeq(Double.NaN), ArraySeq(Double.NaN))
+    checkNotEquals(ArraySeq(Float.NaN), ArraySeq(Float.NaN))
+  }
 }

--- a/test/junit/scala/collection/mutable/ArraySeqTest.scala
+++ b/test/junit/scala/collection/mutable/ArraySeqTest.scala
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import scala.collection.immutable.Seq
+import scala.reflect.ClassTag
 
 @RunWith(classOf[JUnit4])
 class ArraySeqTest {
@@ -79,6 +80,27 @@ class ArraySeqTest {
     assertEquals("1 2 3 4 5 6 7", ArraySeq('1', '2', '3', '4', '5', '6', '7').mkString(" "))
     // this wraps as `ArraySeq` via `Predef`
     assertEquals("1 2 3 4 5 6 7", Array('1', '2', '3', '4', '5', '6', '7').mkString(" "))
+  }
+
+  @Test
+  def t13108(): Unit = {
+    def checkBoth[A: ClassTag](check: (ArraySeq[A], ArraySeq[A]) => Unit, a: ArraySeq[A], b: ArraySeq[A]): Unit = {
+      check(a, b)
+      check(a.map(identity), b)
+      check(a, b.map(identity))
+      check(a.map(identity), b.map(identity))
+    }
+    def checkEquals[A: ClassTag](a: ArraySeq[A], b: ArraySeq[A]): Unit = checkBoth(assertEquals, a, b)
+    def checkNotEquals[A: ClassTag](a: ArraySeq[A], b: ArraySeq[A]): Unit = checkBoth(assertNotEquals, a, b)
+
+    checkEquals(ArraySeq(1, 2, 3), ArraySeq(1, 2, 3))
+    checkNotEquals(ArraySeq(1, 2, 3), ArraySeq(1, 2))
+    checkNotEquals(ArraySeq(1, 2, 3), ArraySeq(1, 2, 4))
+    checkNotEquals(ArraySeq(1, 2, 3), ArraySeq(1, 2, 3, 4))
+    checkEquals(ArraySeq(-0.0f), ArraySeq(0.0f))
+    checkEquals(ArraySeq(-0.0), ArraySeq(0.0))
+    checkNotEquals(ArraySeq(Double.NaN), ArraySeq(Double.NaN))
+    checkNotEquals(ArraySeq(Float.NaN), ArraySeq(Float.NaN))
   }
 }
 


### PR DESCRIPTION
This fixes https://github.com/scala/bug/issues/13108 when comparing Seq[Float] with Seq[Float] it expected
that Float.NaN != Float.NaN and 0.0 equals -0.0f. But before this patch
this was violated by ArraySeq.ofFloat/ofDouble
