### PR TITLE
Update main method discovery in zinc compiler bridge for Java 25

### DIFF
--- a/src/sbt-bridge/scala/tools/xsbt/ExtractAPI.scala
+++ b/src/sbt-bridge/scala/tools/xsbt/ExtractAPI.scala
@@ -774,9 +774,8 @@ class ExtractAPI[GlobalType <: Global](
     allNonLocalClassesInSrc += classWithMembers
     allNonLocalClassSymbols += sym
 
-    if (sym.isStatic && defType == DefinitionType.Module && definitions.hasJavaMainMethod(sym)) {
+    if (hasMainMethod(sym, defType))
       _mainClasses += name
-    }
 
     val classDef = xsbti.api.ClassLikeDef.of(
       name,
@@ -787,6 +786,24 @@ class ExtractAPI[GlobalType <: Global](
       defType
     ) // use original symbol (which is a term symbol when `c.isModule`) for `name` and other non-classy stuff
     classDef
+  }
+
+  private def hasMainMethod(sym: Symbol, defType: DefinitionType): Boolean = {
+    val is25 = scala.util.Properties.isJavaAtLeast(25)
+
+    def hasMain: Boolean = {
+      val mains = sym.tpe.member(nme.main).alternatives
+      mains.exists(_.info match {
+        case MethodType(p :: Nil, restpe) =>
+          definitions.isArrayOfSymbol(p.tpe, definitions.StringClass) && restpe.typeSymbol == definitions.UnitClass
+        case MethodType(Nil, restpe) if is25 =>
+          restpe.typeSymbol == definitions.UnitClass
+        case _ => false
+      })
+    }
+
+    if (is25) !sym.isAbstract && hasMain
+    else sym.isStatic && defType == DefinitionType.Module && hasMain
   }
 
   // TODO: could we restrict ourselves to classes, ignoring the term symbol for modules,

--- a/test/sbt-test/apiinfo/main-discovery/src/main/scala/Hello.scala
+++ b/test/sbt-test/apiinfo/main-discovery/src/main/scala/Hello.scala
@@ -1,13 +1,36 @@
 package runscala
 
 object MainScala {
-	def main(args: Array[String]) {}
+	def main(args: Array[String]): Unit = ()
 
   object StaticInner {
-	  def main(args: Array[String]) {}
+	  def main(args: Array[String]): Unit = ()
   }
 }
 
-class NoMainScala {
-	def main(args: Array[String]) {}
+class NoStatic {
+	def main(args: Array[String]): Unit = ()
+}
+
+class NoArgs {
+  def main(): Unit = ()
+}
+
+class Protected {
+  protected def main(): Unit = ()
+}
+
+trait Tr {
+  def main(): Unit = ()
+}
+
+abstract class Abs {
+  def main(): Unit = ()
+}
+
+class InheritTrait extends Tr
+abstract class AbsInheritAbs extends Abs
+
+class NonVoid {
+  def main(): Int = 1
 }

--- a/test/sbt-test/apiinfo/main-discovery/test
+++ b/test/sbt-test/apiinfo/main-discovery/test
@@ -1,6 +1,13 @@
 > setup; reload
 
 > compile
-> checkMainClasses src/main/java/runjava/MainJava.java: runjava.MainJava runjava.MainJava.StaticInner
-> checkMainClasses src/main/java/runjava/oMainJava.java:
-> checkMainClasses src/main/scala/Hello.scala: runscala.MainScala runscala.MainScala.StaticInner
+
+# before Java 25
+> checkMainClasses 24 src/main/java/runjava/MainJava.java: runjava.MainJava runjava.MainJava.StaticInner
+> checkMainClasses 24 src/main/java/runjava/oMainJava.java:
+> checkMainClasses 24 src/main/scala/Hello.scala: runscala.MainScala runscala.MainScala.StaticInner
+
+# starting Java 25
+> checkMainClasses 25 src/main/java/runjava/MainJava.java: runjava.MainJava runjava.MainJava.StaticInner
+> checkMainClasses 25 src/main/java/runjava/oMainJava.java:
+> checkMainClasses 25 src/main/scala/Hello.scala: runscala.MainScala runscala.MainScala.StaticInner runscala.NoStatic runscala.NoArgs runscala.Protected runscala.InheritTrait

--- a/test/sbt-test/common.sbt.template
+++ b/test/sbt-test/common.sbt.template
@@ -63,19 +63,22 @@ InputKey[Unit]("checkIterations") := {
 }
 
 InputKey[Unit]("checkMainClasses") := {
-  val source :: expected = complete.DefaultParsers.spaceDelimited("<arg>").parsed
-  val analysis = (Compile / compile).value.asInstanceOf[sbt.internal.inc.Analysis]
-  val c = fileConverter.value
+  val javaV :: source :: expected = complete.DefaultParsers.spaceDelimited("<arg>").parsed
+  val is25 = scala.util.Properties.isJavaAtLeast("25")
+    if (is25 == (javaV == "25")) {
+    val analysis = (Compile / compile).value.asInstanceOf[sbt.internal.inc.Analysis]
+    val c = fileConverter.value
 
-  def mainClasses(src: String): Set[String] =
-    analysis.infos.get(c.toVirtualFile(baseDirectory.value.toPath / src)).getMainClasses.toSet
+    def mainClasses(src: String): Set[String] =
+      analysis.infos.get(c.toVirtualFile(baseDirectory.value.toPath / src)).getMainClasses.toSet
 
-  def assertClasses(expected: Set[String], actual: Set[String]) = {
-    def msg = s"Expected $expected classes, got $actual\n\n" + analysis.infos.allInfos
-    assert(expected == actual, msg)
+    def assertClasses(expected: Set[String], actual: Set[String]) = {
+      def msg = s"Expected $expected classes, got $actual\n\n" + analysis.infos.allInfos
+      assert(expected == actual, msg)
+    }
+
+    assertClasses(expected.toSet, mainClasses(source.stripSuffix(":")))
   }
-
-  assertClasses(expected.toSet, mainClasses(source.stripSuffix(":")))
 }
 
 InputKey[Unit]("checkClasses") := {


### PR DESCRIPTION
Java 25 allows main methods to be non-static, non-public and without parameter list.

This PR ensures `sbt run` finds such main methods when running on Java 25+.

ref https://github.com/sbt/sbt/issues/7384