### PR TITLE
Allow using `-Xsource-features` without `-Xsource:3`

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1178,19 +1178,19 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
       private val s = settings
       private val o = s.sourceFeatures
       import s.XsourceFeatures.contains
-      def caseApplyCopyAccess    = isScala3 && contains(o.caseApplyCopyAccess)
-      def caseCompanionFunction  = isScala3 && contains(o.caseCompanionFunction)
-      def caseCopyByName         = isScala3 && contains(o.caseCopyByName)
-      def inferOverride          = isScala3 && contains(o.inferOverride)
-      def noInferStructural      = isScala3 && contains(o.noInferStructural)
-      def any2StringAdd          = isScala3 && contains(o.any2StringAdd)
-      def unicodeEscapesRaw      = isScala3 && contains(o.unicodeEscapesRaw)
-      def stringContextScope     = isScala3 && contains(o.stringContextScope)
-      def leadingInfix           = isScala3 && contains(o.leadingInfix)
-      def packagePrefixImplicits = isScala3 && contains(o.packagePrefixImplicits)
-      def implicitResolution     = isScala3 && contains(o.implicitResolution) || settings.Yscala3ImplicitResolution.value
-      def doubleDefinitions      = isScala3 && contains(o.doubleDefinitions)
-      def etaExpandAlways        = isScala3 && contains(o.etaExpandAlways)
+      def caseApplyCopyAccess    = contains(o.caseApplyCopyAccess)
+      def caseCompanionFunction  = contains(o.caseCompanionFunction)
+      def caseCopyByName         = contains(o.caseCopyByName)
+      def inferOverride          = contains(o.inferOverride)
+      def noInferStructural      = contains(o.noInferStructural)
+      def any2StringAdd          = contains(o.any2StringAdd)
+      def unicodeEscapesRaw      = contains(o.unicodeEscapesRaw)
+      def stringContextScope     = contains(o.stringContextScope)
+      def leadingInfix           = contains(o.leadingInfix)
+      def packagePrefixImplicits = contains(o.packagePrefixImplicits)
+      def implicitResolution     = contains(o.implicitResolution) || settings.Yscala3ImplicitResolution.value
+      def doubleDefinitions      = contains(o.doubleDefinitions)
+      def etaExpandAlways        = contains(o.etaExpandAlways)
     }
 
     // used in sbt

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -688,11 +688,13 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
   def conflictWarning: Option[String] = {
     @nowarn("cat=deprecation")
     def sourceFeatures: Option[String] =
-      Option.when(XsourceFeatures.value.nonEmpty && !isScala3)(s"${XsourceFeatures.name} requires -Xsource:3")
+      Option.when(XsourceFeatures.value.nonEmpty && !isScala3)(s"${XsourceFeatures.name} is used without -Xsource:3, which is not recommended.")
 
     List(sourceFeatures).flatten match {
       case Nil => None
-      case warnings => Some("Conflicting compiler settings were detected. Some settings will be ignored.\n" + warnings.mkString("\n"))
+      case warnings => Some(
+        s"""conflicting compiler settings detected, some settings might be ignored.
+           |${warnings.mkString("\n")}""".stripMargin)
     }
   }
 }

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -1331,8 +1331,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           case coercion  =>
             if (settings.logImplicitConv.value)
               context.echo(qual.pos, s"applied implicit conversion from ${qual.tpe} to ${searchTemplate} = ${coercion.symbol.defString}")
-            if (currentRun.isScala3 && coercion.symbol == currentRun.runDefinitions.Predef_any2stringaddMethod)
-              if (!currentRun.sourceFeatures.any2StringAdd)
+            val noStringAddFlag = currentRun.sourceFeatures.any2StringAdd
+            if ((currentRun.isScala3 || noStringAddFlag) && coercion.symbol == currentRun.runDefinitions.Predef_any2stringaddMethod)
+              if (!noStringAddFlag)
                 runReporting.warning(qual.pos, s"Converting to String for concatenation is not supported in Scala 3 (or with -Xsource-features:any2stringadd).", Scala3Migration, coercion.symbol)
             if (settings.lintUniversalMethods) {
               def targetsUniversalMember(target: => Type): Option[Symbol] = searchTemplate match {


### PR DESCRIPTION
Some of the backports, like `-Xsource-features:case-apply-copy-access`, are useful even for projects that are on Scala 2 for the time being. This PR allows using them without enabling `-Xsource:3`.

There remains a warning about "conflicting compiler settings":

```scala
warning: conflicting compiler settings detected, some settings might be ignored.
-Xsource-features is used without -Xsource:3, which is not recommended.
```

but it can be silenced with `-Wconf:msg=-Xsource-features is used without -Xsource:s`.