### PR TITLE
Tweak list filter & infer method alt 2x [ci: last-only]

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -16,6 +16,7 @@ package typechecker
 import scala.collection.{immutable, mutable}, mutable.ListBuffer
 import scala.reflect.internal.Depth
 import scala.tools.nsc.Reporting.WarningCategory, WarningCategory.LintInferAny
+//import scala.util.chaining._
 import scala.util.control.ControlThrowable
 import symtab.Flags._
 
@@ -814,20 +815,18 @@ trait Infer extends Checkable {
      *    type is set to `Unit`, i.e. the corresponding argument is treated as
      *    an assignment expression (@see checkNames).
      */
-    private def isApplicable(undetparams: List[Symbol], ftpe: Type, argtpes0: List[Type], pt: Type): Boolean = {
-      val res =
-        ftpe match {
-          case OverloadedType(pre, alts) => alts exists (alt => isApplicable(undetparams, pre memberType alt, argtpes0, pt))
-          case ExistentialType(_, qtpe)  => isApplicable(undetparams, qtpe, argtpes0, pt)
-          case mt@MethodType(_, _)       => isApplicableToMethod(undetparams, mt, argtpes0, pt)
-          case NullaryMethodType(restpe) => isApplicable(undetparams, restpe, argtpes0, pt)
-          case PolyType(tparams, restpe) => createFromClonedSymbols(tparams, restpe)((tps1, res1) => isApplicable(tps1 ::: undetparams, res1, argtpes0, pt))
-          case ErrorType                 => true
-          case _                         => false
-        }
-//      println(s"isApplicable $res : $ftpe to $argtpes0 for $pt under $undetparams")
-      res
-    }
+    private def isApplicable(undetparams: List[Symbol], ftpe: Type, argtpes0: List[Type], pt: Type): Boolean =
+      ftpe match {
+        case OverloadedType(pre, alts) => alts.exists(alt => isApplicable(undetparams, pre memberType alt, argtpes0, pt))
+        case ExistentialType(_, qtpe)  => isApplicable(undetparams, qtpe, argtpes0, pt)
+        case mt@MethodType(_, _)       => isApplicableToMethod(undetparams, mt, argtpes0, pt)
+        case NullaryMethodType(restpe) => isApplicable(undetparams, restpe, argtpes0, pt)
+        case PolyType(tparams, restpe) => createFromClonedSymbols(tparams, restpe) { (tps1, res1) =>
+                                            isApplicable(tps1 ::: undetparams, res1, argtpes0, pt) }
+        case ErrorType                 => true
+        case _                         => false
+      }
+      //.tap(res => println(s"isApplicable $res : $ftpe to $argtpes0 for $pt under $undetparams"))
 
     /**
      * Are arguments of the given types applicable to `ftpe`? Type argument inference
@@ -1501,38 +1500,60 @@ trait Infer extends Checkable {
       // with pt = WildcardType if it fails with pt != WildcardType.
       val c = context
       class InferMethodAlternativeTwice extends c.TryTwice {
-        private[this] val OverloadedType(pre, alts) = tree.tpe: @unchecked
+        private[this] var pre: Type = _
+        private[this] val alts = tree.tpe match {
+                        case OverloadedType(pre, alternatives) => // avoid tuple field
+                          this.pre = pre
+                          alternatives
+                        case x => throw new MatchError(x)
+                      }
         private[this] var varargsStar = false
-        private[this] val argtpes = argtpes0 mapConserve {
-          case RepeatedType(tp) => varargsStar = true ; tp
+        private[this] val argtpes = argtpes0.mapConserve {
+          case RepeatedType(tp) => varargsStar = true; tp
           case tp               => tp
         }
+        private[this] val pt = if (pt0.typeSymbol == UnitClass) WildcardType else pt0
 
         private def followType(sym: Symbol) = followApply(memberTypeForSpecificity(pre, sym, tree))
-        // separate method to help the inliner
-        private def isAltApplicable(pt: Type)(alt: Symbol) = context inSilentMode { isApplicable(undetparams, followType(alt), argtpes, pt) && !context.reporter.hasErrors }
-        private def rankAlternatives(sym1: Symbol, sym2: Symbol) = isStrictlyMoreSpecific(followType(sym1), followType(sym2), sym1, sym2)
-        private def bestForExpectedType(pt: Type, isLastTry: Boolean): Unit = {
-          val applicable  = overloadsToConsiderBySpecificity(alts filter isAltApplicable(pt), argtpes, varargsStar)
-          // println(s"bestForExpectedType($argtpes, $pt): $alts -app-> ${alts filter isAltApplicable(pt)} -arity-> $applicable")
-          val ranked      = bestAlternatives(applicable)(rankAlternatives)
-          def finish(s: Symbol): Unit = tree.setSymbol(s).setType(pre.memberType(s))
-          ranked match {
-            case best :: competing :: _ => AmbiguousMethodAlternativeError(tree, pre, best, competing, argtpes, pt, isLastTry) // ambiguous
-            case best :: _              => finish(best)
-            case _   if pt.isWildcard   => NoBestMethodAlternativeError(tree, argtpes, pt, isLastTry)  // failed
-            case _                      => bestForExpectedType(WildcardType, isLastTry)                // failed, but retry with WildcardType
-          }
-        }
 
-        private[this] val pt = if (pt0.typeSymbol == UnitClass) WildcardType else pt0
-        def tryOnce(isLastTry: Boolean): Unit = {
+        override def tryOnce(isLastTry: Boolean): Unit = {
           debuglog(s"infer method alt ${tree.symbol} with alternatives ${alts map pre.memberType} argtpes=$argtpes pt=$pt")
-          bestForExpectedType(pt, isLastTry)
+          def bestForExpectedType(pt: Type): Unit = {
+            val applicable = {
+              var applicableAlts: List[Symbol] = null
+              context.inSilentMode {
+                applicableAlts = alts.filter { alt =>
+                  val ok_? = isApplicable(undetparams, followType(alt), argtpes, pt)
+                  if (context.reporter.hasErrors) {
+                    context.reporter.clearAllErrors()
+                    false
+                  }
+                  else ok_?
+                }
+                true
+              }
+              overloadsToConsiderBySpecificity(applicableAlts, argtpes, varargsStar)
+              //.tap(res => println(s"bestForExpectedType($argtpes, $pt): $alts -app-> $applicableAlts -arity-> $res"))
+            }
+            def rankAlternatives(sym1: Symbol, sym2: Symbol) =
+              isStrictlyMoreSpecific(followType(sym1), followType(sym2), sym1, sym2)
+            bestAlternatives(applicable)(rankAlternatives) match {
+              case best :: rest =>
+                rest match {
+                  case competing :: _ =>
+                    AmbiguousMethodAlternativeError(tree, pre, best, competing, argtpes, pt, isLastTry) // ambiguous
+                  case _ =>
+                    tree.setSymbol(best).setType(pre.memberType(best))
+                }
+              case _ =>
+                if (pt.isWildcard) NoBestMethodAlternativeError(tree, argtpes, pt, isLastTry) // failed
+                else bestForExpectedType(pt = WildcardType) // failed, but retry with WildcardType
+            }
+          }
+          bestForExpectedType(pt)
         }
       }
-
-      (new InferMethodAlternativeTwice).apply()
+      new InferMethodAlternativeTwice()()
     }
 
     /** Assign `tree` the type of all polymorphic alternatives

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -495,8 +495,8 @@ sealed abstract class List[+A]
 
   private[this] def filterCommon(p: A => Boolean, isFlipped: Boolean): List[A] = {
 
-    // everything seen so far so far is not included
-    @tailrec def noneIn(l: List[A]): List[A] = {
+    // Nothing seen so far is included. If an element is found to include, switch to 'allIn'.
+    @tailrec def noneIn(l: List[A]): List[A] =
       if (l.isEmpty)
         Nil
       else {
@@ -507,11 +507,11 @@ sealed abstract class List[+A]
         else
           noneIn(t)
       }
-    }
 
-    // everything from 'start' is included, if everything from this point is in we can return the origin
-    // start otherwise if we discover an element that is out we must create a new partial list.
-    @tailrec def allIn(start: List[A], remaining: List[A]): List[A] = {
+    // Everything from 'start' to 'remaining' is included.
+    // If everything from this point is included we can return the original i.e. 'start'.
+    // Otherwise if we discover an element that is excluded we must create a new partial list.
+    @tailrec def allIn(start: List[A], remaining: List[A]): List[A] =
       if (remaining.isEmpty)
         start
       else {
@@ -521,7 +521,6 @@ sealed abstract class List[+A]
         else
           partialFill(start, remaining)
       }
-    }
 
     // we have seen elements that should be included then one that should be excluded, start building
     def partialFill(origStart: List[A], firstMiss: List[A]): List[A] = {

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -490,82 +490,50 @@ sealed abstract class List[+A]
   }
 
   override def filter(p: A => Boolean): List[A] = {
-
-    // Nothing seen so far is included. If an element is found to include, switch to 'allIn'.
-    @tailrec def noneIn(l: List[A]): List[A] =
-      if (l.isEmpty)
-        Nil
-      else {
-        val h = l.head
-        val t = l.tail
-        if (p(h))
-          allIn(l, t)
-        else
-          noneIn(t)
-      }
-
-    // Everything from 'start' to 'remaining' is included.
-    // If everything from this point is included we can return the original i.e. 'start'.
-    // Otherwise if we discover an element that is excluded we must create a new partial list.
-    @tailrec def allIn(start: List[A], remaining: List[A]): List[A] =
-      if (remaining.isEmpty)
-        start
-      else {
-        val x = remaining.head
-        if (p(x))
-          allIn(start, remaining.tail)
-        else
-          partialFill(start, remaining)
-      }
-
-    // we have seen elements that should be included then one that should be excluded, start building
-    def partialFill(origStart: List[A], firstMiss: List[A]): List[A] = {
-      val newHead = new ::(origStart.head, Nil)
-      var toProcess = origStart.tail
-      var currentLast = newHead
-
-      // we know that all elements are :: until at least firstMiss.tail
-      while (!(toProcess eq firstMiss)) {
-        val newElem = new ::(toProcess.head, Nil)
-        currentLast.next = newElem
-        currentLast = newElem
-        toProcess = toProcess.tail
-      }
-
-      // at this point newHead points to a list which is a duplicate of all the 'in' elements up to the first miss.
-      // currentLast is the last element in that list.
-
-      // now we are going to try and share as much of the tail as we can, only moving elements across when we have to.
-      var next = firstMiss.tail
-      var nextToCopy = next // the next element we would need to copy to our list if we cant share.
-      while (!next.isEmpty) {
-        // generally recommended is next.isNonEmpty but this incurs an extra method call.
-        val head: A = next.head
-        if (p(head)) {
-          next = next.tail
-        } else {
-          // its not a match - do we have outstanding elements?
-          while (!(nextToCopy eq next)) {
-            val newElem = new ::(nextToCopy.head, Nil)
-            currentLast.next = newElem
-            currentLast = newElem
-            nextToCopy = nextToCopy.tail
+    // Look for the next element to include. If there is none, return the result.
+    // Given a next element to include, look for the next element to exclude.
+    // If there is none, then add the suffix to the result and return the result.
+    // Otherwise copy the current segment to the result and continue.
+    var result, last: `::`[A] = null // result, last element of result
+    var end: List[A] = null // tail end of cur segment, may be empty
+    var cur = this
+    while (true) {
+      while (!cur.isEmpty && !p(cur.head)) // advance to segment to include
+        cur = cur.tail
+      if (cur.isEmpty)
+        return {
+          if (result == null) Nil
+          else {
+            releaseFence()
+            result // all done
           }
-          nextToCopy = next.tail
-          next = next.tail
+        }
+      end = cur.tail // no pun on curtail!
+      while (!end.isEmpty && p(end.head)) // advance to end of segment
+        end = end.tail
+      if (end.isEmpty)
+        return {
+          if (result == null) cur // all in
+          else {
+            last.next = cur // share segment as suffix of result
+            releaseFence()
+            result
+          }
+        }
+      else {
+        if (result == null) {
+          result = new ::(cur.head, Nil)
+          last = result
+          cur = cur.tail
+        }
+        while (cur ne end) {
+          last.next = new ::(cur.head, Nil) // copy segment to last of result
+          last = last.tail.asInstanceOf[`::`[A]]
+          cur = cur.tail
         }
       }
-
-      // we have remaining elements - they are unchanged attach them to the end
-      if (!nextToCopy.isEmpty)
-        currentLast.next = nextToCopy
-
-      newHead
     }
-
-    val result = noneIn(this)
-    releaseFence()
-    result
+    Nil
   }
 
   override def filterNot(p: A => Boolean): List[A] = filter(!p(_))

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -489,11 +489,7 @@ sealed abstract class List[+A]
     result
   }
 
-  override def filter(p: A => Boolean): List[A] = filterCommon(p, isFlipped = false)
-
-  override def filterNot(p: A => Boolean): List[A] = filterCommon(p, isFlipped = true)
-
-  private[this] def filterCommon(p: A => Boolean, isFlipped: Boolean): List[A] = {
+  override def filter(p: A => Boolean): List[A] = {
 
     // Nothing seen so far is included. If an element is found to include, switch to 'allIn'.
     @tailrec def noneIn(l: List[A]): List[A] =
@@ -502,7 +498,7 @@ sealed abstract class List[+A]
       else {
         val h = l.head
         val t = l.tail
-        if (p(h) != isFlipped)
+        if (p(h))
           allIn(l, t)
         else
           noneIn(t)
@@ -516,7 +512,7 @@ sealed abstract class List[+A]
         start
       else {
         val x = remaining.head
-        if (p(x) != isFlipped)
+        if (p(x))
           allIn(start, remaining.tail)
         else
           partialFill(start, remaining)
@@ -545,7 +541,7 @@ sealed abstract class List[+A]
       while (!next.isEmpty) {
         // generally recommended is next.isNonEmpty but this incurs an extra method call.
         val head: A = next.head
-        if (p(head) != isFlipped) {
+        if (p(head)) {
           next = next.tail
         } else {
           // its not a match - do we have outstanding elements?
@@ -571,6 +567,8 @@ sealed abstract class List[+A]
     releaseFence()
     result
   }
+
+  override def filterNot(p: A => Boolean): List[A] = filter(!p(_))
 
   override def partition(p: A => Boolean): (List[A], List[A]) = {
     if (isEmpty) List.TupleOfNil

--- a/test/junit/scala/collection/immutable/ListTest.scala
+++ b/test/junit/scala/collection/immutable/ListTest.scala
@@ -123,4 +123,13 @@ class ListTest extends AllocationTest {
     exactAllocates(expected(20), "list  size 20")(
       List("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"))
   }
+
+  @Test def `list filter`: Unit = {
+    assertEquals(List(1, 2, 3, 4, 5), List(1, 2, 3, 4, 5).filter(_ != 0))
+    assertEquals(List(2, 4), List(1, 2, 3, 4, 5).filter(_ % 2 == 0))
+    assertEquals(List(1, 3, 5), List(1, 2, 3, 4, 5).filterNot(_ % 2 == 0))
+    assertEquals(List(1, 2, 3), List(1, 2, 3, 4, 5).filter(_ <= 3))
+    assertEquals(List(4, 5), List(1, 2, 3, 4, 5).filterNot(_ <= 3))
+    assertEquals(List(5), List(1, 2, 3, 4, 5).filter(_ > 4))
+  }
 }


### PR DESCRIPTION
More compact filter method is more amenable to inlining.

Scala 2 inlines filter in filterNot, obviating the previous flip flag to negate the predicate.

Tweak to infer method alt was to reduce method calls, but nothing is proven yet about improving.

(Something about `alt.filter(isAltApplicable)` which calls `ctx.inSilentMode(isApplicable)`. The tweak wraps the whole filter in `inSilentMode` with reporter reset on error. There is a comment about inliner and code structure, to be understood.)
