### PR TITLE
Make style-only changes to doc comments for the standard library

### DIFF
--- a/src/library-aux/scala/Any.scala
+++ b/src/library-aux/scala/Any.scala
@@ -54,7 +54,7 @@ abstract class Any {
    */
   def equals(that: Any): Boolean
 
-  /** Calculate a hash code value for the object.
+  /** Calculates a hash code value for the object.
    *
    *  The default hashing algorithm is platform dependent.
    *
@@ -82,7 +82,7 @@ abstract class Any {
    */
   final def getClass(): Class[_] = sys.error("getClass")
 
-  /** Test two objects for equality.
+  /** Tests two objects for equality.
    *  The expression `x == that` is equivalent to `if (x eq null) that eq null else x.equals(that)`.
    *
    *  @param  that  the object to compare against this object for equality.
@@ -90,7 +90,7 @@ abstract class Any {
    */
   final def ==(that: Any): Boolean = this equals that
 
-  /** Test two objects for inequality.
+  /** Tests two objects for inequality.
    *
    *  @param  that  the object to compare against this object for equality.
    *  @return       `true` if !(this == that), false otherwise.
@@ -109,7 +109,7 @@ abstract class Any {
    */
   final def ## : Int = sys.error("##")
 
-  /** Test whether the dynamic type of the receiver object has the same erasure as `T0`.
+  /** Tests whether the dynamic type of the receiver object has the same erasure as `T0`.
    *
    *  Depending on what `T0` is, the test is done in one of the below ways:
    *
@@ -117,20 +117,20 @@ abstract class Any {
    *    the value of the receiver object is a `BigDecimal` or a subtype of `BigDecimal`.
    *  - `T0` is a parameterized class type, e.g. `List[Int]`: this method returns `true` if
    *    the value of the receiver object is some `List[X]` for any `X`.
-   *    For example, `List(1, 2, 3).isInstanceOf[List[String]]` will return true.
+   *    For example, `List(1, 2, 3).isInstanceOf[List[String]]` will return `true`.
    *  - `T0` is some singleton type `x.type` or literal `x`: this method returns `this.eq(x)`.
    *    For example, `x.isInstanceOf[1]` is equivalent to `x.eq(1)`
-   *  - `T0` is an intersection `X with Y` or `X & Y: this method is equivalent to `x.isInstanceOf[X] && x.isInstanceOf[Y]`
+   *  - `T0` is an intersection `X with Y` or `X & Y`: this method is equivalent to `x.isInstanceOf[X] && x.isInstanceOf[Y]`
    *  - `T0` is a union `X | Y`: this method is equivalent to `x.isInstanceOf[X] || x.isInstanceOf[Y]`
    *  - `T0` is a type parameter or an abstract type member: this method is equivalent
    *    to `isInstanceOf[U]` where `U` is `T0`'s upper bound, `Any` if `T0` is unbounded.
    *    For example, `x.isInstanceOf[A]` where `A` is an unbounded type parameter
-   *    will return true for any value of `x`.
+   *    will return `true` for any value of `x`.
    *
-   *  This is exactly equivalent to the type pattern `_: T0`
+   *  This is exactly equivalent to the type pattern `_: T0`.
    *
-   *  @note due to the unexpectedness of `List(1, 2, 3).isInstanceOf[List[String]]` returning true and
-   *  `x.isInstanceOf[A]` where `A` is a type parameter or abstract member returning true,
+   *  @note due to the unexpectedness of `List(1, 2, 3).isInstanceOf[List[String]]` returning `true` and
+   *  `x.isInstanceOf[A]` where `A` is a type parameter or abstract member returning `true`,
    *  these forms issue a warning.
    *
    *  @return `true` if the receiver object is an instance of erasure of type `T0`; `false` otherwise.

--- a/src/library-aux/scala/AnyRef.scala
+++ b/src/library-aux/scala/AnyRef.scala
@@ -27,18 +27,18 @@ trait AnyRef extends Any {
    */
   def equals(that: Any): Boolean = this eq that
 
-  /** The hashCode method for reference types.  See hashCode in [[scala.Any]].
+  /** The hashCode method for reference types.  See `hashCode` in [[scala.Any]].
    *
    *  @return   the hash code value for this object.
    */
   def hashCode: Int = sys.error("hashCode")
 
-  /** Creates a String representation of this object.  The default
+  /** Creates a `String` representation of this object.  The default
    *  representation is platform dependent.  On the java platform it
    *  is the concatenation of the class name, "@", and the object's
    *  hashcode in hexadecimal.
    *
-   *  @return     a String representation of the object.
+   *  @return     a `String` representation of the object.
    */
   def toString: String = sys.error("toString")
 
@@ -84,11 +84,11 @@ trait AnyRef extends Any {
     if (this eq null) that.asInstanceOf[AnyRef] eq null
     else this equals that
 
-  /** Create a copy of the receiver object.
+  /** Creates a copy of the receiver object.
    *
    *  The default implementation of the `clone` method is platform dependent.
    *
-   *  @note   not specified by SLS as a member of AnyRef
+   *  @note   not specified by SLS as a member of `AnyRef`
    *  @return a copy of the receiver object.
    */
   protected def clone(): AnyRef
@@ -100,29 +100,29 @@ trait AnyRef extends Any {
    *  well as the interaction between `finalize` and non-local returns
    *  and exceptions, are all platform dependent.
    *
-   *  @note   not specified by SLS as a member of AnyRef
+   *  @note   not specified by SLS as a member of `AnyRef`
    */
   protected def finalize(): Unit
 
   /** Wakes up a single thread that is waiting on the receiver object's monitor.
    *
-   *  @note   not specified by SLS as a member of AnyRef
+   *  @note   not specified by SLS as a member of `AnyRef`
    */
   final def notify(): Unit
 
   /** Wakes up all threads that are waiting on the receiver object's monitor.
    *
-   *  @note   not specified by SLS as a member of AnyRef
+   *  @note   not specified by SLS as a member of `AnyRef`
    */
   final def notifyAll(): Unit
 
   /** See [[https://docs.oracle.com/javase/8/docs/api/java/lang/Object.html#wait--]].
    *
-   *  @note   not specified by SLS as a member of AnyRef
+   *  @note   not specified by SLS as a member of `AnyRef`
    */
   final def wait (): Unit
 
-  /** See [[https://docs.oracle.com/javase/8/docs/api/java/lang/Object.html#wait-long-int-]]
+  /** See [[https://docs.oracle.com/javase/8/docs/api/java/lang/Object.html#wait-long-int-]].
    *
    * @param timeout the maximum time to wait in milliseconds.
    * @param nanos   additional time, in nanoseconds range 0-999999.

--- a/src/library-aux/scala/Nothing.scala
+++ b/src/library-aux/scala/Nothing.scala
@@ -20,8 +20,8 @@ package scala
  *  [[scala.collection.immutable.Nil]] of type `List[Nothing]`. Because lists are covariant in Scala,
  *  this makes [[scala.collection.immutable.Nil]] an instance of `List[T]`, for any element of type `T`.
  *
- *  Another usage for Nothing is the return type for methods which never return normally.
- *  One example is method error in [[scala.sys]], which always throws an exception.
+ *  Another usage for `Nothing` is the return type for methods which never return normally.
+ *  One example is method `error` in [[scala.sys]], which always throws an exception.
  */
 sealed trait Nothing
 

--- a/src/library/scala/Array.scala
+++ b/src/library/scala/Array.scala
@@ -43,7 +43,7 @@ object Array {
   val emptyShortArray   = new Array[Short](0)
   val emptyObjectArray  = new Array[Object](0)
 
-  /** Provides an implicit conversion from the Array object to a collection Factory */
+  /** Provides an implicit conversion from the Array object to a collection Factory. */
   implicit def toFactory[A : ClassTag](dummy: Array.type): Factory[A, Array[A]] = new ArrayFactory(dummy)
   @SerialVersionUID(3L)
   private class ArrayFactory[A : ClassTag](dummy: Array.type) extends Factory[A, Array[A]] with Serializable {
@@ -56,7 +56,7 @@ object Array {
    */
   def newBuilder[T](implicit t: ClassTag[T]): ArrayBuilder[T] = ArrayBuilder.make[T](using t)
 
-  /** Build an array from the iterable collection.
+  /** Builds an array from the iterable collection.
    *
    *  {{{
    *  scala> val a = Array.from(Seq(1, 5))
@@ -89,7 +89,7 @@ object Array {
     }
   }
 
-  /** Copy one array to another.
+  /** Copies one array to another.
    *  Equivalent to Java's
    *    `System.arraycopy(src, srcPos, dest, destPos, length)`,
    *  except that this also works for polymorphic and boxed arrays.
@@ -114,7 +114,7 @@ object Array {
       slowcopy(src, srcPos, dest, destPos, length)
   }
 
-  /** Copy one array to another, truncating or padding with default values (if
+  /** Copies one array to another, truncating or padding with default values (if
     * necessary) so the copy has the specified length.
     *
     * Equivalent to Java's
@@ -136,7 +136,7 @@ object Array {
     case original: Array[Boolean]    => java.util.Arrays.copyOf(original, newLength)
   }).asInstanceOf[Array[A]]
 
-  /** Copy one array to another, truncating or padding with default values (if
+  /** Copies one array to another, truncating or padding with default values (if
     * necessary) so the copy has the specified length. The new array can have
     * a different type than the original one as long as the values are
     * assignment-compatible. When copying between primitive and object arrays,
@@ -174,7 +174,7 @@ object Array {
     result
   }
 
-  /** Returns an array of length 0 */
+  /** Returns an array of length 0. */
   def empty[T: ClassTag]: Array[T] = new Array[T](0)
 
   /** Creates an array with given elements.
@@ -204,7 +204,7 @@ object Array {
     }
   }
 
-  /** Creates an array of `Boolean` objects */
+  /** Creates an array of `Boolean` objects. */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Boolean, xs: Boolean*): Array[Boolean] = {
     val array = new Array[Boolean](xs.length + 1)
@@ -217,7 +217,7 @@ object Array {
     array
   }
 
-  /** Creates an array of `Byte` objects */
+  /** Creates an array of `Byte` objects. */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Byte, xs: Byte*): Array[Byte] = {
     val array = new Array[Byte](xs.length + 1)
@@ -230,7 +230,7 @@ object Array {
     array
   }
 
-  /** Creates an array of `Short` objects */
+  /** Creates an array of `Short` objects. */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Short, xs: Short*): Array[Short] = {
     val array = new Array[Short](xs.length + 1)
@@ -243,7 +243,7 @@ object Array {
     array
   }
 
-  /** Creates an array of `Char` objects */
+  /** Creates an array of `Char` objects. */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Char, xs: Char*): Array[Char] = {
     val array = new Array[Char](xs.length + 1)
@@ -256,7 +256,7 @@ object Array {
     array
   }
 
-  /** Creates an array of `Int` objects */
+  /** Creates an array of `Int` objects. */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Int, xs: Int*): Array[Int] = {
     val array = new Array[Int](xs.length + 1)
@@ -269,7 +269,7 @@ object Array {
     array
   }
 
-  /** Creates an array of `Long` objects */
+  /** Creates an array of `Long` objects. */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Long, xs: Long*): Array[Long] = {
     val array = new Array[Long](xs.length + 1)
@@ -282,7 +282,7 @@ object Array {
     array
   }
 
-  /** Creates an array of `Float` objects */
+  /** Creates an array of `Float` objects. */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Float, xs: Float*): Array[Float] = {
     val array = new Array[Float](xs.length + 1)
@@ -295,7 +295,7 @@ object Array {
     array
   }
 
-  /** Creates an array of `Double` objects */
+  /** Creates an array of `Double` objects. */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Double, xs: Double*): Array[Double] = {
     val array = new Array[Double](xs.length + 1)
@@ -308,7 +308,7 @@ object Array {
     array
   }
 
-  /** Creates an array of `Unit` objects */
+  /** Creates an array of `Unit` objects. */
   def apply(x: Unit, xs: Unit*): Array[Unit] = {
     val array = new Array[Unit](xs.length + 1)
     array(0) = x
@@ -320,23 +320,23 @@ object Array {
     array
   }
 
-  /** Creates array with given dimensions */
+  /** Creates array with given dimensions. */
   def ofDim[T: ClassTag](n1: Int): Array[T] =
     new Array[T](n1)
-  /** Creates a 2-dimensional array */
+  /** Creates a 2-dimensional array. */
   def ofDim[T: ClassTag](n1: Int, n2: Int): Array[Array[T]] = {
     val arr: Array[Array[T]] = (new Array[Array[T]](n1): Array[Array[T]])
     for (i <- 0 until n1) arr(i) = new Array[T](n2)
     arr
     // tabulate(n1)(_ => ofDim[T](n2))
   }
-  /** Creates a 3-dimensional array */
+  /** Creates a 3-dimensional array. */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int): Array[Array[Array[T]]] =
     tabulate(n1)(_ => ofDim[T](n2, n3))
-  /** Creates a 4-dimensional array */
+  /** Creates a 4-dimensional array. */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int): Array[Array[Array[Array[T]]]] =
     tabulate(n1)(_ => ofDim[T](n2, n3, n4))
-  /** Creates a 5-dimensional array */
+  /** Creates a 5-dimensional array. */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int): Array[Array[Array[Array[Array[T]]]]] =
     tabulate(n1)(_ => ofDim[T](n2, n3, n4, n5))
 
@@ -548,7 +548,7 @@ object Array {
     }
   }
 
-  /** Compare two arrays per element.
+  /** Compares two arrays per element.
    *
    *  A more efficient version of `xs.sameElements(ys)`.
    *
@@ -559,8 +559,8 @@ object Array {
    *
    *  `Array.equals(xs.asInstanceOf[Array[AnyRef]], ys.asInstanceOf[Array[AnyRef]])`
    *
-   *  @param xs an array of AnyRef
-   *  @param ys an array of AnyRef
+   *  @param xs an array of `AnyRef`
+   *  @param ys an array of `AnyRef`
    *  @return true if corresponding elements are equal
    */
   def equals(xs: Array[AnyRef], ys: Array[AnyRef]): Boolean =
@@ -659,7 +659,7 @@ object Array {
  */
 final class Array[T](_length: Int) extends java.io.Serializable with java.lang.Cloneable {
 
-  /** The length of the array */
+  /** The length of the array. */
   def length: Int = throw new Error()
 
   /** The element at given index.
@@ -673,7 +673,7 @@ final class Array[T](_length: Int) extends java.io.Serializable with java.lang.C
    */
   def apply(i: Int): T = throw new Error()
 
-  /** Update the element at given index.
+  /** Updates the element at given index.
    *
    *  Indices start at `0`; `xs.update(i, x)` replaces the i^th^ element in the array.
    *  Note the syntax `xs(i) = x` is a shorthand for `xs.update(i, x)`.
@@ -684,7 +684,7 @@ final class Array[T](_length: Int) extends java.io.Serializable with java.lang.C
    */
   def update(i: Int, x: T): Unit = { throw new Error() }
 
-  /** Clone the Array.
+  /** Clones the Array.
    *
    *  @return A clone of the Array.
    */

--- a/src/library/scala/Console.scala
+++ b/src/library/scala/Console.scala
@@ -133,15 +133,15 @@ object Console extends AnsiColor {
   protected def setErrDirect(err: PrintStream): Unit  = errVar.value = err
   protected def setInDirect(in: BufferedReader): Unit = inVar.value = in
 
-  /** The default output, can be overridden by `withOut`
+  /** The default output, can be overridden by `withOut`.
    *  @group io-default
    */
   def out: PrintStream = outVar.value
-  /** The default error, can be overridden by `withErr`
+  /** The default error, can be overridden by `withErr`.
    *  @group io-default
    */
   def err: PrintStream = errVar.value
-  /** The default input, can be overridden by `withIn`
+  /** The default input, can be overridden by `withIn`.
    *  @group io-default
    */
   def in: BufferedReader = inVar.value
@@ -176,7 +176,7 @@ object Console extends AnsiColor {
   def withOut[T](out: OutputStream)(thunk: => T): T =
     withOut(new PrintStream(out))(thunk)
 
-  /** Set the default error stream for the duration
+  /** Sets the default error stream for the duration
    *  of execution of one thunk.
    *  @example {{{
    *  withErr(Console.out) { err.println("This goes to default _out_") }
@@ -241,7 +241,7 @@ object Console extends AnsiColor {
 
   /** Prints an object to `out` using its `toString` method.
    *
-   *  @param obj the object to print; may be null.
+   *  @param obj the object to print; may be `null`.
    *  @group console-output
    */
   def print(obj: Any): Unit = {

--- a/src/library/scala/Enumeration.scala
+++ b/src/library/scala/Enumeration.scala
@@ -94,8 +94,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
      the JVM does not invoke it when deserializing subclasses. */
   protected def readResolve(): AnyRef = thisenum.getClass.getField(MODULE_INSTANCE_NAME).get(null)
 
-  /** The name of this enumeration.
-   */
+  /** The name of this enumeration. */
   override def toString: String =
     ((getClass.getName stripSuffix MODULE_SUFFIX_STRING split '.').last split
        Regex.quote(NAME_JOIN_STRING)).last
@@ -112,8 +111,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
     * names. */
   private[this] val nmap: mutable.Map[Int, String] = new mutable.HashMap
 
-  /** The values of this enumeration as a set.
-   */
+  /** The values of this enumeration as a set. */
   def values: ValueSet = {
     if (!vsetDefined) {
       vset = (ValueSet.newBuilder ++= vmap.values).result()
@@ -143,11 +141,10 @@ abstract class Enumeration (initial: Int) extends Serializable {
     *  values in this enumeration. */
   final def maxId = topId
 
-  /** The value of this enumeration with given id `x`
-   */
+  /** The value of this enumeration with given id `x`. */
   final def apply(x: Int): Value = vmap(x)
 
-  /** Return a `Value` from this `Enumeration` whose name matches
+  /** Returns a `Value` from this `Enumeration` whose name matches
    *  the argument `s`.  The names are determined automatically via reflection.
    *
    * @param  s an `Enumeration` name
@@ -222,9 +219,9 @@ abstract class Enumeration (initial: Int) extends Serializable {
   /** The type of the enumerated values. */
   @SerialVersionUID(7091335633555234129L)
   abstract class Value extends Ordered[Value] with Serializable {
-    /** the id and bit location of this enumeration value */
+    /** the id and bit location of this enumeration value. */
     def id: Int
-    /** a marker so we can tell whose values belong to whom come reflective-naming time */
+    /** a marker so we can tell whose values belong to whom come reflective-naming time. */
     private[Enumeration] val outerEnum = thisenum
 
     override def compare(that: Value): Int =
@@ -237,7 +234,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
     }
     override def hashCode: Int = id.##
 
-    /** Create a ValueSet which contains this value and another one */
+    /** Creates a `ValueSet` which contains this value and another one. */
     def + (v: Value): ValueSet = ValueSet(this, v)
   }
 
@@ -270,7 +267,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
     }
   }
 
-  /** An ordering by id for values of this set */
+  /** An ordering by id for values of this set. */
   implicit object ValueOrdering extends Ordering[Value] {
     def compare(x: Value, y: Value): Int = x compare y
   }
@@ -304,7 +301,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
     override def iteratorFrom(start: Value): Iterator[Value] = nnIds iteratorFrom start.id  map (id => thisenum.apply(bottomId + id))
     override def className: String = s"$thisenum.ValueSet"
     /** Creates a bit mask for the zero-adjusted ids in this set as a
-     *  new array of longs */
+     *  new array of longs. */
     def toBitMask: Array[Long] = nnIds.toBitMask
 
     override protected def fromSpecific(coll: IterableOnce[Value]): ValueSet = ValueSet.fromSpecific(coll)
@@ -326,18 +323,18 @@ abstract class Enumeration (initial: Int) extends Serializable {
     @transient private[Enumeration] lazy val byName: Map[String, Value] = iterator.map( v => v.toString -> v).toMap
   }
 
-  /** A factory object for value sets */
+  /** A factory object for value sets. */
   @SerialVersionUID(3L)
   object ValueSet extends SpecificIterableFactory[Value, ValueSet] {
     private final val ordMsg = "No implicit Ordering[${B}] found to build a SortedSet[${B}]. You may want to upcast to a Set[Value] first by calling `unsorted`."
     private final val zipOrdMsg = "No implicit Ordering[${B}] found to build a SortedSet[(Value, ${B})]. You may want to upcast to a Set[Value] first by calling `unsorted`."
 
-    /** The empty value set */
+    /** The empty value set. */
     val empty: ValueSet = new ValueSet(immutable.BitSet.empty)
     /** A value set containing all the values for the zero-adjusted ids
-     *  corresponding to the bits in an array */
+     *  corresponding to the bits in an array. */
     def fromBitMask(elems: Array[Long]): ValueSet = new ValueSet(immutable.BitSet.fromBitMask(elems))
-    /** A builder object for value sets */
+    /** A builder object for value sets. */
     def newBuilder: mutable.Builder[Value, ValueSet] = new mutable.Builder[Value, ValueSet] {
       private[this] val b = new mutable.BitSet
       def addOne (x: Value) = { b += (x.id - bottomId); this }

--- a/src/library/scala/Equals.scala
+++ b/src/library/scala/Equals.scala
@@ -24,7 +24,7 @@ trait Equals extends Any {
    *  Chapter 28]] for discussion and design.
    *
    *  @param    that    the value being probed for possible equality
-   *  @return   true if this instance can possibly equal `that`, otherwise false
+   *  @return   `true` if this instance can possibly equal `that`, otherwise `false`
    */
   def canEqual(that: Any): Boolean
 

--- a/src/library/scala/Function.scala
+++ b/src/library/scala/Function.scala
@@ -22,7 +22,7 @@ object Function {
    */
   def chain[T](fs: scala.collection.Seq[T => T]): T => T = { x => fs.foldLeft(x)((x, f) => f(x)) }
 
-  /** The constant function */
+  /** The constant function. */
   def const[T, U](x: T)(y: U): T = x
 
   /** Turns a function `A => Option[B]` into a `PartialFunction[A, B]`.

--- a/src/library/scala/Function0.scala
+++ b/src/library/scala/Function0.scala
@@ -36,7 +36,7 @@ package scala
  *  }}}
  */
 trait Function0[@specialized(Specializable.Primitives) +R] extends AnyRef { self =>
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(): R

--- a/src/library/scala/Function1.scala
+++ b/src/library/scala/Function1.scala
@@ -65,7 +65,7 @@ object Function1 {
  */
 @annotation.implicitNotFound(msg = "No implicit view available from ${T1} => ${R}.")
 trait Function1[@specialized(Specializable.Arg) -T1, @specialized(Specializable.Return) +R] extends AnyRef { self =>
-  /** Apply the body of this function to the argument.
+  /** Applies the body of this function to the argument.
    *  @return   the result of function application.
    */
   def apply(v1: T1): R

--- a/src/library/scala/Function10.scala
+++ b/src/library/scala/Function10.scala
@@ -19,7 +19,7 @@ package scala
  *
  */
 trait Function10[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, +R] extends AnyRef { self =>
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10): R

--- a/src/library/scala/Function11.scala
+++ b/src/library/scala/Function11.scala
@@ -19,7 +19,7 @@ package scala
  *
  */
 trait Function11[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, +R] extends AnyRef { self =>
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11): R

--- a/src/library/scala/Function12.scala
+++ b/src/library/scala/Function12.scala
@@ -19,7 +19,7 @@ package scala
  *
  */
 trait Function12[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, +R] extends AnyRef { self =>
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12): R

--- a/src/library/scala/Function13.scala
+++ b/src/library/scala/Function13.scala
@@ -19,7 +19,7 @@ package scala
  *
  */
 trait Function13[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, +R] extends AnyRef { self =>
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13): R

--- a/src/library/scala/Function14.scala
+++ b/src/library/scala/Function14.scala
@@ -19,7 +19,7 @@ package scala
  *
  */
 trait Function14[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, +R] extends AnyRef { self =>
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14): R

--- a/src/library/scala/Function15.scala
+++ b/src/library/scala/Function15.scala
@@ -19,7 +19,7 @@ package scala
  *
  */
 trait Function15[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, +R] extends AnyRef { self =>
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15): R

--- a/src/library/scala/Function16.scala
+++ b/src/library/scala/Function16.scala
@@ -19,7 +19,7 @@ package scala
  *
  */
 trait Function16[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, +R] extends AnyRef { self =>
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16): R

--- a/src/library/scala/Function17.scala
+++ b/src/library/scala/Function17.scala
@@ -19,7 +19,7 @@ package scala
  *
  */
 trait Function17[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, +R] extends AnyRef { self =>
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17): R

--- a/src/library/scala/Function18.scala
+++ b/src/library/scala/Function18.scala
@@ -19,7 +19,7 @@ package scala
  *
  */
 trait Function18[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, +R] extends AnyRef { self =>
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18): R

--- a/src/library/scala/Function19.scala
+++ b/src/library/scala/Function19.scala
@@ -19,7 +19,7 @@ package scala
  *
  */
 trait Function19[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, +R] extends AnyRef { self =>
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18, v19: T19): R

--- a/src/library/scala/Function2.scala
+++ b/src/library/scala/Function2.scala
@@ -34,7 +34,7 @@ package scala
  *  }}}
  */
 trait Function2[@specialized(Specializable.Args) -T1, @specialized(Specializable.Args) -T2, @specialized(Specializable.Return) +R] extends AnyRef { self =>
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2): R

--- a/src/library/scala/Function20.scala
+++ b/src/library/scala/Function20.scala
@@ -19,7 +19,7 @@ package scala
  *
  */
 trait Function20[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, -T20, +R] extends AnyRef { self =>
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18, v19: T19, v20: T20): R

--- a/src/library/scala/Function21.scala
+++ b/src/library/scala/Function21.scala
@@ -19,7 +19,7 @@ package scala
  *
  */
 trait Function21[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, -T20, -T21, +R] extends AnyRef { self =>
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18, v19: T19, v20: T20, v21: T21): R

--- a/src/library/scala/Function22.scala
+++ b/src/library/scala/Function22.scala
@@ -19,7 +19,7 @@ package scala
  *
  */
 trait Function22[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, -T20, -T21, -T22, +R] extends AnyRef { self =>
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18, v19: T19, v20: T20, v21: T21, v22: T22): R

--- a/src/library/scala/Function3.scala
+++ b/src/library/scala/Function3.scala
@@ -19,7 +19,7 @@ package scala
  *
  */
 trait Function3[-T1, -T2, -T3, +R] extends AnyRef { self =>
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3): R

--- a/src/library/scala/Function4.scala
+++ b/src/library/scala/Function4.scala
@@ -19,7 +19,7 @@ package scala
  *
  */
 trait Function4[-T1, -T2, -T3, -T4, +R] extends AnyRef { self =>
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4): R

--- a/src/library/scala/Function5.scala
+++ b/src/library/scala/Function5.scala
@@ -19,7 +19,7 @@ package scala
  *
  */
 trait Function5[-T1, -T2, -T3, -T4, -T5, +R] extends AnyRef { self =>
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5): R

--- a/src/library/scala/Function6.scala
+++ b/src/library/scala/Function6.scala
@@ -19,7 +19,7 @@ package scala
  *
  */
 trait Function6[-T1, -T2, -T3, -T4, -T5, -T6, +R] extends AnyRef { self =>
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6): R

--- a/src/library/scala/Function7.scala
+++ b/src/library/scala/Function7.scala
@@ -19,7 +19,7 @@ package scala
  *
  */
 trait Function7[-T1, -T2, -T3, -T4, -T5, -T6, -T7, +R] extends AnyRef { self =>
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7): R

--- a/src/library/scala/Function8.scala
+++ b/src/library/scala/Function8.scala
@@ -19,7 +19,7 @@ package scala
  *
  */
 trait Function8[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, +R] extends AnyRef { self =>
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8): R

--- a/src/library/scala/Function9.scala
+++ b/src/library/scala/Function9.scala
@@ -19,7 +19,7 @@ package scala
  *
  */
 trait Function9[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, +R] extends AnyRef { self =>
-  /** Apply the body of this function to the arguments.
+  /** Applies the body of this function to the arguments.
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9): R

--- a/src/library/scala/MatchError.scala
+++ b/src/library/scala/MatchError.scala
@@ -18,7 +18,7 @@ package scala
  */
 final class MatchError(@transient obj: Any) extends RuntimeException {
   /** There's no reason we need to call toString eagerly,
-   *  so defer it until getMessage is called or object is serialized
+   *  so defer it until getMessage is called or object is serialized.
    */
   private[this] lazy val objString = {
     def ofClass = "of class " + obj.getClass.getName

--- a/src/library/scala/Option.scala
+++ b/src/library/scala/Option.scala
@@ -16,15 +16,15 @@ object Option {
 
   import scala.language.implicitConversions
 
-  /** An implicit conversion that converts an option to an iterable value */
+  /** An implicit conversion that converts an option to an iterable value. */
   implicit def option2Iterable[A](xo: Option[A]): Iterable[A] =
     if (xo.isEmpty) Iterable.empty else Iterable.single(xo.get)
 
-  /** An Option factory which creates Some(x) if the argument is not null,
-   *  and None if it is null.
+  /** An `Option` factory which creates `Some(x)` if the argument is not `null`,
+   *  and `None` if it is `null`.
    *
    *  @param  x the value
-   *  @return   Some(value) if value != null, None if value == null
+   *  @return   `Some(value)` if value != null, `None` if value == null
    */
   def apply[A](x: A): Option[A] = if (x == null) None else Some(x)
 
@@ -34,14 +34,14 @@ object Option {
   def empty[A] : Option[A] = None
 
   /** When a given condition is true, evaluates the `a` argument and returns
-   *  Some(a). When the condition is false, `a` is not evaluated and None is
+   *  `Some(a)`. When the condition is false, `a` is not evaluated and `None` is
    *  returned.
    */
   def when[A](cond: Boolean)(a: => A): Option[A] =
     if (cond) Some(a) else None
 
   /** Unless a given condition is true, this will evaluate the `a` argument and
-   *  return Some(a). Otherwise, `a` is not evaluated and None is returned.
+   *  return `Some(a)`. Otherwise, `a` is not evaluated and `None` is returned.
    */
   @inline def unless[A](cond: Boolean)(a: => A): Option[A] =
     when(!cond)(a)
@@ -90,9 +90,9 @@ object Option {
  *  - [[collect]] — Apply partial pattern match on optional value
  *  - [[filter]] — An optional value satisfies predicate
  *  - [[filterNot]] — An optional value doesn't satisfy predicate
- *  - [[exists]] — Apply predicate on optional value, or false if empty
- *  - [[forall]] — Apply predicate on optional value, or true if empty
- *  - [[contains]] — Checks if value equals optional value, or false if empty
+ *  - [[exists]] — Apply predicate on optional value, or `false` if empty
+ *  - [[forall]] — Apply predicate on optional value, or `true` if empty
+ *  - [[contains]] — Checks if value equals optional value, or `false` if empty
  *  - [[zip]] — Combine two optional values to make a paired optional value
  *  - [[unzip]] — Split an optional pair to two optional values
  *  - [[unzip3]] — Split an optional triple to three optional values
@@ -108,7 +108,7 @@ object Option {
  *  }
  *  }}}
  *
- * Interacting with code that can occasionally return null can be
+ * Interacting with code that can occasionally return `null` can be
  * safely wrapped in $option to become $none and $some otherwise. {{{
  * val abc = new java.util.HashMap[Int, String]
  * abc.put(1, "A")
@@ -122,9 +122,9 @@ object Option {
  * }}}
  *
  *  @note Many of the methods in here are duplicative with those
- *  in the Iterable hierarchy, but they are duplicated for a reason:
- *  the implicit conversion tends to leave one with an Iterable in
- *  situations where one could have retained an Option.
+ *  in the `Iterable` hierarchy, but they are duplicated for a reason:
+ *  the implicit conversion tends to leave one with an `Iterable` in
+ *  situations where one could have retained an `Option`.
  *
  *  @define none `None`
  *  @define some [[scala.Some]]
@@ -144,7 +144,7 @@ object Option {
 sealed abstract class Option[+A] extends IterableOnce[A] with Product with Serializable {
   self =>
 
-  /** Returns true if the option is $none, false otherwise.
+  /** Returns `true` if the option is $none, `false` otherwise.
    *
    * This is equivalent to:
    * {{{
@@ -156,7 +156,7 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
    */
   final def isEmpty: Boolean = this eq None
 
-  /** Returns true if the option is an instance of $some, false otherwise.
+  /** Returns `true` if the option is an instance of $some, `false` otherwise.
    *
    * This is equivalent to:
    * {{{
@@ -203,7 +203,7 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
   /** Returns the option's value if it is nonempty,
    * or `null` if it is empty.
    *
-   * Although the use of null is discouraged, code written to use
+   * Although the use of `null` is discouraged, code written to use
    * $option must often interface with code that expects and returns nulls.
    *
    * This is equivalent to:
@@ -304,7 +304,7 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
     if (isEmpty) None else ev(this.get)
 
   /** Returns this $option if it is nonempty '''and''' applying the predicate $p to
-   * this $option's value returns true. Otherwise, return $none.
+   * this $option's value returns `true`. Otherwise, return $none.
    *
    * This is equivalent to:
    * {{{
@@ -319,7 +319,7 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
     if (isEmpty || p(this.get)) this else None
 
   /** Returns this $option if it is nonempty '''and''' applying the predicate $p to
-   * this $option's value returns false. Otherwise, return $none.
+   * this $option's value returns `false`. Otherwise, return $none.
    *
    * This is equivalent to:
    * {{{
@@ -333,7 +333,7 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
   @inline final def filterNot(p: A => Boolean): Option[A] =
     if (isEmpty || !p(this.get)) this else None
 
-  /** Returns false if the option is $none, true otherwise.
+  /** Returns `false` if the option is $none, `true` otherwise.
    *
    * This is equivalent to:
    * {{{
@@ -389,9 +389,9 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
   final def contains[A1 >: A](elem: A1): Boolean =
     !isEmpty && this.get == elem
 
-  /** Returns true if this option is nonempty '''and''' the predicate
-   * $p returns true when applied to this $option's value.
-   * Otherwise, returns false.
+  /** Returns `true` if this option is nonempty '''and''' the predicate
+   * $p returns `true` when applied to this $option's value.
+   * Otherwise, returns `false`.
    *
    * This is equivalent to:
    * {{{
@@ -405,8 +405,8 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
   @inline final def exists(p: A => Boolean): Boolean =
     !isEmpty && p(this.get)
 
-  /** Returns true if this option is empty '''or''' the predicate
-   * $p returns true when applied to this $option's value.
+  /** Returns `true` if this option is empty '''or''' the predicate
+   * $p returns `true` when applied to this $option's value.
    *
    * This is equivalent to:
    * {{{
@@ -419,8 +419,8 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
    */
   @inline final def forall(p: A => Boolean): Boolean = isEmpty || p(this.get)
 
-  /** Apply the given procedure $f to the option's value,
-   *  if it is nonempty. Otherwise, do nothing.
+  /** Applies the given procedure $f to the option's value,
+   *  if it is nonempty. Otherwise, does nothing.
    *
    * This is equivalent to:
    * {{{
@@ -503,7 +503,7 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
   final def zip[A1 >: A, B](that: Option[B]): Option[(A1, B)] =
     if (isEmpty || that.isEmpty) None else Some((this.get, that.get))
 
-  /** Converts an Option of a pair into an Option of the first element and an Option of the second element.
+  /** Converts an `Option` of a pair into an `Option` of the first element and an `Option` of the second element.
     *
     *  This is equivalent to:
     *  {{{
@@ -528,7 +528,7 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
     }
   }
 
-  /** Converts an Option of a triple into three Options, one containing the element from each position of the triple.
+  /** Converts an `Option` of a triple into three `Option`s, one containing the element from each position of the triple.
     *
     *  This is equivalent to:
     *  {{{

--- a/src/library/scala/PartialFunction.scala
+++ b/src/library/scala/PartialFunction.scala
@@ -19,7 +19,7 @@ import scala.annotation.nowarn
  *  The function [[isDefinedAt]] allows to test dynamically if a value is in
  *  the domain of the function.
  *
- *  Even if `isDefinedAt` returns true for an `a: A`, calling `apply(a)` may
+ *  Even if `isDefinedAt` returns `true` for an `a: A`, calling `apply(a)` may
  *  still throw an exception, so the following code is legal:
  *
  *  {{{
@@ -27,7 +27,7 @@ import scala.annotation.nowarn
  *  }}}
  *
  *  It is the responsibility of the caller to call `isDefinedAt` before
- *  calling `apply`, because if `isDefinedAt` is false, it is not guaranteed
+ *  calling `apply`, because if `isDefinedAt` is `false`, it is not guaranteed
  *  `apply` will throw an exception to indicate an error condition. If an
  *  exception is not thrown, evaluation may result in an arbitrary value.
  *
@@ -268,7 +268,7 @@ object PartialFunction {
     }
   }
 
-  /** Composite function produced by `PartialFunction#orElse` method
+  /** Composite function produced by `PartialFunction#orElse` method.
    */
   private class OrElse[-A, +B] (f1: PartialFunction[A, B], f2: PartialFunction[A, B])
     extends scala.runtime.AbstractPartialFunction[A, B] with Serializable {
@@ -288,7 +288,7 @@ object PartialFunction {
       new OrElse[A, C] (f1 andThen k, f2 andThen k)
   }
 
-  /** Composite function produced by `PartialFunction#andThen` method
+  /** Composite function produced by `PartialFunction#andThen` method.
    */
   private class AndThen[-A, B, +C] (pf: PartialFunction[A, B], k: B => C) extends PartialFunction[A, C] with Serializable {
     def isDefinedAt(x: A) = pf.isDefinedAt(x)
@@ -301,7 +301,7 @@ object PartialFunction {
     }
   }
 
-  /** Composite function produced by `PartialFunction#andThen` method
+  /** Composite function produced by `PartialFunction#andThen` method.
     */
   private class Combined[-A, B, +C] (pf: PartialFunction[A, B], k: PartialFunction[B, C]) extends PartialFunction[A, C] with Serializable {
     def isDefinedAt(x: A): Boolean = {
@@ -390,18 +390,18 @@ object PartialFunction {
   def empty[A, B] : PartialFunction[A, B] = empty_pf
 
   /** A Boolean test that is the result of the given function where defined,
-   *  and false otherwise.
+   *  and `false` otherwise.
    *
    *  It behaves like a `case _ => false` were added to the partial function.
    *
    *  @param  x   the value to test
    *  @param  pf  the partial function
-   *  @return true, iff `x` is in the domain of `pf` and `pf(x) == true`.
+   *  @return `true`, iff `x` is in the domain of `pf` and `pf(x) == true`.
    */
   def cond[A](x: A)(pf: PartialFunction[A, Boolean]): Boolean = pf.applyOrElse(x, constFalse)
 
-  /** Apply the function to the given value if defined, and return the result
-   *  in a `Some`; otherwise, return `None`.
+  /** Applies the function to the given value if defined, and returns the result
+   *  in a `Some`; otherwise, returns `None`.
    *
    *  @param  x     the value to test
    *  @param  pf    the PartialFunction[T, U]

--- a/src/library/scala/Predef.scala
+++ b/src/library/scala/Predef.scala
@@ -105,7 +105,7 @@ import scala.annotation.meta.{ companionClass, companionMethod }
  */
 object Predef extends LowPriorityImplicits {
   /**
-   * Retrieve the runtime representation of a class type. `classOf[T]` is equivalent to
+   * Retrieves the runtime representation of a class type. `classOf[T]` is equivalent to
    * the class literal `T.class` in Java.
    *
    * @example {{{
@@ -122,7 +122,7 @@ object Predef extends LowPriorityImplicits {
   def classOf[T]: Class[T] = null // This is a stub method. The actual implementation is filled in by the compiler.
 
   /**
-   * Retrieve the single value of a type with a unique inhabitant.
+   * Retrieves the single value of a type with a unique inhabitant.
    *
    * @example {{{
    * object Foo
@@ -250,7 +250,7 @@ object Predef extends LowPriorityImplicits {
 
   // assertions ---------------------------------------------------------
 
-  /** Tests an expression, throwing an `AssertionError` if false.
+  /** Tests an expression, throwing an `AssertionError` if `false`.
    *  Calls to this method will not be generated if `-Xelide-below`
    *  is greater than `ASSERTION`.
    *
@@ -264,7 +264,7 @@ object Predef extends LowPriorityImplicits {
       throw new java.lang.AssertionError("assertion failed")
   }
 
-  /** Tests an expression, throwing an `AssertionError` if false.
+  /** Tests an expression, throwing an `AssertionError` if `false`.
    *  Calls to this method will not be generated if `-Xelide-below`
    *  is greater than `ASSERTION`.
    *
@@ -279,10 +279,10 @@ object Predef extends LowPriorityImplicits {
       throw new java.lang.AssertionError("assertion failed: "+ message)
   }
 
-  /** Tests an expression, throwing an `AssertionError` if false.
-   *  This method differs from assert only in the intent expressed:
-   *  assert contains a predicate which needs to be proven, while
-   *  assume contains an axiom for a static checker.  Calls to this method
+  /** Tests an expression, throwing an `AssertionError` if `false`.
+   *  This method differs from `assert` only in the intent expressed:
+   *  `assert` contains a predicate which needs to be proven, while
+   *  `assume` contains an axiom for a static checker.  Calls to this method
    *  will not be generated if `-Xelide-below` is greater than `ASSERTION`.
    *
    *  @see [[scala.annotation.elidable elidable]]
@@ -295,10 +295,10 @@ object Predef extends LowPriorityImplicits {
       throw new java.lang.AssertionError("assumption failed")
   }
 
-  /** Tests an expression, throwing an `AssertionError` if false.
-   *  This method differs from assert only in the intent expressed:
-   *  assert contains a predicate which needs to be proven, while
-   *  assume contains an axiom for a static checker.  Calls to this method
+  /** Tests an expression, throwing an `AssertionError` if `false`.
+   *  This method differs from `assert` only in the intent expressed:
+   *  `assert` contains a predicate which needs to be proven, while
+   *  `assume` contains an axiom for a static checker.  Calls to this method
    *  will not be generated if `-Xelide-below` is greater than `ASSERTION`.
    *
    *  @see [[scala.annotation.elidable elidable]]
@@ -312,7 +312,7 @@ object Predef extends LowPriorityImplicits {
       throw new java.lang.AssertionError("assumption failed: "+ message)
   }
 
-  /** Tests an expression, throwing an `IllegalArgumentException` if false.
+  /** Tests an expression, throwing an `IllegalArgumentException` if `false`.
    *  This method is similar to `assert`, but blames the caller of the method
    *  for violating the condition.
    *
@@ -324,7 +324,7 @@ object Predef extends LowPriorityImplicits {
       throw new IllegalArgumentException("requirement failed")
   }
 
-  /** Tests an expression, throwing an `IllegalArgumentException` if false.
+  /** Tests an expression, throwing an `IllegalArgumentException` if `false`.
    *  This method is similar to `assert`, but blames the caller of the method
    *  for violating the condition.
    *
@@ -409,7 +409,7 @@ object Predef extends LowPriorityImplicits {
 
   /** Prints an object to `out` using its `toString` method.
    *
-   *  @param x the object to print; may be null.
+   *  @param x the object to print; may be `null`.
    *  @group console-output
    */
   def print(x: Any): Unit = Console.print(x)

--- a/src/library/scala/StringContext.scala
+++ b/src/library/scala/StringContext.scala
@@ -88,7 +88,7 @@ case class StringContext(parts: String*) {
    *          if a `parts` string contains a backslash (`\`) character
    *          that does not start a valid escape sequence.
    *  @note   The Scala compiler may replace a call to this method with an equivalent, but more efficient,
-   *          use of a StringBuilder.
+   *          use of a `StringBuilder`.
    */
   def s(args: Any*): String = macro ??? // fasttracked to scala.tools.reflect.FastStringInterpolator::interpolateS
   object s {
@@ -149,9 +149,9 @@ case class StringContext(parts: String*) {
    *  @param `args` The arguments to be inserted into the resulting string.
    *  @throws IllegalArgumentException
    *          if the number of `parts` in the enclosing `StringContext` does not exceed
-   *          the number of arguments `arg` by exactly 1.
+   *          the number of arguments `args` by exactly 1.
    *  @note   The Scala compiler may replace a call to this method with an equivalent, but more efficient,
-   *          use of a StringBuilder.
+   *          use of a `StringBuilder`.
    */
   def raw(args: Any*): String = macro ??? // fasttracked to scala.tools.reflect.FastStringInterpolator::interpolateRaw
 
@@ -409,7 +409,7 @@ object StringContext {
     }
 
   /** replace Unicode escapes starting at index `backslash` which must be the
-   *  index of the first index of a backslash character followed by a `u`
+   *  index of the first index of a backslash character followed by a `u`.
    *  character
    *
    * If a backslash is followed by one or more `u` characters and there is

--- a/src/library/scala/annotation/migration.scala
+++ b/src/library/scala/annotation/migration.scala
@@ -17,7 +17,7 @@ package scala.annotation
  * between versions.  This is intended for methods which for one
  * reason or another retain the same name and type signature,
  * but some aspect of their behavior is different.  An illustrative
- * examples is Stack.iterator, which reversed from LIFO to FIFO
+ * examples is `Stack.iterator`, which reversed from LIFO to FIFO
  * order between Scala 2.7 and 2.8.
  *
  * @param message A message describing the change, which is emitted

--- a/src/library/scala/annotation/strictfp.scala
+++ b/src/library/scala/annotation/strictfp.scala
@@ -13,7 +13,7 @@
 package scala.annotation
 
 /** If this annotation is present on a method or its enclosing class,
- *  the strictfp flag will be emitted.
+ *  the `strictfp` flag will be emitted.
  */
 @deprecatedInheritance("Scheduled for being final in the future", "2.13.0")
 class strictfp extends scala.annotation.StaticAnnotation

--- a/src/library/scala/annotation/unused.scala
+++ b/src/library/scala/annotation/unused.scala
@@ -12,7 +12,7 @@
 
 package scala.annotation
 
-/** Mark an element unused for a given context.
+/** Marks an element unused for a given context.
  *
  *  Unused warnings are suppressed for elements known to be unused.
  *

--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -63,7 +63,7 @@ object ArrayOps {
   /** A lazy filtered array. No filtering is applied until one of `foreach`, `map` or `flatMap` is called. */
   class WithFilter[A](p: A => Boolean, xs: Array[A]) {
 
-    /** Apply `f` to each element for its side effects.
+    /** Applies `f` to each element for its side effects.
       * Note: [U] parameter needed to help scalac's type inference.
       */
     def foreach[U](f: A => U): Unit = {
@@ -575,7 +575,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     */
   def filterNot(p: A => Boolean): Array[A] = filter(x => !p(x))
 
-  /** Sorts this array according to an Ordering.
+  /** Sorts this array according to an `Ordering`.
     *
     *  The sort is stable. That is, elements that are equal (as determined by
     *  `lt`) appear in the same order in the sorted sequence as in the original.
@@ -1314,7 +1314,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     }
   }
 
-  /** Apply `f` to each element for its side effects.
+  /** Applies `f` to each element for its side effects.
     * Note: [U] parameter needed to help scalac's type inference.
     */
   def foreach[U](f: A => U): Unit = {
@@ -1476,7 +1476,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     copied
   }
 
-  /** Create a copy of this array with the specified element type. */
+  /** Creates a copy of this array with the specified element type. */
   def toArray[B >: A: ClassTag]: Array[B] = {
     val destination = new Array[B](xs.length)
     @annotation.unused val copied = copyToArray(destination, 0)

--- a/src/library/scala/collection/BitSet.scala
+++ b/src/library/scala/collection/BitSet.scala
@@ -290,7 +290,7 @@ trait BitSetOps[+C <: BitSet with BitSetOps[C]]
   @`inline` final def ^ (other: BitSet): C = xor(other)
 
   /**
-    * Builds a new bitset by applying a function to all elements of this bitset
+    * Builds a new bitset by applying a function to all elements of this bitset.
     * @param f the function to apply to each element.
     * @return a new bitset resulting from applying the given function ''f'' to
     *         each element of this bitset and collecting the results

--- a/src/library/scala/collection/BuildFrom.scala
+++ b/src/library/scala/collection/BuildFrom.scala
@@ -28,7 +28,7 @@ import scala.reflect.ClassTag
 trait BuildFrom[-From, -A, +C] extends Any { self =>
   def fromSpecific(from: From)(it: IterableOnce[A]): C
 
-  /** Get a Builder for the collection. For non-strict collection types this will use an intermediate buffer.
+  /** Gets a Builder for the collection. For non-strict collection types this will use an intermediate buffer.
     * Building collections with `fromSpecific` is preferred because it can be lazy for lazy collections. */
   def newBuilder(from: From): Builder[A, C]
 
@@ -44,14 +44,14 @@ trait BuildFrom[-From, -A, +C] extends Any { self =>
 
 object BuildFrom extends BuildFromLowPriority1 {
 
-  /** Build the source collection type from a MapOps */
+  /** Builds the source collection type from a `MapOps`. */
   implicit def buildFromMapOps[CC[X, Y] <: Map[X, Y] with MapOps[X, Y, CC, _], K0, V0, K, V]: BuildFrom[CC[K0, V0] with Map[K0, V0], (K, V), CC[K, V] with Map[K, V]] = new BuildFrom[CC[K0, V0], (K, V), CC[K, V]] {
     //TODO: Reuse a prototype instance
     def newBuilder(from: CC[K0, V0]): Builder[(K, V), CC[K, V]] = (from: MapOps[K0, V0, CC, _]).mapFactory.newBuilder[K, V]
     def fromSpecific(from: CC[K0, V0])(it: IterableOnce[(K, V)]): CC[K, V] = (from: MapOps[K0, V0, CC, _]).mapFactory.from(it)
   }
 
-  /** Build the source collection type from a SortedMapOps */
+  /** Builds the source collection type from a `SortedMapOps`. */
   implicit def buildFromSortedMapOps[CC[X, Y] <: SortedMap[X, Y] with SortedMapOps[X, Y, CC, _], K0, V0, K : Ordering, V]: BuildFrom[CC[K0, V0] with SortedMap[K0, V0], (K, V), CC[K, V] with SortedMap[K, V]] = new BuildFrom[CC[K0, V0], (K, V), CC[K, V]] {
     def newBuilder(from: CC[K0, V0]): Builder[(K, V), CC[K, V]] = (from: SortedMapOps[K0, V0, CC, _]).sortedMapFactory.newBuilder[K, V]
     def fromSpecific(from: CC[K0, V0])(it: IterableOnce[(K, V)]): CC[K, V] = (from: SortedMapOps[K0, V0, CC, _]).sortedMapFactory.from(it)
@@ -91,7 +91,7 @@ object BuildFrom extends BuildFromLowPriority1 {
 
 trait BuildFromLowPriority1 extends BuildFromLowPriority2 {
 
-  /** Build the source collection type from an Iterable with SortedOps */
+  /** Builds the source collection type from an `Iterable` with `SortedOps`. */
   // Restating the upper bound of CC in the result type seems redundant, but it serves to prune the
   // implicit search space for faster compilation and reduced change of divergence. See the compilation
   // test in test/junit/scala/collection/BuildFromTest.scala and discussion in https://github.com/scala/scala/pull/10209
@@ -108,7 +108,7 @@ trait BuildFromLowPriority1 extends BuildFromLowPriority2 {
 }
 
 trait BuildFromLowPriority2 {
-  /** Build the source collection type from an IterableOps */
+  /** Builds the source collection type from an `IterableOps`. */
   implicit def buildFromIterableOps[CC[X] <: Iterable[X] with IterableOps[X, CC, _], A0, A]: BuildFrom[CC[A0], A, CC[A]] = new BuildFrom[CC[A0], A, CC[A]] {
     //TODO: Reuse a prototype instance
     def newBuilder(from: CC[A0]): Builder[A, CC[A]] = (from: IterableOps[A0, CC, _]).iterableFactory.newBuilder[A]

--- a/src/library/scala/collection/Factory.scala
+++ b/src/library/scala/collection/Factory.scala
@@ -38,7 +38,7 @@ trait Factory[-A, +C] extends Any {
     */
   def fromSpecific(it: IterableOnce[A]): C
 
-  /** Get a Builder for the collection. For non-strict collection types this will use an intermediate buffer.
+  /** Gets a Builder for the collection. For non-strict collection types this will use an intermediate buffer.
     * Building collections with `fromSpecific` is preferred because it can be lazy for lazy collections. */
   def newBuilder: Builder[A, C]
 }
@@ -260,7 +260,7 @@ trait IterableFactory[+CC[_]] extends Serializable {
 object IterableFactory {
 
   /**
-    * Fixes the element type of `factory` to `A`
+    * Fixes the element type of `factory` to `A`.
     * @param factory The factory to fix the element type
     * @tparam A Type of elements
     * @tparam CC Collection type constructor of the factory (e.g. `Seq`, `List`)
@@ -384,7 +384,7 @@ trait SpecificIterableFactory[-A, +C] extends Factory[A, C] {
 trait MapFactory[+CC[_, _]] extends Serializable {
 
   /**
-   * An empty Map
+   * An empty Map.
    */
   def empty[K, V]: CC[K, V]
 
@@ -412,7 +412,7 @@ trait MapFactory[+CC[_, _]] extends Serializable {
 object MapFactory {
 
   /**
-    * Fixes the key and value types of `factory` to `K` and `V`, respectively
+    * Fixes the key and value types of `factory` to `K` and `V`, respectively.
     * @param factory The factory to fix the key and value types
     * @tparam K Type of keys
     * @tparam V Type of values
@@ -505,7 +505,7 @@ trait EvidenceIterableFactory[+CC[_], Ev[_]] extends Serializable {
 object EvidenceIterableFactory {
 
   /**
-    * Fixes the element type of `factory` to `A`
+    * Fixes the element type of `factory` to `A`.
     * @param factory The factory to fix the element type
     * @tparam A Type of elements
     * @tparam CC Collection type constructor of the factory (e.g. `TreeSet`)

--- a/src/library/scala/collection/Hashing.scala
+++ b/src/library/scala/collection/Hashing.scala
@@ -29,7 +29,7 @@ protected[collection] object Hashing {
     improve(elemHashCode(key))
 
   /**
-    * Utility method to keep a subset of all bits in a given bitmap
+    * Utility method to keep a subset of all bits in a given bitmap.
     *
     * Example
     *    bitmap (binary): 00000001000000010000000100000001

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -73,7 +73,7 @@ import scala.runtime.Statics
   */
 trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Iterator[A]] { self =>
 
-  /** Check if there is a next element available.
+  /** Checks if there is a next element available.
     *
     * @return `true` if there is a next element, `false` otherwise
     * @note   Reuse: $preservesIterator
@@ -83,7 +83,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
   @deprecated("hasDefiniteSize on Iterator is the same as isEmpty", "2.13.0")
   @`inline` override final def hasDefiniteSize = isEmpty
 
-  /** Return the next element and advance the iterator.
+  /** Returns the next element and advances the iterator.
     *
     * @throws NoSuchElementException if there is no next element.
     * @return the next element.
@@ -1119,7 +1119,7 @@ object Iterator extends IterableFactory[Iterator] {
     }
   }
 
-  /** Creates an Iterator that uses a function `f` to produce elements of type `A`
+  /** Creates an `Iterator` that uses a function `f` to produce elements of type `A`
     * and update an internal state of type `S`.
     *
     * @param init State initial value
@@ -1127,7 +1127,7 @@ object Iterator extends IterableFactory[Iterator] {
     *             the end of the collection)
     * @tparam A   Type of the elements
     * @tparam S   Type of the internal state
-    * @return an Iterator that produces elements using `f` until `f` returns `None`
+    * @return an `Iterator` that produces elements using `f` until `f` returns `None`
     */
   override def unfold[A, S](init: S)(f: S => Option[(A, S)]): Iterator[A] = new UnfoldIterator(init)(f)
 

--- a/src/library/scala/collection/Map.scala
+++ b/src/library/scala/collection/Map.scala
@@ -248,7 +248,7 @@ trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
     def next() = iter.next()._2
   }
 
-  /** Apply `f` to each key/value pair for its side effects
+  /** Applies `f` to each key/value pair for its side effects
    *  Note: [U] parameter needed to help scalac's type inference.
    */
   def foreachEntry[U](f: (K, V) => U): Unit = {

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -703,7 +703,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     }
   }
 
-  /** Sorts this $coll according to an Ordering.
+  /** Sorts this $coll according to an `Ordering`.
     *
     *  The sort is stable. That is, elements that are equal (as determined by
     *  `ord.compare`) appear in the same order in the sorted sequence as in the original.
@@ -740,10 +740,10 @@ trait SeqOps[+A, +CC[_], +C] extends Any
    *  $willForceEvaluation
    *
    *  The sort is stable. That is, elements that are equal
-   *  (`lt` returns false for both directions of comparison)
+   *  (`lt` returns `false` for both directions of comparison)
    *  appear in the same order in the sorted sequence as in the original.
    *
-   *  @param  lt  a predicate that is true if
+   *  @param  lt  a predicate that is `true` if
    *              its first argument strictly precedes its second argument in
    *              the desired ordering.
    *  @return     a $coll consisting of the elements of this $coll
@@ -1125,7 +1125,7 @@ object SeqOps {
     }
   }
 
-  /** Make sure a target sequence has fast, correctly-ordered indexing for KMP.
+  /** Makes sure a target sequence has fast, correctly-ordered indexing for KMP.
    *
    *  @param  W    The target sequence
    *  @param  n0   The first element in the target sequence that we should use
@@ -1163,7 +1163,7 @@ object SeqOps {
       }
   }
 
- /** Make a jump table for KMP search.
+ /** Makes a jump table for KMP search.
    *
    *  @param  Wopt The target sequence
    *  @param  wlen Just in case we're only IndexedSeq and not IndexedSeqOptimized

--- a/src/library/scala/collection/SortedMap.scala
+++ b/src/library/scala/collection/SortedMap.scala
@@ -105,13 +105,13 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _],
   def firstKey: K = head._1
   def lastKey: K = last._1
 
-  /** Find the element with smallest key larger than or equal to a given key.
+  /** Finds the element with smallest key larger than or equal to a given key.
     * @param key The given key.
     * @return `None` if there is no such node.
     */
   def minAfter(key: K): Option[(K, V)] = rangeFrom(key).headOption
 
-  /** Find the element with largest key less than a given key.
+  /** Finds the element with largest key less than a given key.
     * @param key The given key.
     * @return `None` if there is no such node.
     */

--- a/src/library/scala/collection/SortedOps.scala
+++ b/src/library/scala/collection/SortedOps.scala
@@ -77,13 +77,13 @@ trait SortedOps[A, +C] {
    */
   def rangeUntil(until: A): C = rangeImpl(None, Some(until))
 
-  /** Create a range projection of this collection with no lower-bound.
+  /** Creates a range projection of this collection with no lower-bound.
     *  @param to The upper-bound (inclusive) of the ranged projection.
     */
   @deprecated("Use rangeTo", "2.13.0")
   final def to(to: A): C = rangeTo(to)
 
-  /** Create a range projection of this collection with no lower-bound.
+  /** Creates a range projection of this collection with no lower-bound.
     *  @param to The upper-bound (inclusive) of the ranged projection.
     */
   def rangeTo(to: A): C

--- a/src/library/scala/collection/SortedSet.scala
+++ b/src/library/scala/collection/SortedSet.scala
@@ -64,7 +64,7 @@ trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
     * Creates an iterator that contains all values from this collection
     * greater than or equal to `start` according to the ordering of
     * this collection. x.iteratorFrom(y) is equivalent to but will usually
-    * be more efficient than x.from(y).iterator
+    * be more efficient than x.from(y).iterator.
     *
     * @param start The lower-bound (inclusive) of the iterator
     */
@@ -76,13 +76,13 @@ trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
   def firstKey: A = head
   def lastKey: A = last
 
-  /** Find the smallest element larger than or equal to a given key.
+  /** Finds the smallest element larger than or equal to a given key.
     * @param key The given key.
     * @return `None` if there is no such node.
     */
   def minAfter(key: A): Option[A] = rangeFrom(key).headOption
 
-  /** Find the largest element less than a given key.
+  /** Finds the largest element less than a given key.
     * @param key The given key.
     * @return `None` if there is no such node.
     */

--- a/src/library/scala/collection/Stepper.scala
+++ b/src/library/scala/collection/Stepper.scala
@@ -38,13 +38,13 @@ import scala.collection.Stepper.EfficientSplit
   * @tparam A the element type of the Stepper
   */
 trait Stepper[@specialized(Double, Int, Long) +A] {
-  /** Check if there's an element available. */
+  /** Checks if there's an element available. */
   def hasStep: Boolean
 
-  /** Return the next element and advance the stepper */
+  /** Returns the next element and advances the stepper */
   def nextStep(): A
 
-  /** Split this stepper, if applicable. The elements of the current Stepper are split up between
+  /** Splits this stepper, if applicable. The elements of the current Stepper are split up between
     * the resulting Stepper and the current stepper.
     *
     * May return `null`, in which case the current Stepper yields the same elements as before.

--- a/src/library/scala/collection/StepperShape.scala
+++ b/src/library/scala/collection/StepperShape.scala
@@ -20,14 +20,14 @@ import scala.collection.Stepper.EfficientSplit
   * specialized Stepper `S` according to the element type `T`.
   */
 sealed trait StepperShape[-T, S <: Stepper[_]] {
-  /** Return the Int constant (as defined in the `StepperShape` companion object) for this `StepperShape`. */
+  /** Returns the `Int` constant (as defined in the `StepperShape` companion object) for this `StepperShape`. */
   def shape: StepperShape.Shape
 
-  /** Create an unboxing primitive sequential Stepper from a boxed `AnyStepper`.
+  /** Creates an unboxing primitive sequential Stepper from a boxed `AnyStepper`.
    * This is an identity operation for reference shapes. */
   def seqUnbox(st: AnyStepper[T]): S
 
-  /** Create an unboxing primitive parallel (i.e. `with EfficientSplit`) Stepper from a boxed `AnyStepper`.
+  /** Creates an unboxing primitive parallel (i.e. `with EfficientSplit`) Stepper from a boxed `AnyStepper`.
    * This is an identity operation for reference shapes. */
   def parUnbox(st: AnyStepper[T] with EfficientSplit): S with EfficientSplit
 }

--- a/src/library/scala/collection/StringOps.scala
+++ b/src/library/scala/collection/StringOps.scala
@@ -64,7 +64,7 @@ object StringOps {
   /** A lazy filtered string. No filtering is applied until one of `foreach`, `map` or `flatMap` is called. */
   class WithFilter(p: Char => Boolean, s: String) {
 
-    /** Apply `f` to each element for its side effects.
+    /** Applies `f` to each element for its side effects.
       * Note: [U] parameter needed to help scalac's type inference.
       */
     def foreach[U](f: Char => U): Unit = {
@@ -184,7 +184,7 @@ final class StringOps(private val s: String) extends AnyVal {
 
   @inline def knownSize: Int = s.length
 
-  /** Get the char at the specified index. */
+  /** Gets the char at the specified index. */
   @inline def apply(i: Int): Char = s.charAt(i)
 
   def sizeCompare(otherSize: Int): Int = Integer.compare(s.length, otherSize)
@@ -265,11 +265,11 @@ final class StringOps(private val s: String) extends AnyVal {
     sb.toString
   }
 
-  /** Builds a new String by applying a partial function to all chars of this String
+  /** Builds a new `String` by applying a partial function to all chars of this `String`
     * on which the function is defined.
     *
-    *  @param pf     the partial function which filters and maps the String.
-    *  @return       a new String resulting from applying the given partial function
+    *  @param pf     the partial function which filters and maps the `String`.
+    *  @return       a new `String` resulting from applying the given partial function
     *                `pf` to each char on which it is defined and collecting the results.
     */
   def collect(pf: PartialFunction[Char, Char]): String = {
@@ -284,10 +284,10 @@ final class StringOps(private val s: String) extends AnyVal {
     b.result()
   }
 
-  /** Builds a new collection by applying a partial function to all chars of this String
+  /** Builds a new collection by applying a partial function to all chars of this `String`
     * on which the function is defined.
     *
-    *  @param pf     the partial function which filters and maps the String.
+    *  @param pf     the partial function which filters and maps the `String`.
     *  @tparam B     the element type of the returned collection.
     *  @return       a new collection resulting from applying the given partial function
     *                `pf` to each char on which it is defined and collecting the results.
@@ -642,7 +642,7 @@ final class StringOps(private val s: String) extends AnyVal {
   }
 
   // Note: String.repeat is added in JDK 11.
-  /** Return the current string concatenated `n` times.
+  /** Returns the current string concatenated `n` times.
    */
   def *(n: Int): String =
     if (n <= 0) {
@@ -675,7 +675,7 @@ final class StringOps(private val s: String) extends AnyVal {
       }
     }
 
-  /** Return an iterator of all lines embedded in this string,
+  /** Returns an iterator of all lines embedded in this string,
    *  including trailing line separator characters.
    *
    *  The empty string yields an empty iterator.
@@ -710,7 +710,7 @@ final class StringOps(private val s: String) extends AnyVal {
     }
   }
 
-  /** Return all lines in this string in an iterator, excluding trailing line
+  /** Returns all lines in this string in an iterator, excluding trailing line
     *  end characters; i.e., apply `.stripLineEnd` to all lines
     *  returned by `linesWithSeparators`.
     */
@@ -781,7 +781,7 @@ final class StringOps(private val s: String) extends AnyVal {
       (ch >= '0' && ch <= '9')) ch.toString
   else "\\" + ch
 
-  /** Split this string around the separator character
+  /** Splits this string around the separator character
     *
     * If this string is the empty string, returns an array of strings
     * that contains a single empty string.
@@ -866,7 +866,7 @@ final class StringOps(private val s: String) extends AnyVal {
   def toBoolean: Boolean               = toBooleanImpl(s)
 
   /**
-   * Try to parse as a `Boolean`
+   * Try to parse as a `Boolean`.
    * @return `Some(true)` if the string is "true" case insensitive,
    * `Some(false)` if the string is "false" case insensitive,
    * and `None` if the string is anything else
@@ -881,7 +881,7 @@ final class StringOps(private val s: String) extends AnyVal {
   def toByte: Byte                     = java.lang.Byte.parseByte(s)
 
   /**
-   * Try to parse as a `Byte`
+   * Try to parse as a `Byte`.
    * @return `Some(value)` if the string contains a valid byte value, otherwise `None`
    * @throws java.lang.NullPointerException if the string is `null`
    */
@@ -894,7 +894,7 @@ final class StringOps(private val s: String) extends AnyVal {
   def toShort: Short                   = java.lang.Short.parseShort(s)
 
   /**
-   * Try to parse as a `Short`
+   * Try to parse as a `Short`.
    * @return `Some(value)` if the string contains a valid short value, otherwise `None`
    * @throws java.lang.NullPointerException if the string is `null`
    */
@@ -907,7 +907,7 @@ final class StringOps(private val s: String) extends AnyVal {
   def toInt: Int                       = java.lang.Integer.parseInt(s)
 
   /**
-   * Try to parse as an `Int`
+   * Try to parse as an `Int`.
    * @return `Some(value)` if the string contains a valid Int value, otherwise `None`
    * @throws java.lang.NullPointerException if the string is `null`
    */
@@ -920,7 +920,7 @@ final class StringOps(private val s: String) extends AnyVal {
   def toLong: Long                     = java.lang.Long.parseLong(s)
 
   /**
-   * Try to parse as a `Long`
+   * Try to parse as a `Long`.
    * @return `Some(value)` if the string contains a valid long value, otherwise `None`
    * @throws java.lang.NullPointerException if the string is `null`
    */
@@ -929,28 +929,28 @@ final class StringOps(private val s: String) extends AnyVal {
   /**
     * Parse as a `Float` (surrounding whitespace is removed with a `trim`).
     * @throws java.lang.NumberFormatException  If the string does not contain a parsable `Float`.
-    * @throws java.lang.NullPointerException  If the string is null.
+    * @throws java.lang.NullPointerException  If the string is `null`.
     */
   def toFloat: Float                   = java.lang.Float.parseFloat(s)
 
   /**
-   * Try to parse as a `Float`
+   * Try to parse as a `Float`.
    * @return `Some(value)` if the string is a parsable `Float`, `None` otherwise
-   * @throws java.lang.NullPointerException If the string is null
+   * @throws java.lang.NullPointerException If the string is `null`
    */
   def toFloatOption: Option[Float]     = StringParsers.parseFloat(s)
 
   /**
     * Parse as a `Double` (surrounding whitespace is removed with a `trim`).
     * @throws java.lang.NumberFormatException  If the string does not contain a parsable `Double`.
-    * @throws java.lang.NullPointerException  If the string is null.
+    * @throws java.lang.NullPointerException  If the string is `null`.
     */
   def toDouble: Double                 = java.lang.Double.parseDouble(s)
 
   /**
-   * Try to parse as a `Double`
+   * Try to parse as a `Double`.
    * @return `Some(value)` if the string is a parsable `Double`, `None` otherwise
-   * @throws java.lang.NullPointerException If the string is null
+   * @throws java.lang.NullPointerException If the string is `null`
    */
   def toDoubleOption: Option[Double]   = StringParsers.parseDouble(s)
 
@@ -1028,7 +1028,7 @@ final class StringOps(private val s: String) extends AnyVal {
     res
   }
 
-  /** Apply `f` to each element for its side effects.
+  /** Applies `f` to each element for its side effects.
     * Note: [U] parameter needed to help scalac's type inference.
     */
   def foreach[U](f: Char => U): Unit = {
@@ -1516,7 +1516,7 @@ final class StringOps(private val s: String) extends AnyVal {
     */
   def distinctBy[B](f: Char => B): String = new WrappedString(s).distinctBy(f).unwrap
 
-  /** Sorts the characters of this string according to an Ordering.
+  /** Sorts the characters of this string according to an `Ordering`.
     *
     *  The sort is stable. That is, elements that are equal (as determined by
     *  `ord.compare`) appear in the same order in the sorted sequence as in the original.

--- a/src/library/scala/collection/concurrent/Map.scala
+++ b/src/library/scala/collection/concurrent/Map.scala
@@ -138,7 +138,7 @@ trait Map[K, V] extends scala.collection.mutable.Map[K, V] {
   private[collection] def replaceRefEq(k: K, oldValue: V, newValue: V): Boolean = replace(k, oldValue, newValue)
 
   /**
-   * Update a mapping for the specified key and its current optionally mapped value
+   * Updates a mapping for the specified key and its current optionally mapped value
    * (`Some` if there is current mapping, `None` if not).
    *
    * If the remapping function returns `Some(v)`, the mapping is updated with the new value `v`.

--- a/src/library/scala/collection/concurrent/TrieMap.scala
+++ b/src/library/scala/collection/concurrent/TrieMap.scala
@@ -101,7 +101,7 @@ private[collection] final class INode[K, V](bn: MainNode[K, V], g: Gen, equiv: E
 
   /** Inserts a key value pair, overwriting the old pair if the keys match.
     *
-    *  @return        true if successful, false otherwise
+    *  @return        `true` if successful, `false` otherwise
     */
   @tailrec def rec_insert(k: K, v: V, hc: Int, lev: Int, parent: INode[K, V], startgen: Gen, ct: TrieMap[K, V]): Boolean = {
     val m = GCAS_READ(ct) // use -Yinline!
@@ -302,7 +302,7 @@ private[collection] final class INode[K, V](bn: MainNode[K, V], g: Gen, equiv: E
     * @param removalPolicy policy deciding whether to remove `k` based on `v` and the
     *                       current value associated with `k` (Always, FullEquals, or ReferenceEq)
     *
-    *  @return              null if not successful, an Option[V] indicating the previous value otherwise
+    *  @return              `null` if not successful, an `Option[V]` indicating the previous value otherwise
     */
   def rec_remove(
     k: K,
@@ -825,7 +825,7 @@ final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater
     * @param v the value compare with the value found associated with the key
     * @param removalPolicy policy deciding whether to remove `k` based on `v` and the
    *                       current value associated with `k` (Always, FullEquals, or ReferenceEq)
-    * @return an Option[V] indicating the previous value
+    * @return an `Option[V]` indicating the previous value
     */
   @tailrec private def removehc(k: K, v: V, removalPolicy: Int, hc: Int): Option[V] = {
     val r = RDCSS_READ_ROOT()

--- a/src/library/scala/collection/convert/StreamExtensions.scala
+++ b/src/library/scala/collection/convert/StreamExtensions.scala
@@ -30,7 +30,7 @@ trait StreamExtensions {
   // collections
 
   implicit class IterableHasSeqStream[A](cc: IterableOnce[A]) {
-    /** Create a sequential [[java.util.stream.Stream Java Stream]] for this collection. If the
+    /** Creates a sequential [[java.util.stream.Stream Java Stream]] for this collection. If the
       * collection contains primitive values, a corresponding specialized Stream is returned (e.g.,
       * [[java.util.stream.IntStream `IntStream`]]).
       */
@@ -44,7 +44,7 @@ trait StreamExtensions {
       def stepper[S <: Stepper[_]](implicit shape : StepperShape[A, S]) : S with EfficientSplit
     }
 
-    /** Create a parallel [[java.util.stream.Stream Java Stream]] for this collection. If the
+    /** Creates a parallel [[java.util.stream.Stream Java Stream]] for this collection. If the
       * collection contains primitive values, a corresponding specialized Stream is returned (e.g.,
       * [[java.util.stream.IntStream `IntStream`]]).
       */
@@ -59,14 +59,14 @@ trait StreamExtensions {
   // maps
 
   implicit class MapHasSeqKeyValueStream[K, V, CC[X, Y] <: collection.MapOps[X, Y, collection.Map, _]](cc: CC[K, V]) {
-    /** Create a sequential [[java.util.stream.Stream Java Stream]] for the keys of this map. If
+    /** Creates a sequential [[java.util.stream.Stream Java Stream]] for the keys of this map. If
       * the keys are primitive values, a corresponding specialized Stream is returned (e.g.,
       * [[java.util.stream.IntStream `IntStream`]]).
       */
     def asJavaSeqKeyStream[S <: BaseStream[_, _], St <: Stepper[_]](implicit s: StreamShape[K, S, St], st: StepperShape[K, St]): S =
       s.fromStepper(cc.keyStepper, par = false)
 
-    /** Create a sequential [[java.util.stream.Stream Java Stream]] for the values of this map. If
+    /** Creates a sequential [[java.util.stream.Stream Java Stream]] for the values of this map. If
       * the values are primitives, a corresponding specialized Stream is returned (e.g.,
       * [[java.util.stream.IntStream `IntStream`]]).
       */
@@ -74,7 +74,7 @@ trait StreamExtensions {
       s.fromStepper(cc.valueStepper, par = false)
 
     // The asJavaSeqStream extension method for IterableOnce doesn't apply because its `CC` takes a single type parameter, whereas the one here takes two
-    /** Create a sequential [[java.util.stream.Stream Java Stream]] for the `(key, value)` pairs of
+    /** Creates a sequential [[java.util.stream.Stream Java Stream]] for the `(key, value)` pairs of
       * this map.
       */
     def asJavaSeqStream[S <: BaseStream[_, _], St <: Stepper[_]](implicit s: StreamShape[(K, V), S, St], st: StepperShape[(K, V), St]): S =
@@ -87,7 +87,7 @@ trait StreamExtensions {
     private type MapOpsWithEfficientValueStepper = collection.MapOps[K, V, collection.Map, _] { def valueStepper[S <: Stepper[_]](implicit shape : StepperShape[V, S]) : S with EfficientSplit }
     private type MapOpsWithEfficientStepper = collection.MapOps[K, V, collection.Map, _] { def stepper[S <: Stepper[_]](implicit shape : StepperShape[(K, V), S]) : S with EfficientSplit }
 
-    /** Create a parallel [[java.util.stream.Stream Java Stream]] for the keys of this map. If
+    /** Creates a parallel [[java.util.stream.Stream Java Stream]] for the keys of this map. If
       * the keys are primitive values, a corresponding specialized Stream is returned (e.g.,
       * [[java.util.stream.IntStream `IntStream`]]).
       */
@@ -98,7 +98,7 @@ trait StreamExtensions {
         isEfficient: CC[K, V] <:< MapOpsWithEfficientKeyStepper): S =
       s.fromStepper(cc.keyStepper, par = true)
 
-    /** Create a parallel [[java.util.stream.Stream Java Stream]] for the values of this map. If
+    /** Creates a parallel [[java.util.stream.Stream Java Stream]] for the values of this map. If
       * the values are primitives, a corresponding specialized Stream is returned (e.g.,
       * [[java.util.stream.IntStream `IntStream`]]).
       */
@@ -110,7 +110,7 @@ trait StreamExtensions {
       s.fromStepper(cc.valueStepper, par = true)
 
     // The asJavaParStream extension method for IterableOnce doesn't apply because its `CC` takes a single type parameter, whereas the one here takes two
-    /** Create a parallel [[java.util.stream.Stream Java Stream]] for the `(key, value)` pairs of
+    /** Creates a parallel [[java.util.stream.Stream Java Stream]] for the `(key, value)` pairs of
       * this map.
       */
     def asJavaParStream[S <: BaseStream[_, _], St <: Stepper[_]](implicit
@@ -124,7 +124,7 @@ trait StreamExtensions {
   // steppers
 
   implicit class StepperHasSeqStream[A](stepper: Stepper[A]) {
-    /** Create a sequential [[java.util.stream.Stream Java Stream]] for this stepper. If the
+    /** Creates a sequential [[java.util.stream.Stream Java Stream]] for this stepper. If the
       * stepper yields primitive values, a corresponding specialized Stream is returned (e.g.,
       * [[java.util.stream.IntStream `IntStream`]]).
       */
@@ -138,7 +138,7 @@ trait StreamExtensions {
   }
 
   implicit class StepperHasParStream[A](stepper: Stepper[A] with EfficientSplit) {
-    /** Create a parallel [[java.util.stream.Stream Java Stream]] for this stepper. If the
+    /** Creates a parallel [[java.util.stream.Stream Java Stream]] for this stepper. If the
       * stepper yields primitive values, a corresponding specialized Stream is returned (e.g.,
       * [[java.util.stream.IntStream `IntStream`]]).
       */
@@ -158,58 +158,58 @@ trait StreamExtensions {
   // JDK spliterators only for double/int/long/reference.
 
   implicit class DoubleArrayHasSeqParStream(a: Array[Double]) {
-    /** Create a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for this array. */
+    /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for this array. */
     def asJavaSeqStream: DoubleStream = java.util.Arrays.stream(a)
-    /** Create a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for this array. */
+    /** Creates a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for this array. */
     def asJavaParStream: DoubleStream = asJavaSeqStream.parallel
   }
 
   implicit class IntArrayHasSeqParStream(a: Array[Int]) {
-    /** Create a sequential [[java.util.stream.IntStream Java IntStream]] for this array. */
+    /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for this array. */
     def asJavaSeqStream: IntStream = java.util.Arrays.stream(a)
-    /** Create a parallel [[java.util.stream.IntStream Java IntStream]] for this array. */
+    /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for this array. */
     def asJavaParStream: IntStream = asJavaSeqStream.parallel
   }
 
   implicit class LongArrayHasSeqParStream(a: Array[Long]) {
-    /** Create a sequential [[java.util.stream.LongStream Java LongStream]] for this array. */
+    /** Creates a sequential [[java.util.stream.LongStream Java LongStream]] for this array. */
     def asJavaSeqStream: LongStream = java.util.Arrays.stream(a)
-    /** Create a parallel [[java.util.stream.LongStream Java LongStream]] for this array. */
+    /** Creates a parallel [[java.util.stream.LongStream Java LongStream]] for this array. */
     def asJavaParStream: LongStream = asJavaSeqStream.parallel
   }
 
   implicit class AnyArrayHasSeqParStream[A <: AnyRef](a: Array[A]) {
-    /** Create a sequential [[java.util.stream.Stream Java Stream]] for this array. */
+    /** Creates a sequential [[java.util.stream.Stream Java Stream]] for this array. */
     def asJavaSeqStream: Stream[A] = java.util.Arrays.stream(a)
-    /** Create a parallel [[java.util.stream.Stream Java Stream]] for this array. */
+    /** Creates a parallel [[java.util.stream.Stream Java Stream]] for this array. */
     def asJavaParStream: Stream[A] = asJavaSeqStream.parallel
   }
 
   implicit class ByteArrayHasSeqParStream(a: Array[Byte]) {
-    /** Create a sequential [[java.util.stream.IntStream Java IntStream]] for this array. */
+    /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for this array. */
     def asJavaSeqStream: IntStream = a.stepper.asJavaSeqStream
-    /** Create a parallel [[java.util.stream.IntStream Java IntStream]] for this array. */
+    /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for this array. */
     def asJavaParStream: IntStream = a.stepper.asJavaParStream
   }
 
   implicit class ShortArrayHasSeqParStream(a: Array[Short]) {
-    /** Create a sequential [[java.util.stream.IntStream Java IntStream]] for this array. */
+    /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for this array. */
     def asJavaSeqStream: IntStream = a.stepper.asJavaSeqStream
-    /** Create a parallel [[java.util.stream.IntStream Java IntStream]] for this array. */
+    /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for this array. */
     def asJavaParStream: IntStream = a.stepper.asJavaParStream
   }
 
   implicit class CharArrayHasSeqParStream(a: Array[Char]) {
-    /** Create a sequential [[java.util.stream.IntStream Java IntStream]] for this array. */
+    /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for this array. */
     def asJavaSeqStream: IntStream = a.stepper.asJavaSeqStream
-    /** Create a parallel [[java.util.stream.IntStream Java IntStream]] for this array. */
+    /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for this array. */
     def asJavaParStream: IntStream = a.stepper.asJavaParStream
   }
 
   implicit class FloatArrayHasSeqParStream(a: Array[Float]) {
-    /** Create a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for this array. */
+    /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for this array. */
     def asJavaSeqStream: DoubleStream = a.stepper.asJavaSeqStream
-    /** Create a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for this array. */
+    /** Creates a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for this array. */
     def asJavaParStream: DoubleStream = a.stepper.asJavaParStream
   }
 
@@ -271,7 +271,7 @@ trait StreamExtensions {
       else factory.fromSpecific(stream.iterator.asScala)
     }
 
-    /** Convert a generic Java Stream wrapping a primitive type to a corresponding primitive
+    /** Converts a generic Java Stream wrapping a primitive type to a corresponding primitive
       * Stream.
       */
     def asJavaPrimitiveStream[S](implicit unboxer: StreamUnboxer[A, S]): S = unboxer(stream)

--- a/src/library/scala/collection/convert/impl/InOrderStepperBase.scala
+++ b/src/library/scala/collection/convert/impl/InOrderStepperBase.scala
@@ -24,7 +24,7 @@ import scala.collection.Stepper.EfficientSplit
   */
 private[convert] abstract class InOrderStepperBase[Sub >: Null, Semi <: Sub](protected var i0: Int, protected var iN: Int)
 extends EfficientSplit {
-  /** Set `true` if the element at `i0` is known to be there.  `false` if either not known or is a gap.
+  /** Sets `true` if the element at `i0` is known to be there.  `false` if either not known or is a gap.
     */
   protected def found: Boolean
 

--- a/src/library/scala/collection/immutable/ArraySeq.scala
+++ b/src/library/scala/collection/immutable/ArraySeq.scala
@@ -298,7 +298,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
   }
 
   /**
-   * Wrap an existing `Array` into an `ArraySeq` of the proper primitive specialization type
+   * Wraps an existing `Array` into an `ArraySeq` of the proper primitive specialization type
    * without copying. Any changes to wrapped array will break the expected immutability.
    *
    * Note that an array containing boxed primitives can be wrapped in an `ArraySeq` without

--- a/src/library/scala/collection/immutable/BitSet.scala
+++ b/src/library/scala/collection/immutable/BitSet.scala
@@ -62,7 +62,7 @@ sealed abstract class BitSet
     } else this
   }
 
-  /** Update word at index `idx`; enlarge set if `idx` outside range of set.
+  /** Updates word at index `idx`; enlarges set if `idx` outside range of set.
     */
   protected def updateWord(idx: Int, w: Long): BitSet
 
@@ -221,7 +221,7 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
           * Array Shrinking:
           * If `this` is not longer than `bs`, then since we must iterate through the full array of words,
           * we can track the new highest index word which is non-zero, at little additional cost. At the end, the new
-          * Array[Long] allocated for the returned BitSet will only be of size `maxNonZeroIndex + 1`
+          * `Array[Long]` allocated for the returned `BitSet` will only be of size `maxNonZeroIndex + 1`
           *
           * Tracking Changes:
           * If the two sets are disjoint, then we can return `this`. Therefor, until at least one change is detected,

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -306,7 +306,7 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
     * }}}
     *
     * @param that the HashMap to merge this HashMap with
-    * @param mergef the merge function which resolves collisions between the two HashMaps. If `mergef` is null, then
+    * @param mergef the merge function which resolves collisions between the two HashMaps. If `mergef` is `null`, then
     *               keys from `this` will overwrite keys from `that`, making the behaviour equivalent to
     *               `that.concat(this)`
     *
@@ -556,9 +556,9 @@ private[immutable] sealed abstract class MapNode[K, +V] extends Node[MapNode[K, 
     * @param originalHash the original hash of `key`
     * @param hash the improved hash of `key`
     * @param shift the shift of the node (distanceFromRoot * BitPartitionSize)
-    * @param replaceValue if true, then the value currently associated to `key` will be replaced with the passed value
+    * @param replaceValue if `true`, then the value currently associated to `key` will be replaced with the passed value
     *                     argument.
-    *                     if false, then the key will be inserted if not already present, however if the key is present
+    *                     if `false`, then the key will be inserted if not already present, however if the key is present
     *                     then the passed value will not replace the current value. That is, if `false`, then this
     *                     method has `update if not exists` semantics.
     */
@@ -787,7 +787,7 @@ private final class BitmapIndexedMapNode[K, +V](
     * @param shallowlyMutableNodeMap bitmap of child nodes of this node, which can be shallowly mutated
     *                                during the call to this method
     *
-    * @return Int which is the bitwise OR of shallowlyMutableNodeMap and any freshly created nodes, which will be
+    * @return `Int` which is the bitwise OR of `shallowlyMutableNodeMap` and any freshly created nodes, which will be
     *         available for mutations in subsequent calls.
     */
   def updateWithShallowMutations[V1 >: V](key: K, value: V1, originalHash: Int, keyHash: Int, shift: Int, shallowlyMutableNodeMap: Int): Int = {
@@ -871,7 +871,7 @@ private final class BitmapIndexedMapNode[K, +V](
       if (key0 == key) {
         if (this.payloadArity == 2 && this.nodeArity == 0) {
           /*
-           * Create new node with remaining pair. The new node will a) either become the new root
+           * Creates new node with remaining pair. The new node will a) either become the new root
            * returned, or b) unwrapped and inlined during returning.
            */
           val newDataMap = if (shift == 0) (dataMap ^ bitpos) else bitposFrom(maskFrom(keyHash, 0))
@@ -2209,7 +2209,7 @@ object HashMap extends MapFactory[HashMap] {
       case _ => (newBuilder[K, V] ++= source).result()
     }
 
-  /** Create a new Builder which can be reused after calling `result()` without an
+  /** Creates a new Builder which can be reused after calling `result()` without an
     * intermediate call to `clear()` in order to build multiple related results.
     */
   def newBuilder[K, V]: ReusableBuilder[(K, V), HashMap[K, V]] = new HashMapBuilder[K, V]

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -533,7 +533,7 @@ private final class BitmapIndexedSetNode[A](
     * @param shallowlyMutableNodeMap bitmap of child nodes of this node, which can be shallowly mutated
     *                                during the call to this method
     *
-    * @return Int which is the bitwise OR of shallowlyMutableNodeMap and any freshly created nodes, which will be
+    * @return `Int` which is the bitwise OR of `shallowlyMutableNodeMap` and any freshly created nodes, which will be
     *         available for mutations in subsequent calls.
     */
   def updateWithShallowMutations(element: A, originalHash: Int, elementHash: Int, shift: Int, shallowlyMutableNodeMap: Int): Int = {
@@ -1752,7 +1752,7 @@ private final class HashCollisionSetNode[A](val originalHash: Int, val hash: Int
     }
 
   /**
-    * Remove an element from the hash collision node.
+    * Removes an element from the hash collision node.
     *
     * When after deletion only one element remains, we return a bit-mapped indexed node with a
     * singleton element and a hash-prefix for trie level 0. This node will be then a) either become
@@ -1943,7 +1943,7 @@ object HashSet extends IterableFactory[HashSet] {
       case _ => (newBuilder[A] ++= source).result()
     }
 
-  /** Create a new Builder which can be reused after calling `result()` without an
+  /** Creates a new Builder which can be reused after calling `result()` without an
     * intermediate call to `clear()` in order to build multiple related results.
     */
   def newBuilder[A]: ReusableBuilder[A, HashSet[A]] = new HashSetBuilder

--- a/src/library/scala/collection/immutable/LazyList.scala
+++ b/src/library/scala/collection/immutable/LazyList.scala
@@ -402,7 +402,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
     if (knownIsEmpty) Iterator.empty
     else new LazyIterator(this)
 
-  /** Apply the given function `f` to each element of this linear sequence
+  /** Applies the given function `f` to each element of this linear sequence
     * (while respecting the order of the elements).
     *
     *  @param f The treatment to apply to each element.
@@ -1258,7 +1258,7 @@ object LazyList extends SeqFactory[LazyList] {
     }
 
   /**
-    * Create an infinite LazyList starting at `start` and incrementing by
+    * Creates an infinite LazyList starting at `start` and incrementing by
     * step `step`.
     *
     * @param start the start value of the LazyList
@@ -1269,7 +1269,7 @@ object LazyList extends SeqFactory[LazyList] {
     newLL(eagerCons(start, from(start + step, step)))
 
   /**
-    * Create an infinite LazyList starting at `start` and incrementing by `1`.
+    * Creates an infinite LazyList starting at `start` and incrementing by `1`.
     *
     * @param start the start value of the LazyList
     * @return the LazyList starting at value `start`.
@@ -1277,7 +1277,7 @@ object LazyList extends SeqFactory[LazyList] {
   def from(start: Int): LazyList[Int] = from(start, 1)
 
   /**
-    * Create an infinite LazyList containing the given element expression (which
+    * Creates an infinite LazyList containing the given element expression (which
     * is computed for each occurrence).
     *
     * @param elem the element composing the resulting LazyList

--- a/src/library/scala/collection/immutable/Map.scala
+++ b/src/library/scala/collection/immutable/Map.scala
@@ -101,7 +101,7 @@ trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]
   def updated[V1 >: V](key: K, value: V1): CC[K, V1]
 
   /**
-   * Update a mapping for the specified key and its current optionally mapped value
+   * Updates a mapping for the specified key and its current optionally mapped value
    * (`Some` if there is current mapping, `None` if not).
    *
    * If the remapping function returns `Some(v)`, the mapping is updated with the new value `v`.
@@ -123,7 +123,7 @@ trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]
   }
 
   /**
-    * Alias for `updated`
+    * Alias for `updated`.
     *
     * @param kv the key/value pair.
     * @tparam V1 the type of the value in the key/value pair.

--- a/src/library/scala/collection/immutable/Queue.scala
+++ b/src/library/scala/collection/immutable/Queue.scala
@@ -83,7 +83,7 @@ sealed class Queue[+A] protected(protected val in: List[A], protected val out: L
 
   /** Checks if the queue is empty.
     *
-    *  @return true, iff there is no element in the queue.
+    *  @return `true`, iff there is no element in the queue.
     */
   override def isEmpty: Boolean = in.isEmpty && out.isEmpty
 

--- a/src/library/scala/collection/immutable/RedBlackTree.scala
+++ b/src/library/scala/collection/immutable/RedBlackTree.scala
@@ -66,7 +66,7 @@ private[collection] object RedBlackTree {
         res
       } else tree.black
     }
-    /** Create a new balanced tree where `newLeft` replaces `tree.left`.
+    /** Creates a new balanced tree where `newLeft` replaces `tree.left`.
      * tree and newLeft are never null */
     protected[this] final def mutableBalanceLeft[A1, B, B1 >: B](tree: Tree[A1, B], newLeft: Tree[A1, B1]): Tree[A1, B1] = {
       // Parameter trees
@@ -109,7 +109,7 @@ private[collection] object RedBlackTree {
         tree.mutableWithLeft(newLeft)
       }
     }
-    /** Create a new balanced tree where `newRight` replaces `tree.right`.
+    /** Creates a new balanced tree where `newRight` replaces `tree.right`.
      * tree and newRight are never null */
     protected[this] final def mutableBalanceRight[A1, B, B1 >: B](tree: Tree[A1, B], newRight: Tree[A1, B1]): Tree[A1, B1] = {
       // Parameter trees
@@ -337,7 +337,7 @@ private[collection] object RedBlackTree {
     new Tree(key, value.asInstanceOf[AnyRef], left, right, sizeAndColour)
   }
 
-  /** Create a new balanced tree where `newLeft` replaces `tree.left`. */
+  /** Creates a new balanced tree where `newLeft` replaces `tree.left`. */
   private[this] def balanceLeft[A, B1](tree: Tree[A, B1], newLeft: Tree[A, B1]): Tree[A, B1] = {
     // Parameter trees
     //            tree              |                   newLeft
@@ -378,7 +378,7 @@ private[collection] object RedBlackTree {
       }
     }
   }
-  /** Create a new balanced tree where `newRight` replaces `tree.right`. */
+  /** Creates a new balanced tree where `newRight` replaces `tree.right`. */
   private[this] def balanceRight[A, B1](tree: Tree[A, B1], newRight: Tree[A, B1]): Tree[A, B1] = {
     // Parameter trees
     //            tree                |                             newRight
@@ -783,7 +783,7 @@ private[collection] object RedBlackTree {
   @`inline` private[RedBlackTree] def mutableBlackTree[A, B](key: A, value: B, left: Tree[A, B], right: Tree[A, B]) = new Tree[A,B](key, value.asInstanceOf[AnyRef], left, right, initialBlackCount)
 
   /** create a new immutable red tree.
-   * left and right may be null
+   * `left` and `right` may be `null`
    */
   private[immutable] def RedTree[A, B](key: A, value: B, left: Tree[A, B], right: Tree[A, B]): Tree[A, B] = {
     //assertNotMutable(left)
@@ -853,9 +853,9 @@ private[collection] object RedBlackTree {
     protected var lookahead: Tree[A, B] = if (start.isDefined) startFrom(start.get) else findLeftMostOrPopOnEmpty(root)
 
     /**
-      * Find the leftmost subtree whose key is equal to the given key, or if no such thing,
+      * Finds the leftmost subtree whose key is equal to the given key, or if no such thing,
       * the leftmost subtree with the key that would be "next" after it according
-      * to the ordering. Along the way build up the iterator's path stack so that "next"
+      * to the ordering. Along the way builds up the iterator's path stack so that "next"
       * functionality works.
       */
     private[this] def startFrom(key: A) : Tree[A,B] = if (root eq null) null else {
@@ -936,7 +936,7 @@ private[collection] object RedBlackTree {
     override def nextResult(tree: Tree[A, B]) = tree.value
   }
 
-  /** Build a Tree suitable for a TreeSet from an ordered sequence of keys */
+  /** Builds a Tree suitable for a TreeSet from an ordered sequence of keys. */
   def fromOrderedKeys[A](xs: Iterator[A], size: Int): Tree[A, Null] = {
     val maxUsedDepth = 32 - Integer.numberOfLeadingZeros(size) // maximum depth of non-leaf nodes
     def f(level: Int, size: Int): Tree[A, Null] = size match {
@@ -952,7 +952,7 @@ private[collection] object RedBlackTree {
     f(1, size)
   }
 
-  /** Build a Tree suitable for a TreeMap from an ordered sequence of key/value pairs */
+  /** Builds a Tree suitable for a TreeMap from an ordered sequence of key/value pairs. */
   def fromOrderedEntries[A, B](xs: Iterator[(A, B)], size: Int): Tree[A, B] = {
     val maxUsedDepth = 32 - Integer.numberOfLeadingZeros(size) // maximum depth of non-leaf nodes
     def f(level: Int, size: Int): Tree[A, B] = size match {

--- a/src/library/scala/collection/immutable/Stream.scala
+++ b/src/library/scala/collection/immutable/Stream.scala
@@ -48,7 +48,7 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
 
   override protected[this] def className: String = "Stream"
 
-  /** Apply the given function `f` to each element of this linear sequence
+  /** Applies the given function `f` to each element of this linear sequence
     * (while respecting the order of the elements).
     *
     *  @param f The treatment to apply to each element.
@@ -497,7 +497,7 @@ object Stream extends SeqFactory[Stream] {
   }
 
   /**
-    * Create an infinite Stream starting at `start` and incrementing by
+    * Creates an infinite Stream starting at `start` and incrementing by
     * step `step`.
     *
     * @param start the start value of the Stream
@@ -508,7 +508,7 @@ object Stream extends SeqFactory[Stream] {
     cons(start, from(start + step, step))
 
   /**
-    * Create an infinite Stream starting at `start` and incrementing by `1`.
+    * Creates an infinite Stream starting at `start` and incrementing by `1`.
     *
     * @param start the start value of the Stream
     * @return the Stream starting at value `start`.
@@ -516,7 +516,7 @@ object Stream extends SeqFactory[Stream] {
   def from(start: Int): Stream[Int] = from(start, 1)
 
   /**
-    * Create an infinite Stream containing the given element expression (which
+    * Creates an infinite Stream containing the given element expression (which
     * is computed for each occurrence).
     *
     * @param elem the element composing the resulting Stream

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -146,7 +146,7 @@ final class TreeSet[A] private[immutable] (private[immutable] val tree: RB.Tree[
   /** Checks if this set contains element `elem`.
     *
     *  @param  elem    the element to check for membership.
-    *  @return true, iff `elem` is contained in this set.
+    *  @return `true`, iff `elem` is contained in this set.
     */
   def contains(elem: A): Boolean = RB.contains(tree, elem)
 

--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -64,7 +64,7 @@ object Vector extends StrictOptimizedSeqFactory[Vector] {
 
   def newBuilder[A]: ReusableBuilder[A, Vector[A]] = new VectorBuilder[A]
 
-  /** Create a Vector with the same element at each index.
+  /** Creates a `Vector` with the same element at each index.
     *
     * Unlike `fill`, which takes a by-name argument for the value and can thereby
     * compute different values for each index, this method guarantees that all

--- a/src/library/scala/collection/mutable/ArrayBuffer.scala
+++ b/src/library/scala/collection/mutable/ArrayBuffer.scala
@@ -63,7 +63,7 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
 
   override def knownSize: Int = super[IndexedSeqOps].knownSize
 
-  /** Ensure that the internal array has at least `n` cells. */
+  /** Ensures that the internal array has at least `n` cells. */
   protected def ensureSize(n: Int): Unit = {
     array = ArrayBuffer.ensureSize(array, size0, n)
   }
@@ -75,7 +75,7 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
   def sizeHint(size: Int): Unit =
     if(size > length && size >= 1) ensureSize(size)
 
-  /** Reduce length to `n`, nulling out all dropped elements */
+  /** Reduces length to `n`, nulling out all dropped elements */
   private def reduceToSize(n: Int): Unit = {
     mutationCount += 1
     Arrays.fill(array, n, size0, null)
@@ -127,7 +127,7 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
 
   /**
     * Clears this buffer and shrinks to @param size (rounding up to the next
-    * natural size)
+    * natural size).
     * @param size
     */
   def clearAndShrink(size: Int = ArrayBuffer.DefaultInitialSize): this.type = {
@@ -242,7 +242,7 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
     copied
   }
 
-  /** Sorts this $coll in place according to an Ordering.
+  /** Sorts this $coll in place according to an `Ordering`.
     *
     * @see [[scala.collection.mutable.IndexedSeqOps.sortInPlace]]
     * @param  ord the ordering to be used to compare elements.

--- a/src/library/scala/collection/mutable/ArrayBuilder.scala
+++ b/src/library/scala/collection/mutable/ArrayBuilder.scala
@@ -45,10 +45,10 @@ sealed abstract class ArrayBuilder[T]
 
   protected[this] def resize(size: Int): Unit
 
-  /** Add all elements of an array. */
+  /** Adds all elements of an array. */
   def addAll(xs: Array[_ <: T]): this.type = addAll(xs, 0, xs.length)
 
-  /** Add a slice of an array. */
+  /** Adds a slice of an array. */
   def addAll(xs: Array[_ <: T], offset: Int, length: Int): this.type = {
     val offset1 = offset.max(0)
     val length1 = length.max(0)

--- a/src/library/scala/collection/mutable/ArrayDeque.scala
+++ b/src/library/scala/collection/mutable/ArrayDeque.scala
@@ -295,7 +295,7 @@ class ArrayDeque[A] protected (
 
   /**
     * Unsafely remove the first element (throws exception when empty)
-    * See also removeHeadOption()
+    * See also removeHeadOption().
     *
     * @param resizeInternalRepr If this is set, resize the internal representation to reclaim space once in a while
     * @throws NoSuchElementException when empty
@@ -322,7 +322,7 @@ class ArrayDeque[A] protected (
 
   /**
     * Unsafely remove the last element (throws exception when empty)
-    * See also removeLastOption()
+    * See also removeLastOption().
     *
     * @param resizeInternalRepr If this is set, resize the internal representation to reclaim space once in a while
     * @throws NoSuchElementException when empty
@@ -340,7 +340,7 @@ class ArrayDeque[A] protected (
   }
 
   /**
-    * Remove all elements from this collection and return the elements while emptying this data structure
+    * Remove all elements from this collection and return the elements while emptying this data structure.
     * @return
     */
   def removeAll(): scala.collection.immutable.Seq[A] = {
@@ -353,7 +353,7 @@ class ArrayDeque[A] protected (
   }
 
   /**
-    * Remove all elements from this collection and return the elements in reverse while emptying this data structure
+    * Remove all elements from this collection and return the elements in reverse while emptying this data structure.
     * @return
     */
   def removeAllReverse(): scala.collection.immutable.Seq[A] = {
@@ -366,7 +366,7 @@ class ArrayDeque[A] protected (
   }
 
   /**
-    * Returns and removes all elements from the left of this queue which satisfy the given predicate
+    * Returns and removes all elements from the left of this queue which satisfy the given predicate.
     *
     *  @param f   the predicate used for choosing elements
     *  @return
@@ -380,7 +380,7 @@ class ArrayDeque[A] protected (
   }
 
   /**
-    * Returns and removes all elements from the right of this queue which satisfy the given predicate
+    * Returns and removes all elements from the right of this queue which satisfy the given predicate.
     *
     *  @param f   the predicate used for choosing elements
     *  @return
@@ -442,7 +442,7 @@ class ArrayDeque[A] protected (
 
   /**
     * Note: This does not actually resize the internal representation.
-    * See clearAndShrink if you want to also resize internally
+    * See clearAndShrink if you want to also resize internally.
     */
   def clear(): Unit = {
     while(nonEmpty) {
@@ -451,7 +451,7 @@ class ArrayDeque[A] protected (
   }
 
   /**
-    * Clears this buffer and shrinks to @param size
+    * Clears this buffer and shrinks to @param size.
     *
     * @param size
     * @return
@@ -476,7 +476,7 @@ class ArrayDeque[A] protected (
     copySliceToArray(srcStart = 0, dest = new Array[B](length), destStart = 0, maxItems = length)
 
   /**
-    * Trims the capacity of this ArrayDeque's instance to be the current size
+    * Trims the capacity of this ArrayDeque's instance to be the current size.
     */
   def trimToSize(): Unit = resize(length)
 
@@ -549,13 +549,13 @@ object ArrayDeque extends StrictOptimizedSeqFactory[ArrayDeque] {
   final val DefaultInitialSize = 16
 
   /**
-    * We try to not repeatedly resize arrays smaller than this
+    * We try to not repeatedly resize arrays smaller than this.
     */
   private[ArrayDeque] final val StableSize = 128
 
   /**
     * Allocates an array whose size is next power of 2 > `len`
-    * Largest possible len is 1<<30 - 1
+    * Largest possible len is 1<<30 - 1.
     *
     * @param len
     * @return
@@ -586,7 +586,7 @@ trait ArrayDequeOps[A, +CC[_], +C <: AnyRef] extends StrictOptimizedSeqOps[A, CC
   /**
     * This is a more general version of copyToArray - this also accepts a srcStart unlike copyToArray
     * This copies maxItems elements from this collections srcStart to dest's destStart
-    * If we reach the end of either collections before we could copy maxItems, we simply stop copying
+    * If we reach the end of either collections before we could copy maxItems, we simply stop copying.
     *
     * @param dest
     * @param srcStart

--- a/src/library/scala/collection/mutable/ArraySeq.scala
+++ b/src/library/scala/collection/mutable/ArraySeq.scala
@@ -55,7 +55,7 @@ sealed abstract class ArraySeq[T]
     * or subtype of the element type. */
   def elemTag: ClassTag[_]
 
-  /** Update element at given index */
+  /** Updates element at given index */
   def update(@deprecatedName("idx", "2.13.0") index: Int, elem: T): Unit
 
   /** The underlying array. Its element type does not have to be equal to the element type of this ArraySeq. A primitive
@@ -109,7 +109,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
   def newBuilder[A : ClassTag]: Builder[A, ArraySeq[A]] = ArrayBuilder.make[A].mapResult(make)
 
   /**
-   * Wrap an existing `Array` into a `ArraySeq` of the proper primitive specialization type
+   * Wraps an existing `Array` into a `ArraySeq` of the proper primitive specialization type
    * without copying.
    *
    * Note that an array containing boxed primitives can be converted to a `ArraySeq` without

--- a/src/library/scala/collection/mutable/BitSet.scala
+++ b/src/library/scala/collection/mutable/BitSet.scala
@@ -278,7 +278,7 @@ class BitSet(protected[collection] final var elems: Array[Long])
         * Array Shrinking:
         * If `this` is not longer than `bs`, then since we must iterate through the full array of words,
         * we can track the new highest index word which is non-zero, at little additional cost. At the end, the new
-        * Array[Long] allocated for the returned BitSet will only be of size `maxNonZeroIndex + 1`
+        * `Array[Long]` allocated for the returned `BitSet` will only be of size `maxNonZeroIndex + 1`
         */
 
       val bsnwords = bs.nwords

--- a/src/library/scala/collection/mutable/Buffer.scala
+++ b/src/library/scala/collection/mutable/Buffer.scala
@@ -234,7 +234,7 @@ trait Buffer[A]
     if (idx < 0) this else takeInPlace(idx)
   }
 
-  /** Append the given element to this $coll until a target length is reached.
+  /** Appends the given element to this $coll until a target length is reached.
    *
    *  @param   len   the target length
    *  @param   elem  the padding value
@@ -256,7 +256,7 @@ trait IndexedBuffer[A] extends IndexedSeq[A]
 
   override def iterableFactory: SeqFactory[IndexedBuffer] = IndexedBuffer
 
-  /** Replace the contents of this $coll with the flatmapped result.
+  /** Replaces the contents of this $coll with the flatmapped result.
    *
    *  @param f the mapping function
    *  @return this $coll
@@ -273,7 +273,7 @@ trait IndexedBuffer[A] extends IndexedSeq[A]
     this
   }
 
-  /** Replace the contents of this $coll with the filtered result.
+  /** Replaces the contents of this $coll with the filtered result.
    *
    *  @param p the filtering function
    *  @return this $coll

--- a/src/library/scala/collection/mutable/Growable.scala
+++ b/src/library/scala/collection/mutable/Growable.scala
@@ -78,7 +78,7 @@ trait Growable[-A] extends Clearable {
 object Growable {
 
   /**
-    * Fills a `Growable` instance with the elements of a given iterable
+    * Fills a `Growable` instance with the elements of a given iterable.
     * @param empty Instance to fill
     * @param it Elements to add
     * @tparam A Element type

--- a/src/library/scala/collection/mutable/HashMap.scala
+++ b/src/library/scala/collection/mutable/HashMap.scala
@@ -219,7 +219,7 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
     * @param key the key to add
     * @param value the value to add
     * @param hash the **improved** hashcode of `key` (see computeHash)
-    * @param getOld if true, then the previous value for `key` will be returned, otherwise, false
+    * @param getOld if `true`, then the previous value for `key` will be returned, otherwise `false`
     */
   private[this] def put0(key: K, value: V, hash: Int, getOld: Boolean): Some[V] = {
     if(contentSize + 1 >= threshold) growTable(table.length * 2)

--- a/src/library/scala/collection/mutable/HashTable.scala
+++ b/src/library/scala/collection/mutable/HashTable.scala
@@ -128,7 +128,7 @@ private[collection] trait HashTable[A, B, Entry >: Null <: HashEntry[A, Entry]] 
     foreachEntry(writeEntry)
   }
 
-  /** Find entry with given key in table, null if not found.
+  /** Finds entry with given key in table, null if not found.
    */
   final def findEntry(key: A): Entry =
     findEntry0(key, index(elemHashCode(key)))
@@ -139,7 +139,7 @@ private[collection] trait HashTable[A, B, Entry >: Null <: HashEntry[A, Entry]] 
     e
   }
 
-  /** Add entry to table
+  /** Adds entry to table
    *  pre: no entry with same key exists
    */
   protected[collection] final def addEntry(e: Entry): Unit = {
@@ -155,7 +155,7 @@ private[collection] trait HashTable[A, B, Entry >: Null <: HashEntry[A, Entry]] 
       resize(2 * table.length)
   }
 
-  /** Find entry with given key in table, or add new one if not found.
+  /** Finds entry with given key in table, or adds new one if not found.
    *  May be somewhat faster then `findEntry`/`addEntry` pair as it
    *  computes entry's hash index only once.
    *  Returns entry found in table or null.
@@ -173,12 +173,12 @@ private[collection] trait HashTable[A, B, Entry >: Null <: HashEntry[A, Entry]] 
    */
   def createNewEntry(key: A, value: B): Entry
 
-  /** Remove entry from table if present.
+  /** Removes entry from table if present.
    */
   final def removeEntry(key: A) : Entry = {
     removeEntry0(key, index(elemHashCode(key)))
   }
-  /** Remove entry from table if present.
+  /** Removes entry from table if present.
    */
   private[collection] final def removeEntry0(key: A, h: Int) : Entry = {
     var e = table(h).asInstanceOf[Entry]
@@ -244,7 +244,7 @@ private[collection] trait HashTable[A, B, Entry >: Null <: HashEntry[A, Entry]] 
     }
   }
 
-  /** Remove all entries from table
+  /** Removes all entries from table
    */
   def clearTable(): Unit = {
     var i = table.length - 1
@@ -359,7 +359,7 @@ private[collection] trait HashTable[A, B, Entry >: Null <: HashEntry[A, Entry]] 
 
   /**
     * Note: we take the most significant bits of the hashcode, not the lower ones
-    * this is of crucial importance when populating the table in parallel
+    * this is of crucial importance when populating the table in parallel.
     */
   protected[collection] final def index(hcode: Int): Int = {
     val ones = table.length - 1

--- a/src/library/scala/collection/mutable/ImmutableBuilder.scala
+++ b/src/library/scala/collection/mutable/ImmutableBuilder.scala
@@ -16,7 +16,7 @@ package mutable
 
 
 /**
-  * Reusable builder for immutable collections
+  * Reusable builder for immutable collections.
   */
 abstract class ImmutableBuilder[-A, C <: IterableOnce[_]](empty: C)
   extends ReusableBuilder[A, C] {

--- a/src/library/scala/collection/mutable/IndexedSeq.scala
+++ b/src/library/scala/collection/mutable/IndexedSeq.scala
@@ -42,7 +42,7 @@ trait IndexedSeqOps[A, +CC[_], +C <: AnyRef]
     this
   }
 
-  /** Sorts this $coll in place according to an Ordering.
+  /** Sorts this $coll in place according to an `Ordering`.
     *
     * @see [[scala.collection.SeqOps.sorted]]
     * @param  ord the ordering to be used to compare elements.

--- a/src/library/scala/collection/mutable/ListBuffer.scala
+++ b/src/library/scala/collection/mutable/ListBuffer.scala
@@ -177,7 +177,7 @@ class ListBuffer[A]
     this
   }
 
-  /** Reduce the length of the buffer, and null out last0
+  /** Reduces the length of the buffer, and nulls out last0
     *  if this reduces the length to 0.
     */
   private def reduceLengthBy(num: Int): Unit = {
@@ -298,7 +298,7 @@ class ListBuffer[A]
     len -= n
   }
 
-  /** Replace the contents of this $coll with the mapped result.
+  /** Replaces the contents of this $coll with the mapped result.
    *
    *  @param f the mapping function
    *  @return this $coll
@@ -313,7 +313,7 @@ class ListBuffer[A]
     this
   }
 
-  /** Replace the contents of this $coll with the flatmapped result.
+  /** Replaces the contents of this $coll with the flatmapped result.
    *
    *  @param f the mapping function
    *  @return this $coll
@@ -339,7 +339,7 @@ class ListBuffer[A]
     this
   }
 
-  /** Replace the contents of this $coll with the filtered result.
+  /** Replaces the contents of this $coll with the filtered result.
    *
    *  @param p the filtering predicate
    *  @return this $coll

--- a/src/library/scala/collection/mutable/OpenHashMap.scala
+++ b/src/library/scala/collection/mutable/OpenHashMap.scala
@@ -120,7 +120,7 @@ class OpenHashMap[Key, Value](initialSize : Int)
     deleted = 0
   }
 
-  /** Return the index of the first slot in the hash table (in probe order)
+  /** Returns the index of the first slot in the hash table (in probe order)
     * that is, in order of preference, either occupied by the given key, deleted, or empty.
     *
     * @param hash hash value for `key`
@@ -222,7 +222,7 @@ class OpenHashMap[Key, Value](initialSize : Int)
   }
 
   /** An iterator over the elements of this map. Use of this iterator follows
-    *  the same contract for concurrent modification as the foreach method.
+    *  the same contract for concurrent modification as the `foreach` method.
     *
     *  @return   the iterator
     */

--- a/src/library/scala/collection/mutable/PriorityQueue.scala
+++ b/src/library/scala/collection/mutable/PriorityQueue.scala
@@ -115,7 +115,7 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
   override protected def newSpecificBuilder: Builder[A, PriorityQueue[A]] = PriorityQueue.newBuilder
   override def empty: PriorityQueue[A] = PriorityQueue.empty
 
-  /** Replace the contents of this $coll with the mapped result.
+  /** Replaces the contents of this $coll with the mapped result.
    *
    *  @param f the mapping function
    *  @return this $coll

--- a/src/library/scala/collection/mutable/Queue.scala
+++ b/src/library/scala/collection/mutable/Queue.scala
@@ -45,7 +45,7 @@ class Queue[A] protected (array: Array[AnyRef], start: Int, end: Int)
   override protected[this] def stringPrefix = "Queue"
 
   /**
-    * Add elements to the end of this queue
+    * Add elements to the end of this queue.
     *
     * @param elem
     * @return this
@@ -69,7 +69,7 @@ class Queue[A] protected (array: Array[AnyRef], start: Int, end: Int)
   def enqueueAll(elems: scala.collection.IterableOnce[A]): this.type = this ++= elems
 
   /**
-    * Removes the first element from this queue and returns it
+    * Removes the first element from this queue and returns it.
     *
     * @return
     * @throws NoSuchElementException when queue is empty
@@ -96,7 +96,7 @@ class Queue[A] protected (array: Array[AnyRef], start: Int, end: Int)
     removeAll(p)
 
   /**
-    * Returns and dequeues all elements from the queue which satisfy the given predicate
+    * Returns and dequeues all elements from the queue which satisfy the given predicate.
     *
     *  @param f   the predicate used for choosing elements
     *  @return The removed elements

--- a/src/library/scala/collection/mutable/RedBlackTree.scala
+++ b/src/library/scala/collection/mutable/RedBlackTree.scala
@@ -602,7 +602,7 @@ private[collection] object RedBlackTree {
 
   // building
 
-  /** Build a Tree suitable for a TreeSet from an ordered sequence of keys */
+  /** Builds a Tree suitable for a TreeSet from an ordered sequence of keys */
   def fromOrderedKeys[A](xs: Iterator[A], size: Int): Tree[A, Null] = {
     val maxUsedDepth = 32 - Integer.numberOfLeadingZeros(size) // maximum depth of non-leaf nodes
     def f(level: Int, size: Int): Node[A, Null] = size match {
@@ -621,7 +621,7 @@ private[collection] object RedBlackTree {
     new Tree(f(1, size), size)
   }
 
-  /** Build a Tree suitable for a TreeMap from an ordered sequence of key/value pairs */
+  /** Builds a Tree suitable for a TreeMap from an ordered sequence of key/value pairs */
   def fromOrderedEntries[A, B](xs: Iterator[(A, B)], size: Int): Tree[A, B] = {
     val maxUsedDepth = 32 - Integer.numberOfLeadingZeros(size) // maximum depth of non-leaf nodes
     def f(level: Int, size: Int): Node[A, B] = size match {

--- a/src/library/scala/collection/mutable/Set.scala
+++ b/src/library/scala/collection/mutable/Set.scala
@@ -38,10 +38,10 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
 
   def result(): C = coll
 
-  /** Check whether the set contains the given element, and add it if not.
+  /** Checks whether the set contains the given element, and adds it if not.
    *
    *  @param elem  the element to be added
-   *  @return true if the element was added
+   *  @return `true` if the element was added
    */
   def add(elem: A): Boolean =
     !contains(elem) && {
@@ -69,7 +69,7 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   /** Removes an element from this set.
    *
    *  @param elem     the element to be removed
-   *  @return true if this set contained the element before it was removed
+   *  @return `true` if this set contained the element before it was removed
    */
   def remove(elem: A): Boolean = {
     val res = contains(elem)

--- a/src/library/scala/collection/mutable/SortedMap.scala
+++ b/src/library/scala/collection/mutable/SortedMap.scala
@@ -16,7 +16,7 @@ package collection.mutable
 import scala.collection.{SortedMapFactory, SortedMapFactoryDefaults}
 
 /**
-  * Base type for mutable sorted map collections
+  * Base type for mutable sorted map collections.
   */
 trait SortedMap[K, V]
   extends collection.SortedMap[K, V]

--- a/src/library/scala/collection/mutable/Stack.scala
+++ b/src/library/scala/collection/mutable/Stack.scala
@@ -51,14 +51,14 @@ class Stack[A] protected (array: Array[AnyRef], start: Int, end: Int)
   override protected[this] def stringPrefix = "Stack"
 
   /**
-    * Add elements to the top of this stack
+    * Adds elements to the top of this stack.
     *
     * @param elem
     * @return
     */
   def push(elem: A): this.type = prepend(elem)
 
-  /** Push two or more elements onto the stack. The last element
+  /** Pushes two or more elements onto the stack. The last element
     *  of the sequence will be on top of the new stack.
     *
     *  @param   elems      the element sequence.
@@ -70,7 +70,7 @@ class Stack[A] protected (array: Array[AnyRef], start: Int, end: Int)
     prepend(elem1).prepend(elem2).pushAll(elems)
   }
 
-  /** Push all elements in the given iterable object onto the stack. The
+  /** Pushes all elements in the given iterable object onto the stack. The
     *  last element in the iterable object will be on top of the new stack.
     *
     *  @param elems the iterable object.
@@ -83,7 +83,7 @@ class Stack[A] protected (array: Array[AnyRef], start: Int, end: Int)
     })
 
   /**
-    * Removes the top element from this stack and return it
+    * Removes the top element from this stack and returns it.
     *
     * @return
     * @throws NoSuchElementException when stack is empty
@@ -91,14 +91,14 @@ class Stack[A] protected (array: Array[AnyRef], start: Int, end: Int)
   def pop(): A = removeHead()
 
   /**
-    * Pop all elements from this stack and return it
+    * Pops all elements from this stack and returns it.
     *
     * @return The removed elements
     */
   def popAll(): scala.collection.Seq[A] = removeAll()
 
   /**
-    * Returns and removes all elements from the top of this stack which satisfy the given predicate
+    * Returns and removes all elements from the top of this stack which satisfy the given predicate.
     *
     *  @param f   the predicate used for choosing elements
     *  @return The removed elements

--- a/src/library/scala/collection/mutable/StringBuilder.scala
+++ b/src/library/scala/collection/mutable/StringBuilder.scala
@@ -115,7 +115,7 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
       case _ => super.toArray
     }
 
-  /** Returns the contents of this StringBuilder as an `Array[Char]`.
+  /** Returns the contents of this `StringBuilder` as an `Array[Char]`.
    *
    *  @return  An array with the characters from this builder.
    */
@@ -134,30 +134,30 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
   }
 
   /** Appends the string representation of the given argument,
-    *  which is converted to a String with `String.valueOf`.
+    *  which is converted to a `String` with `String.valueOf`.
     *
     *  @param  x   an `Any` object.
-    *  @return     this StringBuilder.
+    *  @return     this `StringBuilder`.
     */
   def append(x: Any): this.type = {
     underlying append String.valueOf(x)
     this
   }
 
-  /** Appends the given String to this sequence.
+  /** Appends the given `String` to this sequence.
     *
-    *  @param  s   a String.
-    *  @return     this StringBuilder.
+    *  @param  s   a `String`.
+    *  @return     this `StringBuilder`.
     */
   def append(s: String): this.type = {
     underlying append s
     this
   }
 
-  /** Appends the given CharSequence to this sequence.
+  /** Appends the given `CharSequence` to this sequence.
     *
-    *  @param  cs   a CharSequence.
-    *  @return     this StringBuilder.
+    *  @param  cs   a `CharSequence`.
+    *  @return     this `StringBuilder`.
     */
   def append(cs: java.lang.CharSequence): this.type = {
     underlying.append(cs match {
@@ -179,10 +179,10 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
     this
   }
 
-  /** Appends all the Chars in the given IterableOnce[Char] to this sequence.
+  /** Appends all the `Char`s in the given `IterableOnce[Char]` to this sequence.
     *
     *  @param  xs  the characters to be appended.
-    *  @return     this StringBuilder.
+    *  @return     this `StringBuilder`.
     */
   def appendAll(xs: IterableOnce[Char]): this.type = {
     xs match {
@@ -201,7 +201,7 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
     this
   }
 
-  /** Appends all the Chars in the given Array[Char] to this sequence.
+  /** Appends all the `Char`s in the given `Array[Char]` to this sequence.
     *
     *  @param  xs  the characters to be appended.
     *  @return     a reference to this object.
@@ -211,24 +211,24 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
     this
   }
 
-  /** Appends a portion of the given Array[Char] to this sequence.
+  /** Appends a portion of the given `Array[Char]` to this sequence.
     *
-    *  @param  xs      the Array containing Chars to be appended.
-    *  @param  offset  the index of the first Char to append.
-    *  @param  len     the numbers of Chars to append.
-    *  @return         this StringBuilder.
+    *  @param  xs      the `Array` containing `Char`s to be appended.
+    *  @param  offset  the index of the first `Char` to append.
+    *  @param  len     the numbers of `Char`s to append.
+    *  @return         this `StringBuilder`.
     */
   def appendAll(xs: Array[Char], offset: Int, len: Int): this.type = {
     underlying.append(xs, offset, len)
     this
   }
 
-  /** Append the String representation of the given primitive type
-    *  to this sequence.  The argument is converted to a String with
-    *  String.valueOf.
+  /** Appends the `String` representation of the given primitive type
+    *  to this sequence.  The argument is converted to a `String` with
+    *  `String.valueOf`.
     *
     *  @param   x  a primitive value
-    *  @return     This StringBuilder.
+    *  @return     this `StringBuilder`.
     */
   def append(x: Boolean): this.type = { underlying append x ; this }
   def append(x: Byte): this.type = append(x.toInt)
@@ -239,7 +239,7 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
   def append(x: Double): this.type = { underlying append x ; this }
   def append(x: Char): this.type = { underlying append x ; this }
 
-  /** Remove a subsequence of Chars from this sequence, starting at the
+  /** Removes a subsequence of Chars from this sequence, starting at the
     *  given start index (inclusive) and extending to the end index (exclusive)
     *  or to the end of the String, whichever comes first.
     *
@@ -253,13 +253,13 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
     this
   }
 
-  /** Replaces a subsequence of Chars with the given String.  The semantics
-    *  are as in delete, with the String argument then inserted at index 'start'.
+  /** Replaces a subsequence of `Char`s with the given `String`.  The semantics
+    *  are as in delete, with the `String` argument then inserted at index `start`.
     *
     *  @param  start  The beginning index, inclusive.
     *  @param  end    The ending index, exclusive.
-    *  @param  str    The String to be inserted at the start index.
-    *  @return        This StringBuilder.
+    *  @param  str    The `String` to be inserted at the start index.
+    *  @return        this `StringBuilder`.
     *  @throws StringIndexOutOfBoundsException if start < 0, start > length, or start > end
     */
   def replace(start: Int, end: Int, str: String): this.type = {
@@ -267,14 +267,14 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
     this
   }
 
-  /** Inserts a subarray of the given Array[Char] at the given index
+  /** Inserts a subarray of the given `Array[Char]` at the given index
     *  of this sequence.
     *
     * @param  index   index at which to insert the subarray.
-    * @param  str     the Array from which Chars will be taken.
-    * @param  offset  the index of the first Char to insert.
-    * @param  len     the number of Chars from 'str' to insert.
-    * @return         This StringBuilder.
+    * @param  str     the `Array` from which `Char`s will be taken.
+    * @param  offset  the index of the first `Char` to insert.
+    * @param  len     the number of `Char`s from `str` to insert.
+    * @return         this `StringBuilder`.
     *
     * @throws StringIndexOutOfBoundsException  if index < 0, index > length,
     *         offset < 0, len < 0, or (offset + len) > str.length.
@@ -284,21 +284,21 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
     this
   }
 
-  /** Inserts the String representation (via String.valueOf) of the given
+  /** Inserts the `String` representation (via `String.valueOf`) of the given
     *  argument into this sequence at the given index.
     *
     *  @param  index   the index at which to insert.
     *  @param  x       a value.
-    *  @return         this StringBuilder.
+    *  @return         this `StringBuilder`.
     *  @throws StringIndexOutOfBoundsException  if the index is out of bounds.
     */
   def insert(index: Int, x: Any): this.type = insert(index, String.valueOf(x))
 
-  /** Inserts the String into this character sequence.
+  /** Inserts the `String` into this character sequence.
     *
     *  @param  index the index at which to insert.
-    *  @param  x     a String.
-    *  @return       this StringBuilder.
+    *  @param  x     a `String`.
+    *  @return       this `StringBuilder`.
     *  @throws StringIndexOutOfBoundsException  if the index is out of bounds.
     */
   def insert(index: Int, x: String): this.type = {
@@ -306,21 +306,21 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
     this
   }
 
-  /** Inserts the given Seq[Char] into this sequence at the given index.
+  /** Inserts the given `Seq[Char]` into this sequence at the given index.
     *
     *  @param  index the index at which to insert.
-    *  @param  xs    the Seq[Char].
-    *  @return       this StringBuilder.
+    *  @param  xs    the `Seq[Char]`.
+    *  @return       this `StringBuilder`.
     *  @throws StringIndexOutOfBoundsException  if the index is out of bounds.
     */
   def insertAll(index: Int, xs: IterableOnce[Char]): this.type =
     insertAll(index, (ArrayBuilder.make[Char] ++= xs).result())
 
-  /** Inserts the given Array[Char] into this sequence at the given index.
+  /** Inserts the given `Array[Char]` into this sequence at the given index.
     *
     *  @param  index the index at which to insert.
-    *  @param  xs    the Array[Char].
-    *  @return       this StringBuilder.
+    *  @param  xs    the `Array[Char]`.
+    *  @return       this `StringBuilder`.
     *  @throws StringIndexOutOfBoundsException  if the index is out of bounds.
     */
   def insertAll(index: Int, xs: Array[Char]): this.type = {
@@ -328,12 +328,12 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
     this
   }
 
-  /** Calls String.valueOf on the given primitive value, and inserts the
-    *  String at the given index.
+  /** Calls `String.valueOf` on the given primitive value, and inserts the
+    *  `String` at the given index.
     *
     *  @param  index the offset position.
     *  @param  x     a primitive value.
-    *  @return       this StringBuilder.
+    *  @return       this `StringBuilder`.
     */
   def insert(index: Int, x: Boolean): this.type = insert(index, String.valueOf(x))
   def insert(index: Int, x: Byte): this.type    = insert(index, x.toInt)
@@ -380,7 +380,7 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
    */
   def capacity: Int = underlying.capacity
 
-  /** Ensure that the capacity is at least the given argument.
+  /** Ensures that the capacity is at least the given argument.
    *  If the argument is greater than the current capacity, new
    *  storage will be allocated with size equal to the given
    *  argument or to `(2 * capacity + 2)`, whichever is larger.
@@ -409,7 +409,7 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
     this
   }
 
-  /** Update the sequence at the given index to hold the specified Char.
+  /** Updates the sequence at the given index to hold the specified Char.
    *
    *  @param  index   the index to modify.
    *  @param  ch      the new Char.
@@ -439,7 +439,7 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
    *
    *  @param  start  The beginning index, inclusive.
    *  @param  end    The ending index, exclusive.
-   *  @return The new String.
+   *  @return The new `String`.
    *  @throws StringIndexOutOfBoundsException If either index is out of bounds,
    *          or if start > end.
    */

--- a/src/library/scala/collection/mutable/UnrolledBuffer.scala
+++ b/src/library/scala/collection/mutable/UnrolledBuffer.scala
@@ -164,7 +164,7 @@ sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
     if (idx >= 0 && idx < sz) headptr(idx) = newelem
     else throw CommonErrors.indexOutOfBounds(index = idx, max = sz - 1)
 
-  /** Replace the contents of this $coll with the mapped result.
+  /** Replaces the contents of this $coll with the mapped result.
    *
    *  @param f the mapping function
    *  @return this $coll

--- a/src/library/scala/collection/package.scala
+++ b/src/library/scala/collection/package.scala
@@ -61,7 +61,7 @@ package object collection {
   /** An extractor used to head/tail deconstruct sequences. */
   object +: {
     /** Splits a sequence into head +: tail.
-      * @return Some((head, tail)) if sequence is non-empty. None otherwise.
+      * @return `Some((head, tail))` if sequence is non-empty. `None` otherwise.
       */
     def unapply[A, CC[_] <: Seq[_], C <: SeqOps[A, CC, C]](t: C with SeqOps[A, CC, C]): Option[(A, C)] =
       if(t.isEmpty) None
@@ -71,7 +71,7 @@ package object collection {
   /** An extractor used to init/last deconstruct sequences. */
   object :+ {
     /** Splits a sequence into init :+ last.
-      * @return Some((init, last)) if sequence is non-empty. None otherwise.
+      * @return `Some((init, last))` if sequence is non-empty. `None` otherwise.
       */
     def unapply[A, CC[_] <: Seq[_], C <: SeqOps[A, CC, C]](t: C with SeqOps[A, CC, C]): Option[(C, A)] =
       if(t.isEmpty) None

--- a/src/library/scala/compat/Platform.scala
+++ b/src/library/scala/compat/Platform.scala
@@ -59,7 +59,7 @@ object Platform {
 
   /** Creates a new array of the specified type and given length.
    *
-   *  Note that if `elemClass` is a subclass of [[scala.AnyVal]] then the returned value is an Array of the corresponding java primitive type.
+   *  Note that if `elemClass` is a subclass of [[scala.AnyVal]] then the returned value is an `Array` of the corresponding java primitive type.
    *  For example, the following code `scala.compat.Platform.createArray(classOf[Int], 4)` returns an array of the java primitive type `int`.
    *
    *  For a [[scala.AnyVal]] array, the values of the array are set to 0 for ''numeric value types'' ([[scala.Double]], [[scala.Float]], [[scala.Long]], [[scala.Int]], [[scala.Char]],
@@ -77,8 +77,8 @@ object Platform {
    *  @param length    the length of the new array.
    *  @return          an array of the given component type as an `AnyRef`.
    *  @throws java.lang.NullPointerException If `elemClass` is `null`.
-   *  @throws java.lang.IllegalArgumentException if componentType is [[scala.Unit]] or `java.lang.Void.TYPE`
-   *  @throws java.lang.NegativeArraySizeException if the specified length is negative
+   *  @throws java.lang.IllegalArgumentException if `componentType` is [[scala.Unit]] or `java.lang.Void.TYPE`
+   *  @throws java.lang.NegativeArraySizeException if the specified `length` is negative
    */
   @inline
   @deprecated("Use `java.lang.reflect.Array#newInstance` instead.", since = "2.13.0")
@@ -86,7 +86,7 @@ object Platform {
     java.lang.reflect.Array.newInstance(elemClass, length)
 
   /** Assigns the value of 0 to each element in the array.
-    * @param arr     A non-null Array[Int].
+    * @param arr     A non-null `Array[Int]`.
     * @throws java.lang.NullPointerException If `arr` is `null`.
     */
   @inline

--- a/src/library/scala/concurrent/Awaitable.scala
+++ b/src/library/scala/concurrent/Awaitable.scala
@@ -29,7 +29,7 @@ import scala.concurrent.duration.Duration
 trait Awaitable[+T] {
 
   /**
-   * Await the "completed" state of this `Awaitable`.
+   * Awaits the "completed" state of this `Awaitable`.
    *
    * '''''This method should not be called directly; use [[Await.ready]] instead.'''''
    *
@@ -47,7 +47,7 @@ trait Awaitable[+T] {
   def ready(atMost: Duration)(implicit permit: CanAwait): this.type
 
   /**
-   * Await and return the result (of type `T`) of this `Awaitable`.
+   * Awaits and returns the result (of type `T`) of this `Awaitable`.
    *
    * '''''This method should not be called directly; use [[Await.result]] instead.'''''
    *

--- a/src/library/scala/concurrent/BatchingExecutor.scala
+++ b/src/library/scala/concurrent/BatchingExecutor.scala
@@ -18,7 +18,7 @@ import scala.util.control.NonFatal
 import scala.annotation.{switch, tailrec}
 
 /**
- * Marker trait to indicate that a Runnable is Batchable by BatchingExecutors
+ * Marker trait to indicate that a `Runnable` is `Batchable` by `BatchingExecutor`s
  */
 trait Batchable {
   self: Runnable =>
@@ -40,14 +40,14 @@ private[concurrent] object BatchingExecutorStatics {
 }
 
 /**
- * Mixin trait for an Executor
+ * Mixin trait for an `Executor`
  * which groups multiple nested `Runnable.run()` calls
- * into a single Runnable passed to the original
- * Executor. This can be a useful optimization
+ * into a single `Runnable` passed to the original
+ * `Executor`. This can be a useful optimization
  * because it bypasses the original context's task
  * queue and keeps related (nested) code on a single
  * thread which may improve CPU affinity. However,
- * if tasks passed to the Executor are blocking
+ * if tasks passed to the `Executor` are blocking
  * or expensive, this optimization can prevent work-stealing
  * and make performance worse.
  * A batching executor can create deadlocks if code does

--- a/src/library/scala/concurrent/BlockContext.scala
+++ b/src/library/scala/concurrent/BlockContext.scala
@@ -96,7 +96,7 @@ object BlockContext {
   }
 
   /**
-   * Installs the BlockContext `blockContext` around the invocation to `f` and passes in the previously installed BlockContext to `f`.
+   * Installs the `BlockContext` `blockContext` around the invocation to `f` and passes in the previously installed `BlockContext` to `f`.
    * @return the value produced by applying `f`
    **/
   final def usingBlockContext[I, T](blockContext: BlockContext)(f: BlockContext => T): T = {

--- a/src/library/scala/concurrent/Channel.scala
+++ b/src/library/scala/concurrent/Channel.scala
@@ -27,7 +27,7 @@ class Channel[A] {
   private[this] var lastWritten = written       // aliasing of a linked list
   private[this] var nreaders = 0
 
-  /** Append a value to the FIFO queue to be read by `read`.
+  /** Appends a value to the FIFO queue to be read by `read`.
    *  This operation is nonblocking and can be executed by any thread.
    *
    * @param x object to enqueue to this channel
@@ -39,7 +39,7 @@ class Channel[A] {
     if (nreaders > 0) notify()
   }
 
-  /** Retrieve the next waiting object from the FIFO queue,
+  /** Retrieves the next waiting object from the FIFO queue,
    *  blocking if necessary until an object is available.
    *
    * @return next object dequeued from this channel

--- a/src/library/scala/concurrent/DelayedLazyVal.scala
+++ b/src/library/scala/concurrent/DelayedLazyVal.scala
@@ -35,7 +35,7 @@ class DelayedLazyVal[T](f: () => T, body: => Unit)(implicit exec: ExecutionConte
    */
   def isDone: Boolean = _isDone
 
-  /** The current result of f(), or the final result if complete.
+  /** The current result of `f()`, or the final result if complete.
    *
    *  @return the current value
    */

--- a/src/library/scala/concurrent/ExecutionContext.scala
+++ b/src/library/scala/concurrent/ExecutionContext.scala
@@ -89,7 +89,7 @@ trait ExecutionContext {
      *
      *  This method should no longer be overridden or called. It was
      *  originally expected that `prepare` would be called by
-     *  all libraries that consume ExecutionContexts, in order to
+     *  all libraries that consume `ExecutionContext`s, in order to
      *  capture thread local context. However, this usage has proven
      *  difficult to implement in practice and instead it is
      *  now better to avoid using `prepare` entirely.

--- a/src/library/scala/concurrent/Future.scala
+++ b/src/library/scala/concurrent/Future.scala
@@ -64,7 +64,7 @@ import scala.concurrent.impl.Promise.DefaultPromise
  *  - `InterruptedException` - not contained within futures
  *  - all `scala.util.control.ControlThrowable` except `NonLocalReturnControl` - not contained within futures
  *
- *  Instead, the future is completed with an ExecutionException that has one of the exceptions above as its cause.
+ *  Instead, the future is completed with an `ExecutionException` that has one of the exceptions above as its cause.
  *  If a future is failed with a `scala.runtime.NonLocalReturnControl`,
  *  it is completed with a value from that throwable instead.
  *
@@ -101,7 +101,7 @@ import scala.concurrent.impl.Promise.DefaultPromise
  * thread. That is, the implementation may run multiple callbacks
  * in a batch within a single `execute()` and it may run
  * `execute()` either immediately or asynchronously.
- * Completion of the Future must *happen-before* the invocation of the callback.
+ * Completion of the `Future` must *happen-before* the invocation of the callback.
  */
 trait Future[+T] extends Awaitable[T] {
 
@@ -182,9 +182,9 @@ trait Future[+T] extends Awaitable[T] {
    */
   def foreach[U](f: T => U)(implicit executor: ExecutionContext): Unit = onComplete { _ foreach f }
 
-  /** Creates a new future by applying the 's' function to the successful result of
-   *  this future, or the 'f' function to the failed result. If there is any non-fatal
-   *  exception thrown when 's' or 'f' is applied, that exception will be propagated
+  /** Creates a new future by applying the `s` function to the successful result of
+   *  this future, or the `f` function to the failed result. If there is any non-fatal
+   *  exception thrown when `s` or `f` is applied, that exception will be propagated
    *  to the resulting future.
    *
    * @tparam S  the type of the returned `Future`
@@ -200,8 +200,8 @@ trait Future[+T] extends Awaitable[T] {
         else throw f(t.asInstanceOf[Failure[T]].exception) // will throw fatal errors!
     }
 
-  /** Creates a new Future by applying the specified function to the result
-   * of this Future. If there is any non-fatal exception thrown when 'f'
+  /** Creates a new `Future` by applying the specified function to the result
+   * of this `Future`. If there is any non-fatal exception thrown when `f`
    * is applied then that exception will be propagated to the resulting future.
    *
    * @tparam S  the type of the returned `Future`
@@ -211,8 +211,8 @@ trait Future[+T] extends Awaitable[T] {
    */
   def transform[S](f: Try[T] => Try[S])(implicit executor: ExecutionContext): Future[S]
 
-  /** Creates a new Future by applying the specified function, which produces a Future, to the result
-   * of this Future. If there is any non-fatal exception thrown when 'f'
+  /** Creates a new `Future` by applying the specified function, which produces a `Future`, to the result
+   * of this `Future`. If there is any non-fatal exception thrown when `f`
    * is applied then that exception will be propagated to the resulting future.
    *
    * @tparam S  the type of the returned `Future`
@@ -875,11 +875,11 @@ object Future {
    *  {{{
    *    val myFutureList = Future.traverse(myList)(x => Future(myFunc(x)))
    *  }}}
-   * @tparam A        the type of the value inside the Futures in the collection
+   * @tparam A        the type of the value inside the `Future`s in the collection
    * @tparam B        the type of the value of the returned `Future`
-   * @tparam M        the type of the collection of Futures
-   * @param in        the collection to be mapped over with the provided function to produce a collection of Futures that is then sequenced into a Future collection
-   * @param fn        the function to be mapped over the collection to produce a collection of Futures
+   * @tparam M        the type of the collection of `Future`s
+   * @param in        the collection to be mapped over with the provided function to produce a collection of `Future`s that is then sequenced into a `Future` collection
+   * @param fn        the function to be mapped over the collection to produce a collection of `Future`s
    * @return          the `Future` of the collection of results
    */
   final def traverse[A, B, M[X] <: IterableOnce[X]](in: M[A])(fn: A => Future[B])(implicit bf: BuildFrom[M[A], B, M[B]], executor: ExecutionContext): Future[M[B]] =

--- a/src/library/scala/concurrent/Promise.scala
+++ b/src/library/scala/concurrent/Promise.scala
@@ -14,16 +14,16 @@ package scala.concurrent
 
 import scala.util.{ Try, Success, Failure }
 
-/** Promise is an object which can be completed with a value or failed
+/** `Promise` is an object which can be completed with a value or failed
  *  with an exception.
  *
- *  A promise should always eventually be completed, whether for success or failure, 
- *  in order to avoid unintended resource retention for any associated Futures' 
+ *  A promise should always eventually be completed, whether for success or failure,
+ *  in order to avoid unintended resource retention for any associated `Future`s'
  *  callbacks or transformations.
  *
  *  @define promiseCompletion
  *  If the promise has already been fulfilled, failed or has timed out,
- *  calling this method will throw an IllegalStateException.
+ *  calling this method will throw an `IllegalStateException`.
  *
  *  @define allowedThrowables
  *  If the throwable used to fail this promise is an error, a control exception
@@ -34,7 +34,7 @@ import scala.util.{ Try, Success, Failure }
  *  Note: Using this method may result in non-deterministic concurrent programs.
  */
 trait Promise[T] {
-  /** Future containing the value of this promise.
+  /** `Future` containing the value of this promise.
    */
   def future: Future[T]
 
@@ -125,21 +125,21 @@ object Promise {
    */
   final def apply[T](): Promise[T] = new impl.Promise.DefaultPromise[T]()
 
-  /** Creates an already completed Promise with the specified exception.
+  /** Creates an already completed `Promise` with the specified exception.
    *
    *  @tparam T       the type of the value in the promise
    *  @return         the newly created `Promise` instance
    */
   final def failed[T](exception: Throwable): Promise[T] = fromTry(Failure(exception))
 
-  /** Creates an already completed Promise with the specified result.
+  /** Creates an already completed `Promise` with the specified result.
    *
    *  @tparam T       the type of the value in the promise
    *  @return         the newly created `Promise` instance
    */
   final def successful[T](result: T): Promise[T] = fromTry(Success(result))
 
-  /** Creates an already completed Promise with the specified result or exception.
+  /** Creates an already completed `Promise` with the specified result or exception.
    *
    *  @tparam T       the type of the value in the promise
    *  @return         the newly created `Promise` instance

--- a/src/library/scala/concurrent/SyncVar.scala
+++ b/src/library/scala/concurrent/SyncVar.scala
@@ -25,7 +25,7 @@ class SyncVar[A] {
   private[this] var value: A = _
 
   /**
-   * Wait for this SyncVar to become defined and then get
+   * Wait for this `SyncVar` to become defined and then get
    * the stored value without modifying it.
    *
    * @return value that is held in this container
@@ -67,7 +67,7 @@ class SyncVar[A] {
   }
 
   /**
-   * Wait for this SyncVar to become defined and then get
+   * Wait for this `SyncVar` to become defined and then get
    * the stored value, unsetting it as a side effect.
    *
    * @return value that was held in this container
@@ -90,14 +90,14 @@ class SyncVar[A] {
     finally unsetVal()
   }
 
-  /** Place a value in the SyncVar. If the SyncVar already has a stored value,
+  /** Place a value in the `SyncVar`. If the `SyncVar` already has a stored value,
    * wait until another thread takes it. */
   def put(x: A): Unit = synchronized {
     while (isDefined) wait()
     setVal(x)
   }
 
-  /** Check whether a value is stored in the synchronized variable. */
+  /** Checks whether a value is stored in the synchronized variable. */
   def isSet: Boolean = synchronized {
     isDefined
   }

--- a/src/library/scala/concurrent/duration/Deadline.scala
+++ b/src/library/scala/concurrent/duration/Deadline.scala
@@ -29,33 +29,33 @@ package scala.concurrent.duration
  */
 case class Deadline private (time: FiniteDuration) extends Ordered[Deadline] {
   /**
-   * Return a deadline advanced (i.e., moved into the future) by the given duration.
+   * Returns a deadline advanced (i.e., moved into the future) by the given duration.
    */
   def +(other: FiniteDuration): Deadline = copy(time = time + other)
   /**
-   * Return a deadline moved backwards (i.e., towards the past) by the given duration.
+   * Returns a deadline moved backwards (i.e., towards the past) by the given duration.
    */
   def -(other: FiniteDuration): Deadline = copy(time = time - other)
   /**
-   * Calculate time difference between this and the other deadline, where the result is directed (i.e., may be negative).
+   * Calculates time difference between this and the other deadline, where the result is directed (i.e., may be negative).
    */
   def -(other: Deadline): FiniteDuration = time - other.time
   /**
-   * Calculate time difference between this duration and now; the result is negative if the deadline has passed.
+   * Calculates time difference between this duration and now; the result is negative if the deadline has passed.
    *
    * '''''Note that on some systems this operation is costly because it entails a system call.'''''
    * Check `System.nanoTime` for your platform.
    */
   def timeLeft: FiniteDuration = this - Deadline.now
   /**
-   * Determine whether the deadline still lies in the future at the point where this method is called.
+   * Determines whether the deadline still lies in the future at the point where this method is called.
    *
    * '''''Note that on some systems this operation is costly because it entails a system call.'''''
    * Check `System.nanoTime` for your platform.
    */
   def hasTimeLeft(): Boolean = !isOverdue()
   /**
-   * Determine whether the deadline lies in the past at the point where this method is called.
+   * Determines whether the deadline lies in the past at the point where this method is called.
    *
    * '''''Note that on some systems this operation is costly because it entails a system call.'''''
    * Check `System.nanoTime` for your platform.
@@ -69,7 +69,7 @@ case class Deadline private (time: FiniteDuration) extends Ordered[Deadline] {
 
 object Deadline {
   /**
-   * Construct a deadline due exactly at the point where this method is called. Useful for then
+   * Constructs a deadline due exactly at the point where this method is called. Useful for then
    * advancing it to obtain a future deadline, or for sampling the current time exactly once and
    * then comparing it to multiple deadlines (using subtraction).
    */

--- a/src/library/scala/concurrent/duration/Duration.scala
+++ b/src/library/scala/concurrent/duration/Duration.scala
@@ -18,7 +18,7 @@ import scala.collection.StringParsers
 object Duration {
 
   /**
-   * Construct a Duration from the given length and unit. Observe that nanosecond precision may be lost if
+   * Constructs a `Duration` from the given length and unit. Observe that nanosecond precision may be lost if
    *
    *  - the unit is NANOSECONDS
    *  - and the length has an absolute value greater than `2^53`
@@ -30,13 +30,13 @@ object Duration {
   def apply(length: Double, unit: TimeUnit): Duration     = fromNanos(unit.toNanos(1) * length)
 
   /**
-   * Construct a finite duration from the given length and time unit. The unit given is retained
+   * Constructs a finite duration from the given length and time unit. The unit given is retained
    * throughout calculations as long as possible, so that it can be retrieved later.
    */
   def apply(length: Long, unit: TimeUnit): FiniteDuration = new FiniteDuration(length, unit)
 
   /**
-   * Construct a finite duration from the given length and time unit, where the latter is
+   * Constructs a finite duration from the given length and time unit, where the latter is
    * looked up in a list of string representation. Valid choices are:
    *
    * `d, day, h, hr, hour, m, min, minute, s, sec, second, ms, milli, millisecond, µs, micro, microsecond, ns, nano, nanosecond`
@@ -48,7 +48,7 @@ object Duration {
   // private[this] final val maxPreciseDouble = 9007199254740992d // not used after https://github.com/scala/scala/pull/9233
 
   /**
-   * Parse String into Duration.  Format is `"<length><unit>"`, where
+   * Parses String into Duration.  Format is `"<length><unit>"`, where
    * whitespace is allowed before, between and after the parts. Infinities are
    * designated by `"Inf"`, `"PlusInf"`, `"+Inf"`, `"Duration.Inf"` and `"-Inf"`, `"MinusInf"` or `"Duration.MinusInf"`.
    * Undefined is designated by `"Duration.Undefined"`.
@@ -98,27 +98,27 @@ object Duration {
     timeUnitLabels.flatMap{ case (unit, names) => expandLabels(names) map (_ -> unit) }.toMap
 
   /**
-   * Extract length and time unit out of a string, where the format must match the description for [[Duration$.apply(s:String)* apply(String)]].
+   * Extracts length and time unit out of a string, where the format must match the description for [[Duration$.apply(s:String)* apply(String)]].
    * The extractor will not match for malformed strings or non-finite durations.
    */
   def unapply(s: String): Option[(Long, TimeUnit)] =
     ( try Some(apply(s)) catch { case _: RuntimeException => None } ) flatMap unapply
 
   /**
-   * Extract length and time unit out of a duration, if it is finite.
+   * Extracts length and time unit out of a duration, if it is finite.
    */
   def unapply(d: Duration): Option[(Long, TimeUnit)] =
     if (d.isFinite) Some((d.length, d.unit)) else None
 
   /**
-   * Construct a possibly infinite or undefined Duration from the given number of nanoseconds.
+   * Constructs a possibly infinite or undefined `Duration` from the given number of nanoseconds.
    *
    *  - `Double.PositiveInfinity` is mapped to [[Duration.Inf]]
    *  - `Double.NegativeInfinity` is mapped to [[Duration.MinusInf]]
    *  - `Double.NaN` is mapped to [[Duration.Undefined]]
    *  - `-0d` is mapped to [[Duration.Zero]] (exactly like `0d`)
    *
-   * The semantics of the resulting Duration objects matches the semantics of their Double
+   * The semantics of the resulting `Duration` objects matches the semantics of their `Double`
    * counterparts with respect to arithmetic operations.
    *
    * @throws IllegalArgumentException if the length was finite but the resulting duration cannot be expressed as a [[FiniteDuration]]
@@ -142,7 +142,7 @@ object Duration {
   private[this] final val ns_per_d   = ns_per_h   * 24
 
   /**
-   * Construct a finite duration from the given number of nanoseconds. The
+   * Constructs a finite duration from the given number of nanoseconds. The
    * result will have the coarsest possible time unit which can exactly express
    * this duration.
    *
@@ -165,13 +165,13 @@ object Duration {
   val Zero: FiniteDuration = new FiniteDuration(0, DAYS)
 
   /**
-   * The Undefined value corresponds closely to Double.NaN:
+   * The Undefined value corresponds closely to `Double.NaN`:
    *
    *  - it is the result of otherwise invalid operations
    *  - it does not equal itself (according to `equals()`)
-   *  - it compares greater than any other Duration apart from itself (for which `compare` returns 0)
+   *  - it compares greater than any other `Duration` apart from itself (for which `compare` returns 0)
    *
-   * The particular comparison semantics mirror those of Double.NaN.
+   * The particular comparison semantics mirror those of `Double.NaN`.
    *
    * '''''Use [[eq]] when checking an input of a method against this value.'''''
    */
@@ -232,7 +232,7 @@ object Duration {
 
   /**
    * Infinite duration: greater than any other (apart from Undefined) and not equal to any other
-   * but itself. This value closely corresponds to Double.PositiveInfinity,
+   * but itself. This value closely corresponds to `Double.PositiveInfinity`,
    * matching its semantics in arithmetic operations.
    */
   val Inf: Infinite = new Infinite  {
@@ -249,7 +249,7 @@ object Duration {
 
   /**
    * Infinite duration: less than any other and not equal to any other
-   * but itself. This value closely corresponds to Double.NegativeInfinity,
+   * but itself. This value closely corresponds to `Double.NegativeInfinity`,
    * matching its semantics in arithmetic operations.
    */
   val MinusInf: Infinite = new Infinite {
@@ -263,12 +263,12 @@ object Duration {
   // Java Factories
 
   /**
-   * Construct a finite duration from the given length and time unit. The unit given is retained
+   * Constructs a finite duration from the given length and time unit. The unit given is retained
    * throughout calculations as long as possible, so that it can be retrieved later.
    */
   def create(length: Long, unit: TimeUnit): FiniteDuration = apply(length, unit)
   /**
-   * Construct a Duration from the given length and unit. Observe that nanosecond precision may be lost if
+   * Constructs a `Duration` from the given length and unit. Observe that nanosecond precision may be lost if
    *
    *  - the unit is NANOSECONDS
    *  - and the length has an absolute value greater than `2^53`
@@ -279,7 +279,7 @@ object Duration {
    */
   def create(length: Double, unit: TimeUnit): Duration     = apply(length, unit)
   /**
-   * Construct a finite duration from the given length and time unit, where the latter is
+   * Constructs a finite duration from the given length and time unit, where the latter is
    * looked up in a list of string representation. Valid choices are:
    *
    * `d, day, h, hour, min, minute, s, sec, second, ms, milli, millisecond, µs, micro, microsecond, ns, nano, nanosecond`
@@ -287,7 +287,7 @@ object Duration {
    */
   def create(length: Long, unit: String): FiniteDuration   = apply(length, unit)
   /**
-   * Parse String into Duration.  Format is `"<length><unit>"`, where
+   * Parses String into Duration.  Format is `"<length><unit>"`, where
    * whitespace is allowed before, between and after the parts. Infinities are
    * designated by `"Inf"`, `"PlusInf"`, `"+Inf"` and `"-Inf"` or `"MinusInf"`.
    *
@@ -296,7 +296,7 @@ object Duration {
   def create(s: String): Duration                          = apply(s)
 
   /**
-   * The natural ordering of durations matches the natural ordering for Double, including non-finite values.
+   * The natural ordering of durations matches the natural ordering for `Double`, including non-finite values.
    */
   implicit object DurationIsOrdered extends Ordering[Duration] {
     def compare(a: Duration, b: Duration): Int = a compare b
@@ -347,18 +347,18 @@ object Duration {
  * <h2>Handling of Time Units</h2>
  *
  * Calculations performed on finite durations always retain the more precise unit of either operand, no matter
- * whether a coarser unit would be able to exactly express the same duration. This means that Duration can be
+ * whether a coarser unit would be able to exactly express the same duration. This means that `Duration` can be
  * used as a lossless container for a (length, unit) pair if it is constructed using the corresponding methods
  * and no arithmetic is performed on it; adding/subtracting durations should in that case be done with care.
  *
  * <h2>Correspondence to Double Semantics</h2>
  *
- * The semantics of arithmetic operations on Duration are two-fold:
+ * The semantics of arithmetic operations on `Duration` are two-fold:
  *
  *  - exact addition/subtraction with nanosecond resolution for finite durations, independent of the summands' magnitude
  *  - isomorphic to `java.lang.Double` when it comes to infinite or undefined values
  *
- * The conversion between Duration and Double is done using [[Duration.toUnit]] (with unit NANOSECONDS)
+ * The conversion between `Duration` and `Double` is done using [[Duration.toUnit]] (with unit NANOSECONDS)
  * and [[Duration$.fromNanos(nanos:Double)* Duration.fromNanos(Double)]]
  *
  * <h2>Ordering</h2>
@@ -372,132 +372,132 @@ object Duration {
  */
 sealed abstract class Duration extends Serializable with Ordered[Duration] {
   /**
-   * Obtain the length of this Duration measured in the unit obtained by the `unit` method.
+   * Obtains the length of this `Duration` measured in the unit obtained by the `unit` method.
    *
    * $exc
    */
   def length: Long
   /**
-   * Obtain the time unit in which the length of this duration is measured.
+   * Obtains the time unit in which the length of this duration is measured.
    *
    * $exc
    */
   def unit: TimeUnit
   /**
-   * Return the length of this duration measured in whole nanoseconds, rounding towards zero.
+   * Returns the length of this duration measured in whole nanoseconds, rounding towards zero.
    *
    * $exc
    */
   def toNanos: Long
   /**
-   * Return the length of this duration measured in whole microseconds, rounding towards zero.
+   * Returns the length of this duration measured in whole microseconds, rounding towards zero.
    *
    * $exc
    */
   def toMicros: Long
   /**
-   * Return the length of this duration measured in whole milliseconds, rounding towards zero.
+   * Returns the length of this duration measured in whole milliseconds, rounding towards zero.
    *
    * $exc
    */
   def toMillis: Long
   /**
-   * Return the length of this duration measured in whole seconds, rounding towards zero.
+   * Returns the length of this duration measured in whole seconds, rounding towards zero.
    *
    * $exc
    */
   def toSeconds: Long
   /**
-   * Return the length of this duration measured in whole minutes, rounding towards zero.
+   * Returns the length of this duration measured in whole minutes, rounding towards zero.
    *
    * $exc
    */
   def toMinutes: Long
   /**
-   * Return the length of this duration measured in whole hours, rounding towards zero.
+   * Returns the length of this duration measured in whole hours, rounding towards zero.
    *
    * $exc
    */
   def toHours: Long
   /**
-   * Return the length of this duration measured in whole days, rounding towards zero.
+   * Returns the length of this duration measured in whole days, rounding towards zero.
    *
    * $exc
    */
   def toDays: Long
   /**
-   * Return the number of nanoseconds as floating point number, scaled down to the given unit.
-   * The result may not precisely represent this duration due to the Double datatype's inherent
+   * Returns the number of nanoseconds as floating point number, scaled down to the given unit.
+   * The result may not precisely represent this duration due to the `Double` datatype's inherent
    * limitations (mantissa size effectively 53 bits). Non-finite durations are represented as
-   *  - [[Duration.Undefined]] is mapped to Double.NaN
-   *  - [[Duration.Inf]] is mapped to Double.PositiveInfinity
-   *  - [[Duration.MinusInf]] is mapped to Double.NegativeInfinity
+   *  - [[Duration.Undefined]] is mapped to `Double.NaN`
+   *  - [[Duration.Inf]] is mapped to `Double.PositiveInfinity`
+   *  - [[Duration.MinusInf]] is mapped to `Double.NegativeInfinity`
    */
   def toUnit(unit: TimeUnit): Double
 
   /**
-   * Return the sum of that duration and this. When involving non-finite summands the semantics match those
-   * of Double.
+   * Returns the sum of that duration and this. When involving non-finite summands the semantics match those
+   * of `Double`.
    *
    * $ovf
    */
   def +(other: Duration): Duration
   /**
-   * Return the difference of that duration and this. When involving non-finite summands the semantics match those
-   * of Double.
+   * Returns the difference of that duration and this. When involving non-finite summands the semantics match those
+   * of `Double`.
    *
    * $ovf
    */
   def -(other: Duration): Duration
   /**
-   * Return this duration multiplied by the scalar factor. When involving non-finite factors the semantics match those
-   * of Double.
+   * Returns this duration multiplied by the scalar factor. When involving non-finite factors the semantics match those
+   * of `Double`.
    *
    * $ovf
    */
   def *(factor: Double): Duration
   /**
-   * Return this duration divided by the scalar factor. When involving non-finite factors the semantics match those
-   * of Double.
+   * Returns this duration divided by the scalar factor. When involving non-finite factors the semantics match those
+   * of `Double`.
    *
    * $ovf
    */
   def /(divisor: Double): Duration
   /**
-   * Return the quotient of this and that duration as floating-point number. The semantics are
-   * determined by Double as if calculating the quotient of the nanosecond lengths of both factors.
+   * Returns the quotient of this and that duration as floating-point number. The semantics are
+   * determined by `Double` as if calculating the quotient of the nanosecond lengths of both factors.
    */
   def /(divisor: Duration): Double
   /**
-   * Negate this duration. The only two values which are mapped to themselves are [[Duration.Zero]] and [[Duration.Undefined]].
+   * Negates this duration. The only two values which are mapped to themselves are [[Duration.Zero]] and [[Duration.Undefined]].
    */
   def unary_- : Duration
   /**
    * This method returns whether this duration is finite, which is not the same as
-   * `!isInfinite` for Double because this method also returns `false` for [[Duration.Undefined]].
+   * `!isInfinite` for `Double` because this method also returns `false` for [[Duration.Undefined]].
    */
   def isFinite: Boolean
   /**
-   * Return the smaller of this and that duration as determined by the natural ordering.
+   * Returns the smaller of this and that duration as determined by the natural ordering.
    */
   def min(other: Duration): Duration = if (this < other) this else other
   /**
-   * Return the larger of this and that duration as determined by the natural ordering.
+   * Returns the larger of this and that duration as determined by the natural ordering.
    */
   def max(other: Duration): Duration = if (this > other) this else other
 
   // Java API
 
   /**
-   * Return this duration divided by the scalar factor. When involving non-finite factors the semantics match those
-   * of Double.
+   * Returns this duration divided by the scalar factor. When involving non-finite factors the semantics match those
+   * of `Double`.
    *
    * $ovf
    */
   def div(divisor: Double): Duration = this / divisor
   /**
-   * Return the quotient of this and that duration as floating-point number. The semantics are
-   * determined by Double as if calculating the quotient of the nanosecond lengths of both factors.
+   * Returns the quotient of this and that duration as floating-point number. The semantics are
+   * determined by `Double` as if calculating the quotient of the nanosecond lengths of both factors.
    */
   def div(other: Duration): Double   = this / other
   def gt(other: Duration): Boolean   = this > other
@@ -505,32 +505,32 @@ sealed abstract class Duration extends Serializable with Ordered[Duration] {
   def lt(other: Duration): Boolean   = this < other
   def lteq(other: Duration): Boolean = this <= other
   /**
-   * Return the difference of that duration and this. When involving non-finite summands the semantics match those
-   * of Double.
+   * Returns the difference of that duration and this. When involving non-finite summands the semantics match those
+   * of `Double`.
    *
    * $ovf
    */
   def minus(other: Duration): Duration = this - other
   /**
-   * Return this duration multiplied by the scalar factor. When involving non-finite factors the semantics match those
-   * of Double.
+   * Returns this duration multiplied by the scalar factor. When involving non-finite factors the semantics match those
+   * of `Double`.
    *
    * $ovf
    */
   def mul(factor: Double): Duration    = this * factor
   /**
-   * Negate this duration. The only two values which are mapped to themselves are [[Duration.Zero]] and [[Duration.Undefined]].
+   * Negates this duration. The only two values which are mapped to themselves are [[Duration.Zero]] and [[Duration.Undefined]].
    */
   def neg(): Duration                  = -this
   /**
-   * Return the sum of that duration and this. When involving non-finite summands the semantics match those
-   * of Double.
+   * Returns the sum of that duration and this. When involving non-finite summands the semantics match those
+   * of `Double`.
    *
    * $ovf
    */
   def plus(other: Duration): Duration  = this + other
   /**
-   * Return duration which is equal to this duration but with a coarsest Unit, or self in case it is already the coarsest Unit
+   * Returns duration which is equal to this duration but with a coarsest Unit, or self in case it is already the coarsest Unit
    * <p/>
    * Examples:
    * {{{
@@ -598,7 +598,7 @@ final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duratio
   def toUnit(u: TimeUnit): Double = toNanos.toDouble / NANOSECONDS.convert(1, u)
 
   /**
-   * Construct a [[Deadline]] from this duration by adding it to the current instant `Deadline.now`.
+   * Constructs a [[Deadline]] from this duration by adding it to the current instant `Deadline.now`.
    */
   def fromNow: Deadline = Deadline.now + this
 
@@ -661,14 +661,14 @@ final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duratio
   // overloaded methods taking Long so that you can calculate while statically staying finite
 
   /**
-   * Return the quotient of this duration and the given integer factor.
+   * Returns the quotient of this duration and the given integer factor.
    *
    * @throws java.lang.ArithmeticException if the factor is 0
    */
   def /(divisor: Long): FiniteDuration = fromNanos(toNanos / divisor)
 
   /**
-   * Return the product of this duration and the given integer factor.
+   * Returns the product of this duration and the given integer factor.
    *
    * @throws IllegalArgumentException if the result would overflow the range of FiniteDuration
    */
@@ -677,7 +677,7 @@ final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duratio
   /*
    * This method avoids the use of Long division, which saves 95% of the time spent,
    * by checking that there are enough leading zeros so that the result has a chance
-   * to fit into a Long again; the remaining edge cases are caught by using the sign
+   * to fit into a `Long` again; the remaining edge cases are caught by using the sign
    * of the product for overflow detection.
    *
    * This method is not general purpose because it disallows the (otherwise legal)
@@ -695,14 +695,14 @@ final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duratio
   }
 
   /**
-   * Return the quotient of this duration and the given integer factor.
+   * Returns the quotient of this duration and the given integer factor.
    *
    * @throws java.lang.ArithmeticException if the factor is 0
    */
   def div(divisor: Long): FiniteDuration = this / divisor
 
   /**
-   * Return the product of this duration and the given integer factor.
+   * Returns the product of this duration and the given integer factor.
    *
    * @throws IllegalArgumentException if the result would overflow the range of FiniteDuration
    */

--- a/src/library/scala/concurrent/impl/FutureConvertersImpl.scala
+++ b/src/library/scala/concurrent/impl/FutureConvertersImpl.scala
@@ -76,7 +76,7 @@ private[scala] object FutureConvertersImpl {
       * @inheritdoc
       *
       * WARNING: completing the result of this method will not complete the underlying
-      *          Scala Future or Promise (ie, the one that that was passed to `toJava`.)
+      *          Scala `Future` or `Promise` (ie, the one that that was passed to `toJava`.)
       */
     override def toCompletableFuture: CompletableFuture[T] = this
 

--- a/src/library/scala/concurrent/impl/Promise.scala
+++ b/src/library/scala/concurrent/impl/Promise.scala
@@ -23,7 +23,7 @@ import java.util.Objects.requireNonNull
 import java.io.{IOException, NotSerializableException, ObjectInputStream, ObjectOutputStream}
 
 /**
-  * Latch used to implement waiting on a DefaultPromise's result.
+  * Latch used to implement waiting on a `DefaultPromise`'s result.
   *
   * Inspired by: http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/src/main/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
   * Written by Doug Lea with assistance from members of JCP JSR-166
@@ -47,20 +47,20 @@ private[impl] final class CompletionLatch[T] extends AbstractQueuedSynchronizer 
 
 private[concurrent] object Promise {
   /**
-   * Link represents a completion dependency between 2 DefaultPromises.
-   * As the DefaultPromise referred to by a Link can itself be linked to another promise
+   * `Link` represents a completion dependency between 2 `DefaultPromise`s.
+   * As the `DefaultPromise` referred to by a `Link` can itself be linked to another promise
    * `relink` traverses such chains and compresses them so that the link always points
    * to the root of the dependency chain.
    *
-   * In order to conserve memory, the owner of a Link (a DefaultPromise) is not stored
-   * on the Link, but is instead passed in as a parameter to the operation(s).
+   * In order to conserve memory, the owner of a `Link` (a `DefaultPromise`) is not stored
+   * on the `Link`, but is instead passed in as a parameter to the operation(s).
    *
-   * If when compressing a chain of Links it is discovered that the root has been completed,
-   * the `owner`'s value is completed with that value, and the Link chain is discarded.
+   * If when compressing a chain of `Link`s it is discovered that the root has been completed,
+   * the `owner`'s value is completed with that value, and the `Link` chain is discarded.
    **/
   private[concurrent] final class Link[T](to: DefaultPromise[T]) extends AtomicReference[DefaultPromise[T]](to) {
     /**
-     * Compresses this chain and returns the currently known root of this chain of Links.
+     * Compresses this chain and returns the currently known root of this chain of `Link`s.
      **/
     final def promise(owner: DefaultPromise[T]): DefaultPromise[T] = {
       val c = get()
@@ -68,7 +68,7 @@ private[concurrent] object Promise {
     }
 
     /**
-     * The combination of traversing and possibly unlinking of a given `target` DefaultPromise.
+     * The combination of traversing and possibly unlinking of a given `target` `DefaultPromise`.
      **/
     @inline @tailrec private[this] final def compressed(current: DefaultPromise[T], target: DefaultPromise[T], owner: DefaultPromise[T]): DefaultPromise[T] = {
       val value = target.get()
@@ -84,8 +84,8 @@ private[concurrent] object Promise {
   }
 
   /**
-   * The process of "resolving" a Try is to validate that it only contains
-   * those values which makes sense in the context of Futures.
+   * The process of "resolving" a `Try` is to validate that it only contains
+   * those values which makes sense in the context of `Future`s.
    **/
   // requireNonNull is paramount to guard against null completions
   private[this] final def resolve[T](value: Try[T]): Try[T] =

--- a/src/library/scala/concurrent/package.scala
+++ b/src/library/scala/concurrent/package.scala
@@ -20,13 +20,13 @@ import scala.util.Try
  *
  * == Guide ==
  *
- * A more detailed guide to Futures and Promises, including discussion and examples
+ * A more detailed guide to `Future`s and `Promise`s, including discussion and examples
  * can be found at
  * [[https://docs.scala-lang.org/overviews/core/futures.html]].
  *
  * == Common Imports ==
  *
- * When working with Futures, you will often find that importing the whole concurrent
+ * When working with `Future`s, you will often find that importing the whole concurrent
  * package is convenient:
  *
  * {{{
@@ -66,10 +66,10 @@ import scala.util.Try
  *
  * == Using Futures For Non-blocking Computation ==
  *
- * Basic use of futures is easy with the factory method on Future, which executes a
+ * Basic use of futures is easy with the factory method on `Future`, which executes a
  * provided function asynchronously, handing you back a future result of that function
- * without blocking the current thread. In order to create the Future you will need
- * either an implicit or explicit ExecutionContext to be provided:
+ * without blocking the current thread. In order to create the `Future` you will need
+ * either an implicit or explicit `ExecutionContext` to be provided:
  *
  * {{{
  * import scala.concurrent._
@@ -91,7 +91,7 @@ import scala.util.Try
  * }}}
  *
  * and although this is sometimes necessary to do, in particular for testing purposes, blocking
- * in general is discouraged when working with Futures and concurrency in order to avoid
+ * in general is discouraged when working with `Future`s and concurrency in order to avoid
  * potential deadlocks and improve performance. Instead, use callbacks or combinators to
  * remain in the future domain:
  *
@@ -111,7 +111,7 @@ package object concurrent {
   type CancellationException = java.util.concurrent.CancellationException
   type TimeoutException =      java.util.concurrent.TimeoutException
 
-  /** Used to designate a piece of code which potentially blocks, allowing the current [[BlockContext]] to adjust
+  /** Designates a piece of code which potentially blocks, allowing the current [[BlockContext]] to adjust
    *  the runtime's behavior.
    *  Properly marking blocking code may improve performance or avoid deadlocks.
    *
@@ -142,14 +142,14 @@ package concurrent {
   /**
    * `Await` is what is used to ensure proper handling of blocking for `Awaitable` instances.
    *
-   * While occasionally useful, e.g. for testing, it is recommended that you avoid Await whenever possible—
+   * While occasionally useful, e.g. for testing, it is recommended that you avoid `Await` whenever possible—
    * instead favoring combinators and/or callbacks.
-   * Await's `result` and `ready` methods will block the calling thread's execution until they return,
+   * `Await`'s `result` and `ready` methods will block the calling thread's execution until they return,
    * which will cause performance degradation, and possibly, deadlock issues.
    */
   object Await {
     /**
-     * Await the "completed" state of an `Awaitable`.
+     * Awaits the "completed" state of an `Awaitable`.
      *
      * Although this method is blocking, the internal use of [[scala.concurrent.blocking blocking]] ensures that
      * the underlying [[ExecutionContext]] is given an opportunity to properly manage the blocking.
@@ -179,7 +179,7 @@ package concurrent {
     }
 
     /**
-     * Await and return the result (of type `T`) of an `Awaitable`.
+     * Awaits and returns the result (of type `T`) of an `Awaitable`.
      *
      * Although this method is blocking, the internal use of [[scala.concurrent.blocking blocking]] ensures that
      * the underlying [[ExecutionContext]] is given an opportunity to properly manage the blocking.

--- a/src/library/scala/io/Codec.scala
+++ b/src/library/scala/io/Codec.scala
@@ -44,7 +44,7 @@ class Codec(val charSet: Charset) {
   private[this] var _decodingReplacement: String      = null
   private[this] var _onCodingException: Handler       = e => throw e
 
-  /** The name of the Codec. */
+  /** The name of the `Codec`. */
   override def toString = name
 
   // these methods can be chained to configure the variables above
@@ -77,7 +77,7 @@ class Codec(val charSet: Charset) {
 trait LowPriorityCodecImplicits {
   self: Codec.type =>
 
-  /** The Codec of Last Resort. */
+  /** The `Codec` of Last Resort. */
   implicit lazy val fallbackSystemCodec: Codec = defaultCharsetCodec
 }
 

--- a/src/library/scala/io/Source.scala
+++ b/src/library/scala/io/Source.scala
@@ -25,60 +25,60 @@ import scala.annotation.nowarn
 object Source {
   val DefaultBufSize = 2048
 
-  /** Creates a `Source` from System.in.
+  /** Creates a `Source` from `System.in`.
    */
   def stdin = fromInputStream(System.in)
 
-  /** Creates a Source from an Iterable.
+  /** Creates a `Source` from an `Iterable`.
    *
    *  @param    iterable  the Iterable
-   *  @return   the Source
+   *  @return   the `Source`
    */
   def fromIterable(iterable: Iterable[Char]): Source = new Source {
     val iter = iterable.iterator
   } withReset(() => fromIterable(iterable))
 
-  /** Creates a Source instance from a single character.
+  /** Creates a `Source` instance from a single character.
    */
   def fromChar(c: Char): Source = fromIterable(Array(c))
 
-  /** creates Source from array of characters, with empty description.
+  /** Creates a `Source` from an array of characters, with empty description.
    */
   def fromChars(chars: Array[Char]): Source = fromIterable(chars)
 
-  /** creates Source from a String, with no description.
+  /** Creates a `Source` from a `String`, with no description.
    */
   def fromString(s: String): Source = fromIterable(s)
 
-  /** creates Source from file with given name, setting its description to
+  /** Creates a `Source` from a file with the given name, setting its description to
    *  filename.
    */
   def fromFile(name: String)(implicit codec: Codec): BufferedSource =
     fromFile(new JFile(name))(codec)
 
-  /** creates Source from file with given name, using given encoding, setting
+  /** Creates a `Source` from a file with the given name, using given encoding, setting
    *  its description to filename.
    */
   def fromFile(name: String, enc: String): BufferedSource =
     fromFile(name)(Codec(enc))
 
-  /** creates `source` from file with given file `URI`.
+  /** Creates a `Source` from a file with the given file `URI`.
    */
   def fromFile(uri: URI)(implicit codec: Codec): BufferedSource =
     fromFile(new JFile(uri))(codec)
 
-  /** creates Source from file with given file: URI
+  /** Creates a `Source` from a file with the given file: `URI`.
    */
   def fromFile(uri: URI, enc: String): BufferedSource =
     fromFile(uri)(Codec(enc))
 
-  /** creates Source from file, using default character encoding, setting its
+  /** Creates a `Source` from a file, using default character encoding, setting its
    *  description to filename.
    */
   def fromFile(file: JFile)(implicit codec: Codec): BufferedSource =
     fromFile(file, Source.DefaultBufSize)(codec)
 
-  /** same as fromFile(file, enc, Source.DefaultBufSize)
+  /** Same as `fromFile(file, enc, Source.DefaultBufSize)`.
    */
   def fromFile(file: JFile, enc: String): BufferedSource =
     fromFile(file)(Codec(enc))
@@ -86,7 +86,7 @@ object Source {
   def fromFile(file: JFile, enc: String, bufferSize: Int): BufferedSource =
     fromFile(file, bufferSize)(Codec(enc))
 
-  /** Creates Source from `file`, using given character encoding, setting
+  /** Creates a `Source` from `file`, using given character encoding, setting
    *  its description to filename. Input is buffered in a buffer of size
    *  `bufferSize`.
    */
@@ -101,7 +101,7 @@ object Source {
     )(codec) withDescription s"file:${file.getAbsolutePath}"
   }
 
-  /** Create a `Source` from array of bytes, decoding
+  /** Creates a `Source` from an array of bytes, decoding
    *  the bytes according to codec.
    *
    *  @return      the created `Source` instance.
@@ -112,34 +112,34 @@ object Source {
   def fromBytes(bytes: Array[Byte], enc: String): Source =
     fromBytes(bytes)(Codec(enc))
 
-  /** Create a `Source` from array of bytes, assuming
+  /** Creates a `Source` from an array of bytes, assuming
    *  one byte per character (ISO-8859-1 encoding.)
    */
   @deprecated("Use `fromBytes` and specify an encoding", since="2.13.9")
   def fromRawBytes(bytes: Array[Byte]): Source =
     fromString(new String(bytes, Codec.ISO8859.charSet))
 
-  /** creates `Source` from file with given file: URI
+  /** Creates a `Source` from a file with the given file: `URI`.
    */
   def fromURI(uri: URI)(implicit codec: Codec): BufferedSource =
     fromFile(new JFile(uri))(codec)
 
-  /** same as fromURL(new URL(s))(Codec(enc))
+  /** Same as `fromURL(new URL(s))(Codec(enc))`.
    */
   def fromURL(s: String, enc: String): BufferedSource =
     fromURL(s)(Codec(enc))
 
-  /** same as fromURL(new URL(s))
+  /** Same as `fromURL(new URL(s))`.
    */
   def fromURL(s: String)(implicit codec: Codec): BufferedSource =
     fromURL(new URI(s).toURL)(codec)
 
-  /** same as fromInputStream(url.openStream())(Codec(enc))
+  /** Same as `fromInputStream(url.openStream())(Codec(enc))`.
    */
   def fromURL(url: URL, enc: String): BufferedSource =
     fromURL(url)(Codec(enc))
 
-  /** same as fromInputStream(url.openStream())(codec)
+  /** Same as `fromInputStream(url.openStream())(codec)`.
    */
   def fromURL(url: URL)(implicit codec: Codec): BufferedSource =
     fromInputStream(url.openStream())(codec)
@@ -148,10 +148,10 @@ object Source {
    *  in implicit parameter codec.
    *
    *  @param  inputStream  the input stream from which to read
-   *  @param  bufferSize   buffer size (defaults to Source.DefaultBufSize)
-   *  @param  reset        a () => Source which resets the stream (if unset, reset() will throw an Exception)
-   *  @param  close        a () => Unit method which closes the stream (if unset, close() will do nothing)
-   *  @param  codec        (implicit) a scala.io.Codec specifying behavior (defaults to Codec.default)
+   *  @param  bufferSize   buffer size (defaults to `Source.DefaultBufSize`)
+   *  @param  reset        a `() => Source` which resets the stream (if unset, `reset()` will throw an Exception)
+   *  @param  close        a `() => Unit` method which closes the stream (if unset, `close()` will do nothing)
+   *  @param  codec        (implicit) a `scala.io.Codec` specifying behavior (defaults to `Codec.default`)
    *  @return              the buffered source
    */
   def createBufferedSource(
@@ -244,7 +244,7 @@ abstract class Source extends Iterator[Char] with Closeable {
 
   /** Returns an iterator who returns lines (NOT including newline character(s)).
    *  It will treat any of \r\n, \r, or \n as a line separator (longest match) - if
-   *  you need more refined behavior you can subclass Source#LineIterator directly.
+   *  you need more refined behavior you can subclass `Source#LineIterator` directly.
    */
   def getLines(): Iterator[String] = new LineIterator()
 
@@ -259,10 +259,10 @@ abstract class Source extends Iterator[Char] with Closeable {
   @nowarn("cat=deprecation")
   class Positioner(encoder: Position) {
     def this() = this(RelaxedPosition)
-    /** the last character returned by next. */
+    /** the last character returned by `next`. */
     var ch: Char = _
 
-    /** position of last character returned by next */
+    /** position of last character returned by `next` */
     var pos = 0
 
     /** current line and column */
@@ -287,7 +287,7 @@ abstract class Source extends Iterator[Char] with Closeable {
       ch
     }
   }
-  /** A Position implementation which ignores errors in
+  /** A `Position` implementation which ignores errors in
    *  the positions.
    */
   @nowarn("cat=deprecation")
@@ -305,7 +305,7 @@ abstract class Source extends Iterator[Char] with Closeable {
    *
    *  @param pos the source position (line/column)
    *  @param msg the error message to report
-   *  @param out PrintStream to use (optional: defaults to `Console.err`)
+   *  @param out `PrintStream` to use (optional: defaults to `Console.err`)
    */
   def reportError(
     pos: Int,
@@ -320,7 +320,7 @@ abstract class Source extends Iterator[Char] with Closeable {
   /**
    *  @param pos the source position (line/column)
    *  @param msg the error message to report
-   *  @param out PrintStream to use
+   *  @param out `PrintStream` to use
    */
   def report(pos: Int, msg: String, out: PrintStream): Unit = {
     val line  = Position line pos
@@ -332,7 +332,7 @@ abstract class Source extends Iterator[Char] with Closeable {
   /**
    *  @param pos the source position (line/column)
    *  @param msg the warning message to report
-   *  @param out PrintStream to use (optional: defaults to `Console.out`)
+   *  @param out `PrintStream` to use (optional: defaults to `Console.out`)
    */
   def reportWarning(
     pos: Int,
@@ -359,7 +359,7 @@ abstract class Source extends Iterator[Char] with Closeable {
     descr = text
     this
   }
-  /** Change or disable the positioner. */
+  /** Changes or disables the positioner. */
   def withPositioning(on: Boolean): this.type = {
     positioner = if (on) RelaxedPositioner else NoPositioner
     this
@@ -369,12 +369,12 @@ abstract class Source extends Iterator[Char] with Closeable {
     this
   }
 
-  /** The close() method closes the underlying resource. */
+  /** The `close()` method closes the underlying resource. */
   def close(): Unit = {
     if (closeFunction != null) closeFunction()
   }
 
-  /** The reset() method creates a fresh copy of this Source. */
+  /** The `reset()` method creates a fresh copy of this `Source`. */
   def reset(): Source =
     if (resetFunction != null) resetFunction()
     else throw new UnsupportedOperationException("Source's reset() method was not set.")

--- a/src/library/scala/io/StdIn.scala
+++ b/src/library/scala/io/StdIn.scala
@@ -22,14 +22,14 @@ import java.text.MessageFormat
 private[scala] trait StdIn {
   import scala.Console._
 
-  /** Read a full line from the default input.  Returns `null` if the end of the
+  /** Reads a full line from the default input.  Returns `null` if the end of the
    * input stream has been reached.
    *
    * @return the string read from the terminal or null if the end of stream was reached.
    */
   def readLine(): String = in.readLine()
 
-  /** Print and flush formatted text to the default output, and read a full line from the default input.
+  /** Prints and flushes formatted text to the default output, and reads a full line from the default input.
    *  Returns `null` if the end of the input stream has been reached.
    *
    *  @param text the format of the text to print out, as in `printf`.
@@ -45,7 +45,7 @@ private[scala] trait StdIn {
   /** Reads a boolean value from an entire line of the default input.
    *  Has a fairly liberal interpretation of the input.
    *
-   *  @return the boolean value read, or false if it couldn't be converted to a boolean
+   *  @return the boolean value read, or `false` if it couldn't be converted to a boolean
    *  @throws java.io.EOFException if the end of the input stream has been reached.
    */
   def readBoolean(): Boolean = {
@@ -64,10 +64,10 @@ private[scala] trait StdIn {
 
   /** Reads a byte value from an entire line of the default input.
    *
-   *  @return the Byte that was read
+   *  @return the `Byte` that was read
    *  @throws java.io.EOFException if the end of the
    *  input stream has been reached.
-   *  @throws java.lang.NumberFormatException if the value couldn't be converted to a Byte
+   *  @throws java.lang.NumberFormatException if the value couldn't be converted to a `Byte`
    */
   def readByte(): Byte = {
     val s = readLine()
@@ -79,10 +79,10 @@ private[scala] trait StdIn {
 
   /** Reads a short value from an entire line of the default input.
    *
-   *  @return the short that was read
+   *  @return the `Short` that was read
    *  @throws java.io.EOFException if the end of the
    *  input stream has been reached.
-   *  @throws java.lang.NumberFormatException if the value couldn't be converted to a Short
+   *  @throws java.lang.NumberFormatException if the value couldn't be converted to a `Short`
    */
   def readShort(): Short = {
     val s = readLine()
@@ -94,7 +94,7 @@ private[scala] trait StdIn {
 
   /** Reads a char value from an entire line of the default input.
    *
-   *  @return the Char that was read
+   *  @return the `Char` that was read
    *  @throws java.io.EOFException if the end of the
    *  input stream has been reached.
    *  @throws java.lang.StringIndexOutOfBoundsException if the line read from default input was empty
@@ -109,10 +109,10 @@ private[scala] trait StdIn {
 
   /** Reads an int value from an entire line of the default input.
    *
-   *  @return the Int that was read
+   *  @return the `Int` that was read
    *  @throws java.io.EOFException if the end of the
    *  input stream has been reached.
-   *  @throws java.lang.NumberFormatException if the value couldn't be converted to an Int
+   *  @throws java.lang.NumberFormatException if the value couldn't be converted to an `Int`
    */
   def readInt(): Int = {
     val s = readLine()
@@ -124,10 +124,10 @@ private[scala] trait StdIn {
 
   /** Reads an long value from an entire line of the default input.
    *
-   *  @return the Long that was read
+   *  @return the `Long` that was read
    *  @throws java.io.EOFException if the end of the
    *  input stream has been reached.
-   *  @throws java.lang.NumberFormatException if the value couldn't be converted to a Long
+   *  @throws java.lang.NumberFormatException if the value couldn't be converted to a `Long`
    */
   def readLong(): Long = {
     val s = readLine()
@@ -138,10 +138,10 @@ private[scala] trait StdIn {
   }
 
   /** Reads a float value from an entire line of the default input.
-   *  @return the Float that was read.
+   *  @return the `Float` that was read.
    *  @throws java.io.EOFException if the end of the
    *  input stream has been reached.
-   *  @throws java.lang.NumberFormatException if the value couldn't be converted to a Float
+   *  @throws java.lang.NumberFormatException if the value couldn't be converted to a `Float`
    *
    */
   def readFloat(): Float = {
@@ -154,10 +154,10 @@ private[scala] trait StdIn {
 
   /** Reads a double value from an entire line of the default input.
    *
-   *  @return the Double that was read.
+   *  @return the `Double` that was read.
    *  @throws java.io.EOFException if the end of the
    *  input stream has been reached.
-   *  @throws java.lang.NumberFormatException if the value couldn't be converted to a Float
+   *  @throws java.lang.NumberFormatException if the value couldn't be converted to a `Double`
    */
   def readDouble(): Double = {
     val s = readLine()

--- a/src/library/scala/jdk/Accumulator.scala
+++ b/src/library/scala/jdk/Accumulator.scala
@@ -51,9 +51,9 @@ import scala.language.implicitConversions
   *   stringAcc: scala.jdk.AnyAccumulator[String] = AnyAccumulator(<>, <><>, <><><>, ...
   * }}}
   *
-  * There are two possibilities to process elements of a primitive Accumulator without boxing:
-  * specialized operations of the Accumulator, or the Stepper interface. The most common collection
-  * operations are overloaded or overridden in the primitive Accumulator classes, for example
+  * There are two possibilities to process elements of a primitive `Accumulator` without boxing:
+  * specialized operations of the `Accumulator`, or the `Stepper` interface. The most common collection
+  * operations are overloaded or overridden in the primitive `Accumulator` classes, for example
   * [[IntAccumulator.map(f:Int=>Int)* IntAccumulator.map]] or [[IntAccumulator.exists]].
   * Thanks to Scala's function specialization,
   * `intAcc.exists(x => testOn(x))` does not incur boxing.
@@ -124,7 +124,7 @@ abstract class Accumulator[@specialized(Double, Int, Long) A, +CC[X] <: mutable.
   /** Size of the accumulated collection, as a `Long` */
   final def sizeLong: Long = totalSize
 
-  /** Remove all accumulated elements from this accumulator. */
+  /** Removes all accumulated elements from this accumulator. */
   def clear(): Unit = {
     index = 0
     hIndex = 0

--- a/src/library/scala/jdk/AnyAccumulator.scala
+++ b/src/library/scala/jdk/AnyAccumulator.scala
@@ -20,7 +20,7 @@ import scala.collection.Stepper.EfficientSplit
 import scala.collection.{AnyStepper, Factory, IterableFactoryDefaults, SeqFactory, Stepper, StepperShape, mutable}
 import scala.reflect.ClassTag
 
-/** An Accumulator for arbitrary element types, see [[Accumulator]]. */
+/** An `Accumulator` for arbitrary element types, see [[Accumulator]]. */
 final class AnyAccumulator[A]
   extends Accumulator[A, AnyAccumulator, AnyAccumulator[A]]
     with mutable.SeqOps[A, AnyAccumulator, AnyAccumulator[A]]

--- a/src/library/scala/jdk/DoubleAccumulator.scala
+++ b/src/library/scala/jdk/DoubleAccumulator.scala
@@ -22,7 +22,7 @@ import scala.collection.Stepper.EfficientSplit
 import scala.collection.{AnyStepper, DoubleStepper, Factory, SeqFactory, Stepper, StepperShape, mutable}
 import scala.language.implicitConversions
 
-/** A specialized Accumulator that holds `Double`s without boxing, see [[Accumulator]]. */
+/** A specialized `Accumulator` that holds `Double`s without boxing, see [[Accumulator]]. */
 final class DoubleAccumulator
   extends Accumulator[Double, AnyAccumulator, DoubleAccumulator]
     with mutable.SeqOps[Double, AnyAccumulator, DoubleAccumulator]

--- a/src/library/scala/jdk/IntAccumulator.scala
+++ b/src/library/scala/jdk/IntAccumulator.scala
@@ -22,7 +22,7 @@ import scala.collection.Stepper.EfficientSplit
 import scala.collection.{AnyStepper, Factory, IntStepper, SeqFactory, Stepper, StepperShape, mutable}
 import scala.language.implicitConversions
 
-/** A specialized Accumulator that holds `Int`s without boxing, see [[Accumulator]]. */
+/** A specialized `Accumulator` that holds `Int`s without boxing, see [[Accumulator]]. */
 final class IntAccumulator
   extends Accumulator[Int, AnyAccumulator, IntAccumulator]
     with mutable.SeqOps[Int, AnyAccumulator, IntAccumulator]

--- a/src/library/scala/jdk/LongAccumulator.scala
+++ b/src/library/scala/jdk/LongAccumulator.scala
@@ -22,7 +22,7 @@ import scala.collection.Stepper.EfficientSplit
 import scala.collection.{AnyStepper, Factory, LongStepper, SeqFactory, Stepper, StepperShape, mutable}
 import scala.language.implicitConversions
 
-/** A specialized Accumulator that holds `Long`s without boxing, see [[Accumulator]]. */
+/** A specialized `Accumulator` that holds `Long`s without boxing, see [[Accumulator]]. */
 final class LongAccumulator
   extends Accumulator[Long, AnyAccumulator, LongAccumulator]
     with mutable.SeqOps[Long, AnyAccumulator, LongAccumulator]

--- a/src/library/scala/jdk/package.scala
+++ b/src/library/scala/jdk/package.scala
@@ -33,9 +33,9 @@ package scala
  *    well as primitive variations and Bi-variations.
  * 
  * By convention, converters that wrap an object to provide a different
- * interface to the same underlying data structure use .asScala and .asJava
+ * interface to the same underlying data structure use `.asScala` and `.asJava`
  * extension methods, whereas converters that copy the underlying data structure
- * use .toScala and .toJava.
+ * use `.toScala` and `.toJava`.
  * 
  * In the [[javaapi]] package, the same converters can be found with a
  * java-friendly interface that don't rely on implicit enrichments.

--- a/src/library/scala/math/BigDecimal.scala
+++ b/src/library/scala/math/BigDecimal.scala
@@ -381,7 +381,7 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
       }
   }
 
-  /** Returns the hash code for this BigDecimal.
+  /** Returns the hash code for this `BigDecimal`.
    *  Note that this does not merely use the underlying java object's
    *  `hashCode` because we compare `BigDecimal`s with `compareTo`
    *  which deems 2 == 2.00, whereas in java these are unequal
@@ -396,8 +396,8 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
     computedHashCode
   }
 
-  /** Compares this BigDecimal with the specified value for equality.  Where `Float` and `Double`
-   *  disagree, `BigDecimal` will agree with the `Double` value
+  /** Compares this `BigDecimal` with the specified value for equality.  Where `Float` and `Double`
+   *  disagree, `BigDecimal` will agree with the `Double` value.
    */
   override def equals (that: Any): Boolean = that match {
     case that: BigDecimal     => this equals that
@@ -469,11 +469,11 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
   def underlying: java.math.BigDecimal = bigDecimal
 
 
-  /** Compares this BigDecimal with the specified BigDecimal for equality.
+  /** Compares this `BigDecimal` with the specified `BigDecimal` for equality.
    */
   def equals (that: BigDecimal): Boolean = compare(that) == 0
 
-  /** Compares this BigDecimal with the specified BigDecimal
+  /** Compares this `BigDecimal` with the specified `BigDecimal`.
    */
   def compare (that: BigDecimal): Int = this.bigDecimal compareTo that.bigDecimal
 
@@ -528,26 +528,26 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
    */
   def % (that: BigDecimal): BigDecimal = this.remainder(that)
 
-  /** Returns a BigDecimal whose value is this ** n.
+  /** Returns a `BigDecimal` whose value is this ** n.
    */
   def pow (n: Int): BigDecimal = new BigDecimal(this.bigDecimal.pow(n, mc), mc)
 
-  /** Returns a BigDecimal whose value is the negation of this BigDecimal
+  /** Returns a `BigDecimal` whose value is the negation of this `BigDecimal`.
    */
   def unary_- : BigDecimal = new BigDecimal(this.bigDecimal.negate(mc), mc)
 
-  /** Returns the absolute value of this BigDecimal
+  /** Returns the absolute value of this `BigDecimal`.
    */
   def abs: BigDecimal = if (signum < 0) unary_- else this
 
-  /** Returns the sign of this BigDecimal;
+  /** Returns the sign of this `BigDecimal`;
    *   -1 if it is less than 0,
    *   +1 if it is greater than 0,
    *   0  if it is equal to 0.
    */
   def signum: Int = this.bigDecimal.signum()
 
-  /** Returns the sign of this BigDecimal;
+  /** Returns the sign of this `BigDecimal`;
    *   -1 if it is less than 0,
    *   +1 if it is greater than 0,
    *   0  if it is equal to 0.
@@ -558,8 +558,8 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
    */
   def precision: Int = this.bigDecimal.precision
 
-  /** Returns a BigDecimal rounded according to the supplied MathContext settings, but
-   *  preserving its own MathContext for future operations.
+  /** Returns a `BigDecimal` rounded according to the supplied `MathContext` settings, but
+   *  preserving its own `MathContext` for future operations.
    */
   def round(mc: MathContext): BigDecimal = {
     val r = this.bigDecimal round mc
@@ -576,16 +576,16 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
    */
   def scale: Int = this.bigDecimal.scale
 
-  /** Returns the size of an ulp, a unit in the last place, of this BigDecimal.
+  /** Returns the size of an ulp, a unit in the last place, of this `BigDecimal`.
    */
   def ulp: BigDecimal = new BigDecimal(this.bigDecimal.ulp, mc)
 
-  /** Returns a new BigDecimal based on the supplied MathContext, rounded as needed.
+  /** Returns a new `BigDecimal` based on the supplied `MathContext`, rounded as needed.
    */
   def apply(mc: MathContext): BigDecimal = new BigDecimal(this.bigDecimal round mc, mc)
 
   /** Returns a `BigDecimal` whose scale is the specified value, and whose value is
-   *  numerically equal to this BigDecimal's.
+   *  numerically equal to this `BigDecimal`'s.
    */
   def setScale(scale: Int): BigDecimal =
     if (this.scale == scale) this
@@ -595,52 +595,52 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
     if (this.scale == scale) this
     else new BigDecimal(this.bigDecimal.setScale(scale, JRM.valueOf(mode.id)), mc)
 
-  /** Converts this BigDecimal to a Byte.
-   *  If the BigDecimal is too big to fit in a Byte, only the low-order 8 bits are returned.
+  /** Converts this `BigDecimal` to a `Byte`.
+   *  If the `BigDecimal` is too big to fit in a `Byte`, only the low-order 8 bits are returned.
    *  Note that this conversion can lose information about the overall magnitude of the
-   *  BigDecimal value as well as return a result with the opposite sign.
+   *  `BigDecimal` value as well as return a result with the opposite sign.
    */
   override def byteValue   = intValue.toByte
 
-  /** Converts this BigDecimal to a Short.
-   *  If the BigDecimal is too big to fit in a Short, only the low-order 16 bits are returned.
+  /** Converts this `BigDecimal` to a `Short`.
+   *  If the `BigDecimal` is too big to fit in a `Short`, only the low-order 16 bits are returned.
    *  Note that this conversion can lose information about the overall magnitude of the
-   *  BigDecimal value as well as return a result with the opposite sign.
+   *  `BigDecimal` value as well as return a result with the opposite sign.
    */
   override def shortValue  = intValue.toShort
 
-  /** Converts this BigDecimal to a Char.
-   *  If the BigDecimal is too big to fit in a Char, only the low-order 16 bits are returned.
+  /** Converts this `BigDecimal` to a `Char`.
+   *  If the `BigDecimal` is too big to fit in a `Char`, only the low-order 16 bits are returned.
    *  Note that this conversion can lose information about the overall magnitude of the
-   *  BigDecimal value and that it always returns a positive result.
+   *  `BigDecimal` value and that it always returns a positive result.
    */
   def charValue   = intValue.toChar
 
-  /** Converts this BigDecimal to an Int.
-   *  If the BigDecimal is too big to fit in an Int, only the low-order 32 bits
+  /** Converts this `BigDecimal` to an `Int`.
+   *  If the `BigDecimal` is too big to fit in an `Int`, only the low-order 32 bits
    *  are returned. Note that this conversion can lose information about the
-   *  overall magnitude of the BigDecimal value as well as return a result with
+   *  overall magnitude of the `BigDecimal` value as well as return a result with
    *  the opposite sign.
    */
   def intValue    = this.bigDecimal.intValue
 
-  /** Converts this BigDecimal to a Long.
-   *  If the BigDecimal is too big to fit in a Long, only the low-order 64 bits
+  /** Converts this `BigDecimal` to a `Long`.
+   *  If the `BigDecimal` is too big to fit in a `Long`, only the low-order 64 bits
    *  are returned. Note that this conversion can lose information about the
-   *  overall magnitude of the BigDecimal value as well as return a result with
+   *  overall magnitude of the `BigDecimal` value as well as return a result with
    *  the opposite sign.
    */
   def longValue   = this.bigDecimal.longValue
 
-  /** Converts this BigDecimal to a Float.
-   *  if this BigDecimal has too great a magnitude to represent as a float,
+  /** Converts this `BigDecimal` to a `Float`.
+   *  If this `BigDecimal` has too great a magnitude to represent as a `Float`,
    *  it will be converted to `Float.NEGATIVE_INFINITY` or
    *  `Float.POSITIVE_INFINITY` as appropriate.
    */
   def floatValue  = this.bigDecimal.floatValue
 
-  /** Converts this BigDecimal to a Double.
-   *  if this BigDecimal has too great a magnitude to represent as a double,
+  /** Converts this `BigDecimal` to a `Double`.
+   *  If this `BigDecimal` has too great a magnitude to represent as a `Double`,
    *  it will be converted to `Double.NEGATIVE_INFINITY` or
    *  `Double.POSITIVE_INFINITY` as appropriate.
    */
@@ -674,8 +674,8 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
     */
   def toLongExact = bigDecimal.longValueExact
 
-  /** Creates a partially constructed NumericRange[BigDecimal] in range
-   *  `[start;end)`, where start is the target BigDecimal.  The step
+  /** Creates a partially constructed `NumericRange[BigDecimal]` in range
+   *  `[start;end)`, where start is the target `BigDecimal`.  The step
    *  must be supplied via the "by" method of the returned object in order
    *  to receive the fully constructed range.  For example:
    * {{{
@@ -714,7 +714,7 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
     }
     else None
 
-  /** Returns the decimal String representation of this BigDecimal.
+  /** Returns the decimal `String` representation of this `BigDecimal`.
    */
   override def toString: String = this.bigDecimal.toString
 

--- a/src/library/scala/math/BigInt.scala
+++ b/src/library/scala/math/BigInt.scala
@@ -61,12 +61,12 @@ object BigInt {
     else new BigInt(null, l)
 
   /** Translates a byte array containing the two's-complement binary
-   *  representation of a BigInt into a BigInt.
+   *  representation of a `BigInt` into a `BigInt`.
    */
   def apply(x: Array[Byte]): BigInt =
     apply(new BigInteger(x))
 
-  /** Translates the sign-magnitude representation of a BigInt into a BigInt.
+  /** Translates the sign-magnitude representation of a `BigInt` into a `BigInt`.
    *
    * @param  signum    signum of the number (-1 for negative, 0 for zero, 1
    *                   for positive).
@@ -76,30 +76,30 @@ object BigInt {
   def apply(signum: Int, magnitude: Array[Byte]): BigInt =
     apply(new BigInteger(signum, magnitude))
 
-  /** Constructs a randomly generated positive BigInt that is probably prime,
-   *  with the specified bitLength.
+  /** Constructs a randomly generated positive `BigInt` that is probably prime,
+   *  with the specified `bitLength`.
    */
   def apply(bitlength: Int, certainty: Int, rnd: scala.util.Random): BigInt =
     apply(new BigInteger(bitlength, certainty, rnd.self))
 
-  /** Constructs a randomly generated BigInt, uniformly distributed over the
+  /** Constructs a randomly generated `BigInt`, uniformly distributed over the
    *  range `0` to `(2 ^ numBits - 1)`, inclusive.
    */
   def apply(numbits: Int, rnd: scala.util.Random): BigInt =
     apply(new BigInteger(numbits, rnd.self))
 
-  /** Translates the decimal String representation of a BigInt into a BigInt.
+  /** Translates the decimal `String` representation of a `BigInt` into a `BigInt`.
    */
   def apply(x: String): BigInt =
     apply(new BigInteger(x))
 
   /** Translates the string representation of a `BigInt` in the
-   *  specified `radix` into a BigInt.
+   *  specified `radix` into a `BigInt`.
    */
   def apply(x: String, radix: Int): BigInt =
     apply(new BigInteger(x, radix))
 
-  /** Translates a `java.math.BigInteger` into a BigInt.
+  /** Translates a `java.math.BigInteger` into a `BigInt`.
    */
   def apply(x: BigInteger): BigInt = {
     if (x.bitLength <= 63) {
@@ -108,7 +108,7 @@ object BigInt {
     } else new BigInt(x, Long.MinValue)
   }
 
-  /** Returns a positive BigInt that is probably prime, with the specified bitLength.
+  /** Returns a positive `BigInt` that is probably prime, with the specified `bitLength`.
    */
   def probablePrime(bitLength: Int, rnd: scala.util.Random): BigInt =
     apply(BigInteger.probablePrime(bitLength, rnd.self))
@@ -221,12 +221,12 @@ final class BigInt private (private var _bigInteger: BigInteger, private val _lo
     }
   }
 
-  /** Returns the hash code for this BigInt. */
+  /** Returns the hash code for this `BigInt`. */
   override def hashCode(): Int =
     if (isValidLong) unifiedPrimitiveHashcode
     else bigInteger.##
 
-  /** Compares this BigInt with the specified value for equality. */
+  /** Compares this `BigInt` with the specified value for equality. */
   @nowarn("cat=other-non-cooperative-equals")
   override def equals(that: Any): Boolean = that match {
     case that: BigInt     => this equals that
@@ -243,7 +243,7 @@ final class BigInt private (private var _bigInteger: BigInteger, private val _lo
            def isValidLong: Boolean = longEncoding || _bigInteger == BigInt.longMinValueBigInteger // rhs of || tests == Long.MinValue
 
   /** Returns `true` iff this can be represented exactly by [[scala.Float]]; otherwise returns `false`.
-    */
+   */
   def isValidFloat: Boolean = {
     val bitLen = bitLength
     (bitLen <= 24 ||
@@ -256,7 +256,7 @@ final class BigInt private (private var _bigInteger: BigInteger, private val _lo
     ) && !bitLengthOverflow
   }
   /** Returns `true` iff this can be represented exactly by [[scala.Double]]; otherwise returns `false`.
-    */
+   */
   def isValidDouble: Boolean = {
     val bitLen = bitLength
     (bitLen <= 53 ||
@@ -282,7 +282,7 @@ final class BigInt private (private var _bigInteger: BigInteger, private val _lo
   def isWhole: Boolean = true
   def underlying: BigInteger = bigInteger
 
-  /** Compares this BigInt with the specified BigInt for equality.
+  /** Compares this `BigInt` with the specified `BigInt` for equality.
    */
   def equals(that: BigInt): Boolean =
     if (this.longEncoding)
@@ -290,7 +290,7 @@ final class BigInt private (private var _bigInteger: BigInteger, private val _lo
     else
       !that.longEncoding && (this._bigInteger == that._bigInteger)
 
-  /** Compares this BigInt with the specified BigInt
+  /** Compares this `BigInt` with the specified `BigInt`.
    */
   def compare(that: BigInt): Int =
     if (this.longEncoding) {
@@ -432,8 +432,8 @@ final class BigInt private (private var _bigInteger: BigInteger, private val _lo
     }
 
 
-  /** Returns a BigInt whose value is (this mod that).
-   *  This method differs from `%` in that it always returns a non-negative BigInt.
+  /** Returns a `BigInt` whose value is (this mod that).
+   *  This method differs from `%` in that it always returns a non-negative `BigInt`.
    *  @param that A positive number
    */
   def mod(that: BigInt): BigInt =
@@ -465,35 +465,35 @@ final class BigInt private (private var _bigInteger: BigInteger, private val _lo
    */
   def modInverse(m: BigInt): BigInt = BigInt(this.bigInteger.modInverse(m.bigInteger))
 
-  /** Returns a BigInt whose value is the negation of this BigInt
+  /** Returns a `BigInt` whose value is the negation of this `BigInt`.
    */
   def unary_- : BigInt = if (longEncoding) BigInt(-_long) else BigInt(this.bigInteger.negate())
 
-  /** Returns the absolute value of this BigInt
+  /** Returns the absolute value of this `BigInt`.
    */
   def abs: BigInt = if (signum < 0) -this else this
 
-  /** Returns the sign of this BigInt;
+  /** Returns the sign of this `BigInt`;
    *   -1 if it is less than 0,
    *   +1 if it is greater than 0,
    *   0  if it is equal to 0.
    */
   def signum: Int = if (longEncoding) java.lang.Long.signum(_long) else _bigInteger.signum()
 
-  /** Returns the sign of this BigInt;
+  /** Returns the sign of this `BigInt`;
    *   -1 if it is less than 0,
    *   +1 if it is greater than 0,
    *   0  if it is equal to 0.
    */
   def sign: BigInt = BigInt(signum)
 
-  /** Returns the bitwise complement of this BigInt
+  /** Returns the bitwise complement of this `BigInt`.
    */
   def unary_~ : BigInt =
     // it is equal to -(this + 1)
     if (longEncoding && _long != Long.MaxValue) BigInt(-(_long + 1)) else BigInt(this.bigInteger.not())
 
-  /** Returns true if and only if the designated bit is set.
+  /** Returns `true` if and only if the designated bit is set.
    */
   def testBit(n: Int): Boolean =
     if (longEncoding && n >= 0) {
@@ -503,22 +503,22 @@ final class BigInt private (private var _bigInteger: BigInteger, private val _lo
         _long < 0 // give the sign bit
     } else this.bigInteger.testBit(n)
 
-  /** Returns a BigInt whose value is equivalent to this BigInt with the designated bit set.
+  /** Returns a `BigInt` whose value is equivalent to this `BigInt` with the designated bit set.
    */
   def setBit(n: Int): BigInt  = // note that we do not operate on the Long sign bit #63
     if (longEncoding && n <= 62 && n >= 0) BigInt(_long | (1L << n)) else BigInt(this.bigInteger.setBit(n))
 
-  /** Returns a BigInt whose value is equivalent to this BigInt with the designated bit cleared.
+  /** Returns a `BigInt` whose value is equivalent to this `BigInt` with the designated bit cleared.
    */
   def clearBit(n: Int): BigInt  = // note that we do not operate on the Long sign bit #63
     if (longEncoding && n <= 62 && n >= 0) BigInt(_long & ~(1L << n)) else BigInt(this.bigInteger.clearBit(n))
 
-  /** Returns a BigInt whose value is equivalent to this BigInt with the designated bit flipped.
+  /** Returns a `BigInt` whose value is equivalent to this `BigInt` with the designated bit flipped.
    */
   def flipBit(n: Int): BigInt  = // note that we do not operate on the Long sign bit #63
     if (longEncoding && n <= 62 && n >= 0) BigInt(_long ^ (1L << n)) else BigInt(this.bigInteger.flipBit(n))
 
-  /** Returns the index of the rightmost (lowest-order) one bit in this BigInt
+  /** Returns the index of the rightmost (lowest-order) one bit in this `BigInt`
    * (the number of zero bits to the right of the rightmost one bit).
    */
   def lowestSetBit: Int =
@@ -526,7 +526,7 @@ final class BigInt private (private var _bigInteger: BigInteger, private val _lo
       if (_long == 0) -1 else java.lang.Long.numberOfTrailingZeros(_long)
     } else this.bigInteger.getLowestSetBit()
 
-  /** Returns the number of bits in the minimal two's-complement representation of this BigInt,
+  /** Returns the number of bits in the minimal two's-complement representation of this `BigInt`,
    *  excluding a sign bit.
    */
   def bitLength: Int =
@@ -537,7 +537,7 @@ final class BigInt private (private var _bigInteger: BigInteger, private val _lo
       else 64 - java.lang.Long.numberOfLeadingZeros(_long)
     } else _bigInteger.bitLength()
 
-  /** Returns the number of bits in the two's complement representation of this BigInt
+  /** Returns the number of bits in the two's complement representation of this `BigInt`
    *  that differ from its sign bit.
    */
   def bitCount: Int =
@@ -545,61 +545,61 @@ final class BigInt private (private var _bigInteger: BigInteger, private val _lo
       if (_long < 0) java.lang.Long.bitCount(-(_long + 1)) else java.lang.Long.bitCount(_long)
     } else this.bigInteger.bitCount()
 
-  /** Returns true if this BigInt is probably prime, false if it's definitely composite.
+  /** Returns `true` if this `BigInt` is probably prime, `false` if it's definitely composite.
    *  @param certainty  a measure of the uncertainty that the caller is willing to tolerate:
-   *                    if the call returns true the probability that this BigInt is prime
+   *                    if the call returns `true` the probability that this `BigInt` is prime
    *                    exceeds (1 - 1/2 ^ certainty).
    *                    The execution time of this method is proportional to the value of
    *                    this parameter.
    */
   def isProbablePrime(certainty: Int): Boolean = this.bigInteger.isProbablePrime(certainty)
 
-  /** Converts this BigInt to a <tt>byte</tt>.
-   *  If the BigInt is too big to fit in a byte, only the low-order 8 bits are returned.
+  /** Converts this `BigInt` to a `Byte`.
+   *  If the `BigInt` is too big to fit in a `Byte`, only the low-order 8 bits are returned.
    *  Note that this conversion can lose information about the overall magnitude of the
-   *  BigInt value as well as return a result with the opposite sign.
+   *  `BigInt` value as well as return a result with the opposite sign.
    */
   override def byteValue: Byte = intValue.toByte
 
-  /** Converts this BigInt to a <tt>short</tt>.
-   *  If the BigInt is too big to fit in a short, only the low-order 16 bits are returned.
+  /** Converts this `BigInt` to a `Short`.
+   *  If the `BigInt` is too big to fit in a `Short`, only the low-order 16 bits are returned.
    *  Note that this conversion can lose information about the overall magnitude of the
-   *  BigInt value as well as return a result with the opposite sign.
+   *  `BigInt` value as well as return a result with the opposite sign.
    */
   override def shortValue: Short = intValue.toShort
 
-  /** Converts this BigInt to a <tt>char</tt>.
-   *  If the BigInt is too big to fit in a char, only the low-order 16 bits are returned.
+  /** Converts this `BigInt` to a `Char`.
+   *  If the `BigInt` is too big to fit in a `Char`, only the low-order 16 bits are returned.
    *  Note that this conversion can lose information about the overall magnitude of the
-   *  BigInt value and that it always returns a positive result.
+   *  `BigInt` value and that it always returns a positive result.
    */
   def charValue: Char = intValue.toChar
 
-  /** Converts this BigInt to an <tt>int</tt>.
-   *  If the BigInt is too big to fit in an int, only the low-order 32 bits
+  /** Converts this `BigInt` to an `Int`.
+   *  If the `BigInt` is too big to fit in an `Int`, only the low-order 32 bits
    *  are returned. Note that this conversion can lose information about the
-   *  overall magnitude of the BigInt value as well as return a result with
+   *  overall magnitude of the `BigInt` value as well as return a result with
    *  the opposite sign.
    */
   def intValue: Int = if (longEncoding) _long.toInt else this.bigInteger.intValue
 
-  /** Converts this BigInt to a <tt>long</tt>.
-   *  If the BigInt is too big to fit in a long, only the low-order 64 bits
+  /** Converts this `BigInt` to a `Long`.
+   *  If the `BigInt` is too big to fit in a `Long`, only the low-order 64 bits
    *  are returned. Note that this conversion can lose information about the
-   *  overall magnitude of the BigInt value as well as return a result with
+   *  overall magnitude of the `BigInt` value as well as return a result with
    *  the opposite sign.
    */
   def longValue: Long = if (longEncoding) _long else _bigInteger.longValue
 
-  /** Converts this `BigInt` to a `float`.
-   *  If this `BigInt` has too great a magnitude to represent as a float,
+  /** Converts this `BigInt` to a `Float`.
+   *  If this `BigInt` has too great a magnitude to represent as a `Float`,
    *  it will be converted to `Float.NEGATIVE_INFINITY` or
    *  `Float.POSITIVE_INFINITY` as appropriate.
    */
   def floatValue: Float = this.bigInteger.floatValue
 
-  /** Converts this `BigInt` to a `double`.
-   *  if this `BigInt` has too great a magnitude to represent as a double,
+  /** Converts this `BigInt` to a `Double`.
+   *  If this `BigInt` has too great a magnitude to represent as a `Double`,
    *  it will be converted to `Double.NEGATIVE_INFINITY` or
    *  `Double.POSITIVE_INFINITY` as appropriate.
    */
@@ -607,8 +607,8 @@ final class BigInt private (private var _bigInteger: BigInteger, private val _lo
     if (isValidLong && (-(1L << 53) <= _long && _long <= (1L << 53))) _long.toDouble
     else this.bigInteger.doubleValue
 
-  /** Create a `NumericRange[BigInt]` in range `[start;end)`
-   *  with the specified step, where start is the target BigInt.
+  /** Creates a `NumericRange[BigInt]` in range `[start;end)`
+   *  with the specified step, where start is the target `BigInt`.
    *
    *  @param end    the end value of the range (exclusive)
    *  @param step   the distance between elements (defaults to 1)
@@ -620,18 +620,18 @@ final class BigInt private (private var _bigInteger: BigInteger, private val _lo
    */
   def to(end: BigInt, step: BigInt = BigInt(1)): NumericRange.Inclusive[BigInt] = Range.BigInt.inclusive(this, end, step)
 
-  /** Returns the decimal String representation of this BigInt.
+  /** Returns the decimal `String` representation of this `BigInt`.
    */
   override def toString(): String = if (longEncoding) _long.toString() else _bigInteger.toString()
 
-  /** Returns the String representation in the specified radix of this BigInt.
+  /** Returns the `String` representation in the specified radix of this `BigInt`.
    */
   def toString(radix: Int): String = this.bigInteger.toString(radix)
 
   /** Returns a byte array containing the two's-complement representation of
-   *  this BigInt. The byte array will be in big-endian byte-order: the most
+   *  this `BigInt`. The byte array will be in big-endian byte-order: the most
    *  significant byte is in the zeroth element. The array will contain the
-   *  minimum number of bytes required to represent this BigInt, including at
+   *  minimum number of bytes required to represent this `BigInt`, including at
    *  least one sign bit.
    */
   def toByteArray: Array[Byte] = this.bigInteger.toByteArray()

--- a/src/library/scala/math/Ordered.scala
+++ b/src/library/scala/math/Ordered.scala
@@ -23,9 +23,9 @@ import scala.language.implicitConversions
  *  [[scala.util.Sorting]] and can be compared with standard comparison operators
  *  (e.g. > and <).
  *
- *  Ordered should be used for data with a single, natural ordering (like
- *  integers) while Ordering allows for multiple ordering implementations.
- *  An Ordering instance will be implicitly created if necessary.
+ *  `Ordered` should be used for data with a single, natural ordering (like
+ *  integers) while `Ordering` allows for multiple ordering implementations.
+ *  An `Ordering` instance will be implicitly created if necessary.
  *
  *  [[scala.math.Ordering]] is an alternative to this trait that allows multiple orderings to be
  *  defined for the same type.
@@ -44,7 +44,7 @@ import scala.language.implicitConversions
  *  }}}
  *
  *  It is important that the `equals` method for an instance of `Ordered[A]` be consistent with the
- *  compare method. However, due to limitations inherent in the type erasure semantics, there is no
+ *  `compare` method. However, due to limitations inherent in the type erasure semantics, there is no
  *  reasonable way to provide a default implementation of equality for instances of `Ordered[A]`.
  *  Therefore, if you need to be able to use equality on an instance of `Ordered[A]` you must
  *  provide it yourself either when inheriting or instantiating.
@@ -60,7 +60,7 @@ trait Ordered[A] extends Any with java.lang.Comparable[A] {
 
   /** Result of comparing `this` with operand `that`.
    *
-   * Implement this method to determine how instances of A will be sorted.
+   * This method determines how instances of `A` will be sorted.
    *
    * Returns `x` where:
    *
@@ -73,19 +73,19 @@ trait Ordered[A] extends Any with java.lang.Comparable[A] {
    */
   def compare(that: A): Int
 
-  /** Returns true if `this` is less than `that`
+  /** Returns `true` if `this` is less than `that`
     */
   def <  (that: A): Boolean = (this compare that) <  0
 
-  /** Returns true if `this` is greater than `that`.
+  /** Returns `true` if `this` is greater than `that`.
     */
   def >  (that: A): Boolean = (this compare that) >  0
 
-  /** Returns true if `this` is less than or equal to `that`.
+  /** Returns `true` if `this` is less than or equal to `that`.
     */
   def <= (that: A): Boolean = (this compare that) <= 0
 
-  /** Returns true if `this` is greater than or equal to `that`.
+  /** Returns `true` if `this` is greater than or equal to `that`.
     */
   def >= (that: A): Boolean = (this compare that) >= 0
 

--- a/src/library/scala/math/Ordering.scala
+++ b/src/library/scala/math/Ordering.scala
@@ -88,28 +88,28 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
    */
   def compare(x: T, y: T): Int
 
-  /** Return true if `x` <= `y` in the ordering. */
+  /** Returns `true` if `x` <= `y` in the ordering. */
   override def lteq(x: T, y: T): Boolean = compare(x, y) <= 0
 
-  /** Return true if `x` >= `y` in the ordering. */
+  /** Returns `true` if `x` >= `y` in the ordering. */
   override def gteq(x: T, y: T): Boolean = compare(x, y) >= 0
 
-  /** Return true if `x` < `y` in the ordering. */
+  /** Returns `true` if `x` < `y` in the ordering. */
   override def lt(x: T, y: T): Boolean = compare(x, y) < 0
 
-  /** Return true if `x` > `y` in the ordering. */
+  /** Returns `true` if `x` > `y` in the ordering. */
   override def gt(x: T, y: T): Boolean = compare(x, y) > 0
 
-  /** Return true if `x` == `y` in the ordering. */
+  /** Returns `true` if `x` == `y` in the ordering. */
   override def equiv(x: T, y: T): Boolean = compare(x, y) == 0
 
-  /** Return `x` if `x` >= `y`, otherwise `y`. */
+  /** Returns `x` if `x` >= `y`, otherwise `y`. */
   @uncheckedOverride def max[U <: T](x: U, y: U): U = if (gteq(x, y)) x else y
 
-  /** Return `x` if `x` <= `y`, otherwise `y`. */
+  /** Returns `x` if `x` <= `y`, otherwise `y`. */
   @uncheckedOverride def min[U <: T](x: U, y: U): U = if (lteq(x, y)) x else y
 
-  /** Return the opposite ordering of this one.
+  /** Returns the opposite ordering of this one.
     *
     * Implementations overriding this method MUST override [[isReverseOf]]
     * as well if they change the behavior at all (for example, caching does

--- a/src/library/scala/math/PartialOrdering.scala
+++ b/src/library/scala/math/PartialOrdering.scala
@@ -50,25 +50,25 @@ trait PartialOrdering[T] extends Equiv[T] {
    */
   def tryCompare(x: T, y: T): Option[Int]
 
-  /** Returns `'''true'''` iff `x` comes before `y` in the ordering.
+  /** Returns `true` iff `x` comes before `y` in the ordering.
    */
   def lteq(x: T, y: T): Boolean
 
-  /** Returns `'''true'''` iff `y` comes before `x` in the ordering.
+  /** Returns `true` iff `y` comes before `x` in the ordering.
    */
   def gteq(x: T, y: T): Boolean = lteq(y, x)
 
-  /** Returns `'''true'''` iff `x` comes before `y` in the ordering
+  /** Returns `true` iff `x` comes before `y` in the ordering
    *  and is not the same as `y`.
    */
   def lt(x: T, y: T): Boolean = lteq(x, y) && !equiv(x, y)
 
-  /** Returns `'''true'''` iff `y` comes before `x` in the ordering
+  /** Returns `true` iff `y` comes before `x` in the ordering
    *  and is not the same as `x`.
    */
   def gt(x: T, y: T): Boolean = gteq(x, y) && !equiv(x, y)
 
-  /** Returns `'''true'''` iff `x` is equivalent to `y` in the ordering.
+  /** Returns `true` iff `x` is equivalent to `y` in the ordering.
    */
   def equiv(x: T, y: T): Boolean = lteq(x,y) && lteq(y,x)
 

--- a/src/library/scala/ref/Reference.scala
+++ b/src/library/scala/ref/Reference.scala
@@ -16,9 +16,9 @@ package scala.ref
  * @see `java.lang.ref.Reference`
  */
 trait Reference[+T <: AnyRef] extends Function0[T] {
-  /** return the underlying value */
+  /** Returns the underlying value */
   def apply(): T
-  /** return `Some` underlying if it hasn't been collected, otherwise `None` */
+  /** Returns `Some` underlying if it hasn't been collected, otherwise `None` */
   def get: Option[T]
   override def toString: String = get.map(_.toString).getOrElse("<deleted>")
   def clear(): Unit

--- a/src/library/scala/ref/SoftReference.scala
+++ b/src/library/scala/ref/SoftReference.scala
@@ -24,10 +24,10 @@ class SoftReference[+T <: AnyRef](value : T, queue : ReferenceQueue[T]) extends 
  */
 object SoftReference {
 
-  /** Creates a `SoftReference` pointing to `value` */
+  /** Returns a `SoftReference` pointing to `value` */
   def apply[T <: AnyRef](value: T): SoftReference[T] = new SoftReference(value)
 
-  /** Optionally returns the referenced value, or `None` if that value no longer exists */
+  /** Returns the referenced value, or `None` if that value no longer exists */
   def unapply[T <: AnyRef](sr: SoftReference[T]): Option[T] = Option(sr.underlying.get)
 }
 

--- a/src/library/scala/ref/WeakReference.scala
+++ b/src/library/scala/ref/WeakReference.scala
@@ -13,8 +13,8 @@
 package scala.ref
 
 /**
- *  A wrapper class for java.lang.ref.WeakReference
- *  The new functionality is (1) results are Option values, instead of using null.
+ *  A wrapper class for `java.lang.ref.WeakReference`
+ *  The new functionality is (1) results are `Option` values, instead of using `null`.
  *  (2) There is an extractor that maps the weak reference itself into an option.
  */
 class WeakReference[+T <: AnyRef](value: T, queue: ReferenceQueue[T]) extends ReferenceWrapper[T] {
@@ -26,10 +26,10 @@ class WeakReference[+T <: AnyRef](value: T, queue: ReferenceQueue[T]) extends Re
 /** An extractor for weak reference values */
 object WeakReference {
 
-  /** Creates a weak reference pointing to `value` */
+  /** Returns a weak reference pointing to `value` */
   def apply[T <: AnyRef](value: T): WeakReference[T] = new WeakReference(value)
 
-  /** Optionally returns the referenced value, or `None` if that value no longer exists */
+  /** Returns the referenced value, or `None` if that value no longer exists */
   def unapply[T <: AnyRef](wr: WeakReference[T]): Option[T] = Option(wr.underlying.get)
 }
 

--- a/src/library/scala/reflect/ClassManifestDeprecatedApis.scala
+++ b/src/library/scala/reflect/ClassManifestDeprecatedApis.scala
@@ -184,22 +184,22 @@ object ClassManifestFactory {
 
   def singleType[T <: AnyRef](value: AnyRef): Manifest[T] = Manifest.singleType(value)
 
-  /** ClassManifest for the class type `clazz`, where `clazz` is
+  /** `ClassManifest` for the class type `clazz`, where `clazz` is
     * a top-level or static class.
     * @note This no-prefix, no-arguments case is separate because we
-    *       it's called from ScalaRunTime.boxArray itself. If we
+    *       it's called from `ScalaRunTime.boxArray` itself. If we
     *       pass varargs as arrays into this, we get an infinitely recursive call
-    *       to boxArray. (Besides, having a separate case is more efficient)
+    *       to `boxArray`. (Besides, having a separate case is more efficient)
     */
   def classType[T](clazz: jClass[_]): ClassManifest[T] =
     new ClassTypeManifest[T](None, clazz, Nil)
 
-  /** ClassManifest for the class type `clazz[args]`, where `clazz` is
-    * a top-level or static class and `args` are its type arguments */
+  /** `ClassManifest` for the class type `clazz[args]`, where `clazz` is
+    * a top-level or static class and `args` are its type arguments. */
   def classType[T](clazz: jClass[_], arg1: OptManifest[_], args: OptManifest[_]*): ClassManifest[T] =
     new ClassTypeManifest[T](None, clazz, arg1 :: args.toList)
 
-  /** ClassManifest for the class type `clazz[args]`, where `clazz` is
+  /** `ClassManifest` for the class type `clazz[args]`, where `clazz` is
     * a class with non-package prefix type `prefix` and type arguments `args`.
     */
   def classType[T](prefix: OptManifest[_], clazz: jClass[_], args: OptManifest[_]*): ClassManifest[T] =
@@ -217,13 +217,13 @@ object ClassManifestFactory {
     override def toString = prefix.toString+"#"+name+argString
   }
 
-  /** ClassManifest for the abstract type `prefix # name`. `upperBound` is not
+  /** `ClassManifest` for the abstract type `prefix # name`. `upperBound` is not
     * strictly necessary as it could be obtained by reflection. It was
     * added so that erasure can be calculated without reflection. */
   def abstractType[T](prefix: OptManifest[_], name: String, clazz: jClass[_], args: OptManifest[_]*): ClassManifest[T] =
     new AbstractTypeClassManifest(prefix, name, clazz)
 
-  /** ClassManifest for the abstract type `prefix # name`. `upperBound` is not
+  /** `ClassManifest` for the abstract type `prefix # name`. `upperBound` is not
     * strictly necessary as it could be obtained by reflection. It was
     * added so that erasure can be calculated without reflection.
     * todo: remove after next bootstrap
@@ -232,8 +232,8 @@ object ClassManifestFactory {
     new AbstractTypeClassManifest(prefix, name, upperbound.runtimeClass)
 }
 
-/** Manifest for the class type `clazz[args]`, where `clazz` is
-  * a top-level or static class */
+/** `Manifest` for the class type `clazz[args]`, where `clazz` is
+  * a top-level or static class. */
 @nowarn("""cat=deprecation&origin=scala\.reflect\.ClassManifest""")
 @SerialVersionUID(1L)
 private class ClassTypeManifest[T](

--- a/src/library/scala/reflect/ClassTag.scala
+++ b/src/library/scala/reflect/ClassTag.scala
@@ -61,11 +61,11 @@ trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serial
   /** Produces a `ClassTag` that knows how to instantiate an `Array[Array[T]]` */
   def wrap: ClassTag[Array[T]] = ClassTag[Array[T]](arrayClass(runtimeClass))
 
-  /** Produces a new array with element type `T` and length `len` */
+  /** Produces a new array with element type `T` and length `len`. */
   def newArray(len: Int): Array[T] =
     java.lang.reflect.Array.newInstance(runtimeClass, len).asInstanceOf[Array[T]]
 
-  /** A ClassTag[T] can serve as an extractor that matches only objects of type T.
+  /** A `ClassTag[T]` can serve as an extractor that matches only objects of type `T`.
    *
    * The compiler tries to turn unchecked type tests in pattern matches into checked ones
    * by wrapping a `(_: T)` type pattern as `ct(_: T)`, where `ct` is the `ClassTag[T]` instance.
@@ -90,7 +90,7 @@ trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serial
 }
 
 /**
- * Class tags corresponding to primitive types and constructor/extractor for ClassTags.
+ * `ClassTag`s corresponding to primitive types and constructor/extractor for `ClassTag`s.
  */
 object ClassTag {
   private[this] val ObjectTYPE = classOf[java.lang.Object]

--- a/src/library/scala/reflect/Manifest.scala
+++ b/src/library/scala/reflect/Manifest.scala
@@ -58,7 +58,7 @@ trait Manifest[T] extends ClassManifest[T] with Equals {
     case _                => false
   }
   /** Note: testing for erasure here is important, as it is many times
-   *  faster than <:< and rules out most comparisons.
+   *  faster than `<:<` and rules out most comparisons.
    */
   override def equals(that: Any): Boolean = that match {
     case m: Manifest[_] => (m canEqual this) && (this.runtimeClass == m.runtimeClass) && (this <:< m) && (m <:< this)
@@ -99,26 +99,26 @@ object Manifest {
   val Null: Manifest[scala.Null] = ManifestFactory.Null
   val Nothing: Manifest[scala.Nothing] = ManifestFactory.Nothing
 
-  /** Manifest for the singleton type `value.type`. */
+  /** `Manifest` for the singleton type `value.type`. */
   def singleType[T <: AnyRef](value: AnyRef): Manifest[T] =
     ManifestFactory.singleType[T](value)
 
-  /** Manifest for the class type `clazz[args]`, where `clazz` is
+  /** `Manifest` for the class type `clazz[args]`, where `clazz` is
     * a top-level or static class.
     * @note This no-prefix, no-arguments case is separate because we
-    *       it's called from ScalaRunTime.boxArray itself. If we
+    *       it's called from `ScalaRunTime.boxArray` itself. If we
     *       pass varargs as arrays into this, we get an infinitely recursive call
-    *       to boxArray. (Besides, having a separate case is more efficient)
+    *       to `boxArray`. (Besides, having a separate case is more efficient)
     */
   def classType[T](clazz: Predef.Class[_]): Manifest[T] =
     ManifestFactory.classType[T](clazz)
 
-  /** Manifest for the class type `clazz`, where `clazz` is
+  /** `Manifest` for the class type `clazz`, where `clazz` is
     * a top-level or static class and args are its type arguments. */
   def classType[T](clazz: Predef.Class[T], arg1: Manifest[_], args: Manifest[_]*): Manifest[T] =
     ManifestFactory.classType[T](clazz, arg1, args: _*)
 
-  /** Manifest for the class type `clazz[args]`, where `clazz` is
+  /** `Manifest` for the class type `clazz[args]`, where `clazz` is
     * a class with non-package prefix type `prefix` and type arguments `args`.
     */
   def classType[T](prefix: Manifest[_], clazz: Predef.Class[_], args: Manifest[_]*): Manifest[T] =
@@ -127,17 +127,17 @@ object Manifest {
   def arrayType[T](arg: Manifest[_]): Manifest[Array[T]] =
     ManifestFactory.arrayType[T](arg)
 
-  /** Manifest for the abstract type `prefix # name`. `upperBound` is not
+  /** `Manifest` for the abstract type `prefix # name`. `upperBound` is not
     * strictly necessary as it could be obtained by reflection. It was
     * added so that erasure can be calculated without reflection. */
   def abstractType[T](prefix: Manifest[_], name: String, upperBound: Predef.Class[_], args: Manifest[_]*): Manifest[T] =
     ManifestFactory.abstractType[T](prefix, name, upperBound, args: _*)
 
-  /** Manifest for the unknown type `_ >: L <: U` in an existential. */
+  /** `Manifest` for the unknown type `_ >: L <: U` in an existential. */
   def wildcardType[T](lowerBound: Manifest[_], upperBound: Manifest[_]): Manifest[T] =
     ManifestFactory.wildcardType[T](lowerBound, upperBound)
 
-  /** Manifest for the intersection type `parents_0 with ... with parents_n`. */
+  /** `Manifest` for the intersection type `parents_0 with ... with parents_n`. */
   def intersectionType[T](parents: Manifest[_]*): Manifest[T] =
     ManifestFactory.intersectionType[T](parents: _*)
 
@@ -372,26 +372,26 @@ object ManifestFactory {
     override lazy val toString = value.toString + ".type"
   }
 
-  /** Manifest for the singleton type `value.type`. */
+  /** `Manifest` for the singleton type `value.type`. */
   def singleType[T <: AnyRef](value: AnyRef): Manifest[T] =
     new SingletonTypeManifest[T](value)
 
-  /** Manifest for the class type `clazz[args]`, where `clazz` is
+  /** `Manifest` for the class type `clazz[args]`, where `clazz` is
     * a top-level or static class.
     * @note This no-prefix, no-arguments case is separate because we
-    *       it's called from ScalaRunTime.boxArray itself. If we
+    *       it's called from `ScalaRunTime.boxArray` itself. If we
     *       pass varargs as arrays into this, we get an infinitely recursive call
-    *       to boxArray. (Besides, having a separate case is more efficient)
+    *       to `boxArray`. (Besides, having a separate case is more efficient)
     */
   def classType[T](clazz: Predef.Class[_]): Manifest[T] =
     new ClassTypeManifest[T](None, clazz, Nil)
 
-  /** Manifest for the class type `clazz`, where `clazz` is
+  /** `Manifest` for the class type `clazz`, where `clazz` is
     * a top-level or static class and args are its type arguments. */
   def classType[T](clazz: Predef.Class[T], arg1: Manifest[_], args: Manifest[_]*): Manifest[T] =
     new ClassTypeManifest[T](None, clazz, arg1 :: args.toList)
 
-  /** Manifest for the class type `clazz[args]`, where `clazz` is
+  /** `Manifest` for the class type `clazz[args]`, where `clazz` is
     * a class with non-package prefix type `prefix` and type arguments `args`.
     */
   def classType[T](prefix: Manifest[_], clazz: Predef.Class[_], args: Manifest[_]*): Manifest[T] =
@@ -405,7 +405,7 @@ object ManifestFactory {
     override val hashCode = System.identityHashCode(this)
   }
 
-  /** Manifest for the class type `clazz[args]`, where `clazz` is
+  /** `Manifest` for the class type `clazz[args]`, where `clazz` is
     * a top-level or static class. */
   @SerialVersionUID(1L)
   private class ClassTypeManifest[T](prefix: Option[Manifest[_]],
@@ -427,7 +427,7 @@ object ManifestFactory {
     override def toString = prefix.toString+"#"+name+argString
   }
 
-  /** Manifest for the abstract type `prefix # name`. `upperBound` is not
+  /** `Manifest` for the abstract type `prefix # name`. `upperBound` is not
     * strictly necessary as it could be obtained by reflection. It was
     * added so that erasure can be calculated without reflection. */
   def abstractType[T](prefix: Manifest[_], name: String, upperBound: Predef.Class[_], args: Manifest[_]*): Manifest[T] =
@@ -442,7 +442,7 @@ object ManifestFactory {
         (if (upperBound eq Nothing) "" else " <: "+upperBound)
   }
 
-  /** Manifest for the unknown type `_ >: L <: U` in an existential.
+  /** `Manifest` for the unknown type `_ >: L <: U` in an existential.
     */
   def wildcardType[T](lowerBound: Manifest[_], upperBound: Manifest[_]): Manifest[T] =
     new WildcardManifest[T](lowerBound, upperBound)
@@ -455,7 +455,7 @@ object ManifestFactory {
     override def toString = parents.mkString(" with ")
   }
 
-  /** Manifest for the intersection type `parents_0 with ... with parents_n`. */
+  /** `Manifest` for the intersection type `parents_0 with ... with parents_n`. */
   def intersectionType[T](parents: Manifest[_]*): Manifest[T] =
     new IntersectionTypeManifest[T](parents.toArray)
 }

--- a/src/library/scala/reflect/NameTransformer.scala
+++ b/src/library/scala/reflect/NameTransformer.scala
@@ -61,7 +61,7 @@ object NameTransformer {
   enterOp('?', "$qmark")
   enterOp('@', "$at")
 
-  /** Replace operator symbols by corresponding `\$opname`.
+  /** Replaces operator symbols by corresponding `\$opname`.
    *
    *  @param name the string to encode
    *  @return     the string with all recognized opchars replaced with their encoding
@@ -95,7 +95,7 @@ object NameTransformer {
     if (buf eq null) name else buf.toString()
   }
 
-  /** Replace `\$opname` by corresponding operator symbol.
+  /** Replaces `\$opname` by corresponding operator symbol.
    *
    *  @param name0 the string to decode
    *  @return      the string with all recognized operator symbol encodings replaced with their name

--- a/src/library/scala/reflect/package.scala
+++ b/src/library/scala/reflect/package.scala
@@ -50,7 +50,7 @@ package object reflect {
 
   def classTag[T](implicit ctag: ClassTag[T]) = ctag
 
-  /** Make a java reflection object accessible, if it is not already
+  /** Makes a java reflection object accessible, if it is not already
    *  and it is possible to do so. If a SecurityException is thrown in the
    *  attempt, it is caught and discarded.
    */

--- a/src/library/scala/runtime/LambdaDeserializer.scala
+++ b/src/library/scala/runtime/LambdaDeserializer.scala
@@ -22,7 +22,7 @@ import java.lang.invoke._
  */
 object LambdaDeserializer {
   /**
-   * Deserialize a lambda by calling `LambdaMetafactory.altMetafactory` to spin up a lambda class
+   * Deserializes a lambda by calling `LambdaMetafactory.altMetafactory` to spin up a lambda class
    * and instantiating this class with the captured arguments.
    *
    * A cache may be provided to ensure that subsequent deserialization of the same lambda expression

--- a/src/library/scala/runtime/MethodCache.scala
+++ b/src/library/scala/runtime/MethodCache.scala
@@ -29,7 +29,7 @@ import scala.annotation.tailrec
 private[scala] sealed abstract class MethodCache {
   /** Searches for a cached method in the `MethodCache` chain that
    *  is compatible with receiver class `forReceiver`. If none is cached,
-   *  `null` is returned. If `null` is returned, find's caller should look-
+   *  `null` is returned. If `null` is returned, `find`'s caller should look-
    *  up the right method using whichever means it prefers, and add it to
    *  the cache for later use. */
   def find(forReceiver: JClass[_]): JMethod
@@ -65,7 +65,7 @@ private[scala] final class PolyMethodCache(
 ) extends MethodCache {
 
   /** To achieve tail recursion this must be a separate method
-   *  from `find`, because the type of next is not `PolyMethodCache`.
+   *  from `find`, because the type of `next` is not `PolyMethodCache`.
    */
   @tailrec private def findInternal(forReceiver: JClass[_]): JMethod =
     if (forReceiver eq receiver) method

--- a/src/library/scala/runtime/Nothing$.scala
+++ b/src/library/scala/runtime/Nothing$.scala
@@ -15,7 +15,7 @@ package runtime
 
 
 /**
- * Dummy class which exist only to satisfy the JVM. It corresponds
+ * Dummy class which exists only to satisfy the JVM. It corresponds
  * to `scala.Nothing`. If such type appears in method
  * signatures, it is erased to this one.
  */

--- a/src/library/scala/runtime/Null$.scala
+++ b/src/library/scala/runtime/Null$.scala
@@ -14,9 +14,9 @@ package scala
 package runtime
 
 /**
- * Dummy class which exist only to satisfy the JVM. It corresponds to
+ * Dummy class which exists only to satisfy the JVM. It corresponds to
  * `scala.Null`. If such type appears in method signatures, it is erased
  * to this one. A private constructor ensures that Java code can't create
- * subclasses. The only value of type Null$ should be null
+ * subclasses. The only value of type `Null$` should be `null`
  */
 sealed abstract class Null$ private ()

--- a/src/library/scala/runtime/RichDouble.scala
+++ b/src/library/scala/runtime/RichDouble.scala
@@ -58,13 +58,13 @@ final class RichDouble(val self: Double) extends AnyVal with FractionalProxy[Dou
   /** Converts an angle measured in degrees to an approximately equivalent
    *  angle measured in radians.
    *
-   *  @return the measurement of the angle x in radians.
+   *  @return the measurement of the angle `x` in radians.
    */
   def toRadians: Double = math.toRadians(self)
 
   /** Converts an angle measured in radians to an approximately equivalent
    *  angle measured in degrees.
-   *  @return the measurement of the angle x in degrees.
+   *  @return the measurement of the angle `x` in degrees.
    */
   def toDegrees: Double = math.toDegrees(self)
 }

--- a/src/library/scala/runtime/ScalaRunTime.scala
+++ b/src/library/scala/runtime/ScalaRunTime.scala
@@ -22,7 +22,7 @@ import scala.reflect.{ClassTag, classTag}
 import java.lang.{Class => jClass}
 import java.lang.reflect.{Method => JMethod}
 
-/** The object ScalaRunTime provides support methods required by
+/** The object `ScalaRunTime` provides support methods required by
  *  the scala runtime.  All these methods should be considered
  *  outside the API and subject to change or removal without notice.
  */
@@ -37,7 +37,7 @@ object ScalaRunTime {
   def drop[Repr](coll: Repr, num: Int)(implicit iterable: IsIterable[Repr] { type C <: Repr }): Repr =
     iterable(coll) drop num
 
-  /** Return the class object representing an array with element class `clazz`.
+  /** Returns the class object representing an array with element class `clazz`.
    */
   def arrayClass(clazz: jClass[_]): jClass[_] = {
     // newInstance throws an exception if the erasure is Void.TYPE. see scala/bug#5680
@@ -45,14 +45,14 @@ object ScalaRunTime {
     else java.lang.reflect.Array.newInstance(clazz, 0).getClass
   }
 
-  /** Return the class object representing an unboxed value type,
+  /** Returns the class object representing an unboxed value type,
    *  e.g., classOf[int], not classOf[java.lang.Integer].  The compiler
    *  rewrites expressions like 5.getClass to come here.
    */
   def anyValClass[T <: AnyVal : ClassTag](value: T): jClass[T] =
     classTag[T].runtimeClass.asInstanceOf[jClass[T]]
 
-  /** Retrieve generic array element */
+  /** Retrieves generic array element */
   def array_apply(xs: AnyRef, idx: Int): Any = {
     (xs: @unchecked) match {
       case x: Array[AnyRef]  => x(idx).asInstanceOf[Any]
@@ -84,7 +84,7 @@ object ScalaRunTime {
     }
   }
 
-  /** Get generic array length */
+  /** Gets generic array length */
   @inline def array_length(xs: AnyRef): Int = java.lang.reflect.Array.getLength(xs)
 
   // TODO: bytecode Object.clone() will in fact work here and avoids
@@ -102,7 +102,7 @@ object ScalaRunTime {
     case null => throw new NullPointerException
   }
 
-  /** Convert an array to an object array.
+  /** Converts an array to an object array.
    *  Needed to deal with vararg arguments of primitive types that are passed
    *  to a generic Java vararg parameter T ...
    */
@@ -177,17 +177,17 @@ object ScalaRunTime {
     }
   }
 
-  /** Given any Scala value, convert it to a String.
+  /** Given any Scala value, converts it to a `String`.
    *
    * The primary motivation for this method is to provide a means for
-   * correctly obtaining a String representation of a value, while
-   * avoiding the pitfalls of naively calling toString on said value.
-   * In particular, it addresses the fact that (a) toString cannot be
-   * called on null and (b) depending on the apparent type of an
-   * array, toString may or may not print it in a human-readable form.
+   * correctly obtaining a `String` representation of a value, while
+   * avoiding the pitfalls of naively calling `toString` on said value.
+   * In particular, it addresses the fact that (a) `toString` cannot be
+   * called on `null` and (b) depending on the apparent type of an
+   * array, `toString` may or may not print it in a human-readable form.
    *
    * @param   arg   the value to stringify
-   * @return        a string representation of arg.
+   * @return        a string representation of `arg`.
    */
   def stringOf(arg: Any): String = stringOf(arg, scala.Int.MaxValue)
   def stringOf(arg: Any, maxElements: Int): String = {
@@ -272,7 +272,7 @@ object ScalaRunTime {
     }
   }
 
-  /** stringOf formatted for use in a repl result. */
+  /** `stringOf` formatted for use in a repl result. */
   def replStringOf(arg: Any, maxElements: Int): String =
     stringOf(arg, maxElements) match {
       case null => "null toString"

--- a/src/library/scala/runtime/Tuple2Zipped.scala
+++ b/src/library/scala/runtime/Tuple2Zipped.scala
@@ -19,7 +19,7 @@ import scala.language.implicitConversions
 
 /** This interface is intended as a minimal interface, not complicated
  *  by the requirement to resolve type constructors, for implicit search (which only
- *  needs to find an implicit conversion to Iterable for our purposes.)
+ *  needs to find an implicit conversion to `Iterable` for our purposes.)
  *  @define Coll `ZippedIterable2`
  *  @define coll collection
  *  @define collectExample

--- a/src/library/scala/runtime/Tuple3Zipped.scala
+++ b/src/library/scala/runtime/Tuple3Zipped.scala
@@ -17,7 +17,7 @@ package runtime
 import scala.collection.{BuildFrom, IterableOps}
 import scala.language.implicitConversions
 
-/** See comment on ZippedIterable2
+/** See comment on `ZippedIterable2`
  *  @define Coll `ZippedIterable3`
  *  @define coll collection
  *  @define collectExample

--- a/src/library/scala/sys/BooleanProp.scala
+++ b/src/library/scala/sys/BooleanProp.scala
@@ -18,17 +18,17 @@ import scala.language.implicitConversions
 /** A few additional conveniences for Boolean properties.
  */
 trait BooleanProp extends Prop[Boolean] {
-  /** The semantics of value are determined at Prop creation.  See methods
-   *  `valueIsTrue` and `keyExists` in object BooleanProp for examples.
+  /** The semantics of `value` are determined at `Prop` creation.  See methods
+   *  `valueIsTrue` and `keyExists` in object `BooleanProp` for examples.
    *
-   *  @return   true if the current String is considered true, false otherwise
+   *  @return   `true` if the current `String` is considered `true`, `false` otherwise
    */
   def value: Boolean
 
-  /** Alter this property so that `value` will be true. */
+  /** Alter this property so that `value` will be `true`. */
   def enable(): Unit
 
-  /** Alter this property so that `value` will be false. */
+  /** Alter this property so that `value` will be `false`. */
   def disable(): Unit
 
   /** Toggle the property between enabled and disabled states. */
@@ -64,23 +64,23 @@ object BooleanProp {
   }
 
   /** The java definition of property truth is that the key be in the map and
-   *  the value be equal to the String "true", case insensitively.  This method
-   *  creates a BooleanProp instance which adheres to that definition.
+   *  the value be equal to the `String` "true", case insensitively.  This method
+   *  creates a `BooleanProp` instance which adheres to that definition.
    *
-   *  @return   A BooleanProp which acts like java's Boolean.getBoolean
+   *  @return   A `BooleanProp` which acts like java's `Boolean.getBoolean`
    */
   def valueIsTrue[T](key: String): BooleanProp = new BooleanPropImpl(key, _.toLowerCase == "true")
 
-  /** As an alternative, this method creates a BooleanProp which is true
+  /** As an alternative, this method creates a `BooleanProp` which is `true`
    *  if the key exists in the map and is not assigned a value other than "true",
-   *  compared case-insensitively, or the empty string.  This way -Dmy.property
-   *  results in a true-valued property, but -Dmy.property=false does not.
+   *  compared case-insensitively, or the empty string.  This way `-Dmy.property`
+   *  results in a `true`-valued property, but `-Dmy.property=false` does not.
    *
-   *  @return   A BooleanProp with a liberal truth policy
+   *  @return   A `BooleanProp` with a liberal truth policy
    */
   def keyExists[T](key: String): BooleanProp = new BooleanPropImpl(key, s => s == "" || s.equalsIgnoreCase("true"))
 
-  /** A constant true or false property which ignores all method calls.
+  /** A constant `true` or `false` property which ignores all method calls.
    */
   def constant(key: String, isOn: Boolean): BooleanProp = new ConstantImpl(key, isOn)
 

--- a/src/library/scala/sys/Prop.scala
+++ b/src/library/scala/sys/Prop.scala
@@ -25,14 +25,14 @@ trait Prop[+T] {
   def key: String
 
   /** If the key exists in the properties map, converts the value
-   *  to type `T` using valueFn.  As yet no validation is performed:
+   *  to type `T` using `valueFn`.  As yet no validation is performed:
    *  it will throw an exception on a failed conversion.
    *  @return   the converted value, or `zero` if not in the map
    */
   def value: T
 
-  /** True if the key exists in the properties map.  Note that this
-   *  is not sufficient for a Boolean property to be considered true.
+  /** Returns `true` if the key exists in the properties map.  Note that this
+   *  is not sufficient for a `Boolean` property to be considered `true`.
    *  @return   whether the map contains the key
    */
   def isSet: Boolean
@@ -40,7 +40,7 @@ trait Prop[+T] {
   /** Sets the property.
    *
    *  @param    newValue  the new string value
-   *  @return   the old value, or null if it was unset.
+   *  @return   the old value, or `null` if it was unset.
    */
   def set(newValue: String): String
 
@@ -48,13 +48,13 @@ trait Prop[+T] {
    */
   def setValue[T1 >: T](value: T1): T
 
-  /** Gets the current string value if any.  Will not return null: use
+  /** Returns the current string value if any.  Will not return `null`: use
    *  `isSet` to test for existence.
    *  @return   the current string value if any, else the empty string
    */
   def get: String
 
-  /** Some(value) if the property is set, None otherwise.
+  /** `Some(value)` if the property is set, `None` otherwise.
    */
   def option: Option[T]
 
@@ -67,20 +67,20 @@ trait Prop[+T] {
   def clear(): Unit
 
   /** A value of type `T` for use when the property is unset.
-   *  The default implementation delivers null for reference types
-   *  and 0/0.0/false for non-reference types.
+   *  The default implementation delivers `null` for reference types
+   *  and 0/0.0/`false` for non-reference types.
    */
   protected def zero: T
 }
 
 object Prop {
   /** A creator of property instances.  For any type `T`, if an implicit
-   *  parameter of type Creator[T] is in scope, a Prop[T] can be created
-   *  via this object's apply method.
+   *  parameter of type `Creator[T]` is in scope, a `Prop[T]` can be created
+   *  via this object's `apply` method.
    */
   @annotation.implicitNotFound("No implicit property creator available for type ${T}.")
   trait Creator[+T] {
-    /** Creates a Prop[T] of this type based on the given key. */
+    /** Returns a `Prop[T]` of this type based on the given key. */
     def apply(key: String): Prop[T]
   }
 

--- a/src/library/scala/sys/PropImpl.scala
+++ b/src/library/scala/sys/PropImpl.scala
@@ -39,7 +39,7 @@ private[sys] class PropImpl[+T](val key: String, valueFn: String => T) extends P
   def option: Option[T] = if (isSet) Some(value) else None
   def or[T1 >: T](alt: => T1): T1 = if (isSet) value else alt
 
-  /** The underlying property map, in our case always sys.props */
+  /** The underlying property map, in our case always `sys.props` */
   protected def underlying: mutable.Map[String, String] = scala.sys.props
   protected def zero: T = null.asInstanceOf[T]
   private def getString = if (isSet) "currently: " + get else "unset"

--- a/src/library/scala/sys/ShutdownHookThread.scala
+++ b/src/library/scala/sys/ShutdownHookThread.scala
@@ -13,7 +13,7 @@
 package scala
 package sys
 
-/** A minimal Thread wrapper to enhance shutdown hooks.  It knows
+/** A minimal `Thread` wrapper to enhance shutdown hooks.  It knows
  *  how to unregister itself.
  */
 class ShutdownHookThread private (runnable: Runnable, name: String) extends Thread(runnable, name) {

--- a/src/library/scala/sys/SystemProperties.scala
+++ b/src/library/scala/sys/SystemProperties.scala
@@ -22,7 +22,7 @@ import scala.language.implicitConversions
  *  Changes to System properties will be immediately visible in the map,
  *  and modifications made to the map will be immediately applied to the
  *  System properties.  If a security manager is in place which prevents
- *  the properties from being read or written, the AccessControlException
+ *  the properties from being read or written, the `AccessControlException`
  *  will be caught and discarded.
  *  @define Coll `collection.mutable.Map`
  *  @define coll mutable map

--- a/src/library/scala/sys/package.scala
+++ b/src/library/scala/sys/package.scala
@@ -20,36 +20,36 @@ import scala.jdk.CollectionConverters._
  *  world outside of it.
  */
 package object sys {
-  /** Throw a new RuntimeException with the supplied message.
+  /** Throws a new `RuntimeException` with the supplied message.
    *
-   *  @return   Nothing.
+   *  @return   `Nothing`.
    */
   def error(message: String): Nothing = throw new RuntimeException(message)
 
-  /** Exit the JVM with the default status code.
+  /** Exits the JVM with the default status code.
    *
-   *  @return   Nothing.
+   *  @return   `Nothing`.
    */
   def exit(): Nothing = exit(0)
 
-  /** Exit the JVM with the given status code.
+  /** Exits the JVM with the given status code.
    *
-   *  @return   Nothing.
+   *  @return   `Nothing`.
    */
   def exit(status: Int): Nothing = {
     java.lang.System.exit(status)
     throw new Throwable()
   }
 
-  /** A convenience method to get the current Runtime instance.
+  /** A convenience method to get the current `Runtime` instance.
    *
    *  @return   the result of `java.lang.Runtime.getRuntime()`
    */
   def runtime: Runtime = Runtime.getRuntime
 
-  /** A bidirectional, mutable Map representing the current system Properties.
+  /** A bidirectional, mutable `Map` representing the current system properties.
    *
-   *  @return   a SystemProperties.
+   *  @return   a `SystemProperties`.
    *  @see      [[scala.sys.SystemProperties]]
    */
   def props: SystemProperties = new SystemProperties
@@ -57,12 +57,12 @@ package object sys {
   // TODO: consider whether layering a Map on top of Java's properties is really needed -- we could simply provide:
   //  def prop(p: String) = Option(System.getProperty(p))
 
-  /** An immutable Map representing the current system environment.
+  /** An immutable `Map` representing the current system environment.
    *
    *  If lookup fails, use `System.getenv(_)` for case-insensitive lookup
    *  on a certain platform. If that also fails, throw `NoSuchElementException`.
    *
-   *  @return   a Map containing the system environment variables.
+   *  @return   a `Map` containing the system environment variables.
    */
   def env: Map[String, String] = Map.from(System.getenv().asScala).withDefault { v =>
     val s = System.getenv(v)
@@ -70,22 +70,22 @@ package object sys {
     s
   }
 
-  /** Register a shutdown hook to be run when the VM exits.
+  /** Registers a shutdown hook to be run when the VM exits.
    *  The hook is automatically registered: the returned value can be ignored,
-   *  but is available in case the Thread requires further modification.
-   *  It can also be unregistered by calling ShutdownHookThread#remove().
+   *  but is available in case the `Thread` requires further modification.
+   *  It can also be unregistered by calling `ShutdownHookThread#remove()`.
    *
    *  Note that shutdown hooks are NOT guaranteed to be run.
    *
    *  @param    body  the body of code to run at shutdown
-   *  @return   the   Thread which will run the shutdown hook.
+   *  @return   the   `Thread` which will run the shutdown hook.
    *  @see      [[scala.sys.ShutdownHookThread]]
    */
   def addShutdownHook(body: => Unit): ShutdownHookThread = ShutdownHookThread(body)
 
-  /** Returns all active thread in the current thread's thread group and subgroups.
+  /** Returns all active threads in the current thread's thread group and subgroups.
    *
-   *  @return   an IndexedSeq containing the threads.
+   *  @return   an `IndexedSeq` containing the threads.
    */
   def allThreads(): IndexedSeq[Thread] = {
     val num    = Thread.activeCount()

--- a/src/library/scala/sys/process/BasicIO.scala
+++ b/src/library/scala/sys/process/BasicIO.scala
@@ -35,7 +35,7 @@ object BasicIO {
   /** Size of the buffer used in all the functions that copy data */
   final val BufferSize = 8192
 
-  /** Used to separate lines in the `processFully` function that takes `Appendable`. */
+  /** Used to separate lines in the `processFully` function that takes an `Appendable`. */
   final val Newline    = System.lineSeparator
 
   private[process] final class LazilyListed[T](
@@ -88,7 +88,7 @@ object BasicIO {
     def protect(out: OutputStream): OutputStream = if ((out eq stdout) || (out eq stderr)) Uncloseable(out) else out
   }
 
-  /** Creates a `ProcessIO` from a function `String => Unit`. It can attach the
+  /** Returns a `ProcessIO` from a function `String => Unit`. It can attach the
     * process input to stdin, and it will either send the error stream to
     * stderr, or to a `ProcessLogger`.
     *
@@ -108,7 +108,7 @@ object BasicIO {
   def apply(withIn: Boolean, output: String => Unit, log: Option[ProcessLogger]) =
     new ProcessIO(input(withIn), processFully(output), getErr(log))
 
-  /** Creates a `ProcessIO` that appends its output to an `Appendable`. It can
+  /** Returns a `ProcessIO` that appends its output to an `Appendable`. It can
     * attach the process input to stdin, and it will either send the error
     * stream to stderr, or to a `ProcessLogger`.
     *
@@ -131,7 +131,7 @@ object BasicIO {
   def apply(withIn: Boolean, buffer: Appendable, log: Option[ProcessLogger]) =
     new ProcessIO(input(withIn), processFully(buffer), getErr(log))
 
-  /** Creates a `ProcessIO` from a `ProcessLogger` . It can attach the
+  /** Returns a `ProcessIO` from a `ProcessLogger` . It can attach the
     * process input to stdin.
     *
     * @param withIn True if the process input should be attached to stdin.
@@ -214,7 +214,7 @@ object BasicIO {
     readFully()
   }
 
-  /** Copy contents of stdin to the `OutputStream`. */
+  /** Copies contents of stdin to the `OutputStream`. */
   def connectToIn(o: OutputStream): Unit = transferFully(Uncloseable protect stdin, o)
 
   /** Returns a function `OutputStream => Unit` that either reads the content
@@ -235,17 +235,17 @@ object BasicIO {
   /** Returns a `ProcessIO` connected to stdout, stderr and the provided `in` */
   def standard(in: OutputStream => Unit): ProcessIO = new ProcessIO(in, toStdOut, toStdErr)
 
-  /** Send all the input from the stream to stderr, and closes the input stream
+  /** Sends all the input from the stream to stderr, and closes the input stream
    * afterwards.
    */
   def toStdErr = (in: InputStream) => transferFully(in, stderr)
 
-  /** Send all the input from the stream to stdout, and closes the input stream
+  /** Sends all the input from the stream to stdout, and closes the input stream
    * afterwards.
    */
   def toStdOut = (in: InputStream) => transferFully(in, stdout)
 
-  /** Copy all input from the input stream to the output stream. Closes the
+  /** Copies all input from the input stream to the output stream. Closes the
     * input stream once it's all read.
     */
   def transferFully(in: InputStream, out: OutputStream): Unit =

--- a/src/library/scala/sys/process/Process.scala
+++ b/src/library/scala/sys/process/Process.scala
@@ -49,28 +49,28 @@ object Process extends ProcessImpl with ProcessCreation { }
  *  found on and used through [[scala.sys.process.Process]]'s companion object.
  */
 trait ProcessCreation {
-  /** Creates a [[scala.sys.process.ProcessBuilder]] from a `String`, including the
+  /** Returns a [[scala.sys.process.ProcessBuilder]] from a `String`, including the
     * parameters.
     *
     * @example {{{ apply("cat file.txt") }}}
     */
   def apply(command: String): ProcessBuilder                         = apply(command, None)
 
-  /** Creates a [[scala.sys.process.ProcessBuilder]] from a sequence of `String`,
+  /** Returns a [[scala.sys.process.ProcessBuilder]] from a sequence of `String`,
     * where the head is the command and each element of the tail is a parameter.
     *
     * @example {{{ apply("cat" :: files) }}}
     */
   def apply(command: scala.collection.Seq[String]): ProcessBuilder   = apply(command, None)
 
-  /** Creates a [[scala.sys.process.ProcessBuilder]] from a command represented by a `String`,
+  /** Returns a [[scala.sys.process.ProcessBuilder]] from a command represented by a `String`,
     * and a sequence of `String` representing the arguments.
     *
     * @example {{{ apply("cat", files) }}}
     */
   def apply(command: String, arguments: scala.collection.Seq[String]): ProcessBuilder = apply(command +: arguments, None)
 
-  /** Creates a [[scala.sys.process.ProcessBuilder]] with working dir set to `File` and extra
+  /** Returns a [[scala.sys.process.ProcessBuilder]] with working dir set to `File` and extra
     * environment variables.
     *
     * @example {{{ apply("java", new java.io.File("/opt/app"), "CLASSPATH" -> "library.jar") }}}
@@ -78,7 +78,7 @@ trait ProcessCreation {
   def apply(command: String, cwd: File, extraEnv: (String, String)*): ProcessBuilder =
     apply(command, Some(cwd), extraEnv: _*)
 
-  /** Creates a [[scala.sys.process.ProcessBuilder]] with working dir set to `File` and extra
+  /** Returns a [[scala.sys.process.ProcessBuilder]] with working dir set to `File` and extra
     * environment variables.
     *
     * @example {{{ apply("java" :: javaArgs, new java.io.File("/opt/app"), "CLASSPATH" -> "library.jar") }}}
@@ -86,7 +86,7 @@ trait ProcessCreation {
   def apply(command: scala.collection.Seq[String], cwd: File, extraEnv: (String, String)*): ProcessBuilder =
     apply(command, Some(cwd), extraEnv: _*)
 
-  /** Creates a [[scala.sys.process.ProcessBuilder]] with working dir optionally set to
+  /** Returns a [[scala.sys.process.ProcessBuilder]] with working dir optionally set to
     * `File` and extra environment variables.
     *
     * @example {{{ apply("java", params.get("cwd"), "CLASSPATH" -> "library.jar") }}}
@@ -94,7 +94,7 @@ trait ProcessCreation {
   def apply(command: String, cwd: Option[File], extraEnv: (String, String)*): ProcessBuilder =
     apply(Parser.tokenize(command), cwd, extraEnv: _*)
 
-  /** Creates a [[scala.sys.process.ProcessBuilder]] with working dir optionally set to
+  /** Returns a [[scala.sys.process.ProcessBuilder]] with working dir optionally set to
     * `File` and extra environment variables.
     *
     * @example {{{ apply("java" :: javaArgs, params.get("cwd"), "CLASSPATH" -> "library.jar") }}}
@@ -106,7 +106,7 @@ trait ProcessCreation {
     apply(jpb)
   }
 
-  /** Creates a [[scala.sys.process.ProcessBuilder]] from a `java.lang.ProcessBuilder`.
+  /** Returns a [[scala.sys.process.ProcessBuilder]] from a `java.lang.ProcessBuilder`.
     *
     * @example {{{
     * apply((new java.lang.ProcessBuilder("ls", "-l")) directory new java.io.File(System.getProperty("user.home")))
@@ -114,35 +114,35 @@ trait ProcessCreation {
     */
   def apply(builder: JProcessBuilder): ProcessBuilder = new Simple(builder)
 
-  /** Creates a [[scala.sys.process.ProcessBuilder]] from a `java.io.File`. This
-    * `ProcessBuilder` can then be used as a `Source` or a `Sink`, so one can
+  /** Returns a [[scala.sys.process.ProcessBuilder]] from a `java.io.File`. This
+    * `ProcessBuilder` can then be used as a [[scala.sys.process.ProcessBuilder.Source Source]] or a [[scala.sys.process.ProcessBuilder.Sink Sink]], so one can
     * pipe things from and to it.
     */
   def apply(file: File): FileBuilder                  = new FileImpl(file)
 
-  /** Creates a [[scala.sys.process.ProcessBuilder]] from a `java.net.URL`. This
-    * `ProcessBuilder` can then be used as a `Source`, so that one can pipe things
+  /** Returns a [[scala.sys.process.ProcessBuilder]] from a `java.net.URL`. This
+    * `ProcessBuilder` can then be used as a [[scala.sys.process.ProcessBuilder.Source Source]], so that one can pipe things
     * from it.
     */
   def apply(url: URL): URLBuilder                     = new URLImpl(url)
 
-  /** Creates a [[scala.sys.process.ProcessBuilder]] from a `Boolean`. This can be
+  /** Returns a [[scala.sys.process.ProcessBuilder]] from a `Boolean`. This can be
     * to force an exit value.
     */
   def apply(value: Boolean): ProcessBuilder           = apply(value.toString, if (value) 0 else 1)
 
-  /** Creates a [[scala.sys.process.ProcessBuilder]] from a `String` name and a
+  /** Returns a [[scala.sys.process.ProcessBuilder]] from a `String` name and a
     * `Boolean`. This can be used to force an exit value, with the name being
     * used for `toString`.
     */
   def apply(name: String, exitValue: => Int): ProcessBuilder = new Dummy(name, exitValue)
 
-  /** Creates a sequence of [[scala.sys.process.ProcessBuilder.Source]] from a sequence of
-    * something else for which there's an implicit conversion to `Source`.
+  /** Returns a sequence of [[scala.sys.process.ProcessBuilder.Source]] from a sequence of
+    * something else for which there's an implicit conversion to [[scala.sys.process.ProcessBuilder.Source Source]].
     */
   def applySeq[T](builders: scala.collection.Seq[T])(implicit convert: T => Source): scala.collection.Seq[Source] = builders.map(convert)
 
-  /** Creates a [[scala.sys.process.ProcessBuilder]] from one or more
+  /** Returns a [[scala.sys.process.ProcessBuilder]] from one or more
     * [[scala.sys.process.ProcessBuilder.Source]], which can then be
     * piped to something else.
     *
@@ -162,7 +162,7 @@ trait ProcessCreation {
     */
   def cat(file: Source, files: Source*): ProcessBuilder = cat(file +: files)
 
-  /** Creates a [[scala.sys.process.ProcessBuilder]] from a non-empty sequence
+  /** Returns a [[scala.sys.process.ProcessBuilder]] from a non-empty sequence
     * of [[scala.sys.process.ProcessBuilder.Source]], which can then be
     * piped to something else.
     *
@@ -182,8 +182,8 @@ trait ProcessCreation {
 trait ProcessImplicits {
   import Process._
 
-  /** Return a sequence of [[scala.sys.process.ProcessBuilder.Source]] from a sequence
-    * of values for which an implicit conversion to `Source` is available.
+  /** Returns a sequence of [[scala.sys.process.ProcessBuilder.Source]] from a sequence
+    * of values for which an implicit conversion to [[scala.sys.process.ProcessBuilder.Source Source]] is available.
     */
   implicit def buildersToProcess[T](builders: scala.collection.Seq[T])(implicit convert: T => Source): scala.collection.Seq[Source] = applySeq(builders)
 

--- a/src/library/scala/sys/process/ProcessBuilder.scala
+++ b/src/library/scala/sys/process/ProcessBuilder.scala
@@ -137,186 +137,186 @@ import ProcessBuilder.{Sink, Source}
   */
 trait ProcessBuilder extends Source with Sink {
   /** Starts the process represented by this builder, blocks until it exits, and
-    * returns the output as a String.  Standard error is sent to the console.  If
+    * returns the output as a `String`.  Standard error is sent to the console.  If
     * the exit code is non-zero, an exception is thrown.
     */
   def !! : String
 
   /** Starts the process represented by this builder, blocks until it exits, and
-    * returns the output as a String.  Standard error is sent to the provided
-    * ProcessLogger.  If the exit code is non-zero, an exception is thrown.
+    * returns the output as a `String`.  Standard error is sent to the provided
+    * `ProcessLogger`.  If the exit code is non-zero, an exception is thrown.
     */
   def !!(log: ProcessLogger): String
 
   /** Starts the process represented by this builder, blocks until it exits, and
-    * returns the output as a String.  Standard error is sent to the console.  If
+    * returns the output as a `String`.  Standard error is sent to the console.  If
     * the exit code is non-zero, an exception is thrown.  The newly started
     * process reads from standard input of the current process.
     */
   def !!< : String
 
   /** Starts the process represented by this builder, blocks until it exits, and
-    * returns the output as a String.  Standard error is sent to the provided
-    * ProcessLogger.  If the exit code is non-zero, an exception is thrown.  The
+    * returns the output as a `String`.  Standard error is sent to the provided
+    * `ProcessLogger`.  If the exit code is non-zero, an exception is thrown.  The
     * newly started process reads from standard input of the current process.
     */
   def !!<(log: ProcessLogger): String
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a LazyList that blocks when lines are not available but the process has not
+    * a `LazyList` that blocks when lines are not available but the process has not
     * completed.  Standard error is sent to the console.  If the process exits
-    * with a non-zero value, the LazyList will provide all lines up to termination
+    * with a non-zero value, the `LazyList` will provide all lines up to termination
     * and then throw an exception.
     */
   def lazyLines: LazyList[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-   * a LazyList that blocks when lines are not available but the process has not
+   * a `LazyList` that blocks when lines are not available but the process has not
    * completed.
    * The producer process will block if the given capacity of lines if filled
-   * without being consumed from the LazyList.
+   * without being consumed from the `LazyList`.
    * Standard error is sent to the console.  If the process exits
-   * with a non-zero value, the LazyList will provide all lines up to termination
+   * with a non-zero value, the `LazyList` will provide all lines up to termination
    * and then throw an exception.
    */
   def lazyLines(capacity: Integer): LazyList[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a LazyList that blocks when lines are not available but the process has not
-    * completed.  Standard error is sent to the provided ProcessLogger.  If the
-    * process exits with a non-zero value, the LazyList will provide all lines up
+    * a `LazyList` that blocks when lines are not available but the process has not
+    * completed.  Standard error is sent to the provided `ProcessLogger`.  If the
+    * process exits with a non-zero value, the `LazyList` will provide all lines up
     * to termination and then throw an exception.
     */
   def lazyLines(log: ProcessLogger): LazyList[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-   * a LazyList that blocks when lines are not available but the process has not
+   * a `LazyList` that blocks when lines are not available but the process has not
    * completed.
    * The producer process will block if the given capacity of lines if filled
-   * without being consumed from the LazyList.
-   * Standard error is sent to the provided ProcessLogger.  If the
-   * process exits with a non-zero value, the LazyList will provide all lines up
+   * without being consumed from the `LazyList`.
+   * Standard error is sent to the provided `ProcessLogger`.  If the
+   * process exits with a non-zero value, the `LazyList` will provide all lines up
    * to termination and then throw an exception.
    */
   def lazyLines(log: ProcessLogger, capacity: Integer): LazyList[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a LazyList that blocks when lines are not available but the process has not
+    * a `LazyList` that blocks when lines are not available but the process has not
     * completed.  Standard error is sent to the console. If the process exits
-    * with a non-zero value, the LazyList will provide all lines up to termination
+    * with a non-zero value, the `LazyList` will provide all lines up to termination
     * but will not throw an exception.
     */
   def lazyLines_! : LazyList[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-   * a LazyList that blocks when lines are not available but the process has not
+   * a `LazyList` that blocks when lines are not available but the process has not
    * completed.
    * The producer process will block if the given capacity of lines if filled
    * without being consumed from the stream.
    * Standard error is sent to the console. If the process exits
-   * with a non-zero value, the LazyList will provide all lines up to termination
+   * with a non-zero value, the `LazyList` will provide all lines up to termination
    * but will not throw an exception.
    */
   def lazyLines_!(capacity: Integer): LazyList[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a LazyList that blocks when lines are not available but the process has not
-    * completed.  Standard error is sent to the provided ProcessLogger. If the
-    * process exits with a non-zero value, the LazyList will provide all lines up
+    * a `LazyList` that blocks when lines are not available but the process has not
+    * completed.  Standard error is sent to the provided `ProcessLogger`. If the
+    * process exits with a non-zero value, the `LazyList` will provide all lines up
     * to termination but will not throw an exception.
     */
   def lazyLines_!(log: ProcessLogger): LazyList[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-   * a LazyList that blocks when lines are not available but the process has not
+   * a `LazyList` that blocks when lines are not available but the process has not
    * completed.
    * The producer process will block if the given capacity of lines if filled
    * without being consumed from the stream.
-   * Standard error is sent to the provided ProcessLogger. If the
-   * process exits with a non-zero value, the LazyList will provide all lines up
+   * Standard error is sent to the provided `ProcessLogger`. If the
+   * process exits with a non-zero value, the `LazyList` will provide all lines up
    * to termination but will not throw an exception.
    */
   def lazyLines_!(log: ProcessLogger, capacity: Integer): LazyList[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a Stream that blocks when lines are not available but the process has not
+    * a `Stream` that blocks when lines are not available but the process has not
     * completed.  Standard error is sent to the console.  If the process exits
-    * with a non-zero value, the Stream will provide all lines up to termination
+    * with a non-zero value, the `Stream` will provide all lines up to termination
     * and then throw an exception.
     */
   @deprecated("use lazyLines", since = "2.13.0")
   def lineStream: Stream[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a Stream that blocks when lines are not available but the process has not
+    * a `Stream` that blocks when lines are not available but the process has not
     * completed.
     * The producer process will block if the given capacity of lines if filled
     * without being consumed from the stream.
     * Standard error is sent to the console.  If the process exits
-    * with a non-zero value, the Stream will provide all lines up to termination
+    * with a non-zero value, the `Stream` will provide all lines up to termination
     * and then throw an exception.
     */
   @deprecated("use lazyLines", since = "2.13.0")
   def lineStream(capacity: Integer): Stream[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a Stream that blocks when lines are not available but the process has not
-    * completed.  Standard error is sent to the provided ProcessLogger.  If the
-    * process exits with a non-zero value, the Stream will provide all lines up
+    * a `Stream` that blocks when lines are not available but the process has not
+    * completed.  Standard error is sent to the provided `ProcessLogger`.  If the
+    * process exits with a non-zero value, the `Stream` will provide all lines up
     * to termination and then throw an exception.
     */
   @deprecated("use lazyLines", since = "2.13.0")
   def lineStream(log: ProcessLogger): Stream[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a Stream that blocks when lines are not available but the process has not
+    * a `Stream` that blocks when lines are not available but the process has not
     * completed.
     * The producer process will block if the given capacity of lines if filled
     * without being consumed from the stream.
-    * Standard error is sent to the provided ProcessLogger.  If the
-    * process exits with a non-zero value, the Stream will provide all lines up
+    * Standard error is sent to the provided `ProcessLogger`.  If the
+    * process exits with a non-zero value, the `Stream` will provide all lines up
     * to termination and then throw an exception.
     */
   @deprecated("use lazyLines", since = "2.13.0")
   def lineStream(log: ProcessLogger, capacity: Integer): Stream[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a Stream that blocks when lines are not available but the process has not
+    * a `Stream` that blocks when lines are not available but the process has not
     * completed.  Standard error is sent to the console. If the process exits
-    * with a non-zero value, the Stream will provide all lines up to termination
+    * with a non-zero value, the `Stream` will provide all lines up to termination
     * but will not throw an exception.
     */
   @deprecated("use lazyLines_!", since = "2.13.0")
   def lineStream_! : Stream[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a Stream that blocks when lines are not available but the process has not
+    * a `Stream` that blocks when lines are not available but the process has not
     * completed.
     * The producer process will block if the given capacity of lines if filled
     * without being consumed from the stream.
     * Standard error is sent to the console. If the process exits
-    * with a non-zero value, the Stream will provide all lines up to termination
+    * with a non-zero value, the `Stream` will provide all lines up to termination
     * but will not throw an exception.
     */
   @deprecated("use lazyLines_!", since = "2.13.0")
   def lineStream_!(capacity: Integer): Stream[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a Stream that blocks when lines are not available but the process has not
-    * completed.  Standard error is sent to the provided ProcessLogger. If the
-    * process exits with a non-zero value, the Stream will provide all lines up
+    * a `Stream` that blocks when lines are not available but the process has not
+    * completed.  Standard error is sent to the provided `ProcessLogger`. If the
+    * process exits with a non-zero value, the `Stream` will provide all lines up
     * to termination but will not throw an exception.
     */
   @deprecated("use lazyLines_!", since = "2.13.0")
   def lineStream_!(log: ProcessLogger): Stream[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a Stream that blocks when lines are not available but the process has not
+    * a `Stream` that blocks when lines are not available but the process has not
     * completed.
     * The producer process will block if the given capacity of lines if filled
     * without being consumed from the stream.
-    * Standard error is sent to the provided ProcessLogger. If the
-    * process exits with a non-zero value, the Stream will provide all lines up
+    * Standard error is sent to the provided `ProcessLogger`. If the
+    * process exits with a non-zero value, the `Stream` will provide all lines up
     * to termination but will not throw an exception.
     */
   @deprecated("use lazyLines_!", since = "2.13.0")
@@ -329,7 +329,7 @@ trait ProcessBuilder extends Source with Sink {
 
   /** Starts the process represented by this builder, blocks until it exits, and
     * returns the exit code.  Standard output and error are sent to the given
-    * ProcessLogger.
+    * `ProcessLogger`.
     */
   def !(log: ProcessLogger): Int
 
@@ -341,7 +341,7 @@ trait ProcessBuilder extends Source with Sink {
 
   /** Starts the process represented by this builder, blocks until it exits, and
     * returns the exit code.  Standard output and error are sent to the given
-    * ProcessLogger.  The newly started process reads from standard input of the
+    * `ProcessLogger`.  The newly started process reads from standard input of the
     * current process.
     */
   def !<(log: ProcessLogger): Int
@@ -351,54 +351,54 @@ trait ProcessBuilder extends Source with Sink {
   def run(): Process
 
   /** Starts the process represented by this builder.  Standard output and error
-    * are sent to the given ProcessLogger.
+    * are sent to the given `ProcessLogger`.
     */
   def run(log: ProcessLogger): Process
 
   /** Starts the process represented by this builder.  I/O is handled by the
-    * given ProcessIO instance.
+    * given `ProcessIO` instance.
     */
   def run(io: ProcessIO): Process
 
   /** Starts the process represented by this builder.  Standard output and error
     * are sent to the console.  The newly started process reads from standard
-    * input of the current process if `connectInput` is true.
+    * input of the current process if `connectInput` is `true`.
     */
   def run(connectInput: Boolean): Process
 
   /** Starts the process represented by this builder.  Standard output and error
-    * are sent to the given ProcessLogger.  The newly started process reads from
-    * standard input of the current process if `connectInput` is true.
+    * are sent to the given `ProcessLogger`.  The newly started process reads from
+    * standard input of the current process if `connectInput` is `true`.
     */
   def run(log: ProcessLogger, connectInput: Boolean): Process
 
-  /** Constructs a command that runs this command first and then `other` if this
+  /** Returns a command that runs this command first and then `other` if this
     * command succeeds.
     */
   def #&& (other: ProcessBuilder): ProcessBuilder
 
-  /** Constructs a command that runs this command first and then `other` if this
+  /** Returns a command that runs this command first and then `other` if this
     * command does not succeed.
     */
   def #|| (other: ProcessBuilder): ProcessBuilder
 
-  /** Constructs a command that will run this command and pipes the output to
+  /** Returns a command that will run this command and pipes the output to
     * `other`.  `other` must be a simple command.
     */
   def #| (other: ProcessBuilder): ProcessBuilder
 
-  /** Constructs a command that will run this command and then `other`.  The
+  /** Returns a command that will run this command and then `other`.  The
     * exit code will be the exit code of `other`.
     */
   def ### (other: ProcessBuilder): ProcessBuilder
 
 
-  /** True if this command can be the target of a pipe.  */
+  /** Returns `true` if this command can be the target of a pipe.  */
   def canPipeTo: Boolean
 
-  /** True if this command has an exit code which should be propagated to the
-    * user.  Given a pipe between A and B, if B.hasExitValue is true then the
-    * exit code will be the one from B; if it is false, the one from A.  This
+  /** Returns `true` if this command has an exit code which should be propagated to the
+    * user.  Given a pipe between A and B, if `B.hasExitValue` is `true` then the
+    * exit code will be the one from B; if it is `false`, the one from A.  This
     * exists to prevent output redirections (implemented as pipes) from masking
     * useful process error codes.
     */
@@ -416,16 +416,16 @@ object ProcessBuilder extends ProcessBuilderImpl {
     * [[scala.sys.process.ProcessBuilder.Sink]] from a file.
     */
   trait FileBuilder extends Sink with Source {
-    /** Append the contents of a `java.io.File` to this file */
+    /** Appends the contents of a `java.io.File` to this file */
     def #<<(f: File): ProcessBuilder
 
-    /** Append the contents from a `java.net.URL` to this file */
+    /** Appends the contents from a `java.net.URL` to this file */
     def #<<(u: URL): ProcessBuilder
 
-    /** Append the contents of a `java.io.InputStream` to this file */
+    /** Appends the contents of a `java.io.InputStream` to this file */
     def #<<(i: => InputStream): ProcessBuilder
 
-    /** Append the contents of a [[scala.sys.process.ProcessBuilder]] to this file */
+    /** Appends the contents of a [[scala.sys.process.ProcessBuilder]] to this file */
     def #<<(p: ProcessBuilder): ProcessBuilder
   }
 
@@ -441,7 +441,7 @@ object ProcessBuilder extends ProcessBuilderImpl {
     /** Appends the output stream of this process to the given file. */
     def #>> (f: File): ProcessBuilder = toFile(f, append = true)
 
-    /** Writes the output stream of this process to the given OutputStream. The
+    /** Writes the output stream of this process to the given `OutputStream`. The
       * argument is call-by-name, so the stream is recreated, written, and closed each
       * time this process is executed.
       */
@@ -467,7 +467,7 @@ object ProcessBuilder extends ProcessBuilderImpl {
     /** Reads the given URL into the input stream of this process. */
     def #< (f: URL): ProcessBuilder = #< (new URLInput(f))
 
-    /** Reads the given InputStream into the input stream of this process. The
+    /** Reads the given `InputStream` into the input stream of this process. The
       * argument is call-by-name, so the stream is recreated, read, and closed each
       * time this process is executed.
       */

--- a/src/library/scala/sys/process/ProcessIO.scala
+++ b/src/library/scala/sys/process/ProcessIO.scala
@@ -32,7 +32,7 @@ import processInternal._
   * explicitly closed.
   *
   * `ProcessBuilder` will call `writeInput`, `processOutput` and `processError`
-  * in separate threads, and if daemonizeThreads is true, they will all be
+  * in separate threads, and if `daemonizeThreads` is `true`, they will all be
   * marked as daemon threads.
   *
   * @param writeInput Function that will be called with the `OutputStream` to
@@ -58,15 +58,15 @@ final class ProcessIO(
 ) {
   def this(in: OutputStream => Unit, out: InputStream => Unit, err: InputStream => Unit) = this(in, out, err, daemonizeThreads = false)
 
-  /** Creates a new `ProcessIO` with a different handler for the process input. */
+  /** Returns a new `ProcessIO` with a different handler for the process input. */
   def withInput(write: OutputStream => Unit): ProcessIO   = new ProcessIO(write, processOutput, processError, daemonizeThreads)
 
-  /** Creates a new `ProcessIO` with a different handler for the normal output. */
+  /** Returns a new `ProcessIO` with a different handler for the normal output. */
   def withOutput(process: InputStream => Unit): ProcessIO = new ProcessIO(writeInput, process, processError, daemonizeThreads)
 
-  /** Creates a new `ProcessIO` with a different handler for the error output. */
+  /** Returns a new `ProcessIO` with a different handler for the error output. */
   def withError(process: InputStream => Unit): ProcessIO  = new ProcessIO(writeInput, processOutput, process, daemonizeThreads)
 
-  /** Creates a new `ProcessIO`, with `daemonizeThreads` true. */
+  /** Returns a new `ProcessIO`, with `daemonizeThreads` `true`. */
   def daemonized(): ProcessIO = new ProcessIO(writeInput, processOutput, processError, daemonizeThreads = true)
 }

--- a/src/library/scala/sys/process/ProcessLogger.scala
+++ b/src/library/scala/sys/process/ProcessLogger.scala
@@ -81,15 +81,15 @@ class FileProcessLogger(file: File) extends ProcessLogger with Closeable with Fl
  *  when run.
  */
 object ProcessLogger {
-  /** Creates a [[scala.sys.process.ProcessLogger]] that redirects output to a `java.io.File`. */
+  /** Returns a [[scala.sys.process.ProcessLogger]] that redirects output to a `java.io.File`. */
   def apply(file: File): FileProcessLogger = new FileProcessLogger(file)
 
-  /** Creates a [[scala.sys.process.ProcessLogger]] that sends all output, standard and error,
+  /** Returns a [[scala.sys.process.ProcessLogger]] that sends all output, standard and error,
    *  to the passed function.
    */
   def apply(fn: String => Unit): ProcessLogger = apply(fn, fn)
 
-  /** Creates a [[scala.sys.process.ProcessLogger]] that sends all output to the corresponding
+  /** Returns a [[scala.sys.process.ProcessLogger]] that sends all output to the corresponding
    *  function.
    *
    *  @param fout  This function will receive standard output.

--- a/src/library/scala/typeConstraints.scala
+++ b/src/library/scala/typeConstraints.scala
@@ -116,7 +116,7 @@ sealed abstract class <:<[-From, +To] extends (From => To) with Serializable {
     type G[+T] = C => T
     substituteCo[G](r)
   }
-  /** If `From <: To` and `C <: From`, then `C <: To` (subtyping is transitive) */
+  /** If `From <: To` and `C <: From`, then `C <: To` (subtyping is transitive). */
   def compose[C](r: C <:< From): C <:< To = {
     type G[+T] = C <:< T
     substituteCo[G](r)
@@ -125,7 +125,7 @@ sealed abstract class <:<[-From, +To] extends (From => To) with Serializable {
     type G[-T] = T => C
     substituteContra[G](r)
   }
-  /** If `From <: To` and `To <: C`, then `From <: C` (subtyping is transitive) */
+  /** If `From <: To` and `To <: C`, then `From <: C` (subtyping is transitive). */
   def andThen[C](r: To <:< C): From <:< C = {
     type G[-T] = T <:< C
     substituteContra[G](r)
@@ -168,7 +168,7 @@ object <:< {
   implicit def refl[A]: A =:= A = singleton.asInstanceOf[A =:= A]
   // = new =:=[A, A] { override def substituteBoth[F[_, _]](faa: F[A, A]): F[A, A] = faa }
 
-  /** If `A <: B` and `B <: A`, then `A = B` (subtyping is antisymmetric) */
+  /** If `A <: B` and `B <: A`, then `A = B` (subtyping is antisymmetric). */
   def antisymm[A, B](implicit l: A <:< B, r: B <:< A): A =:= B = singleton.asInstanceOf[A =:= B]
   // = ??? (I don't think this is possible to implement "safely")
 }
@@ -217,18 +217,18 @@ sealed abstract class =:=[From, To] extends (From <:< To) with Serializable {
 
   /** @inheritdoc */ override def apply(f: From) = super.apply(f)
 
-  /** If `From = To` then `To = From` (equality is symmetric) */
+  /** If `From = To` then `To = From` (equality is symmetric). */
   def flip: To =:= From = {
     type G[T, F] = F =:= T
     substituteBoth[G](this)
   }
 
-  /** If `From = To` and `C = From`, then `C = To` (equality is transitive) */
+  /** If `From = To` and `C = From`, then `C = To` (equality is transitive). */
   def compose[C](r: C =:= From): C =:= To = {
     type G[T] = C =:= T
     substituteCo[G](r)
   }
-  /** If `From = To` and `To = C`, then `From = C` (equality is transitive) */
+  /** If `From = To` and `To = C`, then `From = C` (equality is transitive). */
   def andThen[C](r: To =:= C): From =:= C = {
     type G[T] = T =:= C
     substituteContra[G](r)

--- a/src/library/scala/util/DynamicVariable.scala
+++ b/src/library/scala/util/DynamicVariable.scala
@@ -19,7 +19,7 @@ import java.lang.InheritableThreadLocal
  *  value is found through dynamic scope, but where access to the
  *  variable itself is resolved through static scope.
  *
- *  The current value can be retrieved with the value method. New values
+ *  The current value can be retrieved with the `value` method. New values
  *  should be pushed using the `withValue` method. Values pushed via
  *  `withValue` only stay valid while the `withValue`'s second argument, a
  *  parameterless closure, executes. When the second argument finishes,
@@ -43,10 +43,10 @@ class DynamicVariable[T](init: T) {
     override def initialValue: T with AnyRef = init.asInstanceOf[T with AnyRef]
   }
 
-  /** Retrieve the current value */
+  /** Retrieves the current value */
   def value: T = tl.get.asInstanceOf[T]
 
-  /** Set the value of the variable while executing the specified
+  /** Sets the value of the variable while executing the specified
     * thunk.
     *
     * @param newval The value to which to set the variable
@@ -60,8 +60,8 @@ class DynamicVariable[T](init: T) {
     finally tl set oldval
   }
 
-  /** Change the currently bound value, discarding the old value.
-    * Usually withValue() gives better semantics.
+  /** Changes the currently bound value, discarding the old value.
+    * Usually `withValue()` gives better semantics.
     */
   def value_=(newval: T) = tl set newval
 

--- a/src/library/scala/util/Either.scala
+++ b/src/library/scala/util/Either.scala
@@ -507,8 +507,8 @@ object Either {
   def cond[A, B](test: Boolean, right: => B, left: => A): Either[A, B] =
     if (test) Right(right) else Left(left)
 
-  /** Allows use of a `merge` method to extract values from Either instances
-   *  regardless of whether they are Left or Right.
+  /** Allows use of a `merge` method to extract values from `Either` instances
+   *  regardless of whether they are `Left` or `Right`.
    *
    *  {{{
    *  val l = Left(List(1)): Either[List[Int], Vector[Int]]

--- a/src/library/scala/util/Properties.scala
+++ b/src/library/scala/util/Properties.scala
@@ -146,7 +146,7 @@ private[scala] trait PropertiesTrait {
     case s      => "" == s || "true".equalsIgnoreCase(s)
   }
 
-  /** System.console.isTerminal, or just check for null console on JDK < 22 */
+  /** `System.console.isTerminal`, or just check for `null` console on JDK < 22 */
   private[scala] lazy val consoleIsTerminal: Boolean = {
     import language.reflectiveCalls
     val console = System.console

--- a/src/library/scala/util/Random.scala
+++ b/src/library/scala/util/Random.scala
@@ -255,7 +255,7 @@ class Random(val self: java.util.Random) extends AnyRef with Serializable {
 }
 
 /** The object `Random` offers a default implementation
- *  of scala.util.Random and random-related convenience methods.
+ *  of `scala.util.Random` and random-related convenience methods.
  */
 object Random extends Random {
 

--- a/src/library/scala/util/Sorting.scala
+++ b/src/library/scala/util/Sorting.scala
@@ -36,18 +36,18 @@ import scala.math.Ordering
   * other libraries that cover this use case.
   */
 object Sorting {
-  /** Sort an array of Doubles using `java.util.Arrays.sort`. */
+  /** Sorts an array of `Double`s using `java.util.Arrays.sort`. */
   def quickSort(a: Array[Double]): Unit = java.util.Arrays.sort(a)
 
-  /** Sort an array of Ints using `java.util.Arrays.sort`. */
+  /** Sorts an array of `Int`s using `java.util.Arrays.sort`. */
   def quickSort(a: Array[Int]): Unit    = java.util.Arrays.sort(a)
 
-  /** Sort an array of Floats using `java.util.Arrays.sort`. */
+  /** Sorts an array of `Float`s using `java.util.Arrays.sort`. */
   def quickSort(a: Array[Float]): Unit  = java.util.Arrays.sort(a)
 
   private final val qsortThreshold = 16
 
-  /** Sort array `a` with quicksort, using the Ordering on its elements.
+  /** Sorts array `a` with quicksort, using the `Ordering` on its elements.
     * This algorithm sorts in place, so no additional memory is used aside from
     * what might be required to box individual elements during comparison.
     */
@@ -250,11 +250,11 @@ object Sorting {
     case null => throw new NullPointerException
   }
 
-  /** Sort array `a` using the Ordering on its elements, preserving the original ordering where possible.
+  /** Sorts array `a` using the `Ordering` on its elements, preserving the original ordering where possible.
     * Uses `java.util.Arrays.sort` unless `K` is a primitive type. This is the same as `stableSort(a, 0, a.length)`. */
   @`inline` def stableSort[K: Ordering](a: Array[K]): Unit = stableSort(a, 0, a.length)
 
-  /** Sort array `a` or a part of it using the Ordering on its elements, preserving the original ordering where possible.
+  /** Sorts array `a` or a part of it using the `Ordering` on its elements, preserving the original ordering where possible.
     * Uses `java.util.Arrays.sort` unless `K` is a primitive type.
     *
     * @param a The array to sort
@@ -263,12 +263,12 @@ object Sorting {
     */
   def stableSort[K: Ordering](a: Array[K], from: Int, until: Int): Unit = sort(a, from, until, Ordering[K])
 
-  /** Sort array `a` using function `f` that computes the less-than relation for each element.
+  /** Sorts array `a` using function `f` that computes the less-than relation for each element.
     * Uses `java.util.Arrays.sort` unless `K` is a primitive type. This is the same as `stableSort(a, f, 0, a.length)`. */
   @`inline` def stableSort[K](a: Array[K], f: (K, K) => Boolean): Unit = stableSort(a, f, 0, a.length)
 
   // TODO: make this fast for primitive K (could be specialized if it didn't go through Ordering)
-  /** Sort array `a` or a part of it using function `f` that computes the less-than relation for each element.
+  /** Sorts array `a` or a part of it using function `f` that computes the less-than relation for each element.
     * Uses `java.util.Arrays.sort` unless `K` is a primitive type.
     *
     * @param a The array to sort
@@ -278,7 +278,7 @@ object Sorting {
     */
   def stableSort[K](a: Array[K], f: (K, K) => Boolean, from: Int, until: Int): Unit = sort(a, from, until, Ordering fromLessThan f)
 
-  /** A sorted Array, using the Ordering for the elements in the sequence `a`.  Uses `java.util.Arrays.sort` unless `K` is a primitive type. */
+  /** A sorted `Array`, using the `Ordering` for the elements in the sequence `a`.  Uses `java.util.Arrays.sort` unless `K` is a primitive type. */
   def stableSort[K: ClassTag: Ordering](a: scala.collection.Seq[K]): Array[K] = {
     val ret = a.toArray
     sort(ret, 0, ret.length, Ordering[K])
@@ -286,14 +286,14 @@ object Sorting {
   }
 
   // TODO: make this fast for primitive K (could be specialized if it didn't go through Ordering)
-  /** A sorted Array, given a function `f` that computes the less-than relation for each item in the sequence `a`.  Uses `java.util.Arrays.sort` unless `K` is a primitive type. */
+  /** A sorted `Array`, given a function `f` that computes the less-than relation for each item in the sequence `a`.  Uses `java.util.Arrays.sort` unless `K` is a primitive type. */
   def stableSort[K: ClassTag](a: scala.collection.Seq[K], f: (K, K) => Boolean): Array[K] = {
     val ret = a.toArray
     sort(ret, 0, ret.length, Ordering fromLessThan f)
     ret
   }
 
-  /** A sorted Array, given an extraction function `f` that returns an ordered key for each item in the sequence `a`.  Uses `java.util.Arrays.sort` unless `K` is a primitive type. */
+  /** A sorted `Array`, given an extraction function `f` that returns an ordered key for each item in the sequence `a`.  Uses `java.util.Arrays.sort` unless `K` is a primitive type. */
   def stableSort[K: ClassTag, M: Ordering](a: scala.collection.Seq[K], f: K => M): Array[K] = {
     val ret = a.toArray
     sort(ret, 0, ret.length, Ordering[M] on f)

--- a/src/library/scala/util/Try.scala
+++ b/src/library/scala/util/Try.scala
@@ -59,7 +59,7 @@ import scala.util.control.NonFatal
  * ''Note'': only non-fatal exceptions are caught by the combinators on `Try` (see [[scala.util.control.NonFatal]]).
  * Serious system errors, on the other hand, will be thrown.
  *
- * ''Note:'': all Try combinators will catch exceptions and return failure unless otherwise specified in the documentation.
+ * ''Note:'': all `Try` combinators will catch exceptions and return failure unless otherwise specified in the documentation.
  */
 sealed abstract class Try[+T] extends Product with Serializable {
 
@@ -115,22 +115,22 @@ sealed abstract class Try[+T] extends Product with Serializable {
   /** Creates a non-strict filter, which eventually converts this to a `Failure`
    *  if the predicate is not satisfied.
    *
-   *  Note: unlike filter, withFilter does not create a new Try.
+   *  Note: unlike `filter`, `withFilter` does not create a new `Try`.
    *        Instead, it restricts the domain of subsequent
    *        `map`, `flatMap`, `foreach`, and `withFilter` operations.
    *
-   * As Try is a one-element collection, this may be a bit overkill,
-   * but it's consistent with withFilter on Option and the other collections.
+   * As `Try` is a one-element collection, this may be a bit overkill,
+   * but it's consistent with `withFilter` on `Option` and the other collections.
    *
    *  @param p   the predicate used to test elements.
    *  @return    an object of class `WithFilter`, which supports
    *             `map`, `flatMap`, `foreach`, and `withFilter` operations.
-   *             All these operations apply to those elements of this Try
+   *             All these operations apply to those elements of this `Try`
    *             which satisfy the predicate `p`.
    */
   @inline final def withFilter(p: T => Boolean): WithFilter = new WithFilter(p)
 
-  /** We need a whole WithFilter class to honor the "doesn't create a new
+  /** We need a whole `WithFilter` class to honor the "doesn't create a new
    *  collection" contract even though it seems unlikely to matter much in a
    *  collection with max size 1.
    */
@@ -149,7 +149,7 @@ sealed abstract class Try[+T] extends Product with Serializable {
 
   /**
    * Applies the given function `f` if this is a `Failure`, otherwise returns this if this is a `Success`.
-   * This is like map for the exception.
+   * This is like `map` for the exception.
    */
   def recover[U >: T](pf: PartialFunction[Throwable, U]): Try[U]
 

--- a/src/library/scala/util/control/Breaks.scala
+++ b/src/library/scala/util/control/Breaks.scala
@@ -80,7 +80,7 @@ class Breaks {
     def catchBreak(onBreak: => T): T
   }
 
-  /** Try a computation that produces a value, supplying a default
+  /** Tries a computation that produces a value, supplying a default
    *  to be used if the computation terminates with a `break`.
    *
    * {{{
@@ -97,7 +97,7 @@ class Breaks {
         try op catch { case ex: BreakControl if ex eq breakException => onBreak }
     }
 
-  /** Break from the dynamically closest enclosing breakable block that also uses
+  /** Breaks from the dynamically closest enclosing `breakable` block that also uses
    *  this `Breaks` instance.
    *
    *  @note This might be different from the statically closest enclosing block!
@@ -106,7 +106,7 @@ class Breaks {
   def break(): Nothing = throw breakException
 }
 
-/** An object that can be used for the break control abstraction.
+/** An object that can be used for the `break` control abstraction.
  *
  *  Example usage:
  *  {{{

--- a/src/library/scala/util/control/Exception.scala
+++ b/src/library/scala/util/control/Exception.scala
@@ -169,7 +169,7 @@ object Exception {
 
   /** !!! Not at all sure of every factor which goes into this,
    *  and/or whether we need multiple standard variations.
-   *  @return true if `x` is $protectedExceptions otherwise false.
+   *  @return `true` if `x` is $protectedExceptions otherwise `false`.
    */
   def shouldRethrow(x: Throwable): Boolean = x match {
     case _: ControlThrowable      => true
@@ -218,11 +218,11 @@ object Exception {
 
     protected val name = "Catch"
 
-    /** Create a new Catch with additional exception handling logic. */
+    /** Creates a new `Catch` with additional exception handling logic. */
     def or[U >: T](pf2: Catcher[U]): Catch[U] = new Catch(pf orElse pf2, fin, rethrow)
     def or[U >: T](other: Catch[U]): Catch[U] = or(other.pf)
 
-    /** Apply this catch logic to the supplied body. */
+    /** Applies this catch logic to the supplied body. */
     def apply[U >: T](body: => U): U =
       try body
       catch {
@@ -231,7 +231,7 @@ object Exception {
       }
       finally fin foreach (_.invoke())
 
-    /** Create a new Catch container from this object and the supplied finally body.
+    /** Creates a new `Catch` container from this object and the supplied finally body.
      *  @param body The additional logic to apply after all existing finally bodies
      */
     def andFinally(body: => Unit): Catch[T] = {
@@ -239,23 +239,23 @@ object Exception {
       new Catch(pf, Some(appendedFin), rethrow)
     }
 
-    /** Apply this catch logic to the supplied body, mapping the result
+    /** Applies this catch logic to the supplied body, mapping the result
      *  into `Option[T]` - `None` if any exception was caught, `Some(T)` otherwise.
      */
     def opt[U >: T](body: => U): Option[U] = toOption(Some(body))
 
-    /** Apply this catch logic to the supplied body, mapping the result
+    /** Applies this catch logic to the supplied body, mapping the result
      *  into `Either[Throwable, T]` - `Left(exception)` if an exception was caught,
      *  `Right(T)` otherwise.
      */
     def either[U >: T](body: => U): Either[Throwable, U] = toEither(Right(body))
 
-    /** Apply this catch logic to the supplied body, mapping the result
+    /** Applies this catch logic to the supplied body, mapping the result
      * into `Try[T]` - `Failure` if an exception was caught, `Success(T)` otherwise.
      */
     def withTry[U >: T](body: => U): scala.util.Try[U] = toTry(Success(body))
 
-    /** Create a `Catch` object with the same `isDefinedAt` logic as this one,
+    /** Creates a `Catch` object with the same `isDefinedAt` logic as this one,
       * but with the supplied `apply` method replacing the current one. */
     def withApply[U](f: Throwable => U): Catch[U] = {
       val pf2 = new Catcher[U] {
@@ -306,7 +306,7 @@ object Exception {
   def catching[T](c: Catcher[T]): Catch[T] = new Catch(c)
 
   /** Creates a `Catch` object which will catch any of the supplied exceptions.
-   *  Unlike "catching" which filters out those in shouldRethrow, this one will
+   *  Unlike `catching`, which filters out those in `shouldRethrow`, this one will
    *  catch whatever you ask of it including $protectedExceptions.
    *  @group composition-catch-promiscuously
    */

--- a/src/library/scala/util/control/NonFatal.scala
+++ b/src/library/scala/util/control/NonFatal.scala
@@ -18,7 +18,7 @@ package util.control
  * (for example, `OutOfMemoryError` and `StackOverflowError`, subclasses of `VirtualMachineError`), `ThreadDeath`,
  * `LinkageError`, `InterruptedException`, `ControlThrowable`.
  *
- * Note that [[scala.util.control.ControlThrowable]], an internal Throwable, is not matched by
+ * Note that [[scala.util.control.ControlThrowable]], an internal `Throwable`, is not matched by
  * `NonFatal` (and would therefore be thrown).
  *
  * For example, all harmless Throwables can be caught by:
@@ -34,7 +34,7 @@ package util.control
  */
 object NonFatal {
   /**
-   * Returns true if the provided `Throwable` is to be considered non-fatal, or false if it is to be considered fatal
+   * Returns `true` if the provided `Throwable` is to be considered non-fatal, or `false` if it is to be considered fatal
    */
   @annotation.nowarn("cat=deprecation")  // avoid warning on mention of ThreadDeath
   def apply(t: Throwable): Boolean = t match {
@@ -43,7 +43,7 @@ object NonFatal {
     case _ => true
   }
   /**
-   * Returns Some(t) if NonFatal(t) == true, otherwise None
+   * Returns `Some(t)` if `NonFatal(t) == true`, otherwise `None`
    */
   def unapply(t: Throwable): Option[Throwable] = if (apply(t)) Some(t) else None
 }

--- a/src/library/scala/util/control/TailCalls.scala
+++ b/src/library/scala/util/control/TailCalls.scala
@@ -95,17 +95,17 @@ object TailCalls {
    *  computation. */
   protected case class Done[A](value: A) extends TailRec[A]
 
-  /** Internal class representing a continuation with function A => TailRec[B].
-   *  It is needed for the flatMap to be implemented. */
+  /** Internal class representing a continuation with function `A => TailRec[B]`.
+   *  It is needed for the `flatMap` to be implemented. */
   protected case class Cont[A, B](a: TailRec[A], f: A => TailRec[B]) extends TailRec[B]
 
-  /** Perform a tailcall.
+  /** Performs a tailcall.
    *  @param rest  the expression to be evaluated in the tailcall
    *  @return a `TailRec` object representing the expression `rest`
    */
   def tailcall[A](rest: => TailRec[A]): TailRec[A] = Call(() => rest)
 
-  /** Return the final result from a tailcalling computation.
+  /** Returns the final result from a tailcalling computation.
    *  @param  `result` the result value
    *  @return a `TailRec` object representing a computation which immediately
    *          returns `result`

--- a/src/library/scala/util/hashing/MurmurHash3.scala
+++ b/src/library/scala/util/hashing/MurmurHash3.scala
@@ -16,14 +16,14 @@ package util.hashing
 import java.lang.Integer.{ rotateLeft => rotl }
 
 private[hashing] class MurmurHash3 {
-  /** Mix in a block of data into an intermediate hash value. */
+  /** Mixes in a block of data into an intermediate hash value. */
   final def mix(hash: Int, data: Int): Int = {
     var h = mixLast(hash, data)
     h = rotl(h, 13)
     h * 5 + 0xe6546b64
   }
 
-  /** May optionally be used as the last mixing step. Is a little bit faster than mix,
+  /** May optionally be used as the last mixing step. Is a little bit faster than `mix`,
    *  as it does no further mixing of the resulting hash. For the last element this is not
    *  necessary as the hash is thoroughly mixed during finalization anyway. */
   final def mixLast(hash: Int, data: Int): Int = {
@@ -36,10 +36,10 @@ private[hashing] class MurmurHash3 {
     hash ^ k
   }
 
-  /** Finalize a hash to incorporate the length and make sure all bits avalanche. */
+  /** Finalizes a hash to incorporate the length and make sure all bits avalanche. */
   final def finalizeHash(hash: Int, length: Int): Int = avalanche(hash ^ length)
 
-  /** Force all bits of the hash to avalanche. Used for finalizing the hash. */
+  /** Forces all bits of the hash to avalanche. Used for finalizing the hash. */
   private final def avalanche(hash: Int): Int = {
     var h = hash
 
@@ -99,7 +99,7 @@ private[hashing] class MurmurHash3 {
   }
 
 
-  /** Compute the hash of a string */
+  /** Computes the hash of a string */
   final def stringHash(str: String, seed: Int): Int = {
     var h = seed
     var i = 0
@@ -112,7 +112,7 @@ private[hashing] class MurmurHash3 {
     finalizeHash(h, str.length)
   }
 
-  /** Compute a hash that is symmetric in its arguments - that is a hash
+  /** Computes a hash that is symmetric in its arguments - that is a hash
    *  where the order of appearance of elements does not matter.
    *  This is useful for hashing sets, for example.
    */
@@ -135,8 +135,8 @@ private[hashing] class MurmurHash3 {
     finalizeHash(h, n)
   }
 
-  /** Compute a hash that depends on the order of its arguments. Potential range
-    * hashes are recognized to produce a hash that is compatible with rangeHash.
+  /** Computes a hash that depends on the order of its arguments. Potential range
+    * hashes are recognized to produce a hash that is compatible with `rangeHash`.
     */
   final def orderedHash(xs: IterableOnce[Any], seed: Int): Int = {
     val it = xs.iterator
@@ -171,8 +171,8 @@ private[hashing] class MurmurHash3 {
 
   }
 
-  /** Compute the hash of an array. Potential range hashes are recognized to produce a
-    * hash that is compatible with rangeHash.
+  /** Computes the hash of an array. Potential range hashes are recognized to produce a
+    * hash that is compatible with `rangeHash`.
     */
   final def arrayHash[@specialized T](a: Array[T], seed: Int): Int = {
     var h = seed
@@ -208,16 +208,16 @@ private[hashing] class MurmurHash3 {
     }
   }
 
-  /** Compute the hash of a Range with at least 2 elements. Ranges with fewer
-    * elements need to use seqHash instead. The `last` parameter must be the
-    * actual last element produced by a Range, not the nominal `end`.
+  /** Computes the hash of a `Range` with at least 2 elements. Ranges with fewer
+    * elements need to use `seqHash` instead. The `last` parameter must be the
+    * actual last element produced by a `Range`, not the nominal `end`.
     */
   final def rangeHash(start: Int, step: Int, last: Int, seed: Int): Int =
     avalanche(mix(mix(mix(seed, start), step), last))
 
-  /** Compute the hash of a byte array. Faster than arrayHash, because
+  /** Computes the hash of a `Byte` array. Faster than `arrayHash`, because
    *  it hashes 4 bytes at once. Note that the result is not compatible with
-   *  arrayHash!
+   *  `arrayHash`!
    */
   final def bytesHash(data: Array[Byte], seed: Int): Int = {
     var len = data.length
@@ -250,8 +250,8 @@ private[hashing] class MurmurHash3 {
     finalizeHash(h, data.length)
   }
 
-  /** Compute the hash of an IndexedSeq. Potential range hashes are recognized to produce a
-    * hash that is compatible with rangeHash.
+  /** Computes the hash of an `IndexedSeq`. Potential range hashes are recognized to produce a
+    * hash that is compatible with `rangeHash`.
     */
   final def indexedSeqHash(a: scala.collection.IndexedSeq[Any], seed: Int): Int = {
     var h = seed
@@ -287,8 +287,8 @@ private[hashing] class MurmurHash3 {
     }
   }
 
-  /** Compute the hash of a List. Potential range hashes are recognized to produce a
-    * hash that is compatible with rangeHash.
+  /** Computes the hash of a `List`. Potential range hashes are recognized to produce a
+    * hash that is compatible with `rangeHash`.
     */
   final def listHash(xs: scala.collection.immutable.List[_], seed: Int): Int = {
     var n = 0
@@ -332,9 +332,9 @@ private[hashing] class MurmurHash3 {
  * This algorithm is designed to generate well-distributed non-cryptographic
  * hashes. It is designed to hash data in 32 bit chunks (ints).
  *
- * The mix method needs to be called at each step to update the intermediate
- * hash value. For the last chunk to incorporate into the hash mixLast may
- * be used instead, which is slightly faster. Finally finalizeHash needs to
+ * The `mix` method needs to be called at each step to update the intermediate
+ * hash value. For the last chunk to incorporate into the hash `mixLast` may
+ * be used instead, which is slightly faster. Finally `finalizeHash` needs to
  * be called to compute the final hash value.
  *
  * This is based on the earlier MurmurHash3 code by Rex Kerr, but the
@@ -367,7 +367,7 @@ object MurmurHash3 extends MurmurHash3 {
   def productHash(x: Product): Int = caseClassHash(x, productSeed, null)
 
   /**
-   * Compute the `hashCode` of a case class instance. This method returns the same value as `x.hashCode`
+   * Computes the `hashCode` of a case class instance. This method returns the same value as `x.hashCode`
    * if `x` is an instance of a case class with the default, synthetic `hashCode`.
    *
    * This method can be used to implement case classes with a cached `hashCode`:

--- a/src/library/scala/util/matching/Regex.scala
+++ b/src/library/scala/util/matching/Regex.scala
@@ -196,7 +196,7 @@ import java.util.regex.{ Pattern, Matcher }
  *  @param groupNames A mapping from names to indices in capture groups
  *
  *  @define replacementString
- *  In the replacement String, a dollar sign (`\$`) followed by a number will be
+ *  In the replacement `String`, a dollar sign (`\$`) followed by a number will be
  *  interpreted as a reference to a group in the matched pattern, with numbers
  *  1 through 9 corresponding to the first nine groups, and 0 standing for the
  *  whole match. Any other character is an error. The backslash (`\`) character
@@ -209,7 +209,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
 
   import Regex._
 
-  /** Compile a regular expression, supplied as a string, into a pattern that
+  /** Compiles a regular expression, supplied as a string, into a pattern that
    *  can be matched against inputs.
    *
    *  If group names are supplied, they can be used this way:
@@ -318,7 +318,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    *  cat(0) match { case r(_,_) => true }  // no match
    *  }}}
    *
-   *  @param  c     The Char to match
+   *  @param  c     The `Char` to match
    *  @return       The match
    */
   def unapplySeq(c: Char): Option[List[Char]] = {
@@ -330,7 +330,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
 
   /** Tries to match on a [[scala.util.matching.Regex.Match]].
    *
-   *  A previously failed match results in None.
+   *  A previously failed match results in `None`.
    *
    *  If a successful match was made against the current pattern, then that result is used.
    *
@@ -345,7 +345,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
   //  @see UnanchoredRegex
   protected def runMatcher(m: Matcher): Boolean = m.matches()
 
-  /** Return all non-overlapping matches of this `Regex` in the given character
+  /** Returns all non-overlapping matches of this `Regex` in the given character
    *  sequence as a [[scala.util.matching.Regex.MatchIterator]],
    *  which is a special [[scala.collection.Iterator]] that returns the
    *  matched strings but can also be queried for more data about the last match,
@@ -386,7 +386,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    */
   def findAllIn(source: CharSequence): MatchIterator = new Regex.MatchIterator(source, this, groupNames)
 
-  /** Return all non-overlapping matches of this regexp in given character sequence as a
+  /** Returns all non-overlapping matches of this regexp in given character sequence as a
    *  [[scala.collection.Iterator]] of [[scala.util.matching.Regex.Match]].
    *
    *  @param source The text to match against.
@@ -404,7 +404,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
     }
   }
 
-  /** Return an optional first matching string of this `Regex` in the given character sequence,
+  /** Returns an optional first matching string of this `Regex` in the given character sequence,
    *  or None if there is no match.
    *
    *  @param source The text to match against.
@@ -416,7 +416,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
     if (m.find) Some(m.group) else None
   }
 
-  /** Return an optional first match of this `Regex` in the given character sequence,
+  /** Returns an optional first match of this `Regex` in the given character sequence,
    *  or None if it does not exist.
    *
    *  If the match is successful, the [[scala.util.matching.Regex.Match]] can be queried for
@@ -431,7 +431,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
     if (m.find) Some(new Match(source, m, groupNames)) else None
   }
 
-  /** Return an optional match of this `Regex` at the beginning of the
+  /** Returns an optional match of this `Regex` at the beginning of the
    *  given character sequence, or None if it matches no prefix
    *  of the character sequence.
    *
@@ -447,7 +447,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
     if (m.lookingAt) Some(m.group) else None
   }
 
-  /** Return an optional match of this `Regex` at the beginning of the
+  /** Returns an optional match of this `Regex` at the beginning of the
    *  given character sequence, or None if it matches no prefix
    *  of the character sequence.
    *
@@ -468,7 +468,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
     * Like the extractor, this method takes anchoring into account.
     *
     * @param source The text to match against
-    * @return       true if and only if `source` matches this `Regex`.
+    * @return       `true` if and only if `source` matches this `Regex`.
     * @see          [[Regex#unanchored]]
     * @example      {{{"""\d+""".r matches "123" // returns true}}}
     */
@@ -564,7 +564,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
   def split(toSplit: CharSequence): Array[String] =
     pattern.split(toSplit)
 
-  /** Create a new Regex with the same pattern, but no requirement that
+  /** Creates a new Regex with the same pattern, but no requirement that
    *  the entire String matches in extractor patterns and [[Regex#matches]].
    *
    *  Normally, matching on `date` behaves as though the pattern were
@@ -617,7 +617,7 @@ object Regex {
    */
   trait MatchData {
 
-    /** Basically, wraps a platform Matcher. */
+    /** Basically, wraps a platform `Matcher`. */
     protected def matcher: Matcher
 
     /** The source from which the match originated */
@@ -660,7 +660,7 @@ object Regex {
       if (start(i) >= 0) source.subSequence(start(i), end(i)).toString
       else null
 
-    /** All capturing groups, i.e., not including group(0). */
+    /** All capturing groups, i.e., not including `group(0)`. */
     def subgroups: List[String] = (1 to groupCount).toList map group
 
     /** The char sequence before first character of match,
@@ -813,7 +813,7 @@ object Regex {
     // 0 = not yet matched, 1 = matched, 2 = advanced to match, 3 = no more matches
     private[this] var nextSeen = 0
 
-    /** Return true if `next` will find a match.
+    /** Returns `true` if `next` will find a match.
      *  As a side effect, advance the underlying matcher if necessary;
      *  queries about the current match data pertain to the underlying matcher.
      */
@@ -866,13 +866,13 @@ object Regex {
     /** The number of subgroups. */
     def groupCount: Int = { ensure() ; matcher.groupCount }
 
-    /** Convert to an iterator that yields MatchData elements instead of Strings. */
+    /** Converts to an iterator that yields `MatchData` elements instead of `String`s. */
     def matchData: Iterator[Match] = new AbstractIterator[Match] {
       def hasNext = self.hasNext
       def next() = { self.next(); new Match(source, matcher, _groupNames).force }
     }
 
-    /** Convert to an iterator that yields MatchData elements instead of Strings and has replacement support. */
+    /** Converts to an iterator that yields `MatchData` elements instead of `String`s and has replacement support. */
     private[matching] def replacementData = new AbstractIterator[Match] with Replacement {
       protected def matcher = self.matcher
       def hasNext = self.hasNext


### PR DESCRIPTION
The following style changes are made in this commit:

1. Use indicative mood (Returns, Builds, ... not imperative mood (Return, Build, ...).
2. Terminate initial sentence with a period.
3. Place code artifact names (for classes, methods, etc.) in backticks so they will render in code font.

Only doc comments are changed, and only to make the above style changes.

Reasoning: Indicative mood is recommended over imperative mood by the Scaladoc Style Guide:

https://docs.scala-lang.org/style/scaladoc.html

Which says: Document what the method does do not what the method should do. In other words, say “returns the result of applying f to x” rather than “return the result of applying f to x”. Subtle, but important.

It is also what most Scaladoc comments in the standard library does, so this PR makes that consistent. It is also the way doc comments are written in Javadoc for the Java standard library. It is essentially writing the documentation as if you are explaining to a user (Returns something...) rather than an implementor (Return something...).

The terminating period is also used some of the time, but not always, in the existing doc comments for the standard library. This makes it consistent. Some phrases are not full sentences, but you can think of the subject as "implicit." "Returns true" means "This method returns true." Also if you have a bullet list where some of the items are complete sentences, and others not, the style guide (Chicago Manual of Style) I go by suggests putting periods after all items. And the Java standard library documentation seems to do this. 

A few spots are missed in this PR, but it hits most of them. I'm hoping we can merge this into 2.13.x and I can do further cleanup in later PRs.