### PR TITLE
CI: upgrade setup-java to v5

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{matrix.java}}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 8


### PR DESCRIPTION
Dependabot submitted this on 2.13.x; I'm resubmitting on 2.12.x instead, plus Yoshida-san changed our Dependabot branch settings so any future upgrades will go to 2.12.x
