### PR TITLE
Overload lint ignores deprecated members

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -202,7 +202,7 @@ abstract class RefChecks extends Transform {
       val byName =
         clazz.info.members
           .reverseIterator
-          .filter(m => ofInterest(m.info))
+          .filter(m => !m.isDeprecated && ofInterest(m.info))
           .toList
           .groupBy(_.name.dropLocal)
       def isCompetitive(syms: List[Symbol], sawNlly: Boolean, sawNonNlly: Boolean): Boolean =

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2930,7 +2930,7 @@ trait Types
 
   object MethodType extends MethodTypeExtractor
 
-  /** A method without parameter lists.
+  /** A method without parameter lists, i.e., parameterless or parameterlistless.
    *
    *  Note: a MethodType with paramss that is a ListOfNil is called "nilary", to disambiguate.
    */

--- a/test/files/neg/t7415.scala
+++ b/test/files/neg/t7415.scala
@@ -89,6 +89,12 @@ trait Matchers {
 }
 object InnocentTest extends Matchers
 
+trait T2 {
+  @deprecated("old api", since="2.0")
+  def foo = 0
+}
+object Evolved extends Base with T2 // no warn deprecated alternative, compare Mixed above
+
 object Test extends App {
   implicit val t: T = new T {}
   val d1 = new Derived1 {} // no warn innocent client, already warned in evil parent


### PR DESCRIPTION
Fixes scala/bug#13138
