### PR TITLE
Named arg for infix is a migration warning

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -1014,7 +1014,7 @@ self =>
       def mkNamed(args: List[Tree]) = if (!isExpr) args else
         args.map(treeInfo.assignmentToMaybeNamedArg(_))
           .tap(res => if (currentRun.isScala3 && args.lengthCompare(1) == 0 && (args.head ne res.head))
-            deprecationWarning(args.head.pos.point, "named argument is deprecated for infix syntax", since="2.13.16"))
+            migrationWarning(args.head.pos.point, "named argument is deprecated for infix syntax", since="2.13.16"))
       var isMultiarg = false
       val arguments = right match {
         case Parens(Nil)               => literalUnit :: Nil

--- a/test/files/neg/infix-named-arg.check
+++ b/test/files/neg/infix-named-arg.check
@@ -1,6 +1,6 @@
-infix-named-arg.scala:5: warning: named argument is deprecated for infix syntax
+infix-named-arg.scala:4: error: named argument is deprecated for infix syntax
+Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or @nowarn to demote them to warnings or suppress.
+Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
   def f = 42 + (x = 1)
                   ^
-error: No warnings can be incurred under -Werror.
-1 warning
 1 error

--- a/test/files/neg/infix-named-arg.scala
+++ b/test/files/neg/infix-named-arg.scala
@@ -1,5 +1,4 @@
-
-//> using options -Werror -Xlint -Xsource:3
+//> using options -Xsource:3
 
 class C {
   def f = 42 + (x = 1)


### PR DESCRIPTION
Per https://github.com/scala/scala/pull/10857/files#r2329927042

```
-Xsource:3 issues migration warnings in category `cat=scala3-migration`
```
