### PR TITLE
feat: Add `andThen` to Function2.

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -78,6 +78,26 @@ object MimaFilters extends AutoPlugin {
 
     // scala/scala#11124
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.JavaUniverse.knownFalseSubTypes"),
+
+    // ADD andThen to Function2 in Scala 2.13.17 scala/scala#11121
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.Function2.andThen"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.jdk.FunctionWrappers#FromJavaBiConsumer.andThen"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.jdk.FunctionWrappers#FromJavaBiFunction.andThen"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.jdk.FunctionWrappers#FromJavaBiPredicate.andThen"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.jdk.FunctionWrappers#FromJavaBinaryOperator.andThen"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.jdk.FunctionWrappers#FromJavaDoubleBinaryOperator.andThen"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.jdk.FunctionWrappers#FromJavaIntBinaryOperator.andThen"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.jdk.FunctionWrappers#FromJavaLongBinaryOperator.andThen"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.jdk.FunctionWrappers#FromJavaObjDoubleConsumer.andThen"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.jdk.FunctionWrappers#FromJavaObjIntConsumer.andThen"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.jdk.FunctionWrappers#FromJavaObjLongConsumer.andThen"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.jdk.FunctionWrappers#FromJavaToDoubleBiFunction.andThen"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.jdk.FunctionWrappers#FromJavaToIntBiFunction.andThen"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.jdk.FunctionWrappers#FromJavaToLongBiFunction.andThen"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.AbstractFunction2.andThen"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.macros.ParseException.andThen"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.macros.ReificationException.andThen"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.macros.TypecheckException.andThen")
   )
 
   override val buildSettings = Seq(

--- a/project/genprod.scala
+++ b/project/genprod.scala
@@ -199,6 +199,7 @@ object FunctionTwo extends Function(2) {
    *  @tparam   A   the result type of function `g`
    *  @param    g   a function R => A
    *  @return       a new function `f` such that `f(x1, x2) == g(apply(x1, x2))`
+   *  @since    2.13.17
    */
   @annotation.unspecialized def andThen[A](g: R => A): (T1, T2) => A = { (v1, v2) => g(apply(v1, v2)) }
 """  + curryMethod + tupleMethod

--- a/project/genprod.scala
+++ b/project/genprod.scala
@@ -131,7 +131,7 @@ object FunctionOne extends Function(1) {
  *  is that the latter can specify inputs which it will not handle."""
 
   override def moreMethods = """
-  /** Composes two instances of Function1 in a new Function1, with this function applied last.
+  /** Composes two instances of `Function1` in a new `Function1`, with this function applied last.
    *
    *  @tparam   A   the type to which function `g` can be applied
    *  @param    g   a function A => T1
@@ -139,7 +139,7 @@ object FunctionOne extends Function(1) {
    */
   @annotation.unspecialized def compose[A](g: A => T1): A => R = { x => apply(g(x)) }
 
-  /** Composes two instances of Function1 in a new Function1, with this function applied first.
+  /** Composes two instances of `Function1` in a new `Function1`, with this function applied first.
    *
    *  @tparam   A   the result type of function `g`
    *  @param    g   a function R => A
@@ -192,6 +192,16 @@ object FunctionTwo extends Function(2) {
  *    }
  *    assert(max(0, 1) == anonfun2(0, 1))
  * """)
+
+  override def moreMethods: String = """
+  /** Composes a `Function1` with this in a new `Function2`, with this function applied first.
+   *
+   *  @tparam   A   the result type of function `g`
+   *  @param    g   a function R => A
+   *  @return       a new function `f` such that `f(x1, x2) == g(apply(x1, x2))`
+   */
+  @annotation.unspecialized def andThen[A](g: R => A): (T1, T2) => A = { (v1, v2) => g(apply(v1, v2)) }
+"""  + curryMethod + tupleMethod
 }
 
 object Function {

--- a/src/library/scala/Function0.scala
+++ b/src/library/scala/Function0.scala
@@ -11,7 +11,7 @@
  */
 
 // GENERATED CODE: DO NOT EDIT.
-// genprod generated these sources at: 2025-09-05T14:31:34.771878Z
+// genprod generated these sources at: 2025-09-17T05:46:52.798640Z
 
 package scala
 

--- a/src/library/scala/Function0.scala
+++ b/src/library/scala/Function0.scala
@@ -11,7 +11,7 @@
  */
 
 // GENERATED CODE: DO NOT EDIT.
-// genprod generated these sources at: 2022-01-17T20:47:12.170348200Z
+// genprod generated these sources at: 2025-09-05T14:31:34.771878Z
 
 package scala
 

--- a/src/library/scala/Function2.scala
+++ b/src/library/scala/Function2.scala
@@ -38,6 +38,14 @@ trait Function2[@specialized(Specializable.Args) -T1, @specialized(Specializable
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2): R
+
+  /** Composes a `Function1` with this in a new `Function2`, with this function applied first.
+   *
+   *  @tparam   A   the result type of function `g`
+   *  @param    g   a function R => A
+   *  @return       a new function `f` such that `f(x1, x2) == g(apply(x1, x2))`
+   */
+  @annotation.unspecialized def andThen[A](g: R => A): (T1, T2) => A = { (v1, v2) => g(apply(v1, v2)) }
   /** Creates a curried version of this function.
    *
    *  @return   a function `f` such that `f(x1)(x2) == apply(x1, x2)`

--- a/src/library/scala/Function2.scala
+++ b/src/library/scala/Function2.scala
@@ -44,6 +44,7 @@ trait Function2[@specialized(Specializable.Args) -T1, @specialized(Specializable
    *  @tparam   A   the result type of function `g`
    *  @param    g   a function R => A
    *  @return       a new function `f` such that `f(x1, x2) == g(apply(x1, x2))`
+   *  @since    2.13.17
    */
   @annotation.unspecialized def andThen[A](g: R => A): (T1, T2) => A = { (v1, v2) => g(apply(v1, v2)) }
   /** Creates a curried version of this function.

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -212,11 +212,10 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
       }
       this
     case _ =>
-      class accum extends AbstractFunction2[K, V1, Unit] with Function1[(K, V1), Unit] {
+      class accum extends AbstractFunction2[K, V1, Unit] {
         var changed = false
         var shallowlyMutableNodeMap: Int = 0
         var current: BitmapIndexedMapNode[K, V1] = rootNode
-        def apply(kv: (K, V1)) = apply(kv._1, kv._2)
         def apply(key: K, value: V1): Unit = {
           val originalHash = key.##
           val improved = improve(originalHash)
@@ -252,7 +251,10 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
           if (it.isEmpty) this
           else {
             val accum = new accum
-            it.foreach(accum)
+            while(it.hasNext) {
+              val kv = it.next()
+              accum(kv._1, kv._2)
+            }
             newHashMapOrThis(accum.current)
           }
       }


### PR DESCRIPTION
Motivation:
The Java BiFunction has a `andThen` method, I think this should be nice for Scala 's Functio2 too.

The mima filter is still missing.