### PR TITLE
Revert JLine to version 3.29.0 for Scala 2.13.17

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -9,4 +9,4 @@ starr.version=2.13.17-M1
 scala-asm.version=9.8.0-scala-1
 
 # REPL
-jline.version=3.30.6
+jline.version=3.29.0


### PR DESCRIPTION
When running the REPL through `sbt console`, the JLine jar from both the compiler and sbt seem to be on the classpath. It looks like classes may be loaded from either jar, depending on the time the class is needed.

We need to figure out how to isolate this better. For 2.13.17 it seems apropriate to keep JLine at 3.29. Compared to past activity, there seem to be more substantial changes in the 3.30 version.

https://github.com/sbt/sbt/issues/8294