### PR TITLE
chore: Return knownSize 1 when list just contains one element

### DIFF
--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -646,6 +646,7 @@ final case class :: [+A](override val head: A, private[scala] var next: List[A @
   releaseFence()
   override def headOption: Some[A] = Some(head)
   override def tail: List[A] = next
+  override def knownSize: Int = if (this.next eq Nil) 1 else -1
 }
 
 case object Nil extends List[Nothing] {

--- a/test/junit/scala/collection/immutable/ListTest.scala
+++ b/test/junit/scala/collection/immutable/ListTest.scala
@@ -123,4 +123,15 @@ class ListTest extends AllocationTest {
     exactAllocates(expected(20), "list  size 20")(
       List("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"))
   }
+
+  @Test def testKnownSizeForEmptyList(): Unit = {
+    val list = List.empty[Int]
+    assertEquals(0, list.knownSize)
+  }
+
+  @Test def testKnownSizeForOneElementList(): Unit = {
+    val list = "a" :: Nil
+    assertEquals(1, list.knownSize)
+  }
+
 }


### PR DESCRIPTION
Motivation:
I think we should return 1 when there is just one element in the list

Motivation:
https://github.com/apache/pekko/pull/2556/files
This will help optimization like the code above.

