### PR TITLE
chore: add stdlib in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,8 @@
 # Files of which NthPortal has a lot of knowledge. Wildcards cover tests
 *LazyList*  @NthPortal
 **/scala/util/Using*  @NthPortal
+
+# Any changes to the Scala 2 Standard Library must be approve
+# by one of the officers responsible of maintaining it
+/src/library/      @scala/stdlib-officers
+/src/library-aux/  @scala/stdlib-officers


### PR DESCRIPTION
We make sure that any changes to the stdlib is reviewed by the @scala/stdlib-officers from now.