### PR TITLE
fix MiMa on JDK 25 by restoring some filters

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -43,6 +43,13 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.generic.CommonErrors"),
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.generic.CommonErrors$"),
 
+    // KEEP: new jdk 25 method in CharSequence => mixin forwarders
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.Predef#ArrayCharSequence.getChars"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.Predef#SeqCharSequence.getChars"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.mutable.StringBuilder.getChars"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.ArrayCharSequence.getChars"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.SeqCharSequence.getChars"),
+
   )
 
   override val buildSettings = Seq(


### PR DESCRIPTION
restored with `KEEP` this time so they don't get inadvertently removed again
