### PR TITLE
Restore memory leak test for reflection

### DIFF
--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -1345,6 +1345,8 @@ private final class BitmapIndexedMapNode[K, +V](
   override def hashCode(): Int =
     throw new UnsupportedOperationException("Trie nodes do not support hashing.")
 
+  override def toString = s"${getClass.getName}@${Integer.toHexString(System.identityHashCode(this))}"
+
   override def concat[V1 >: V](that: MapNode[K, V1], shift: Int): BitmapIndexedMapNode[K, V1] = that match {
     case bm: BitmapIndexedMapNode[K, V] @unchecked =>
       if (size == 0) return bm
@@ -2089,6 +2091,8 @@ private final class HashCollisionMapNode[K, +V ](
 
   override def hashCode(): Int =
     throw new UnsupportedOperationException("Trie nodes do not support hashing.")
+
+  override def toString = s"${getClass.getName}@${Integer.toHexString(System.identityHashCode(this))}"
 
   override def cachedJavaKeySetHashCode: Int = size * hash
 

--- a/test/files/run/t8946.scala
+++ b/test/files/run/t8946.scala
@@ -1,0 +1,35 @@
+//> using jvm 17+
+//> using javaOpt --add-opens java.base/java.lang=ALL-UNNAMED
+//> using options -Xsource:3
+
+import scala.jdk.CollectionConverters.*
+import scala.jdk.OptionConverters.*
+import scala.reflect.runtime.*, universe.*
+import scala.tools.testkit.AssertUtil.assertNotReachable
+import scala.tools.testkit.ReflectUtil.*
+
+// `t8946 reflection subtype does not hold onto Thread`
+object Test extends App {
+  CanOpener.deworm()
+  val reflector = new Thread("scala.reflector") {
+    override def run() = typeOf[List[String]] <:< typeOf[Seq[_]]
+  }
+  val joiner: Thread => Unit = { t =>
+    t.start()
+    t.join()
+  }
+  assertNotReachable(reflector, universe)(joiner(reflector))
+  // without the fix to use WeakHashMap in ThreadLocalStorage:
+  //AssertionError: Root scala.reflect.runtime.JavaUniverse@6ce86ce1 held reference Thread[#23,scala.reflector,5,]
+}
+
+// Modules are a can of worms for tools which must tread through arbitrary packages.
+object CanOpener {
+  def deworm(): Unit = {
+    val True = java.lang.Boolean.TRUE
+    val unnamed = getClass.getClassLoader.getUnnamedModule
+    val method = getMethodAccessible[Module]("implAddExportsOrOpens")
+    for (base <- ModuleLayer.boot.findModule("java.base").toScala; pkg <- base.getPackages.asScala)
+      method.invokeAs[Unit](base, pkg, unnamed, True, True)
+  }
+}


### PR DESCRIPTION
    Craft the test to evade modern module restrictions.
    It reflectively opens packages in java.base.
    Note that enumerating the many opens in the test file
    runs afoul of partest limit(10) on test header for options.
    Avoid constructing an eager dynamic string for junit assert.
    Also arbitrary objects may throw on String.valueOf such as
    HashMap nodes which do not support hashCode.

Follow-up to https://github.com/scala/scala/pull/4170 and https://github.com/som-snytt/scala/commit/7029bb7d7593e2706806655c4b8645609bbf7c24