### PR TITLE
Correctly handle opaque types with type parameters

### DIFF
--- a/src/reflect/scala/reflect/internal/transform/Erasure.scala
+++ b/src/reflect/scala/reflect/internal/transform/Erasure.scala
@@ -152,7 +152,15 @@ trait Erasure {
         else if (sym.isDerivedValueClass) eraseDerivedValueClassRef(tref)
         else if (isDottyEnumSingleton(sym)) apply(mergeParents(tp.parents)) // TODO [tasty]: dotty enum singletons are not modules.
         else if (sym.isClass) eraseNormalClassRef(tref)
-        else apply(transparentDealias(sym, pre, sym.owner)) // alias type or abstract type (including opaque type)
+        else {
+          // This `else` branch is triggered when we're erasing a type alias or abstract type
+          // (including Scala 3 opaque types). Dealias and erase the underlying type. For polymorphic aliases like
+          // `type F[X] = X`, we must apply the type arguments to get the concrete type before erasure.
+          val dealiased = transparentDealias(sym, pre, sym.owner)
+          val applied = if (args.nonEmpty) appliedType(dealiased, args) else dealiased
+
+          apply(applied)
+        }
       case PolyType(tparams, restpe) =>
         apply(restpe)
       case ExistentialType(tparams, restpe) =>

--- a/test/tasty/run/src-2/tastytest/TestOpaqueConstructorParameter.scala
+++ b/test/tasty/run/src-2/tastytest/TestOpaqueConstructorParameter.scala
@@ -1,0 +1,12 @@
+package tastytest
+
+object TestOpaqueConstructorParameter extends Suite("TestOpaqueConstructorParameter") {
+  import OpaqueConstructorParameter._
+
+  test("constructor with opaque type parameters") {
+    val holder = new OpaqueHolder(id(42L), id("hello"))
+
+    assert(holder.longId == 42L)
+    assert(holder.stringId == "hello")
+  }
+}

--- a/test/tasty/run/src-3/tastytest/OpaqueConstructorParameter.scala
+++ b/test/tasty/run/src-3/tastytest/OpaqueConstructorParameter.scala
@@ -1,0 +1,9 @@
+package tastytest
+
+object OpaqueConstructorParameter {
+  opaque type Id[X] <: X = X
+
+  def id[X](x: X): Id[X] = x
+}
+
+class OpaqueHolder(val longId: OpaqueConstructorParameter.Id[Long], val stringId: OpaqueConstructorParameter.Id[String])


### PR DESCRIPTION
Fixes scala/bug#13072