### PR TITLE
Check reflective if ident ref is selection [ci: last-only]

### DIFF
--- a/test/files/neg/t13109.check
+++ b/test/files/neg/t13109.check
@@ -1,0 +1,15 @@
+t13109.scala:6: warning: reflective access of structural type member method x should be enabled
+by making the implicit value scala.language.reflectiveCalls visible.
+This can be achieved by adding the import clause 'import scala.language.reflectiveCalls'
+or by setting the compiler option -language:reflectiveCalls.
+See the Scaladoc for value scala.language.reflectiveCalls for a discussion
+why the feature should be explicitly enabled.
+  def f1 = b.x // warn
+             ^
+t13109.scala:10: warning: reflective access of structural type member method x should be enabled
+by making the implicit value scala.language.reflectiveCalls visible.
+    x // also expect warn but not report
+    ^
+error: No warnings can be incurred under -Werror.
+2 warnings
+1 error

--- a/test/files/neg/t13109.scala
+++ b/test/files/neg/t13109.scala
@@ -1,0 +1,12 @@
+//> using options -feature -Werror
+
+class A {
+  val b = new AnyRef { def x: Int = 2 }
+
+  def f1 = b.x // warn
+
+  def f2 = {
+    import b._
+    x // also expect warn but not report
+  }
+}

--- a/test/files/presentation/doc/doc.scala
+++ b/test/files/presentation/doc/doc.scala
@@ -1,4 +1,4 @@
-//> using options -Xlint -Werror
+//> using options -Xlint -Werror -feature -language:reflectiveCalls
 import scala.reflect.internal.util.{ BatchSourceFile, SourceFile }
 import scala.tools.nsc.doc
 import scala.tools.nsc.doc.base._


### PR DESCRIPTION
Fixes scala/bug#13109

Some identifier references are implicitly selections.