### PR TITLE
Enter package object parent term decls less destructively

### DIFF
--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -357,11 +357,30 @@ abstract class SymbolTable extends macros.Universe
       }
     }
     // enter decls of parent classes
-    for (p <- container.parentSymbolsIterator) {
-      if (p != definitions.ObjectClass) {
-        openPackageModule(p, dest)
+    def enterFromParentOf(container: Symbol): Unit =
+      for (p <- container.parentSymbolsIterator if p != definitions.ObjectClass) {
+        for (member <- p.info.decls.iterator if !member.isPrivate && member.isType) {
+          val existing = dest.info.decl(member.name)
+          if (existing.exists && existing.isType)
+            dest.info.decls.unlink(existing)
+        }
+        for (member <- p.info.decls.iterator if !member.isPrivate && !member.isConstructor) {
+          dest.info.decls.enter(member)
+        }
+        enterFromParentOf(p)
       }
+    enterFromParentOf(container)
+  }
+
+  /** if there's a `package` member object in `pkgClass`, enter its members into it. */
+  def openPackageModule(pkgClass: Symbol, force: Boolean = false): Unit = {
+    val pkgModule  = pkgClass.packageObject
+    def fromSource = pkgModule.rawInfo match {
+      case ltp: SymLoader => ltp.fromSource
+      case _ => false
     }
+    if (pkgModule.isModule && !fromSource)
+      openPackageModule(pkgModule, pkgClass)
   }
 
   /** Convert array parameters denoting a repeated parameter of a Java method
@@ -386,17 +405,6 @@ abstract class SymbolTable extends macros.Universe
 
   abstract class SymLoader extends LazyType {
     def fromSource = false
-  }
-
-  /** if there's a `package` member object in `pkgClass`, enter its members into it. */
-  def openPackageModule(pkgClass: Symbol, force: Boolean = false): Unit = {
-    val pkgModule  = pkgClass.packageObject
-    def fromSource = pkgModule.rawInfo match {
-      case ltp: SymLoader => ltp.fromSource
-      case _ => false
-    }
-    if (pkgModule.isModule && !fromSource)
-      openPackageModule(pkgModule, pkgClass)
   }
 
   object perRunCaches {

--- a/test/files/pos/po-overload.scala
+++ b/test/files/pos/po-overload.scala
@@ -1,0 +1,90 @@
+package p {
+  object X extends App {
+    B.f(0) // ok
+    q.f(0) // nope
+  }
+
+  trait A {
+    def f(x: String): String
+  }
+
+  package q {
+    object `package` extends A {
+      def f(x: Int): String = "po q int"
+      override def f(x: String): String = "po q str"
+    }
+    class C {
+      def g = f(42)
+    }
+  }
+
+  object B extends A {
+    def f(x: Int): String    = ???
+    override def f(x: String): String = ???
+  }
+}
+package p2 {
+  object X extends App {
+    B.f(0) // ok
+    q.f(0) // nope
+  }
+
+  trait A {
+    def f(x: String): String = "A"
+  }
+
+  package q {
+    object `package` extends A {
+      def f(x: Int): String = "po q int"
+      override def f(x: String): String = "po q str"
+    }
+    class C {
+      def g = f(42)
+    }
+  }
+
+  object B extends A {
+    def f(x: Int): String    = ???
+    override def f(x: String): String = ???
+  }
+}
+package p3 {
+  trait A {
+    class C
+    //type C
+    //object C
+    val pi = 3.14
+  }
+  package q {
+    object `package` extends A {
+      class C // warning: shadowing a nested class of a parent is deprecated
+    }
+    class D {
+      def c = new C
+      def x = pi
+    }
+  }
+}
+package p4 {
+  object X {
+    q.f(0)
+  }
+
+  trait A {
+    def f(x: String): String = "A"
+  }
+  trait B extends A {
+    def pi = 3.14
+  }
+
+  package q {
+    object `package` extends B {
+      def f(x: Int): String = "po q int"
+      override def f(x: String): String = "po q str"
+    }
+    class C {
+      def g = f(42)
+      def x = pi
+    }
+  }
+}


### PR DESCRIPTION
Fixes scala/bug#13149

Respect overloading by not unlinking terms from parents of package objects. 