### PR TITLE
Fix TASTy reader crash with Java annotations and -Wunused

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala
@@ -618,9 +618,22 @@ trait TypeDiagnostics extends splain.SplainDiagnostics {
           case _ =>
         }
         annots.addOne(annot)
-        traverse(annot.original)
-        annot.args.foreach(traverse)
-        annot.assocs.foreach { case (_, arg) => traverseConstantArg(arg) }
+        // Catch TypeError when traversing annotations to handle TASTy compatibility issues.
+        // When reading Scala 3 TASTy files with Java annotations containing class parameters,
+        // the TASTy reader may fail to resolve special internal packages (scala/bug#13143).
+        // Since we're only checking for unused symbols, it's safe to skip annotations that
+        // can't be traversed - this won't affect unused detection for symbols in the current
+        // compilation unit.
+        try {
+          traverse(annot.original)
+          annot.args.foreach(traverse)
+          annot.assocs.foreach { case (_, arg) => traverseConstantArg(arg) }
+        } catch {
+          case e: TypeError if e.msg.contains("could not find") =>
+            // Skip annotations that reference missing dependencies (typically from TASTy reader)
+          case e: TypeError if e.msg.contains("whilst reading annotation") =>
+            // Skip annotations that fail during TASTy annotation reading
+        }
       }
 
     override def traverse(t: Tree): Unit = {


### PR DESCRIPTION
# Fix TASTy reader crash with Java annotations and -Wunused

## Summary

Fixes #13143 (https://github.com/scala/bug/issues/13143)

This PR fixes a regression introduced in Scala 2.13.17 where the compiler crashes with a `TypeError` when reading TASTy files from Scala 3 classes that contain Java annotations with class parameters (e.g., `@Component(service = Array(classOf[A]))`), but only when `-Wunused` compiler flags are enabled.

## Problem

The issue was introduced by commit 1d561f6fa5, which added annotation traversal to the unused symbol checker. This causes the TASTy reader to eagerly resolve type references in annotations, including special Scala 3 internal packages that don't exist in Scala 2's classpath, resulting in:

```
error: could not find package <special-ops> whilst reading annotation of class A;
perhaps it is missing from the classpath.
```

## Solution

The fix wraps annotation traversal in the unused checker (`TypeDiagnostics.descend()`) with a try-catch block that handles specific `TypeError` exceptions from the TASTy reader:
- Errors containing "could not find" (missing package/class errors)
- Errors containing "whilst reading annotation" (TASTy annotation reading context)

This approach is safe because:
1. We're only checking for unused symbols - skipping unreadable annotations won't affect detection
2. The caught errors are specifically from external TASTy-read symbols, not the current compilation unit
3. It only affects the unused warnings checker, not normal compilation
4. It's narrowly targeted to avoid hiding other legitimate type errors

## Testing

### Reproduction
The issue occurs with a multi-project build:
- Project A (Scala 3): Contains a class with Java annotation having class parameters
- Project B (Scala 2.13.17+): Depends on A, uses `-Ytasty-reader` and `-Wunused` flags

### Verification
- Existing `-Wunused` tests should continue to pass
- Existing TASTy reader tests should continue to pass
- The fix allows compilation to succeed in the reproduction scenario above

## Changes

- Modified `src/compiler/scala/tools/nsc/typechecker/TypeDiagnostics.scala`
- Added targeted exception handling in the `descend()` method for annotation traversal
- No changes to TASTy reader logic or other compilation phases
