### PR TITLE
Backport missing interpolator skips unpositioned literal

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5612,7 +5612,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           // testing pos works and may suffice
           //openMacros exists (_.macroApplication.pos includes lit.pos)
           // tests whether the lit belongs to the expandee of an open macro
-          openMacros exists (_.macroApplication.attachments.get[MacroExpansionAttachment] match {
+          !lit.pos.isDefined ||
+          openMacros.exists(_.macroApplication.attachments.get[MacroExpansionAttachment] match {
             case Some(MacroExpansionAttachment(_, t: Tree)) => t exists (_ == lit)
             case _                                          => false
           })

--- a/test/files/pos/t13116/inpervolated_2.scala
+++ b/test/files/pos/t13116/inpervolated_2.scala
@@ -1,0 +1,25 @@
+// scalac: -Werror -Xlint
+
+import annotation._
+
+package t8013 {
+
+  // unsuspecting user of perverse macro
+  trait User {
+    import Perverse._
+    val foo = "bar"
+    Console.println {
+      p"Hello, $foo"
+    }
+    Console.println {
+      p(s"Hello, $foo")
+    }
+    Console.println {
+      "Hello, $foo"
+    }: @nowarn
+  }
+}
+
+object Test extends App {
+  new t8013.User {}
+}

--- a/test/files/pos/t13116/inpervolator_1.scala
+++ b/test/files/pos/t13116/inpervolator_1.scala
@@ -1,0 +1,36 @@
+
+package t8013
+
+// perverse macro to confuse Xlint
+
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox.Context
+
+object Perverse {
+
+  implicit class Impervolator(sc: StringContext) {
+    def p(args: Any*): String = macro pImpl
+  }
+  // remarkably, the args are unused; notice the difficulty of adding a non-interpolator version
+  def p(args: Any*): String = macro pImpl
+
+  // turn a nice interpolation into something that looks
+  // nothing like an interpolation or anything we might
+  // recognize, but which includes a "$id" in an apply.
+  def pImpl(c: Context)(args: c.Expr[Any]*): c.Expr[String] = {
+    import c.universe._
+    val macroPos = c.macroApplication.pos
+    val text = macroPos.source.lineToString(macroPos.line - 1) substring macroPos.column
+    val tt = Literal(Constant(text))
+    c.typecheck(tt)
+    val tree = q"t8013.Perverse.pervert($tt)"
+    c.Expr[String](tree)
+  }
+
+  // identity doesn't seem very perverse in this context
+  //def pervert(text: String): String = text
+  def pervert(text: String): String = {
+    Console println s"Perverting [$text]"
+    text
+  }
+}


### PR DESCRIPTION
Minimalist backport since weaver-test still builds for 2.12.

Not for forward-merge!