### PR TITLE
Revert "Adjust apt source for postgres"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,6 @@ jobs:
         - bundle install --path vendor/bundle
         # https://travis-ci.community/t/travis-focal-ubuntu-image-uses-now-expired-mongodb-4-4-package/14293/3
         - wget -qO - https://www.mongodb.org/static/pgp/server-4.4.asc | sudo apt-key add -
-        # https://www.postgresql.org/about/news/announcing-apt-archivepostgresqlorg-2024
-        - sudo sed -i 's|http://apt.postgresql.org/pub/repos/apt|https://apt-archive.postgresql.org/pub/repos/apt|g' /etc/apt/sources.list.d/postgresql.list
         # cribbed from https://github.com/SebastiaanKlippert/go-wkhtmltopdf/blob/master/.travis.yml
         - sudo apt-get update
         - sudo apt-get install -y build-essential xorg xfonts-75dpi libpng16-16 libssl1.1


### PR DESCRIPTION
This reverts https://github.com/scala/scala/pull/11108.

I swear I tested it, but now the postgres repo no longer seems to be in any of the sources.list files. Maybe they fixed it on the travis side.