### PR TITLE
Prevent accidentally dropping annotations

### DIFF
--- a/src/reflect/scala/reflect/internal/AnnotationInfos.scala
+++ b/src/reflect/scala/reflect/internal/AnnotationInfos.scala
@@ -120,7 +120,7 @@ trait AnnotationInfos extends api.Annotations { self: SymbolTable =>
       Some((info.atp, info.args, info.assocs))
 
     def mkFilter(category: Symbol, defaultRetention: Boolean)(ann: AnnotationInfo) =
-      (ann.metaAnnotations, ann.defaultTargets) match {
+      (ann.targetAnnotations, ann.defaultTargets) match {
         case (Nil, Nil)      => defaultRetention
         case (Nil, defaults) => defaults contains category
         case (metas, _)      => metas exists (_ matches category)
@@ -338,8 +338,7 @@ trait AnnotationInfos extends api.Annotations { self: SymbolTable =>
     // Forces LazyAnnotationInfo, no op otherwise
     def completeInfo(): Unit = ()
 
-    /** Annotations annotating annotations are confusing so I drew
-     *  an example.  Given the following code:
+    /** Annotations annotating annotations are confusing. Clarifying example:
      *
      *  class A {
      *    @(deprecated @setter) @(inline @getter)
@@ -348,31 +347,29 @@ trait AnnotationInfos extends api.Annotations { self: SymbolTable =>
      *
      *  For the setter `x_=` in A, annotations contains one AnnotationInfo =
      *    List(deprecated @setter)
-     *  The single AnnotationInfo in that list, i.e. `@(deprecated @setter)`, has metaAnnotations =
+     *  The single AnnotationInfo in that list, i.e. `@(deprecated @setter)`, has targetAnnotations =
      *    List(setter)
      *
      *  Similarly, the getter `x` in A has an @inline annotation, which has
-     *  metaAnnotations = List(getter).
+     *  targetAnnotations = List(getter).
      */
     def symbol = atp.typeSymbol
 
-    /** These are meta-annotations attached at the use site; they
-     *  only apply to this annotation usage.  For instance, in
-     *    `@(deprecated @setter @field) val ...`
-     *  metaAnnotations = List(setter, field).
+    /**
+     * These are target annotations attached at the use site; they only apply to this annotation usage.
+     * For instance, in `@(deprecated @setter @field) val ...` we get `targetAnnotations = List(setter, field)`.
      */
-    def metaAnnotations: List[AnnotationInfo] = atp match {
+    def targetAnnotations: List[AnnotationInfo] = atp match {
       case AnnotatedType(metas, _) => metas
       case _                       => Nil
     }
 
     /** The default kind of members to which this annotation is attached.
-      * For instance, for scala.deprecated defaultTargets =
-      * List(getter, setter, beanGetter, beanSetter).
+      * For instance, for scala.deprecated: defaultTargets = List(getter, setter, beanGetter, beanSetter, field)
       *
       * NOTE: have to call symbol.initialize, since we won't get any annotations if the symbol hasn't yet been completed
       */
-    def defaultTargets = symbol.initialize.annotations map (_.symbol) filter isMetaAnnotation
+    def defaultTargets = symbol.initialize.annotations map (_.symbol) filter isTargetAnnotation
 
     // Test whether the typeSymbol of atp conforms to the given class.
     def matches(clazz: Symbol) = !symbol.isInstanceOf[StubSymbol] && (symbol isNonBottomSubClass clazz)

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1387,11 +1387,20 @@ trait Definitions extends api.StandardDefinitions {
     lazy val languageFeatureModule      = getRequiredModule("scala.languageFeature")
 
     @tailrec
-    final def isMetaAnnotation(sym: Symbol): Boolean = metaAnnotations(sym) || (
+    final def isTargetAnnotation(sym: Symbol): Boolean = targetAnnotations(sym) || (
       // Trying to allow for deprecated locations
-      sym.isAliasType && isMetaAnnotation(sym.info.typeSymbol)
+      sym.isAliasType && isTargetAnnotation(sym.info.typeSymbol)
     )
-    lazy val metaAnnotations: Set[Symbol] = getPackage("scala.annotation.meta").info.members.filter(_ isSubClass StaticAnnotationClass).toSet
+    lazy val targetAnnotations: Set[Symbol] = Set(
+      BeanGetterTargetClass,
+      BeanSetterTargetClass,
+      FieldTargetClass,
+      GetterTargetClass,
+      ParamTargetClass,
+      SetterTargetClass,
+      ObjectTargetClass,
+      ClassTargetClass,
+      MethodTargetClass)
 
     // According to the scala.annotation.meta package object:
     // * By default, annotations on (`val`-, `var`- or plain) constructor parameters

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -507,7 +507,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.InheritedAttr
     definitions.JUnitAnnotations
     definitions.languageFeatureModule
-    definitions.metaAnnotations
+    definitions.targetAnnotations
     definitions.AnnotationDefaultAttr
     definitions.isPhantomClass
     definitions.syntheticCoreClasses

--- a/test/files/run/t13140.check
+++ b/test/files/run/t13140.check
@@ -1,0 +1,34 @@
+
+scala> :power
+Power mode enabled. :phase is at typer.
+import scala.tools.nsc._, intp.global._, definitions._
+Try :help or completions for vals._ and power._
+
+scala> @annotation.meta.languageFeature("", false) class ann(x: Int) extends annotation.StaticAnnotation
+class ann
+
+scala> class C { @ann(21) val x = 1 }
+class C
+
+scala> typeOf[C].member(TermName("x ")).annotations.head
+val res0: $r.intp.global.AnnotationInfo = ann(21)
+
+scala> object defs {
+  import scala.annotation.StaticAnnotation
+  sealed trait InputAnnotation extends StaticAnnotation
+  class body(val s: String) extends InputAnnotation
+  class jsonbody extends body("x")
+  case class Cls(@jsonbody id: String)
+}
+object defs
+
+scala> import defs._
+import defs._
+
+scala> val a = typeOf[Cls].typeSymbol.primaryConstructor.paramss.head.head.annotations.head
+val a: $r.intp.global.AnnotationInfo = defs.jsonbody
+
+scala> a.argsForSuper(typeOf[body].typeSymbol)
+val res1: List[$r.intp.global.Tree] = List("x")
+
+scala> :quit

--- a/test/files/run/t13140.scala
+++ b/test/files/run/t13140.scala
@@ -1,0 +1,20 @@
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  def code =
+    """:power
+      |@annotation.meta.languageFeature("", false) class ann(x: Int) extends annotation.StaticAnnotation
+      |class C { @ann(21) val x = 1 }
+      |typeOf[C].member(TermName("x ")).annotations.head
+      |object defs {
+      |  import scala.annotation.StaticAnnotation
+      |  sealed trait InputAnnotation extends StaticAnnotation
+      |  class body(val s: String) extends InputAnnotation
+      |  class jsonbody extends body("x")
+      |  case class Cls(@jsonbody id: String)
+      |}
+      |import defs._
+      |val a = typeOf[Cls].typeSymbol.primaryConstructor.paramss.head.head.annotations.head
+      |a.argsForSuper(typeOf[body].typeSymbol)
+      |""".stripMargin
+}


### PR DESCRIPTION
Explicitly define "target meta annotations" in the compiler.

When target annotations `@(deprecated @getter)` were introduced, all annotations in the package `annotation.meta` were target annotations.

In the meantime there are others, which broke annotation filtering.

```
    def mkFilter(category: Symbol, defaultRetention: Boolean)(ann: AnnotationInfo) =
      (ann.targetAnnotations, ann.defaultTargets) match {
        case (Nil, Nil)      => defaultRetention
        case (Nil, defaults) => defaults contains category
        case (metas, _)      => metas exists (_ matches category)
      }
```

we ended up in the second case with `defaults` being the `superArg` meta annotation, which is not a target annotation.

Fixes https://github.com/scala/bug/issues/13140