### PR TITLE
Never emit abstract final inner class [ci: last-only]

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -533,10 +533,16 @@ abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
 
       enterOwnInnerClasses()
 
-      clazz setInfo completer
-      clazz setFlag sflags
+      clazz.setInfo(completer)
+      clazz.setFlag(sflags)
+
+      // Kotlin interop (scala/bug#13110)
+      if (clazz.isAbstract)
+        clazz.resetFlag(Flags.FINAL)
+
       moduleClass setInfo staticInfo
       moduleClass setFlag JAVA
+
       staticModule setInfo moduleClass.tpe
       staticModule setFlag JAVA
 

--- a/test/files/run/t13110/J.java
+++ b/test/files/run/t13110/J.java
@@ -1,0 +1,11 @@
+
+public interface J {
+    void f(E e);
+
+    enum E {
+        X {
+            public void g() { return; }
+	};
+        abstract public void g();
+    }
+}

--- a/test/files/run/t13110/test_2.scala
+++ b/test/files/run/t13110/test_2.scala
@@ -1,0 +1,8 @@
+
+class JImpl extends J {
+  override def f(e: J.E): Unit = ()
+}
+
+object Test extends App {
+  new JImpl
+}


### PR DESCRIPTION
Fixes scala/bug#13110

The commit just massages the flags for the `InnerClasses` attribute. It follows Dotty in dropping `final` and retaining `abstract`.

It might be nicer to notice the discrepancy earlier, ~but for this case it doesn't matter, perhaps~ so go ahead and reset `final` on a symbol that is understood to be abstract by `ClassfileParser`.

This Java test is not meaningful except as a regression test or to demonstrate Java behavior.

The local test:
```
//> using dep org.jetbrains:markdown-jvm:0.7.3
//> using scala 2.13.17-bin-SNAPSHOT

import org.intellij.markdown.parser.LookaheadText
import org.intellij.markdown.parser.constraints.MarkdownConstraints
import org.intellij.markdown.parser.markerblocks.MarkerBlock

object Main {
  def main(args: Array[String]): Unit = {
    println(new MyClass)
  }
}

class MyClass extends MarkerBlock {
  override def acceptAction(closingAction: MarkerBlock.ClosingAction): Boolean = ???
  override def allowsSubBlocks(): Boolean = ???
  override def getBlockConstraints: MarkdownConstraints = ???
  override def getNextInterestingOffset(position: LookaheadText#Position): Int = ???
  override def isInterestingOffset(position: LookaheadText#Position): Boolean = ???
  override def processToken(position: LookaheadText#Position, markdownConstraints: MarkdownConstraints): MarkerBlock.ProcessingResult = ???
}
```
I verified that the class flag fix works without the backstop for the attribute.