### PR TITLE
Backport: Calculate import selector position

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -354,8 +354,8 @@ trait ContextErrors {
       def AmbiguousParentClassError(tree: Tree) =
         issueNormalTypeError(tree, "ambiguous parent class qualifier")
 
-      //typedSelect
-      def NotAMemberError(sel: Tree, qual: Tree, name: Name) = {
+      //typedSelect or checkSelector
+      def NotAMemberError(sel: Tree /*Select|Import*/, qual: Tree, name: Name) = {
         def errMsg = {
           val owner            = qual.tpe.typeSymbol
           val target           = qual.tpe.widen
@@ -390,7 +390,14 @@ trait ContextErrors {
             else s"$nameString is not a member of $targetStr$addendum"
           )
         }
-        issueNormalTypeError(sel, errMsg)
+        sel match {
+          case tree: Import => // selector name is unique; use it to improve position
+            tree.selectors.find(_.introduces(name)) match {
+              case Some(badsel) => issueTypeError(PosAndMsgTypeError(tree.posOf(badsel), errMsg))
+              case _ => issueNormalTypeError(sel, errMsg)
+            }
+          case _ => issueNormalTypeError(sel, errMsg)
+        }
         // the error has to be set for the copied tree, otherwise
         // the error remains persistent across multiple compilations
         // and causes problems

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1606,8 +1606,7 @@ trait Contexts { self: Analyzer =>
 
   class ImportInfo(val tree: Import, val depth: Int) {
     def pos = tree.pos
-    def posOf(sel: ImportSelector) =
-      if (sel.namePos >= 0) tree.pos withPoint sel.namePos else tree.pos
+    def posOf(sel: ImportSelector) = tree.posOf(sel)
 
     /** The prefix expression */
     def qual: Tree = tree.symbol.info match {

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -353,7 +353,7 @@ trait Namers extends MethodSynthesis {
     }
 
     def createImportSymbol(tree: Import) =
-      NoSymbol.newImport(tree.pos) setInfo (namerOf(tree.symbol) importTypeCompleter tree)
+      NoSymbol.newImport(tree.pos).setInfo(namerOf(tree.symbol).importTypeCompleter(tree))
 
     /** All PackageClassInfoTypes come from here. */
     def createPackageSymbol(pos: Position, pid: RefTree): Symbol = {
@@ -766,7 +766,7 @@ trait Namers extends MethodSynthesis {
       newNamer(context.make(tree, sym.moduleClass, sym.info.decls)) enterSyms tree.stats
     }
 
-    private def enterImport(tree: Import) = {
+    private def enterImport(tree: Import): Unit = {
       val sym = createImportSymbol(tree)
       tree.symbol = sym
     }

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -18,7 +18,7 @@ import Flags._
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.reflect.macros.Attachments
-import util.{ReusableInstance, Statistics}
+import util.{Position, ReusableInstance, Statistics}
 
 trait Trees extends api.Trees {
   self: SymbolTable =>
@@ -421,14 +421,37 @@ trait Trees extends api.Trees {
       }
   }
 
-  case class ImportSelector(name: Name, namePos: Int, rename: Name, renamePos: Int) extends ImportSelectorApi
+  case class ImportSelector(name: Name, namePos: Int, rename: Name, renamePos: Int) extends ImportSelectorApi {
+    def isWildcard = name == nme.WILDCARD && rename == null
+    def isGiven    = name == nme.WILDCARD && rename == nme.`given`
+    def isMask     = name != nme.WILDCARD && rename == nme.WILDCARD
+    def isRename   = name != rename && rename != null && rename != nme.WILDCARD
+    def isSpecific = !isWildcard
+    private def isLiteralWildcard = name == nme.WILDCARD && rename == nme.WILDCARD
+    private def sameName(name: Name, other: Name) =  (name eq other) || (name ne null) && name.start == other.start && name.length == other.length
+    def hasName(other: Name) = sameName(name, other)
+    def introduces(target: Name) =
+      if (target == nme.WILDCARD) isLiteralWildcard
+      else target != null && !isGiven && sameName(rename, target)
+  }
   object ImportSelector extends ImportSelectorExtractor {
     val wild     = ImportSelector(nme.WILDCARD, -1, null, -1)
     val wildList = List(wild) // OPT This list is shared for performance.
   }
 
   case class Import(expr: Tree, selectors: List[ImportSelector])
-       extends SymTree with ImportApi
+       extends SymTree with ImportApi {
+    def posOf(sel: ImportSelector): Position = {
+      val pos0 = this.pos
+      val start = sel.namePos
+      if (start >= 0 && selectors.contains(sel)) {
+        val hasRename = sel.rename != null && sel.renamePos >= 0 // !sel.isWildcard
+        val end = if (hasRename) sel.renamePos + sel.rename.length else start + sel.name.length
+        Position.range(pos0.source, start, start, end)
+      }
+      else pos0
+    }
+  }
   object Import extends ImportExtractor
 
   case class Template(parents: List[Tree], self: ValDef, body: List[Tree])

--- a/test/files/neg/t12734.check
+++ b/test/files/neg/t12734.check
@@ -1,0 +1,7 @@
+t12734.scala:3: error: object AssertionErrer is not a member of package java.lang
+import java.lang.{AssertionErrer, Integer => JInt, String, Thread}
+                  ^
+t12734.scala:5: error: object connection is not a member of package scala
+import scala.connection._
+             ^
+two errors found

--- a/test/files/neg/t12734.scala
+++ b/test/files/neg/t12734.scala
@@ -1,0 +1,16 @@
+//> using options -Xlint
+
+import java.lang.{AssertionErrer, Integer => JInt, String, Thread}
+import scala.annotation._
+import scala.connection._
+
+trait T {
+  def t: Thread
+}
+
+/*
+Previous result shows the selectors with same range but different points.
+[ERROR] [RangePosition(t12734.scala, 76, 83, 117)]: object AssertionErrer is not a member of package java.lang
+did you mean AssertionError?
+[WARNING] [RangePosition(t12734.scala, 76, 94, 117)]: Unused import
+*/

--- a/test/files/neg/t2773.check
+++ b/test/files/neg/t2773.check
@@ -1,6 +1,6 @@
 t2773.scala:5: error: value x is not a member of C
   import c.x
-         ^
+           ^
 t2773.scala:6: error: not found: value x
   println(x)
           ^

--- a/test/files/neg/t5801.check
+++ b/test/files/neg/t5801.check
@@ -1,6 +1,6 @@
 t5801.scala:1: error: object sth is not a member of package scala
 import scala.sth
-       ^
+             ^
 t5801.scala:4: error: not found: value sth
   def foo(a: Int)(implicit b: sth.Sth): Unit = {}
                               ^

--- a/test/files/neg/t6340.check
+++ b/test/files/neg/t6340.check
@@ -1,10 +1,13 @@
 t6340.scala:11: error: value D is not a member of object Foo
   import Foo.{ A, B, C, D, E, X, Y, Z }
-         ^
+                        ^
+t6340.scala:11: error: value E is not a member of object Foo
+  import Foo.{ A, B, C, D, E, X, Y, Z }
+                           ^
 t6340.scala:16: error: not found: type D
   val d = new D
               ^
 t6340.scala:17: error: not found: type W
   val w = new W
               ^
-three errors found
+four errors found


### PR DESCRIPTION
This is a backport of 36868f8f1631936825cfd68e9c1463da481be7d3. Same motivation as the original PR, it helps diagnostics in Metals for 2.12.

I had to add a few "API" methods in ImportSelector that were introduced in 2.13, but otherwise this cherry-picks the referenced commit.