### PR TITLE
Don't resolve symlinks in -Wconf:src

### DIFF
--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -774,8 +774,10 @@ object Reporting {
       private[this] val cache = mutable.Map.empty[SourceFile, Boolean]
 
       def check(pos: Position) = cache.getOrElseUpdate(pos.source, {
-        val sourceFile = pos.source.file.absolute.file
-        val sourcePath = sourceFile.toPath.normalize.toString.replace("\\", "/")
+        val sourcePath = Option(pos.source.file.absolute.file)
+          .map(_.toPath.normalize.toString)
+          .getOrElse(pos.source.path)
+          .replace("\\", "/")
         pattern.findFirstIn(sourcePath).nonEmpty
       })
       def matches(message: Message): Boolean = check(message.pos)

--- a/src/compiler/scala/tools/nsc/Reporting.scala
+++ b/src/compiler/scala/tools/nsc/Reporting.scala
@@ -774,7 +774,8 @@ object Reporting {
       private[this] val cache = mutable.Map.empty[SourceFile, Boolean]
 
       def check(pos: Position) = cache.getOrElseUpdate(pos.source, {
-        val sourcePath = pos.source.file.canonicalPath.replace("\\", "/")
+        val sourceFile = pos.source.file.absolute.file
+        val sourcePath = sourceFile.toPath.normalize.toString.replace("\\", "/")
         pattern.findFirstIn(sourcePath).nonEmpty
       })
       def matches(message: Message): Boolean = check(message.pos)

--- a/test/junit/scala/tools/nsc/reporters/WConfTest.scala
+++ b/test/junit/scala/tools/nsc/reporters/WConfTest.scala
@@ -329,16 +329,21 @@ class WConfTest extends BytecodeTesting {
     check(v123, v124, ng)
   }
 
-  @Test
-  def sourcePatternTest(): Unit = {
-    def m(p: String) = Reporting.Message.Plain(
-      Position.offset(new BatchSourceFile(new PlainFile(new File(new JFile(p))) {
-        override lazy val canonicalPath: String = p
-      }, Array().toIndexedSeq), 0),
+  def wrapFileInMessage(file: PlainFile) = Reporting.Message.Plain(
+      Position.offset(new BatchSourceFile(file, Array().toIndexedSeq), 0),
       msg = "",
       WarningCategory.Other,
       site = "",
       actions = Nil)
+
+  @Test
+  def sourcePatternTest(): Unit = {
+    def m(p: String) = wrapFileInMessage(new PlainFile(
+      new File(new JFile(p)) {
+        // Avoid invoking getAbsolutePath() on the underlying JFile, as it will
+        // prepend the current working directory to Windows-like paths.
+        override def isAbsolute = true
+      }))
 
     val aTest = Reporting.WConf.parseFilter("src=a/.*Test.scala", rootDir = "").getOrElse(null)
     assertTrue(aTest.matches(m("/a/FooTest.scala")))
@@ -362,5 +367,34 @@ class WConfTest extends BytecodeTesting {
     assertTrue(!withRootDirWin.matches(m("c:/root/path/xa/FooTest.scala")))
     assertTrue(!withRootDirWin.matches(m("c:/root/a/FooTest.scala")))
     assertTrue(!withRootDirWin.matches(m("c:/root/path/b/a/FooTest.scala")))
+  }
+
+  @Test
+  def sourcePatternDoesNotResolveSymlinksTest(): Unit = {
+    def m(symlinkPath: String, actualPath: String) = wrapFileInMessage(
+        new PlainFile(new File(new JFile(symlinkPath))) {
+          // The filter implementation should no longer invoke canonicalPath,
+          // which will resolve symlink paths. See: scala/bug#13145.
+          override lazy val canonicalPath: String = actualPath
+        })
+
+    val externalFiles = Reporting.WConf.parseFilter(
+      "src=external/.*.scala", rootDir = "").getOrElse(null)
+
+    // Use different symlinks to avoid a cache hit in the second assertion.
+    assertTrue(externalFiles.matches(
+      m("external/FileInExternalDir.scala", "/tmp/external/File.scala")))
+    assertTrue(externalFiles.matches(
+      m("external/FileInCacheDir.scala", "/tmp/cache/File.scala")))
+  }
+
+  @Test
+  def sourcePatternMatchesNormalizedPaths(): Unit = {
+    def m(p: String) = wrapFileInMessage(new PlainFile(new File(new JFile(p)) {}))
+
+    val normalizedFiles = Reporting.WConf.parseFilter(
+      "src=foo/baz/.*.scala", rootDir = "").getOrElse(null)
+
+    assertTrue(normalizedFiles.matches(m("foo/./bar/../quux/../baz/File.scala")))
   }
 }

--- a/test/junit/scala/tools/nsc/reporters/WConfTest.scala
+++ b/test/junit/scala/tools/nsc/reporters/WConfTest.scala
@@ -20,9 +20,11 @@ import java.io.{File => JFile}
 import scala.collection.mutable.ListBuffer
 import scala.reflect.internal.util.{BatchSourceFile, Position}
 import scala.reflect.internal.{Reporter => InternalReporter}
-import scala.reflect.io.PlainFile
-import scala.tools.nsc.Reporting.{Version, WarningCategory}
+import scala.reflect.io.AbstractFile
 import scala.reflect.io.File
+import scala.reflect.io.PlainFile
+import scala.reflect.io.VirtualFile
+import scala.tools.nsc.Reporting.{Version, WarningCategory}
 import scala.tools.nsc.reporters.StoreReporter.Info
 import scala.tools.testkit.AssertUtil.fail
 import scala.tools.testkit.BytecodeTesting
@@ -329,7 +331,7 @@ class WConfTest extends BytecodeTesting {
     check(v123, v124, ng)
   }
 
-  def wrapFileInMessage(file: PlainFile) = Reporting.Message.Plain(
+  def wrapFileInMessage(file: AbstractFile) = Reporting.Message.Plain(
       Position.offset(new BatchSourceFile(file, Array().toIndexedSeq), 0),
       msg = "",
       WarningCategory.Other,
@@ -396,5 +398,18 @@ class WConfTest extends BytecodeTesting {
       "src=foo/baz/.*.scala", rootDir = "").getOrElse(null)
 
     assertTrue(normalizedFiles.matches(m("foo/./bar/../quux/../baz/File.scala")))
+  }
+
+  @Test
+  def sourcePatternMatchesVirtualFiles(): Unit = {
+    def m(p: String) = wrapFileInMessage(new VirtualFile(p))
+
+    val virtualFiles = Reporting.WConf.parseFilter(
+      "src=virtual/.*.scala", rootDir = "").getOrElse(null)
+
+    // Make sure the VirtualFile path starts with "/", otherwise the
+    // "src=virtual/.*" pattern will not match it. This is because the `src`
+    // parser prepends "/" to the regex to ensure it matches a path segment.
+    assertTrue(virtualFiles.matches(m("/virtual/File.scala")))
   }
 }


### PR DESCRIPTION
Updates the -Wconf:src filter to resolve each source path to its absolute, normalized form (instead of its canonicalized form) before matching it.

Previously, filters intended to match symlinked paths would not apply when their canonicalized paths didn't contain the same path components. For example, Bazel 9 changed the location of symlinked source repositories for external dependencies such that their canonicalized paths no longer contained an `external/` component. This rendered `-Wconf:src=external/.*:s` filters to silence warnings in these external source repositories ineffective.

This implementation closely matches the Scala3 implementation (as of 3.8.0-RC3), though it does not use `toURI`. Testing revealed that `toURI` prepends the current working directory to Windows-like paths unconditionally, and converts backslashes in such paths to `%5C` escape sequences.

- https://github.com/scala/scala3/blob/3.8.0-RC3/compiler/src/dotty/tools/dotc/reporting/WConf.scala#L33

Fixes scala/bug#13145. Review by @lrytz.