### PR TITLE
Prevent accidental `$lambda` when flattening classes in LambdaLift

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
+++ b/src/compiler/scala/tools/nsc/transform/LambdaLift.scala
@@ -264,7 +264,7 @@ abstract class LambdaLift extends InfoTransform {
 
         val join = nme.NAME_JOIN_STRING
         if (sym.isAnonymousFunction && sym.owner.isMethod) {
-          freshen("" + sym.name + join + nme.ensureNonAnon(sym.owner.name.toString) + join)
+          freshen(s"${sym.name}${nme.ensureNonAnon(join + sym.owner.name.toString)}$join")
         } else {
           val name = freshen(s"${sym.name}${join}")
           // scala/bug#5652 If the lifted symbol is accessed from an inner class, it will be made public. (where?)

--- a/test/files/pos/t10857.scala
+++ b/test/files/pos/t10857.scala
@@ -1,0 +1,10 @@
+class JSFunction
+
+trait JSFunction0[+R] extends JSFunction {
+  def apply(): R
+}
+
+object A {
+  def lambdaAnything() = test(() => 1)
+  def test(cmp: JSFunction0[Int]) = ()
+}


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/10857