### PR TITLE
Fix false positive `universal-methods` lint warning in synthetic code

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -5484,7 +5484,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             wrapErrors(t, _.typed1(t, mode, pt))
           }
           def checkDubiousUnitSelection(result: Tree): Unit =
-            if (!isPastTyper && isUniversalMember(result.symbol))
+            if (!isPastTyper && isUniversalMember(result.symbol) && result.pos.isRange)
               context.warning(tree.pos, s"dubious usage of ${result.symbol} with unit value", WarningCategory.LintUniversalMethods)
 
           val sym = tree.symbol

--- a/test/files/pos/t13134.scala
+++ b/test/files/pos/t13134.scala
@@ -1,0 +1,6 @@
+//> using options -Werror -Xlint
+
+object Main {
+  def callFunction(function: PartialFunction[Unit, Unit]): Unit = function(???)
+  def main(arguments: Array[String]): Unit = callFunction { _ => }
+}


### PR DESCRIPTION
Fixes scala/bug#13134, a false positive `universal-methods` lint warning in synthetic code for partial functions.

Only warn a dubious selection that has a range position, which is more likely to be user-written code.