### PR TITLE
[REVERTED] REPL: JLine 3.30.6 (was 3.29.0)

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -9,4 +9,4 @@ starr.version=2.13.17-M1
 scala-asm.version=9.8.0-scala-1
 
 # REPL
-jline.version=3.29.0
+jline.version=3.30.6


### PR DESCRIPTION
I looked through all the release notes at https://github.com/jline/jline3/releases and I don't see anything concerning (but you never know!)

3.30.0 came out in May, so it seems like a mature series; though 3.30.5 and 3.30.6 did just come out yesterday. we should check for new versions one more time before releasing 2.13.17