### PR TITLE
[BACKPORT] Prevent presentation compiler crash on base type cache invalidation

### DIFF
--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -4738,10 +4738,16 @@ trait Types
         invalidateCaches(tp, updatedSyms)
       }
 
-  def invalidateCaches(t: Type, updatedSyms: List[Symbol]): Unit =
+  def invalidateCaches(t: Type, updatedSyms: List[Symbol]): Unit = {
+    def needClearBaseTypeCache(ct: CompoundType) = {
+      // was `ct.baseClasses.exists(changedSymbols)`, but `baseClasses` may force types early (scala/bug#13112)
+      val cache = ct.baseTypeSeqCache
+      cache != null && updatedSyms.exists(cache.baseTypeIndex(_) >= 0)
+    }
+
     t match {
       case tr: TypeRef      if updatedSyms.contains(tr.sym) => tr.invalidateTypeRefCaches()
-      case ct: CompoundType if ct.baseClasses.exists(updatedSyms.contains) => ct.invalidatedCompoundTypeCaches()
+      case ct: CompoundType if needClearBaseTypeCache(ct) => ct.invalidatedCompoundTypeCaches()
       case st: SingleType =>
         if (updatedSyms.contains(st.sym)) st.invalidateSingleTypeCaches()
         val underlying = st.underlying
@@ -4749,6 +4755,7 @@ trait Types
           invalidateCaches(underlying, updatedSyms)
       case _ =>
     }
+  }
 
 
   val shorthands = Set(

--- a/test/junit/scala/tools/nsc/interactive/PresentationCompilerTest.scala
+++ b/test/junit/scala/tools/nsc/interactive/PresentationCompilerTest.scala
@@ -1,0 +1,34 @@
+package scala.tools.nsc.interactive
+
+import org.junit.Test
+
+import scala.reflect.internal.util.BatchSourceFile
+import scala.tools.nsc.interactive.tests.InteractiveTest
+
+class PresentationCompilerTest {
+  @Test def run13112(): Unit = {
+    t13112.main(null)
+  }
+}
+
+object t13112 extends InteractiveTest {
+  val code =
+    """case class Foo(name: String = "")
+      |object Foo extends Foo("")
+      |""".stripMargin
+
+  override def execute(): Unit = {
+    val source = new BatchSourceFile("Foo.scala", code)
+
+    val res = new Response[Unit]
+    compiler.askReload(List(source), res)
+    res.get
+    askLoadedTyped(source).get
+
+    // the second round was failing (see scala/bug#13112 for details)
+    compiler.askReload(List(source), res)
+    res.get
+    val reloadRes = askLoadedTyped(source).get
+    assert(reloadRes.isLeft)
+  }
+}


### PR DESCRIPTION
Backport of #11116

See bug description for details.