### PR TITLE
Upgrade ASM for JDK 26 support (-target:26, optimizer)

### DIFF
--- a/project/ScalaOptionParser.scala
+++ b/project/ScalaOptionParser.scala
@@ -126,5 +126,5 @@ object ScalaOptionParser {
   private def scaladocPathSettingNames = List("-doc-root-content", "-diagrams-dot-path")
   private def scaladocMultiStringSettingNames = List("-doc-external-doc")
 
-  private val targetSettingNames = (5 to 25).flatMap(v => s"$v" :: s"jvm-1.$v" :: s"jvm-$v" :: s"1.$v" :: Nil).toList
+  private val targetSettingNames = (5 to 26).flatMap(v => s"$v" :: s"jvm-1.$v" :: s"jvm-$v" :: s"1.$v" :: Nil).toList
 }

--- a/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/analysis/BackendUtils.scala
@@ -95,6 +95,7 @@ abstract class BackendUtils extends PerRunInit {
       case "23" => asm.Opcodes.V23
       case "24" => asm.Opcodes.V24
       case "25" => asm.Opcodes.V25
+      case "26" => asm.Opcodes.V26
       // to be continued...
     })
 

--- a/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala
@@ -118,7 +118,7 @@ object StandardScalaSettings {
   val MaxTargetVersion = ScalaVersion(javaSpecVersion) match {
     case SpecificScalaVersion(1, minor, _, _) => minor
     case SpecificScalaVersion(major, _, _, _) => major
-    case _ => 25
+    case _ => 26
   }
   val MaxSupportedTargetVersion = 8
   val DefaultTargetVersion = "8"

--- a/test/junit/scala/tools/nsc/settings/TargetTest.scala
+++ b/test/junit/scala/tools/nsc/settings/TargetTest.scala
@@ -113,7 +113,10 @@ class TargetTest {
     check("-target:jvm-25", "8", "25")
     check("-target:25", "8", "25")
 
-    checkFail("-target:jvm-26")   // not yet...
+    check("-target:jvm-26", "8", "26")
+    check("-target:26", "8", "26")
+
+    checkFail("-target:jvm-27")   // not yet...
     checkFail("-target:jvm-3000") // not in our lifetime
     checkFail("-target:msil")     // really?
 

--- a/versions.properties
+++ b/versions.properties
@@ -21,5 +21,5 @@ scala.binary.version=2.12
 scala-xml.version.number=2.3.0
 scala-parser-combinators.version.number=1.0.7
 scala-swing.version.number=2.0.3
-scala-asm.version=9.8.0-scala-1
+scala-asm.version=9.9.0-scala-1
 jline.version=2.14.6


### PR DESCRIPTION
Fixes https://github.com/scala/scala/pull/11172

Note: compilation of `Ordering` subclasses (overriding `min` / `max`) may fail on Java 26, see [comment on #11175](https://github.com/scala/scala/pull/11175#issuecomment-3542497701)