### PR TITLE
fix: Fixes infer-any warning on F[_]

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Infer.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Infer.scala
@@ -483,6 +483,10 @@ trait Infer extends Checkable {
         WildcardType.fillList(tvars.length)
     }
 
+    def isRetractable(tparam: Symbol, targ: Type, restpe: Type): Boolean =
+      targ.typeSymbol == NothingClass &&                                   // only retract Nothings
+        (restpe.isWildcard || !varianceInType(restpe)(tparam).isPositive)  // don't retract covariant occurrences
+
     /** Retract arguments that were inferred to Nothing because inference failed. Correct types for repeated params.
      *
      * We detect Nothing-due-to-failure by only retracting a parameter if either:
@@ -503,12 +507,7 @@ trait Infer extends Checkable {
       val okArgs, allArgs = ListBuffer.empty[Type]
 
       foreach3(tparams, tvars, targs) { (tparam, tvar, targ) =>
-        val retract = (
-              targ.typeSymbol == NothingClass                                         // only retract Nothings
-          && (restpe.isWildcard || !varianceInType(restpe)(tparam).isPositive)  // don't retract covariant occurrences
-        )
-
-        if (retract) {
+        if (isRetractable(tparam, targ, restpe)) {
           undetParams += tparam
           allArgs += NothingTpe
         } else {
@@ -594,7 +593,9 @@ trait Infer extends Checkable {
               !tvar.constr.hiBounds.exists(t => topTypes.contains(t.typeSymbol)))
             context.warning(fn.pos, s"a type was inferred to be `${targ.typeSymbol.name
               }`; this may indicate a programming error.", LintInferAny)
-          if (!tparam.isMonomorphicType && !targ.isHigherKinded)
+          if (!tparam.isMonomorphicType &&
+              !targ.isHigherKinded &&
+              !isRetractable(tparam, targ, restpe))
             context.warning(fn.pos, s"a type was inferred to be kind-polymorphic `${targ.typeSymbol.name
               }` to conform to `${tparam.defString}`", LintInferAny)
         }

--- a/test/files/neg/t13128.check
+++ b/test/files/neg/t13128.check
@@ -1,0 +1,9 @@
+t13128.scala:9: warning: a type was inferred to be kind-polymorphic `Nothing` to conform to `F[_]`
+  def t1 = f1(1) // warn
+           ^
+t13128.scala:12: warning: a type was inferred to be kind-polymorphic `Nothing` to conform to `F[_]`
+  def t2 = f2(1)((x: Some[Int]) => 1) // warn
+           ^
+error: No warnings can be incurred under -Werror.
+2 warnings
+1 error

--- a/test/files/neg/t13128.scala
+++ b/test/files/neg/t13128.scala
@@ -1,0 +1,13 @@
+//> using options -Xlint:infer-any -Werror
+
+// https://github.com/scala/bug/issues/13128
+trait Bippy {
+  def f[F[_]](i: Int)(ev: F[Int]): Int
+  def t = f(1)(Some(1)) // no warn
+
+  def f1[F[_]](i: Int): Int
+  def t1 = f1(1) // warn
+
+  def f2[F[_]](i: Int)(ev: F[Int] => Int): Int
+  def t2 = f2(1)((x: Some[Int]) => 1) // warn
+}


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/13128

## Problem
infer-any linter warns on `F[_]` when the function is curried.

## Solution
Don't warn when the inference is retractable, which is Nothing.