### PR TITLE
Check for synthetic case methods in unused lint

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/Fields.scala
+++ b/src/compiler/scala/tools/nsc/transform/Fields.scala
@@ -24,13 +24,13 @@ import symtab.Flags._
   * The underlying field symbol does not exist until this phase.
   *
   * For `val`s defined in classes, we still emit a field immediately.
-  * TODO: uniformly assign getter symbol to all `ValDef`s, stop using `accessed`.
+  * Would be nice to uniformly assign getter symbol to all `ValDef`s, stop using `accessed`.
   *
   * This phase synthesizes accessors, fields and bitmaps (for lazy or init-checked vals under -Xcheckinit)
   * in the first (closest in the subclassing lattice) subclass (not a trait) of a trait.
   *
   * For lazy vals and modules, we emit accessors that using double-checked locking (DCL) to balance thread safety
-  * and performance. For both lazy vals and modules, the a compute method contains the DCL's slow path.
+  * and performance. For both lazy vals and modules, the compute method contains the DCL's slow path.
   *
   * Local lazy vals do not receive bitmaps, but use a Lazy*Holder that has the volatile init bit and the computed value.
   * See `mkLazyLocalDef`.
@@ -74,10 +74,10 @@ import symtab.Flags._
   * The only change due to overriding is that its value is never written to the field
   * (the overridden val's value is, of course, stored in the field in addition to its side-effect being performed).
   *
-  * TODO: Java 9 support for vals defined in traits. They are currently emitted as final,
-  *       but the write (putfield) to the val does not occur syntactically within the <init> method
-  *       (it's done by the trait setter, which is called from the trait's mixin constructor,
-  *       which is called from the subclass's constructor...)
+  * Would be nice to accommodate Java 9 support for vals defined in traits.
+  * They are currently emitted as final, but the write (putfield) to the val does not occur syntactically
+  * within the <init> method (it's done by the trait setter, which is called from the trait's mixin constructor,
+  * which is called from the subclass's constructor...)
   */
 abstract class Fields extends InfoTransform with ast.TreeDSL with TypingTransformers with AccessorSynthesis {
   import global._

--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -516,6 +516,8 @@ trait TypeDiagnostics extends splain.SplainDiagnostics {
 
     def recordReference(sym: Symbol): Unit = targets.addOne(sym)
 
+    def recordType(tp: Type): Unit = treeTypes.addOne(tp)
+
     def checkNowarn(tree: Tree): Unit =
       tree match {
         case tree: Bind =>
@@ -553,12 +555,27 @@ trait TypeDiagnostics extends splain.SplainDiagnostics {
 
     def handleRefTree(t: RefTree): Unit = {
       val sym = t.symbol
-      if (isExisting(sym) && !currentOwner.hasTransOwner(sym) && !t.hasAttachment[ForAttachment.type])
+      if (isExisting(sym) && !isCurrentlyEnclosedBy(sym) && !t.hasAttachment[ForAttachment.type])
         recordReference(sym)
     }
 
+    // sym is an owner or an owner is a synthetic case method owned by sym's companion module
+    // note: isConstructor avoids only super.<init> at typer
+    def isCurrentlyEnclosedBy(sym: Symbol): Boolean =
+      currentOwner.hasTransOwner(sym) || sym.isCaseClass && {
+        val module = sym.companionModule.moduleClass
+        def enclosed =
+          currentOwner.ownersIterator
+            .takeWhile(!_.isClass)
+            .exists(owner =>
+                 owner.owner == module
+              && (owner.isCase && owner.isSynthetic || owner.isConstructor)
+            )
+        currentOwner == module || enclosed
+      }
+
     def handleTreeType(t: Tree): Unit =
-      if ((t.tpe ne null) && t.tpe != NoType) {
+      if ((t.tpe ne null) && t.tpe != NoType /*&& !treeInfo.isSuperConstrCall(t)*/) { // see isCurrentlyEnclosedBy
         for (tp <- t.tpe if tp != NoType && !treeTypes(tp)) {
           // Include references to private/local aliases (which might otherwise refer to an enclosing class)
           val isAlias = {
@@ -566,17 +583,17 @@ trait TypeDiagnostics extends splain.SplainDiagnostics {
             td.isAliasType && (td.isLocalToBlock || td.isPrivate)
           }
           // Ignore type references to an enclosing class. A reference to C must be outside C to avoid warning.
-          if (isAlias || !currentOwner.hasTransOwner(tp.typeSymbol)) tp match {
+          if (isAlias || !isCurrentlyEnclosedBy(tp.typeSymbol)) tp match {
             case NoType | NoPrefix    =>
             case NullaryMethodType(_) =>
             case MethodType(_, _)     =>
             case SingleType(_, _)     =>
             case ConstantType(Constant(k: Type)) =>
               log(s"classOf $k referenced from $currentOwner")
-              treeTypes += k
+              recordType(k)
             case _                    =>
               log(s"${if (isAlias) "alias " else ""}$tp referenced from $currentOwner")
-              treeTypes += tp
+              recordType(tp)
           }
           for (annot <- tp.annotations)
             descend(annot)
@@ -715,7 +732,7 @@ trait TypeDiagnostics extends splain.SplainDiagnostics {
         && !isSuppressed(m)
         && !m.isTypeParameterOrSkolem // would be nice to improve this
         && (m.isPrivate || m.isLocalToBlock || isEffectivelyPrivate(m))
-        && !treeTypes.exists(_.exists(_.typeSymbolDirect == m))
+        && !treeTypes.exists(_.typeSymbolDirect == m)
       )
     def isSyntheticWarnable(sym: Symbol) = {
       def privateSyntheticDefault: Boolean =

--- a/test/files/neg/i24235.check
+++ b/test/files/neg/i24235.check
@@ -1,0 +1,6 @@
+i24235.scala:4: warning: private class Unused in object Test is never used
+  private case class Unused(i: Int = 42)
+                     ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/i24235.scala
+++ b/test/files/neg/i24235.scala
@@ -1,0 +1,5 @@
+//> using options -Werror -Wunused:privates -Xsource:3 -Xsource-features:case-companion-function
+
+object Test {
+  private case class Unused(i: Int = 42)
+}

--- a/test/files/neg/i24235b.check
+++ b/test/files/neg/i24235b.check
@@ -1,0 +1,6 @@
+i24235b.scala:3: warning: private class Unused in object Test is never used
+  private case class Unused(i: Int = 42)
+                     ^
+error: No warnings can be incurred under -Werror.
+1 warning
+1 error

--- a/test/files/neg/i24235b.scala
+++ b/test/files/neg/i24235b.scala
@@ -1,0 +1,14 @@
+//> using options -Werror -Wunused:privates
+object Test {
+  private case class Unused(i: Int = 42)
+
+  private case class C()
+  private object C {
+    val c = new C().toString // obviously a usage; rhs is not in ctor at typer
+  }
+
+  private case class D()
+  private object D {
+    new D() // D for ditto
+  }
+}


### PR DESCRIPTION
Backports https://github.com/scala/scala3/pull/24239

Avoid recording references in synthetic methods of case class companion.

Also avoid visiting the type of `super.<init>` in the constructor of the companion, for the case when the companion extends a function. 