### PR TITLE
Don't type check synthetic args in presence of errors

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -3782,7 +3782,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             } else if (lencmp > 0) {
               tryTupleApply orElse duplErrorTree {
                 val (argsNoNames, argPos) = removeNames(Typer.this)(args, params)
-                argsNoNames.foreach(typed(_, mode, ErrorType)) // typecheck args
+                // typecheck args to get better / helpful messages (scala/scala#11036), but not synthetic ones (scala/bug#13141)
+                argsNoNames.foreach(arg => if (arg.pos.isRange) typed(arg, mode, ErrorType))
                 TooManyArgsNamesDefaultsError(tree, fun, formals, args, argPos)
               }
             } else if (lencmp == 0) {
@@ -3873,7 +3874,8 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
                     }
 
                     val (argsNoNames, _) = removeNames(Typer.this)(allArgs, params) // report bad names
-                    argsNoNames.foreach(typed(_, mode, ErrorType)) // typecheck args
+                    // typecheck args to get better / helpful messages (scala/scala#11036), but not synthetic ones (scala/bug#13141)
+                    argsNoNames.foreach(arg => if (arg.pos.isRange) typed(arg, mode, ErrorType))
                     duplErrorTree(NotEnoughArgsError(tree, fun, missing))
                   }
                 }
@@ -5207,8 +5209,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
         def reportError(error: SilentTypeError): Tree = {
           error.reportableErrors.foreach(context.issue)
           error.warnings.foreach { case ContextWarning(p, m, c, s, as) => context.warning(p, m, c, s, as) }
+          // typecheck args to get better / helpful messages (scala/scala#11036), but not synthetic ones (scala/bug#13141)
           args.map { case NamedArg(_, rhs) => rhs case arg => arg }
-            .foreach(typed(_, mode, ErrorType))
+            .foreach(arg => if (arg.pos.isRange) typed(arg, mode, ErrorType))
           setError(tree)
         }
         def advice1(convo: Tree, errors: List[AbsTypeError], err: SilentTypeError): List[AbsTypeError] =

--- a/test/files/pos/t13141.scala
+++ b/test/files/pos/t13141.scala
@@ -1,0 +1,27 @@
+trait SF[F[+_, +_], +E, +A]
+
+trait QuasiFunctor[F[_]]
+
+trait catsFunctor[R[_[_]]]
+
+trait Lifecycle[+F[_], +A]
+object Lifecycle {
+  implicit def catsFunctorForLifecycle[F[_], Functor[_[_]]](implicit e1: QuasiFunctor[F], e2: catsFunctor[Functor]): Functor[({type L[A] = Lifecycle[F, A]})#L] = ???
+}
+
+object Scenario {
+  def fromLifecycle[F[+_, +_], E, A, E1](conv: E => E1)(l: Lifecycle[({type L[A] = F[E, A]})#L, A]): Lifecycle[({type L[A] = SF[F, E1, A]})#L, A] = ???
+  def fromLifecycle[F[+_, +_], E, A](l: Lifecycle[({type L[A] = F[E, A]})#L, A]): Lifecycle[({type L[A] = SF[F, E, A]})#L, A] = ???
+}
+
+object app extends App {
+  def x[F[+_, +_]]: Lifecycle[({type L[A] = SF[F, Throwable, A]})#L, Unit] = {
+    Scenario.fromLifecycle {
+      ??? : Lifecycle[({type L[A] = F[Throwable, A]})#L, Unit]
+    }
+  }
+  locally {
+    lazy val _ = x
+    println("Compiled")
+  }
+}


### PR DESCRIPTION
Since 2.13.17 (https://github.com/scala/scala/pull/11036), invocation arguments are type checked on errors to improve reporting.

Don't do that for synthetic arguments. In the example, implicit search tests type checking a view

```
catsFunctorForLifecycle: [F[_], Functor[_[_]]](implicit e1: QuasiFunctor[F], e2: catsFunctor[Functor]): Functor[[A]Lifecycle[F,A]]
```

by applying it to a synthetic `<argument>` built from the expected type

```
Lifecycle[[A]?F[Any, A],?A] => Lifecycle[[A]SF[?F,Nothing,A],?A]
```

Typing fails as there's not enough arguments.

Fixes https://github.com/scala/bug/issues/13141