### PR TITLE
Add StringBuilder. appendCodePoint

### DIFF
--- a/src/library/scala/collection/mutable/StringBuilder.scala
+++ b/src/library/scala/collection/mutable/StringBuilder.scala
@@ -144,6 +144,16 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
     this
   }
 
+  /** Appends the string representation of the given code point to this sequence.
+    *
+    * @param  n   a Unicode code point.
+    * @return     this StringBuilder.
+    */
+  def appendCodePoint(n: Int): this.type = {
+    underlying appendCodePoint n
+    this
+  }
+
   /** Appends the given String to this sequence.
     *
     *  @param  s   a String.

--- a/src/library/scala/collection/mutable/StringBuilder.scala
+++ b/src/library/scala/collection/mutable/StringBuilder.scala
@@ -148,6 +148,8 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
     *
     * @param  n   a Unicode code point.
     * @return     this StringBuilder.
+    *
+    * @since 2.13.17
     */
   def appendCodePoint(n: Int): this.type = {
     underlying appendCodePoint n

--- a/test/junit/scala/collection/mutable/StringBuilderTest.scala
+++ b/test/junit/scala/collection/mutable/StringBuilderTest.scala
@@ -40,4 +40,21 @@ class StringBuilderTest {
     assertEquals("Xa,b,cY", res.toString)
     assertSame(b, res)
   }
+
+  @Test def `appendCodePoint`: Unit = {
+    val b = new StringBuilder()
+    val res: b.type = b.appendCodePoint(0x1F44D) // 👍 emoji
+    assertEquals("👍", res.toString)
+    assertSame(b, res)
+
+    // Test with a basic ASCII character
+    val b2 = new StringBuilder()
+    b2.appendCodePoint(65) // 'A'
+    assertEquals("A", b2.toString)
+
+    // Test with surrogate pair (Unicode code point > 0xFFFF)
+    val b3 = new StringBuilder()
+    b3.appendCodePoint(0x1F600) // 😀 emoji
+    assertEquals("😀", b3.toString)
+  }
 }


### PR DESCRIPTION
Add `StringBuilder.appendCodePoint` to support dealing with surrogate code points.

My use case: when parsing an escaped string in a language, we advance code point by code point on the raw string to properly handle Unicode. It will be convenient to have `appendCodePoint` such that we can assemble the code points in the final string.