### PR TITLE
Deprecate `-Xmain-class`

### DIFF
--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -122,6 +122,9 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
   val resident           = BooleanSetting      ("-Xresident", "Compiler stays resident: read source filenames from standard input.")
   val script             = StringSetting       ("-Xscript", "object", "Treat the source file as a script and wrap it in a main method.", "Main")
   val mainClass          = StringSetting       ("-Xmain-class", "path", "Class for manifest's Main-Class entry (only useful with -d <jar>)", "")
+    .withDeprecationMessage(
+      """the Scala compiler will stop emitting the Main-Class manifest entry, since it is only supported by the legacy `scala` runner.
+        |scala-cli disregards the entry, instead it finds main classes when running a jar.""".stripMargin)
   val sourceReader       = StringSetting       ("-Xsource-reader", "classname", "Specify a custom method for reading source files.", "")
   val reporter           = StringSetting       ("-Xreporter", "classname", "Specify a custom subclass of FilteringReporter for compiler messages.", "scala.tools.nsc.reporters.ConsoleReporter")
   private val XsourceHelp =

--- a/test/files/neg/main2.check
+++ b/test/files/neg/main2.check
@@ -1,3 +1,5 @@
+warning: -Xmain-class is deprecated: the Scala compiler will stop emitting the Main-Class manifest entry, since it is only supported by the legacy `scala` runner.
+scala-cli disregards the entry, instead it finds main classes when running a jar.
 main2.scala:7: warning: X has a valid main method (args: Array[String]): Unit,
   but p.X will not have an entry point on the JVM.
   Reason: companion is a trait, which means no static forwarder can be generated.
@@ -5,5 +7,5 @@ main2.scala:7: warning: X has a valid main method (args: Array[String]): Unit,
   object X {
          ^
 error: No warnings can be incurred under -Werror.
-1 warning
+2 warnings
 1 error

--- a/test/files/neg/main2.scala
+++ b/test/files/neg/main2.scala
@@ -1,4 +1,4 @@
-//> using options -Xfatal-warnings -Xmain-class p.X
+//> using options -deprecation -Xfatal-warnings -Xmain-class p.X
 //
 
 // emit a warning


### PR DESCRIPTION
The Main-Class manifest attribute written in direct-to-jar compilation is only useful when using the legacy `scala` runner script.

scala-cli does not read the attribute, it detects main classes instead.

Running a Scala jar using `java -jar` does not work either because the Scala library will not be on the classpath; combining `-jar` with `-classpath` does not work.