### PR TITLE
When detecting subtyping loops remember problematic cases on the way out

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -75,6 +75,9 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.mutable.StringBuilder.getChars"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.ArrayCharSequence.getChars"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.SeqCharSequence.getChars"),
+
+    // scala/scala#11124
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.reflect.runtime.JavaUniverse.knownFalseSubTypes"),
   )
 
   override val buildSettings = Seq(

--- a/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
@@ -18,6 +18,7 @@ package tpe
 import scala.annotation.tailrec
 import scala.collection.mutable
 import util.{StringContextStripMarginOps, TriState}
+import java.util.IdentityHashMap
 
 trait TypeComparers {
   self: SymbolTable =>
@@ -30,7 +31,7 @@ trait TypeComparers {
   private[this] val _pendingSubTypes = new mutable.HashSet[SubTypePair]
   def pendingSubTypes = _pendingSubTypes
 
-  private[this] val _knownFalseSubTypes = new mutable.HashMap[Type, Type]
+  private[this] val _knownFalseSubTypes = new IdentityHashMap[Type, List[Type]]
   def knownFalseSubTypes = _knownFalseSubTypes
 
   final case class SubTypePair(tp1: Type, tp2: Type) {
@@ -200,7 +201,7 @@ trait TypeComparers {
   private def methodHigherOrderTypeParamsSubVariance(low: Symbol, high: Symbol) =
     methodHigherOrderTypeParamsSameVariance(low, high) || low.variance.isInvariant
 
-  def isSameType2(tp1: Type, tp2: Type): Boolean = {
+  private def isSameType2(tp1: Type, tp2: Type): Boolean = {
     def retry() = {
       // OPT no need to compare eta-expansions of a pair of distinct class type refs, we'd get the same result (false).
       // e.g. we know that TypeRef(..., Some, Nil) is not the same as TypeRef(..., Option, Nil) without needing to compare
@@ -298,7 +299,9 @@ trait TypeComparers {
       if (subsametypeRecursions >= LogPendingSubTypesThreshold) {
         val p = SubTypePair(tp1, tp2)
         if (pendingSubTypes(p)) {
-          knownFalseSubTypes(tp1) = tp2 // see scala/bug#13119
+          val ts = knownFalseSubTypes.get(tp1)
+          val cur = if (ts != null) ts else Nil
+          knownFalseSubTypes.put(tp1, tp2 :: cur) // see scala/bug#13119
           false // see neg/t8146-no-finitary*
         } else
           try {
@@ -307,8 +310,8 @@ trait TypeComparers {
           } finally {
             pendingSubTypes -= p
           }
-      } else if (!knownFalseSubTypes.isEmpty && knownFalseSubTypes.get(tp1).contains(tp2)) {
-        // redundant `isEmtpy` check is probably premature optimization, but isSubType is perf sensitive
+      } else if (!knownFalseSubTypes.isEmpty && { val ts = knownFalseSubTypes.get(tp1); ts != null && ts.contains(tp2) }) {
+        // redundant `isEmpty` check is probably premature optimization, but isSubType is perf sensitive
         false
       } else {
         isSubType1(tp1, tp2, depth)
@@ -389,7 +392,7 @@ trait TypeComparers {
   }
 
   // @assume tp1.isHigherKinded || tp2.isHigherKinded
-  def isHKSubType(tp1: Type, tp2: Type, depth: Depth): Boolean = {
+  private def isHKSubType(tp1: Type, tp2: Type, depth: Depth): Boolean = {
 
     def hkSubVariance(tparams1: List[Symbol], tparams2: List[Symbol]) =
       (tparams1 corresponds tparams2)(methodHigherOrderTypeParamsSubVariance)
@@ -648,18 +651,17 @@ trait TypeComparers {
         isSubType(tp1, tp2)
     }
 
-  def isNumericSubType(tp1: Type, tp2: Type) = (
-    isNumericSubClass(primitiveBaseClass(tp1.dealiasWiden), primitiveBaseClass(tp2.dealias))
-   )
-
-  /** If the given type has a primitive class among its base classes,
-   *  the symbol of that class. Otherwise, NoSymbol.
-   */
-  private def primitiveBaseClass(tp: Type): Symbol = {
-    @tailrec def loop(bases: List[Symbol]): Symbol = bases match {
-      case Nil     => NoSymbol
-      case x :: xs => if (isPrimitiveValueClass(x)) x else loop(xs)
+  def isNumericSubType(tp1: Type, tp2: Type) = {
+    /* If the given type has a primitive class among its base classes,
+     * the symbol of that class. Otherwise, NoSymbol.
+     */
+    def primitiveBaseClass(tp: Type): Symbol = {
+      def loop(bases: List[Symbol]): Symbol = bases match {
+        case base :: bases => if (isPrimitiveValueClass(base)) base else loop(bases)
+        case nil => NoSymbol
+      }
+      loop(tp.baseClasses)
     }
-    loop(tp.baseClasses)
+    isNumericSubClass(primitiveBaseClass(tp1.dealiasWiden), primitiveBaseClass(tp2.dealias))
   }
 }

--- a/src/reflect/scala/reflect/runtime/SynchronizedTypes.scala
+++ b/src/reflect/scala/reflect/runtime/SynchronizedTypes.scala
@@ -18,6 +18,7 @@ import scala.collection.mutable
 import java.lang.ref.{WeakReference => jWeakRef}
 import scala.ref.{WeakReference => sWeakRef}
 import scala.reflect.internal.Depth
+import java.util.IdentityHashMap
 
 /** This trait overrides methods in reflect.internal, bracketing
  *  them in synchronized { ... } to make them thread-safe
@@ -69,7 +70,7 @@ private[reflect] trait SynchronizedTypes extends internal.Types { self: SymbolTa
   private lazy val _pendingSubTypes = mkThreadLocalStorage(new mutable.HashSet[SubTypePair])
   override def pendingSubTypes = _pendingSubTypes.get
 
-  private lazy val _knownFalseSubTypes = mkThreadLocalStorage(new mutable.HashMap[Type, Type])
+  private lazy val _knownFalseSubTypes = mkThreadLocalStorage(new IdentityHashMap[Type, List[Type]])
   override def knownFalseSubTypes = _knownFalseSubTypes.get
 
   private lazy val _basetypeRecursions = mkThreadLocalStorage(0)

--- a/src/reflect/scala/reflect/runtime/SynchronizedTypes.scala
+++ b/src/reflect/scala/reflect/runtime/SynchronizedTypes.scala
@@ -69,6 +69,9 @@ private[reflect] trait SynchronizedTypes extends internal.Types { self: SymbolTa
   private lazy val _pendingSubTypes = mkThreadLocalStorage(new mutable.HashSet[SubTypePair])
   override def pendingSubTypes = _pendingSubTypes.get
 
+  private lazy val _knownFalseSubTypes = mkThreadLocalStorage(new mutable.HashMap[Type, Type])
+  override def knownFalseSubTypes = _knownFalseSubTypes.get
+
   private lazy val _basetypeRecursions = mkThreadLocalStorage(0)
   override def basetypeRecursions = _basetypeRecursions.get
   override def basetypeRecursions_=(value: Int) = _basetypeRecursions.set(value)

--- a/test/files/pos/t13119.scala
+++ b/test/files/pos/t13119.scala
@@ -1,0 +1,9 @@
+trait A[T]
+final class C[T, E] extends A[T with E]
+
+object T {
+  def f(x: A[?]): Int = x match {
+    case b: C[?, ?] => 0
+    case _ => 1
+  }
+}


### PR DESCRIPTION
The test causes a subtyping test that loops, which is caught by existing infrastructure (LogPendingSubTypesThreshold). However, before reaching the threshold the subtyping check branches off into two equal cases at every iteration. For details, see the [bug report](https://github.com/scala/bug/issues/13119#issuecomment-3274770803).

To avoid having to reach the threshold on every one of these branches, remember the problematic subtyping tests on the way back.

Fixes https://github.com/scala/bug/issues/13119