### PR TITLE
Fix unused local warning in macro expansion after untypecheck

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/Trees.scala
+++ b/src/compiler/scala/tools/nsc/ast/Trees.scala
@@ -19,6 +19,8 @@ import java.lang.System.lineSeparator
 import scala.annotation.nowarn
 
 trait Trees extends scala.reflect.internal.Trees { self: Global =>
+  import self.analyzer.OriginalTreeAttachment
+
   // --- additional cases --------------------------------------------------------
   /** Only used during parsing */
   case class Parens(args: List[Tree]) extends Tree {
@@ -323,8 +325,18 @@ trait Trees extends scala.reflect.internal.Trees { self: Global =>
               // The typer does not accept UnApply. Replace it with Apply, which can be retyped.
               case UnApply(Unapplied(Applied(Select(fun, nme.unapply | nme.unapplySeq), _, _)), args) =>
                 Apply(transform(fun), transformTrees(args))
-              case _ =>
-                val dupl = tree.duplicate
+              case tree =>
+                val dupl = {
+                  val original = tree match {
+                    case tree @ Literal(_) =>
+                      tree.attachments.get[OriginalTreeAttachment] match {
+                        case Some(OriginalTreeAttachment(original)) => original
+                        case _ => tree
+                      }
+                    case tree => tree
+                  }
+                  original.duplicate
+                }
                 // Typically the resetAttrs transformer cleans both symbols and types.
                 // However there are exceptions when we cannot erase symbols due to idiosyncrasies of the typer.
                 // vetoXXX local variables declared below describe the conditions under which we cannot erase symbols.

--- a/test/files/pos/t13139/macro_0.scala
+++ b/test/files/pos/t13139/macro_0.scala
@@ -1,0 +1,12 @@
+// using scala 2.13.17
+// using dep org.scala-lang:scala-compiler:2.13.17
+
+import language.experimental.macros
+import scala.reflect.macros.blackbox.Context
+
+object Stub {
+  def stub[A](impl: A): Unit = macro stub0[A]
+
+  def stub0[A: c.WeakTypeTag](c: Context)(impl: c.Expr[A]): c.Tree =
+    c.untypecheck(impl.tree)
+}

--- a/test/files/pos/t13139/test_1.scala
+++ b/test/files/pos/t13139/test_1.scala
@@ -1,0 +1,10 @@
+//> using options -Werror -Wmacros:both -Wunused:_
+
+case class Foo(foo: String, flag: Boolean)
+
+object Main extends App {
+  val randStr = ""
+  println {
+    Stub.stub(Foo(flag = true, foo = randStr))
+  }
+}


### PR DESCRIPTION
Fixes scala/bug#13139

The OP macro uses resetAttrs, which did not reset a constant with an original that is a local val (due to renamed arg).
