### PR TITLE
Fix false positive unused warning for private val used in annotation

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -590,8 +590,20 @@ trait TypeDiagnostics extends splain.SplainDiagnostics {
 
     def descend(annot: AnnotationInfo): Unit =
       if (!annots(annot)) {
+        def traverseConstantArg(arg: ClassfileAnnotArg): Unit = arg match {
+          case arg: LiteralAnnotArg =>
+            arg.attachments.get[OriginalTreeAttachment] match {
+              case Some(OriginalTreeAttachment(original)) => traverse(original)
+              case _ =>
+            }
+          case ArrayAnnotArg(args) => args.foreach(traverseConstantArg)
+          case NestedAnnotArg(annInfo) => descend(annInfo)
+          case _ =>
+        }
         annots.addOne(annot)
         traverse(annot.original)
+        annot.args.foreach(traverse)
+        annot.assocs.foreach { case (_, arg) => traverseConstantArg(arg) }
       }
 
     override def traverse(t: Tree): Unit = {
@@ -659,6 +671,7 @@ trait TypeDiagnostics extends splain.SplainDiagnostics {
             case b @ Bind(n, _) if n != nme.DEFAULT_CASE => addPatVar(b)
             case _ =>
           }
+        case NamedArg(_, rhs) => traverse(rhs)
         case t: RefTree => handleRefTree(t)
         case Assign(lhs, _) if isExisting(lhs.symbol) => setVars += lhs.symbol
         case Function(ps, _) if !t.isErrorTyped =>

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4019,7 +4019,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     def typedAnnotation(ann: Tree, annotee: Option[Tree], mode: Mode = EXPRmode): AnnotationInfo = {
       var hasError: Boolean = false
       var unmappable: Boolean = false
-      val pending = ListBuffer[AbsTypeError]()
+      val pending = ListBuffer.empty[AbsTypeError]
       def ErroneousAnnotation = new ErroneousAnnotation().setOriginal(ann)
 
       def rangeFinder(): (Int, Int) =
@@ -4134,9 +4134,15 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           if (unit.isJava) unmappable = true
           else if (!isDefaultArg(ttree)) reportAnnotationError(AnnotationNotAConstantError(ttree))
           None
-        } else if (const.value == null) {
-          reportAnnotationError(AnnotationArgNullError(tr)); None
-        } else
+        }
+        else if (const.value == null) {
+          reportAnnotationError(AnnotationArgNullError(tr))
+          None
+        }
+        else if (isJava)
+          // for Wunused; not needed for Scala ConstantAnnotation, there we have a valid `annotationInfo.original`
+          Some(LiteralAnnotArg(const).updateAttachment(OriginalTreeAttachment(ttree)))
+        else
           Some(LiteralAnnotArg(const))
       }
 
@@ -4200,25 +4206,29 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           .map(args => ArrayAnnotArg(args.toArray))
       }
 
-      @inline def constantly = {
-        // Arguments of Java annotations and ConstantAnnotations are checked to be constants and
-        // stored in the `assocs` field of the resulting AnnotationInfo
+      // Arguments of Java annotations and ConstantAnnotations are checked to be constants and
+      // stored in the `assocs` field of the resulting AnnotationInfo
+      def constantly =
         if (argss.lengthIs > 1) {
           reportAnnotationError(MultipleArgumentListForAnnotationError(ann))
         } else {
           val annScopeJava = annType.decls.filter(sym => sym.isMethod && !sym.isConstructor && sym.isJavaDefined)
 
-          val names = mutable.Set[Symbol]()
+          val names = mutable.Set.empty[Symbol]
           names ++= annScopeJava.iterator
 
-          def hasValue = names exists (_.name == nme.value)
+          def hasValue = names.exists(_.name == nme.value)
           val namedArgs = argss match {
-            case List(List(arg)) if !isNamedArg(arg) && hasValue => gen.mkNamedArg(nme.value, arg) :: Nil
-            case List(args)                                      => args
-            case x                                               => throw new MatchError(x)
+            case args :: Nil =>
+              args match {
+                case arg :: Nil if !isNamedArg(arg) && hasValue => gen.mkNamedArg(nme.value, arg) :: Nil
+                case args => args
+              }
+            case x => throw new MatchError(x)
           }
 
-          val nvPairs = namedArgs map {
+          // name, optional value
+          val nvPairs = namedArgs.map {
             case arg @ NamedArg(Ident(name), rhs) =>
               val sym = annScopeJava.lookup(name)
               if (sym == NoSymbol) {
@@ -4230,7 +4240,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
               } else {
                 names -= sym
                 sym.cookJavaRawInfo() // #3429
-                val annArg = tree2ConstArg(rhs, sym.tpe.resultType)
+                val pt = sym.tpe.resultType
+                val annArg = tree2ConstArg(rhs, pt)
                 (sym.name, annArg)
               }
             case arg =>
@@ -4249,11 +4260,13 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           else {
             if (annTypeSym == JavaDeprecatedAttr && !context.unit.isJava && settings.lintDeprecation)
               context.warning(ann.pos, """Prefer the Scala annotation over Java's `@Deprecated` to provide a message and version: @deprecated("message", since = "MyLib 1.0")""", WarningCategory.LintDeprecation)
-            AnnotationInfo(annType, Nil, nvPairs.map(p => (p._1, p._2.get))).setOriginal(Apply(typedFun, namedArgs).setPos(ann.pos))
+            AnnotationInfo(annType, Nil, nvPairs.map(p => (p._1, p._2.get)))
+              .setOriginal(Apply(typedFun, namedArgs).setPos(ann.pos))
           }
         }
-      }
-      @inline def statically = {
+      // end constantly
+
+      def statically = {
         val typedAnn: Tree = {
           // local dummy fixes scala/bug#5544
           val localTyper = newTyper(context.make(ann, context.owner.newLocalDummy(ann.pos)))
@@ -4298,6 +4311,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
           info
         }
       }
+      // end statically
 
       finish {
         if (isJava)

--- a/src/reflect/scala/reflect/internal/AnnotationInfos.scala
+++ b/src/reflect/scala/reflect/internal/AnnotationInfos.scala
@@ -75,7 +75,7 @@ trait AnnotationInfos extends api.Annotations { self: SymbolTable =>
    *  - arrays of constants
    *  - or nested classfile annotations (only for Java annotation)
    *
-   * TODO: rename to `ConstantAnnotationArg`
+   * aka `ConstantAnnotationArg`
    */
   @nowarn("""cat=deprecation&origin=scala\.reflect\.api\.Annotations\.JavaArgumentApi""")
   sealed abstract class ClassfileAnnotArg extends Product with JavaArgumentApi
@@ -87,7 +87,7 @@ trait AnnotationInfos extends api.Annotations { self: SymbolTable =>
    *  `Char`, `Int`, `Long`, `Float`, `Double`, `String`, `java.lang.Class` or
    *  an instance of a Java enumeration value).
    */
-  case class LiteralAnnotArg(const: Constant) extends ClassfileAnnotArg {
+  case class LiteralAnnotArg(const: Constant) extends ClassfileAnnotArg with Attachable {
     override def toString = const.escapedStringValue
   }
 
@@ -189,7 +189,7 @@ trait AnnotationInfos extends api.Annotations { self: SymbolTable =>
    * If `atp` conforms to `ConstantAnnotation` (which is true for annotations defined in Java), the annotation
    * arguments are compile-time constants represented in `assocs`. Note that default arguments are *not* present
    * in `assocs`. The `assocsWithDefaults` extends `assocs` with the default values from the annotation definition.
-   * Example: `class a(x: Int = 1) extends ConstantAnnotation`.F or `@ann()` without arguments `assocsWithDefaults`
+   * Example: `class a(x: Int = 1) extends ConstantAnnotation`. For `@ann()` without arguments `assocsWithDefaults`
    * contains `x -> 1`.
    *
    * If `atp` is not a `ConstantAnnotation`, the annotation arguments are represented as type trees in `args`.

--- a/test/files/neg/t13130.check
+++ b/test/files/neg/t13130.check
@@ -1,0 +1,6 @@
+t13130.scala:9: warning: method f in class C is deprecated (since 1.0): nope
+  def g = f
+          ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/t13130.scala
+++ b/test/files/neg/t13130.scala
@@ -1,0 +1,10 @@
+//> using options -Werror -Wunused:privates -deprecation
+
+class C {
+  private final val when = "1.0"
+
+  @deprecated("nope", since = when)
+  def f = 42
+
+  def g = f
+}

--- a/test/files/pos/t13130/Ann.java
+++ b/test/files/pos/t13130/Ann.java
@@ -1,0 +1,15 @@
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Ann {
+    String value();
+    String notes() default "";
+    String[] tags() default "";
+    String produces() default "";
+    String consumes() default "";
+}

--- a/test/files/pos/t13130/test.scala
+++ b/test/files/pos/t13130/test.scala
@@ -1,0 +1,8 @@
+//> using options -Werror -Wunused:privates
+
+class C {
+  private final val k = "hello, world"
+
+  @Ann(value = "i13130", produces = k)
+  def f(): Unit = ()
+}


### PR DESCRIPTION
Fixes scala/bug#13130, a false positive unused warning for a `final private val` used as annotation argument.

Java or Constant annotations don't hold trees but wrappers of constant values for arguments to the annotation. For purposes of constant folding, there is no tree to receive an `OriginalTreeAttachment`, for tools to analyze.

`AnnotationInfo` has an original tree property to support reification, but that tree is the untyped named args.

This commit makes `LiteralAnnotArg` extend `Attachable` so that it can bear an "original" tree which is really the typed tree for the arg. The `unused` linter drills through the annot arg to its original, which allows it to resolve symbolic references to constant values.