### PR TITLE
Handle missing annotation classes more gracefully

### DIFF
--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -1453,13 +1453,20 @@ abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
     if (flags.isStatic) staticScope else instanceScope
 
   // Append annotation. For Java deprecation, prefer an annotation with values (since, etc).
-  private def addUniqueAnnotation(symbol: Symbol, annot: AnnotationInfo): symbol.type =
-    if (annot.atp.typeSymbol == JavaDeprecatedAttr) {
+  private def addUniqueAnnotation(symbol: Symbol, annot: AnnotationInfo): symbol.type = {
+    // skip jdk internal synthetic symbols
+    def skipAnnot = settings.release.isSetByUser && {
+      annot.symbol match {
+        case sym: StubSymbol => sym.name.startsWith("jdk.internal.") && sym.name.endsWith("+Annotation")
+        case _ => false
+      }
+    }
+    if (annot.symbol == JavaDeprecatedAttr) {
       def ensureDepr(sym: Symbol): sym.type = {
         if (sym.hasAnnotation(JavaDeprecatedAttr))
           if (List(0, 1).exists(annot.constantAtIndex(_).isDefined))
             sym.setAnnotations {
-              def drop(cur: AnnotationInfo): Boolean = cur.atp.typeSymbol == JavaDeprecatedAttr
+              def drop(cur: AnnotationInfo): Boolean = cur.symbol == JavaDeprecatedAttr
               sym.annotations.foldRight(annot :: Nil)((a, all) => if (drop(a)) all else a :: all)
             }
           else sym
@@ -1469,7 +1476,11 @@ abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
         ensureDepr(staticModule)
       ensureDepr(symbol)
     }
-    else symbol.addAnnotation(annot)
+    else if (skipAnnot)
+      symbol
+    else
+      symbol.addAnnotation(annot)
+  }
 }
 object ClassfileParser {
   private implicit class GoodTimes(private val n: Int) extends AnyVal {

--- a/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/ClassfileParser.scala
@@ -1454,13 +1454,17 @@ abstract class ClassfileParser(reader: ReusableInstance[ReusableDataReader]) {
 
   // Append annotation. For Java deprecation, prefer an annotation with values (since, etc).
   private def addUniqueAnnotation(symbol: Symbol, annot: AnnotationInfo): symbol.type = {
-    // skip jdk internal synthetic symbols
-    def skipAnnot = settings.release.isSetByUser && {
+    // Silently ignore missing annotation classes like javac and Scala 3
+    def skipAnnot =
       annot.symbol match {
-        case sym: StubSymbol => sym.name.startsWith("jdk.internal.") && sym.name.endsWith("+Annotation")
+        case sym: StubSymbol =>
+          if (settings.isDeveloper || (settings.debug.value && !sym.name.startsWith("jdk.internal."))) {
+            val msg = s"Error while parsing annotations in $file: annotation class ${sym.name} not present on classpath"
+            loaders.warning(NoPosition, msg, WarningCategory.OtherDebug, clazz.fullNameString)
+          }
+          true
         case _ => false
       }
-    }
     if (annot.symbol == JavaDeprecatedAttr) {
       def ensureDepr(sym: Symbol): sym.type = {
         if (sym.hasAnnotation(JavaDeprecatedAttr))

--- a/test/files/pos/t13131/MyClassMacros_1.scala
+++ b/test/files/pos/t13131/MyClassMacros_1.scala
@@ -1,0 +1,9 @@
+package macros
+
+import scala.language.experimental.macros
+
+trait MyClassMacros {
+
+  implicit def derived[T]: MyClass[T] = macro MyClassMacroImpl.derived[T]
+
+}

--- a/test/files/pos/t13131/MyClass_1.scala
+++ b/test/files/pos/t13131/MyClass_1.scala
@@ -1,0 +1,7 @@
+package macros
+
+final case class MyClass[T]() {
+  def xyz = "xyz"
+}
+
+object MyClass extends MyClassMacros

--- a/test/files/pos/t13131/MyFile_2.scala
+++ b/test/files/pos/t13131/MyFile_2.scala
@@ -1,0 +1,14 @@
+//> using jvm 21+
+//> using options --release:17
+
+package app
+
+import java.time.LocalDateTime
+
+import macros.MyClass
+
+object MyFile {
+
+  implicit val x: String = implicitly[MyClass[LocalDateTime]].xyz
+
+}

--- a/test/files/pos/t13131/macro_1.scala
+++ b/test/files/pos/t13131/macro_1.scala
@@ -1,0 +1,33 @@
+//> using jvm 21+
+//> using options --release:17
+
+package macros
+
+import scala.reflect.macros.blackbox
+
+object MyClassMacroImpl {
+
+  def derived[T: c.WeakTypeTag](c: blackbox.Context): c.Expr[MyClass[T]] = {
+    import c.universe._
+
+    val deprecatedType = typeOf[scala.deprecated]
+
+    val weakType = weakTypeOf[T]
+    val annotations = weakType.typeSymbol.annotations
+
+    annotations
+      .foreach { ann =>
+        val isSubType = ann.tree.tpe <:< deprecatedType
+        /*
+        import scala.reflect.internal.{AnnotationInfos, SymbolTable}
+        val g = c.universe.asInstanceOf[AnnotationInfos with SymbolTable]
+        val isSubType = ann.asInstanceOf[g.AnnotationInfo].matches(symbolOf[scala.deprecated].asInstanceOf[g.Symbol])
+        */
+        assert(!isSubType)
+      }
+
+    c.Expr[MyClass[T]](
+      q"""_root_.macros.MyClass.apply()"""
+    )
+  }
+}


### PR DESCRIPTION
The reader of ct.sym must cope with certain special symbols.

To align with Scala 3, skip any annotation if the class is missing.

Warn under `-Xdev`, or under `-Vdebug` but not for `jdk.internal` classes because `-Vdebug` is already verbose (warns about the stub and also `MissingRequirementError`).

Fixes scala/bug#13131