### PR TITLE
Add parent to Ordering to allow `override` on `min` / `max`

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -50,6 +50,13 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.ArrayCharSequence.getChars"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.SeqCharSequence.getChars"),
 
+    // scala/scala#11153
+    ProblemFilters.exclude[MissingClassProblem]("scala.math.Ordering$OrderingMinMax"),
+    // Adding `with OrderingMinMax` to `Ordering` causes mima to report a forwards bin compat warning for every subtype of Ordering, e.g.
+    //   > the type hierarchy of Ordering#Char is different in other version. Missing types {Ordering$OrderingMinMax}
+    // This should only affect the standard library, other projects are not enforcing forwards binary compatibility.
+    !_.description("other").contains("different in other version. Missing types {scala.math.Ordering$OrderingMinMax}"),
+
   )
 
   override val buildSettings = Seq(

--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -14,9 +14,9 @@ package scala
 package math
 
 import java.util.Comparator
-
 import scala.language.implicitConversions
 import scala.annotation.migration
+import scala.math.Ordering.OrderingMinMax
 
 /** Ordering is a trait whose instances each represent a strategy for sorting
   * instances of a type.
@@ -69,7 +69,7 @@ import scala.annotation.migration
   *
   * @see [[scala.math.Ordered]], [[scala.util.Sorting]], [[scala.math.Ordering.Implicits]]
   */
-trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializable {
+trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializable with OrderingMinMax[T] {
   outer =>
 
   /** Returns whether a comparison between `x` and `y` is defined, and if so
@@ -103,10 +103,10 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
   override def equiv(x: T, y: T): Boolean = compare(x, y) == 0
 
   /** Return `x` if `x` >= `y`, otherwise `y`. */
-  def max[U <: T](x: U, y: U): U = if (gteq(x, y)) x else y
+  override def max[U <: T](x: U, y: U): U = if (gteq(x, y)) x else y
 
   /** Return `x` if `x` <= `y`, otherwise `y`. */
-  def min[U <: T](x: U, y: U): U = if (lteq(x, y)) x else y
+  override def min[U <: T](x: U, y: U): U = if (lteq(x, y)) x else y
 
   /** Return the opposite ordering of this one.
     *
@@ -924,5 +924,12 @@ object Ordering extends LowPriorityOrderingImplicits {
       case _ => false
     }
     override def hashCode(): Int = (ord1, ord2, ord3, ord4, ord5, ord6, ord7, ord8, ord9).hashCode()
+  }
+
+  // Java 26 adds `min` / `max` default methods to `Comparator`, which requires our `min` / `max` methods in
+  // `Ordering` to have the `override` modifier. This parent trait allows that modifier on earlier Java versions.
+  private[Ordering] trait OrderingMinMax[T] {
+    def min[U <: T](x: U, y: U): U
+    def max[U <: T](x: U, y: U): U
   }
 }

--- a/test/files/run/repl-type-verbose.check
+++ b/test/files/run/repl-type-verbose.check
@@ -160,7 +160,7 @@ PolyType(
       args = List(TypeParamTypeRef(TypeParam(T)))
       normalize = TypeRef(
         TypeSymbol(
-          abstract trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializable
+          abstract trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializable with math.Ordering.OrderingMinMax[T]
 
         )
         args = List(TypeParamTypeRef(TypeParam(T)))


### PR DESCRIPTION
Java 26 adds `min` / `max` default methods to `Comparator`, which requires our `min` / `max` methods in `Ordering` to have the `override` modifier.

Add a new parent trait with abstract declarations to allow that modifier on earlier Java versions.

Fixes https://github.com/scala/bug/issues/13127