### PR TITLE
Fix IsIterableOnce scaladoc

### DIFF
--- a/src/library/scala/collection/generic/IsIterableOnce.scala
+++ b/src/library/scala/collection/generic/IsIterableOnce.scala
@@ -26,7 +26,7 @@ package generic
  *    class FilterMapImpl[Repr, I <: IsIterableOnce[Repr]](coll: Repr, it: I) {
  *      final def filterMap[B, That](f: it.A => Option[B])(implicit bf: BuildFrom[Repr, B, That]): That = {
  *        val b = bf.newBuilder(coll)
- *        for(e <- it(coll).iterator) f(e) foreach (b +=)
+ *        for(e <- it(coll).iterator) f(e) foreach (b += _)
  *        b.result()
  *      }
  *    }


### PR DESCRIPTION
avoid postfix

```
Welcome to Scala 2.13.18 (OpenJDK 64-Bit Server VM, Java 21.0.9).
Type in expressions for evaluation. Or try :help.

scala> import scala.collection.generic.IsIterableOnce
import scala.collection.generic.IsIterableOnce

scala> import scala.collection.BuildFrom
import scala.collection.BuildFrom

scala> class FilterMapImpl[Repr, I <: IsIterableOnce[Repr]](coll: Repr, it: I) {
     |   final def filterMap[B, That](f: it.A => Option[B])(implicit bf: BuildFrom[Repr, B, That]): That = {
     |     val b = bf.newBuilder(coll)
     |     for(e <- it(coll).iterator) f(e) foreach (b +=)
     |     b.result()
     |   }
     | }
           for(e <- it(coll).iterator) f(e) foreach (b +=)
                                                       ^
On line 4: error: postfix operator += needs to be enabled
       by making the implicit value scala.language.postfixOps visible.
       This can be achieved by adding the import clause 'import scala.language.postfixOps'
       or by setting the compiler option -language:postfixOps.
       See the Scaladoc for value scala.language.postfixOps for a discussion
       why the feature needs to be explicitly enabled.

scala> class FilterMapImpl[Repr, I <: IsIterableOnce[Repr]](coll: Repr, it: I) {
     |   final def filterMap[B, That](f: it.A => Option[B])(implicit bf: BuildFrom[Repr, B, That]): That = {
     |     val b = bf.newBuilder(coll)
     |     for(e <- it(coll).iterator) f(e) foreach (b += _)
     |     b.result()
     |   }
     | }
class FilterMapImpl
```