### PR TITLE
Bump copyright year to 2026

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,6 @@
 Scala
-Copyright (c) 2002-2025 EPFL
-Copyright (c) 2011-2025 Lightbend, Inc. dba Akka
+Copyright (c) 2002-2026 EPFL
+Copyright (c) 2011-2026 Lightbend, Inc. dba Akka
 
 Scala includes software developed at
 LAMP/EPFL (https://lamp.epfl.ch/) and

--- a/doc/LICENSE.md
+++ b/doc/LICENSE.md
@@ -2,9 +2,9 @@ Scala is licensed under the [Apache License Version 2.0](https://www.apache.org/
 
 ## Scala License
 
-Copyright (c) 2002-2025 EPFL
+Copyright (c) 2002-2026 EPFL
 
-Copyright (c) 2011-2025 Lightbend, Inc. dba Akka
+Copyright (c) 2011-2026 Lightbend, Inc. dba Akka
 
 All rights reserved.
 

--- a/doc/License.rtf
+++ b/doc/License.rtf
@@ -23,8 +23,8 @@ Scala is licensed under the\'a0{\field{\*\fldinst{HYPERLINK "https://www.apache.
 \fs48 \cf2 Scala License\
 \pard\pardeftab720\sl360\sa320\partightenfactor0
 
-\f0\b0\fs28 \cf2 Copyright (c) 2002-2025 EPFL\
-Copyright (c) 2011-2025 Lightbend, Inc. dba Akka\
+\f0\b0\fs28 \cf2 Copyright (c) 2002-2026 EPFL\
+Copyright (c) 2011-2026 Lightbend, Inc. dba Akka\
 All rights reserved.\
 \pard\pardeftab720\sl360\sa320\partightenfactor0
 \cf2 \cb4 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at {\field{\*\fldinst{HYPERLINK "http://www.apache.org/licenses/LICENSE-2.0"}}{\fldrslt http://www.apache.org/licenses/LICENSE-2.0}}.\

--- a/project/VersionUtil.scala
+++ b/project/VersionUtil.scala
@@ -29,7 +29,7 @@ object VersionUtil {
   )
 
   lazy val generatePropertiesFileSettings = Seq[Setting[_]](
-    copyrightString := "Copyright 2002-2025, LAMP/EPFL and Lightbend, Inc. dba Akka",
+    copyrightString := "Copyright 2002-2026, LAMP/EPFL and Lightbend, Inc. dba Akka",
     shellBannerString := """
       |     ________ ___   / /  ___
       |    / __/ __// _ | / /  / _ |

--- a/src/library/scala/util/Properties.scala
+++ b/src/library/scala/util/Properties.scala
@@ -92,7 +92,7 @@ private[scala] trait PropertiesTrait {
   /** A verbose alternative to [[versionNumberString]].
    */
   val versionString         = s"version ${scalaPropOrElse("version.number", "(unknown)")}"
-  val copyrightString       = scalaPropOrElse("copyright.string", "Copyright 2002-2025, LAMP/EPFL and Lightbend, Inc. dba Akka")
+  val copyrightString       = scalaPropOrElse("copyright.string", "Copyright 2002-2026, LAMP/EPFL and Lightbend, Inc. dba Akka")
 
   /** This is the encoding to use reading in source files, overridden with -encoding.
    *  Note that it uses "prop" i.e. looks in the scala jar, not the system properties.

--- a/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala
@@ -341,7 +341,7 @@ trait EntityPage extends HtmlPage {
     val postamble =
       List(Div(id = "tooltip"),
            if (Set("epfl", "EPFL").contains(tpl.universe.settings.docfooter.value))
-             Div(id = "footer", elems = Txt("Scala programming documentation. Copyright (c) 2002-2025 ") :: A(href = "https://www.epfl.ch", target = "_top", elems = Txt("EPFL")) :: Txt(" and ") :: A(href = "https://akka.io", target = "_top", elems = Txt("Akka")) :: Txt("."))
+             Div(id = "footer", elems = Txt("Scala programming documentation. Copyright (c) 2002-2026 ") :: A(href = "https://www.epfl.ch", target = "_top", elems = Txt("EPFL")) :: Txt(" and ") :: A(href = "https://akka.io", target = "_top", elems = Txt("Akka")) :: Txt("."))
            else
              Div(id = "footer", elems = Txt(tpl.universe.settings.docfooter.value)))
 

--- a/src/scalap/decoder.properties
+++ b/src/scalap/decoder.properties
@@ -1,2 +1,2 @@
 version.number=2.0.1
-copyright.string=(c) 2002-2025 LAMP/EPFL
+copyright.string=(c) 2002-2026 LAMP/EPFL


### PR DESCRIPTION
based on https://github.com/scala/scala/pull/10973.