### PR TITLE
Prevent presentation compiler crash on base type cache invalidation

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -5291,6 +5291,12 @@ trait Types
       } finally res = saved
     }
 
+    private def needClearBaseTypeCache(ct: CompoundType) = {
+      // was `ct.baseClasses.exists(changedSymbols)`, but `baseClasses` may force types early (scala/bug#13112)
+      val cache = ct.baseTypeSeqCache
+      cache != null && changedSymbols.exists(cache.baseTypeIndex(_) >= 0)
+    }
+
     def apply(tp: Type): Unit = tp match {
       case _ if seen.containsKey(tp) =>
 
@@ -5304,7 +5310,7 @@ trait Types
         }
         seen.put(tp, res)
 
-      case ct: CompoundType if ct.baseClasses.exists(changedSymbols) =>
+      case ct: CompoundType if needClearBaseTypeCache(ct) =>
         ct.invalidatedCompoundTypeCaches()
         res = true
         seen.put(tp, res)

--- a/test/junit/scala/tools/nsc/interactive/PresentationCompilerTest.scala
+++ b/test/junit/scala/tools/nsc/interactive/PresentationCompilerTest.scala
@@ -1,0 +1,34 @@
+package scala.tools.nsc.interactive
+
+import org.junit.Test
+
+import scala.reflect.internal.util.BatchSourceFile
+import scala.tools.nsc.interactive.tests.InteractiveTest
+
+class PresentationCompilerTest {
+  @Test def run13112(): Unit = {
+    t13112.main(null)
+  }
+}
+
+object t13112 extends InteractiveTest {
+  val code =
+    """case class Foo(name: String = "")
+      |object Foo extends Foo("")
+      |""".stripMargin
+
+  override def execute(): Unit = {
+    val source = new BatchSourceFile("Foo.scala", code)
+
+    val res = new Response[Unit]
+    compiler.askReload(List(source), res)
+    res.get
+    askLoadedTyped(source).get
+
+    // the second round was failing (see scala/bug#13112 for details)
+    compiler.askReload(List(source), res)
+    res.get
+    val reloadRes = askLoadedTyped(source).get
+    assert(reloadRes.isLeft)
+  }
+}


### PR DESCRIPTION
See [bug description for details](https://github.com/scala/bug/issues/13112#issuecomment-3236366017).

Fixes https://github.com/scala/bug/issues/13112