### PR TITLE
Performance: override some methods of `ArrayBuffer` to operate directly on internal array

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -50,6 +50,20 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.ArrayCharSequence.getChars"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.SeqCharSequence.getChars"),
 
+    // Optimized overrides for array-backed collections (narrower return types)
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.mutable.ArrayBuffer.filter"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.mutable.ArrayBuffer.filterNot"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.mutable.ArraySeq.filter"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.mutable.ArraySeq.filterNot"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.ArraySeq.filter"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.ArraySeq.filterNot"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.mutable.ArrayDeque.filter"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.mutable.ArrayDeque.filterNot"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.mutable.Queue.filter"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.mutable.Queue.filterNot"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.mutable.Stack.filter"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.mutable.Stack.filterNot"),
+
   )
 
   override val buildSettings = Seq(

--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -53,6 +53,71 @@ import scala.util.Sorting
 
 object ArrayOps {
 
+  /** Apply `f` to each element for its side effects, using type-specialized array access.
+   *  Allocation-free static method for array-backed collections.
+   */
+  private[collection] def foreach[A, U](xs: Array[_], f: A => U, len: Int): Unit = {
+    var i = 0
+    (xs: Any @unchecked) match {
+      case xs: Array[AnyRef]  => while (i < len) { f(xs(i).asInstanceOf[A]); i = i+1 }
+      case xs: Array[Int]     => while (i < len) { f(xs(i).asInstanceOf[A]); i = i+1 }
+      case xs: Array[Double]  => while (i < len) { f(xs(i).asInstanceOf[A]); i = i+1 }
+      case xs: Array[Long]    => while (i < len) { f(xs(i).asInstanceOf[A]); i = i+1 }
+      case xs: Array[Float]   => while (i < len) { f(xs(i).asInstanceOf[A]); i = i+1 }
+      case xs: Array[Char]    => while (i < len) { f(xs(i).asInstanceOf[A]); i = i+1 }
+      case xs: Array[Byte]    => while (i < len) { f(xs(i).asInstanceOf[A]); i = i+1 }
+      case xs: Array[Short]   => while (i < len) { f(xs(i).asInstanceOf[A]); i = i+1 }
+      case xs: Array[Boolean] => while (i < len) { f(xs(i).asInstanceOf[A]); i = i+1 }
+    }
+  }
+
+  /** Finds index of the first element satisfying a predicate after or at `from`. Allocation-free. */
+  private[collection] def indexWhere[A](xs: Array[_], p: A => Boolean, from: Int, len: Int): Int = {
+    var i = if (from > 0) from else 0
+    while (i < len) {
+      if (p(xs(i).asInstanceOf[A])) return i
+      i += 1
+    }
+    -1
+  }
+
+  /** Finds the first element satisfying a predicate. Allocation-free. */
+  private[collection] def find[A](xs: Array[_], p: A => Boolean, from: Int, len: Int): Option[A] = {
+    val idx = indexWhere(xs, p, from, len)
+    if (idx == -1) None else Some(xs(idx).asInstanceOf[A])
+  }
+
+  /** Tests whether a predicate holds for all elements. Allocation-free. */
+  private[collection] def forall[A](xs: Array[_], p: A => Boolean, len: Int): Boolean = {
+    var i = 0
+    while (i < len) {
+      if (!p(xs(i).asInstanceOf[A])) return false
+      i += 1
+    }
+    true
+  }
+
+  /** Counts elements satisfying a predicate. Allocation-free. */
+  private[collection] def count[A](xs: Array[_], p: A => Boolean, len: Int): Int = {
+    var i, res = 0
+    while (i < len) {
+      if (p(xs(i).asInstanceOf[A])) res += 1
+      i += 1
+    }
+    res
+  }
+
+  /** Filters elements satisfying a predicate into a builder. Allocation-free. */
+  private[collection] def filter[A, C](xs: Array[_], p: A => Boolean, len: Int, b: mutable.Builder[A, C]): C = {
+    var i = 0
+    while (i < len) {
+      val x = xs(i).asInstanceOf[A]
+      if (p(x)) b += x
+      i += 1
+    }
+    b.result()
+  }
+
   @SerialVersionUID(3L)
   private class ArrayView[A](xs: Array[A]) extends AbstractIndexedSeqView[A] {
     def length = xs.length

--- a/src/library/scala/collection/immutable/ArraySeq.scala
+++ b/src/library/scala/collection/immutable/ArraySeq.scala
@@ -239,6 +239,29 @@ sealed abstract class ArraySeq[+A]
     b
   }
 
+  override def foreach[U](f: A => U): Unit =
+    ArrayOps.foreach(unsafeArray, f, length)
+
+  override def indexWhere(p: A => Boolean, from: Int): Int =
+    ArrayOps.indexWhere(unsafeArray, p, from, length)
+
+  override def find(p: A => Boolean): Option[A] =
+    ArrayOps.find(unsafeArray, p, 0, length)
+
+  override def exists(p: A => Boolean): Boolean =
+    ArrayOps.indexWhere(unsafeArray, p, 0, length) >= 0
+
+  override def forall(p: A => Boolean): Boolean =
+    ArrayOps.forall(unsafeArray, p, length)
+
+  override def count(p: A => Boolean): Int =
+    ArrayOps.count(unsafeArray, p, length)
+
+  override def filter(pred: A => Boolean): ArraySeq[A] =
+    ArrayOps.filter(unsafeArray, pred, length, newSpecificBuilder)
+
+  override def filterNot(pred: A => Boolean): ArraySeq[A] = filter(x => !pred(x))
+
   override def tail: ArraySeq[A] = ArraySeq.unsafeWrapArray(new ArrayOps(unsafeArray).tail).asInstanceOf[ArraySeq[A]]
 
   override def reverse: ArraySeq[A] = ArraySeq.unsafeWrapArray(new ArrayOps(unsafeArray).reverse).asInstanceOf[ArraySeq[A]]

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -278,6 +278,28 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
 
   override def sliding(size: Int, step: Int): Iterator[ArrayBuffer[A]] =
     new MutationTracker.CheckedIterator(super.sliding(size = size, step = step), mutationCount)
+
+  override def foreach[U](f: A => U): Unit =
+    ArrayOps.foreach(array, f, length)
+
+  override def filter(pred: A => Boolean): ArrayBuffer[A] =
+    ArrayOps.filter(array, pred, length, newSpecificBuilder)
+
+  override def filterNot(pred: A => Boolean): ArrayBuffer[A] = filter(x => !pred(x))
+
+  override def indexWhere(p: A => Boolean, from: Int): Int =
+    ArrayOps.indexWhere(array, p, from, length)
+
+  override def find(p: A => Boolean): Option[A] =
+    ArrayOps.find(array, p, 0, length)
+
+  override def exists(p: A => Boolean): Boolean = indexWhere(p) >= 0
+
+  override def forall(p: A => Boolean): Boolean =
+    ArrayOps.forall(array, p, length)
+
+  override def count(p: A => Boolean): Int =
+    ArrayOps.count(array, p, length)
 }
 
 /**

--- a/src/library/scala/collection/mutable/ArrayDeque.scala
+++ b/src/library/scala/collection/mutable/ArrayDeque.scala
@@ -475,6 +475,102 @@ class ArrayDeque[A] protected (
   override def toArray[B >: A: ClassTag]: Array[B] =
     copySliceToArray(srcStart = 0, dest = new Array[B](length), destStart = 0, maxItems = length)
 
+  override def foreach[U](f: A => U): Unit = {
+    val a = array
+    val mask = a.length - 1
+    val n = length
+    var idx = start
+    var i = 0
+    while (i < n) {
+      f(a(idx).asInstanceOf[A])
+      idx = (idx + 1) & mask
+      i += 1
+    }
+  }
+
+  override def indexWhere(p: A => Boolean, from: Int): Int = {
+    val a = array
+    val mask = a.length - 1
+    val n = length
+    var i = if (from > 0) from else 0
+    var idx = (start + i) & mask
+    while (i < n) {
+      if (p(a(idx).asInstanceOf[A])) return i
+      idx = (idx + 1) & mask
+      i += 1
+    }
+    -1
+  }
+
+  override def find(p: A => Boolean): Option[A] = {
+    val a = array
+    val mask = a.length - 1
+    val n = length
+    var idx = start
+    var i = 0
+    while (i < n) {
+      val x = a(idx).asInstanceOf[A]
+      if (p(x)) return Some(x)
+      idx = (idx + 1) & mask
+      i += 1
+    }
+    None
+  }
+
+  override def exists(p: A => Boolean): Boolean = indexWhere(p) >= 0
+
+  override def forall(p: A => Boolean): Boolean = {
+    val a = array
+    val mask = a.length - 1
+    val n = length
+    var idx = start
+    var i = 0
+    while (i < n) {
+      if (!p(a(idx).asInstanceOf[A])) return false
+      idx = (idx + 1) & mask
+      i += 1
+    }
+    true
+  }
+
+  override def count(p: A => Boolean): Int = {
+    val a = array
+    val mask = a.length - 1
+    val n = length
+    var idx = start
+    var i, res = 0
+    while (i < n) {
+      if (p(a(idx).asInstanceOf[A])) res += 1
+      idx = (idx + 1) & mask
+      i += 1
+    }
+    res
+  }
+
+  override def filter(pred: A => Boolean): ArrayDeque[A] = {
+    val n = length
+    if (n == 0) return empty
+    val a = array
+    val mask = a.length - 1
+    val tmp = new Array[AnyRef](n)
+    var idx = start
+    var i, j = 0
+    while (i < n) {
+      val x = a(idx)
+      if (pred(x.asInstanceOf[A])) { tmp(j) = x; j += 1 }
+      idx = (idx + 1) & mask
+      i += 1
+    }
+    if (j == 0) empty
+    else {
+      val arr = ArrayDeque.alloc(j)
+      System.arraycopy(tmp, 0, arr, 0, j)
+      new ArrayDeque(arr, 0, j)
+    }
+  }
+
+  override def filterNot(pred: A => Boolean): ArrayDeque[A] = filter(x => !pred(x))
+
   /**
     * Trims the capacity of this ArrayDeque's instance to be the current size.
     */

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -92,6 +92,29 @@ sealed abstract class ArraySeq[T]
     if (length > 1) scala.util.Sorting.stableSort(array.asInstanceOf[Array[B]])
     this
   }
+
+  override def foreach[U](f: T => U): Unit =
+    ArrayOps.foreach(array, f, length)
+
+  override def indexWhere(p: T => Boolean, from: Int): Int =
+    ArrayOps.indexWhere(array, p, from, length)
+
+  override def find(p: T => Boolean): Option[T] =
+    ArrayOps.find(array, p, 0, length)
+
+  override def exists(p: T => Boolean): Boolean =
+    ArrayOps.indexWhere(array, p, 0, length) >= 0
+
+  override def forall(p: T => Boolean): Boolean =
+    ArrayOps.forall(array, p, length)
+
+  override def count(p: T => Boolean): Int =
+    ArrayOps.count(array, p, length)
+
+  override def filter(pred: T => Boolean): ArraySeq[T] =
+    ArrayOps.filter(array, pred, length, newSpecificBuilder)
+
+  override def filterNot(pred: T => Boolean): ArraySeq[T] = filter(x => !pred(x))
 }
 
 /** A companion object used to create instances of `ArraySeq`.

--- a/src/library/scala/collection/mutable/Queue.scala
+++ b/src/library/scala/collection/mutable/Queue.scala
@@ -119,6 +119,26 @@ class Queue[A] protected (array: Array[AnyRef], start: Int, end: Int)
   override protected def ofArray(array: Array[AnyRef], end: Int): Queue[A] =
     new Queue(array, start = 0, end)
 
+  override def filter(pred: A => Boolean): Queue[A] = {
+    val n = length
+    if (n == 0) return empty
+    val tmp = new Array[AnyRef](n)
+    var i, j = 0
+    while (i < n) {
+      val x = apply(i)
+      if (pred(x)) { tmp(j) = x.asInstanceOf[AnyRef]; j += 1 }
+      i += 1
+    }
+    if (j == 0) empty
+    else {
+      val arr = ArrayDeque.alloc(j)
+      System.arraycopy(tmp, 0, arr, 0, j)
+      new Queue(arr, 0, j)
+    }
+  }
+
+  override def filterNot(pred: A => Boolean): Queue[A] = filter(x => !pred(x))
+
 }
 
 /**

--- a/src/library/scala/collection/mutable/Stack.scala
+++ b/src/library/scala/collection/mutable/Stack.scala
@@ -123,6 +123,26 @@ class Stack[A] protected (array: Array[AnyRef], start: Int, end: Int)
   override protected def ofArray(array: Array[AnyRef], end: Int): Stack[A] =
     new Stack(array, start = 0, end)
 
+  override def filter(pred: A => Boolean): Stack[A] = {
+    val n = length
+    if (n == 0) return empty
+    val tmp = new Array[AnyRef](n)
+    var i, j = 0
+    while (i < n) {
+      val x = apply(i)
+      if (pred(x)) { tmp(j) = x.asInstanceOf[AnyRef]; j += 1 }
+      i += 1
+    }
+    if (j == 0) empty
+    else {
+      val arr = ArrayDeque.alloc(j)
+      System.arraycopy(tmp, 0, arr, 0, j)
+      new Stack(arr, 0, j)
+    }
+  }
+
+  override def filterNot(pred: A => Boolean): Stack[A] = filter(x => !pred(x))
+
 }
 
 /**

--- a/test/benchmarks/src/main/scala/scala/collection/mutable/ArrayBufferBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/mutable/ArrayBufferBenchmark.scala
@@ -39,6 +39,10 @@ class ArrayBufferBenchmark {
     list = ref.toList
   }
 
+  @Benchmark def foreach(bh: Blackhole): Unit = {
+    ref.foreach(bh.consume)
+  }
+
   @Benchmark def filterInPlace(bh: Blackhole): Unit = {
     val b = ref.clone()
     b.filterInPlace(_ % 2 == 0)


### PR DESCRIPTION
Motivation:
I wanted to use ArrayBuffer, but found it does not override the `foreach` method.

refs: https://github.com/apache/pekko/pull/2262

I got the number with numbers:
```
jmh:run -i 10 -wi 5 -f2 -t1 scala.collection.mutable.ArrayBufferBenchmark

old --

[info] Benchmark                     (size)  Mode  Cnt     Score    Error  Units
[info] ArrayBufferBenchmark.foreach   10000  avgt   10  6198.500 ± 68.184  ns/op

--- array

[info] Benchmark                     (size)  Mode  Cnt     Score    Error  Units
[info] ArrayBufferBenchmark.foreach   10000  avgt   10  3293.280 ± 45.680  ns/op
```

for 10000 elements only