### PR TITLE
Re-introduce null checks to ScalaRunTime.wrapXArray

### DIFF
--- a/src/library/scala/runtime/ScalaRunTime.scala
+++ b/src/library/scala/runtime/ScalaRunTime.scala
@@ -280,20 +280,23 @@ object ScalaRunTime {
       case s => s + "\n"
     }
 
-  // Convert arrays to immutable.ArraySeq for use with Scala varargs.
-  // By construction, calls to these methods always receive a fresh (and non-null), non-empty array.
-  // In cases where an empty array would appear, the compiler uses a direct reference to Nil instead.
-  // Synthetic Java varargs forwarders (@annotation.varargs or varargs bridges when overriding) may pass
-  // `null` to these methods; but returning `null` or `ArraySeq(null)` makes little difference in practice.
-  def genericWrapArray[T](xs: Array[T]): ArraySeq[T] = ArraySeq.unsafeWrapArray(xs)
-  def wrapRefArray[T <: AnyRef](xs: Array[T]): ArraySeq[T] = new ArraySeq.ofRef[T](xs)
-  def wrapIntArray(xs: Array[Int]): ArraySeq[Int] = new ArraySeq.ofInt(xs)
-  def wrapDoubleArray(xs: Array[Double]): ArraySeq[Double] = new ArraySeq.ofDouble(xs)
-  def wrapLongArray(xs: Array[Long]): ArraySeq[Long] = new ArraySeq.ofLong(xs)
-  def wrapFloatArray(xs: Array[Float]): ArraySeq[Float] = new ArraySeq.ofFloat(xs)
-  def wrapCharArray(xs: Array[Char]): ArraySeq[Char] = new ArraySeq.ofChar(xs)
-  def wrapByteArray(xs: Array[Byte]): ArraySeq[Byte] = new ArraySeq.ofByte(xs)
-  def wrapShortArray(xs: Array[Short]): ArraySeq[Short] = new ArraySeq.ofShort(xs)
-  def wrapBooleanArray(xs: Array[Boolean]): ArraySeq[Boolean] = new ArraySeq.ofBoolean(xs)
-  def wrapUnitArray(xs: Array[Unit]): ArraySeq[Unit] = new ArraySeq.ofUnit(xs)
+  // Convert an array to an immutable.ArraySeq for use with Scala varargs.
+  // `foo(x, y)` is compiled to `foo(wrapXArray(Array(x, y))).
+  // For `foo()`, the Scala 2 compiler uses a reference to `Nil` instead; Scala 3 doesn't have this special case.
+  //
+  // The `null` checks are there for backwards compatibility. They were removed in 2.13.17 (scala/scala#11021)
+  // which led to a ticket in Scala 3 (scala/scala3#24204). The argument may be null:
+  //   - When calling a Scala `@varargs` method from Java
+  //   - When using an array as sequence argument in Scala 3: `foo((null: Array[X])*)`
+  def genericWrapArray[T](xs: Array[T]): ArraySeq[T]          = if (xs ne null) ArraySeq.unsafeWrapArray(xs) else null
+  def wrapRefArray[T <: AnyRef](xs: Array[T]): ArraySeq[T]    = if (xs ne null) new ArraySeq.ofRef[T](xs) else null
+  def wrapIntArray(xs: Array[Int]): ArraySeq[Int]             = if (xs ne null) new ArraySeq.ofInt(xs) else null
+  def wrapDoubleArray(xs: Array[Double]): ArraySeq[Double]    = if (xs ne null) new ArraySeq.ofDouble(xs) else null
+  def wrapLongArray(xs: Array[Long]): ArraySeq[Long]          = if (xs ne null) new ArraySeq.ofLong(xs) else null
+  def wrapFloatArray(xs: Array[Float]): ArraySeq[Float]       = if (xs ne null) new ArraySeq.ofFloat(xs) else null
+  def wrapCharArray(xs: Array[Char]): ArraySeq[Char]          = if (xs ne null) new ArraySeq.ofChar(xs) else null
+  def wrapByteArray(xs: Array[Byte]): ArraySeq[Byte]          = if (xs ne null) new ArraySeq.ofByte(xs) else null
+  def wrapShortArray(xs: Array[Short]): ArraySeq[Short]       = if (xs ne null) new ArraySeq.ofShort(xs) else null
+  def wrapBooleanArray(xs: Array[Boolean]): ArraySeq[Boolean] = if (xs ne null) new ArraySeq.ofBoolean(xs) else null
+  def wrapUnitArray(xs: Array[Unit]): ArraySeq[Unit]          = if (xs ne null) new ArraySeq.ofUnit(xs) else null
 }

--- a/test/files/run/pr11021/J.java
+++ b/test/files/run/pr11021/J.java
@@ -1,0 +1,6 @@
+public class J {
+  public static int m() {
+    String[] arg = null;
+    return Test.va(arg);
+  }
+}

--- a/test/files/run/pr11021/Test.scala
+++ b/test/files/run/pr11021/Test.scala
@@ -1,0 +1,14 @@
+object Test {
+  @annotation.varargs def va(s: String*) =
+    if (s == null) 0
+    else 1
+
+  def main(args: Array[String]) = {
+    val arr: Array[String] = null
+    val seq: Seq[String] = null
+
+    assert(va(arr: _*) == 0): @annotation.nowarn("cat=deprecation")
+    assert(va(seq: _*) == 0)
+    assert(J.m() == 0)
+  }
+}

--- a/test/junit/scala/runtime/ScalaRunTimeTest.scala
+++ b/test/junit/scala/runtime/ScalaRunTimeTest.scala
@@ -62,4 +62,9 @@ class ScalaRunTimeTest {
     assertEquals(null, stringOf(tpolecat))
     assertEquals("null toString", replStringOf(tpolecat, 100))
   }
+
+  @Test def scala3ticket24204(): Unit = {
+    assertEquals(null, ScalaRunTime.wrapRefArray(null: Array[String]))
+    assertEquals(null, ScalaRunTime.genericWrapArray(null: Array[String]))
+  }
 }


### PR DESCRIPTION
When using an array as sequence argument in Scala 3, the compiler emits a conversion to a `Seq` using `ScalaRunTime.wrapXArray`. The change in PR 11021 affects the semantics of such code.

Reverts https://github.com/scala/scala/pull/11021

Ref https://github.com/scala/scala3/issues/24204