### PR TITLE
Making natives test working on newer jdk then 8

### DIFF
--- a/test/files/jvm/natives.scala
+++ b/test/files/jvm/natives.scala
@@ -4,24 +4,21 @@ object Test {
 
   //println("java.library.path=" + System.getProperty("java.library.path"))
 
-  val userNativelib = System.getenv("scala_test_nativelib") // set to 'natives' for freshly built binary on linux. See mkLibNatives.sh
-  val os = System.getProperty("os.name")
-  val arch = System.getProperty("os.arch")
-  var libName = ""
-
-  if (userNativelib == null) {
-    libName = (os, arch) match {
-      case ("Mac OS X", "aarch64") =>
-        "natives-arm"
-      case ("Mac OS X", "x86_64") =>
-        "natives-x86"
-      case _ =>
-         val wordSize = System.getProperty("sun.arch.data.model", "32")
-        "natives-" + wordSize
-    }
-  } else {
-    libName=userNativelib
-  }
+  val libName =
+    // set to 'natives' for freshly built binary on linux. See mkLibNatives.sh
+    sys.env.getOrElse("scala_test_nativelib", {
+      val os = sys.props("os.name")
+      val arch = sys.props("os.arch")
+      (os, arch) match {
+        case ("Mac OS X", "aarch64") =>
+          "natives-arm"
+        case ("Mac OS X", "x86_64") =>
+          "natives-x86"
+        case _ =>
+          val wordSize = sys.props.getOrElse("sun.arch.data.model", "32")
+          s"natives-$wordSize"
+      }
+    })
 
   System.loadLibrary(libName)
 

--- a/test/files/jvm/natives.scala
+++ b/test/files/jvm/natives.scala
@@ -4,17 +4,23 @@ object Test {
 
   //println("java.library.path=" + System.getProperty("java.library.path"))
 
+  val userNativelib = System.getenv("scala_test_nativelib") // set to 'natives' for freshly built binary on linux. See mkLibNatives.sh
   val os = System.getProperty("os.name")
   val arch = System.getProperty("os.arch")
+  var libName = ""
 
-  val libName = (os, arch) match {
-    case ("Mac OS X", "aarch64") =>
-      "natives-arm"
-    case ("Mac OS X", "x86_64") =>
-      "natives-x86"
-    case _ =>
-       val wordSize = System.getProperty("sun.arch.data.model", "32")
-      "natives-" + wordSize
+  if (userNativelib == null) {
+    libName = (os, arch) match {
+      case ("Mac OS X", "aarch64") =>
+        "natives-arm"
+      case ("Mac OS X", "x86_64") =>
+        "natives-x86"
+      case _ =>
+         val wordSize = System.getProperty("sun.arch.data.model", "32")
+        "natives-" + wordSize
+    }
+  } else {
+    libName=userNativelib
   }
 
   System.loadLibrary(libName)


### PR DESCRIPTION
Hello!

I'm running the native test on s390x and ppc64le, and I use it with newer jdk then 8. Then of course I'm running against freshly build libnatives.so.

This small PR is doing my life much more easier and is removing the depndece on legacy JDK.  Wdyt?

Note, that "new" header file is slightly different"
```
@@ -8,11 +8,11 @@
 extern "C" {
 #endif
 /*
- * Class:     Test__
- * Method:    sayHello
- * Signature: (Ljava/lang/String;)Ljava/lang/String;
+ * Class:      Test__
+ * Method:     sayHello
+ * Signature:  (Ljava/lang/String;)Ljava/lang/String;
  */
-JNIEXPORT jstring JNICALL Java_Test_00024_sayHello
+JNIEXPORT jstring JNICALL Java_Test___sayHello
   (JNIEnv *, jobject, jstring);
 
 #ifdef __cplusplus
```

But works fine