### PR TITLE
Do not import any sbt subprojects in IntelliJ IDEA in which BSP is disabled

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -447,7 +447,7 @@ lazy val skipProjectInIDEs: Seq[Setting[_]] = Seq(
   bspEnabled := false,
   // Additionally, the current project should not be imported in IntelliJ IDEA.
   // The setting is defined in https://github.com/JetBrains/sbt-ide-settings?tab=readme-ov-file#using-the-settings-without-plugin
-  SettingKey[Boolean]("ide-skip-project") := !bspEnabled.value
+  SettingKey[Boolean]("ide-skip-project").withRank(KeyRanks.Invisible) := !bspEnabled.value
 )
 
 // This project provides the STARR scalaInstance for bootstrapping


### PR DESCRIPTION
- This change improves the development experience of the Scala 2 compiler repo in IntelliJ IDEA when using the default sbt project import flow.
- All sbt projects which are not exported to BSP clients are now also not imported into IntelliJ IDEA.

I'd also like to discuss backporting these changes to the 2.12.x branch, which is still actively maintained.

Additionally, I'd like to start a discussion about the current state of the "IDE Setup" [section](https://github.com/scala/scala?tab=readme-ov-file#ide-setup) of the README and potentially contribute some updates to it.

I tried importing the project in IntelliJ IDEA by running the `sbt intellij` script which generates the IDEA project files and opening the repository that way, as recently as last week. I observed that the project could not be built and fails during compilation. On the other hand, just opening the repository directory in IDEA and letting the default sbt import do its thing, fully imports the project and allows it to be compiled without issues.

Thanks in advance.