### PR TITLE
Avoid NPE when calling hashCode on a value class wrapping null

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/SyntheticMethods.scala
@@ -241,11 +241,18 @@ trait SyntheticMethods extends ast.TreeDSL {
       equalsCore(m, List(clazz.derivedValueClassUnbox))
     }
 
-    /* The hashcode method for value classes
-     * def hashCode(): Int = this.underlying.hashCode
+    /* The hashcode method for value classes. If the value is primitive:
+     *  def hashCode(): Int = this.underlying.hashCode
+     * otherwise, the null-safe variant:
+     *   def hashCode(): Int = java.util.Objects.hashCode(this.underlying)
      */
-    def hashCodeDerivedValueClassMethod: Tree = createMethod(nme.hashCode_, Nil, IntTpe) { _ =>
-      Select(mkThisSelect(clazz.derivedValueClassUnbox), nme.hashCode_)
+    def hashCodeDerivedValueClassMethod: Tree = createMethod(nme.hashCode_, Nil, IntTpe) { m =>
+      val acc = clazz.derivedValueClassUnbox
+      val tp = acc.info.resultType
+      if (isPrimitiveValueType(tp))
+        Select(mkThisSelect(acc), nme.hashCode_)
+      else
+        gen.mkMethodCall(Objects_hashCode, List(mkThisSelect(acc)))
     }
 
     /* The _1, _2, etc. methods to implement ProductN, disabled

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1286,6 +1286,9 @@ trait Definitions extends api.StandardDefinitions {
     def Object_hashCode  = getMemberMethod(ObjectClass, nme.hashCode_)
     def Object_toString  = getMemberMethod(ObjectClass, nme.toString_)
 
+    lazy val ObjectsClass = getRequiredModule("java.util.Objects").moduleClass
+    def Objects_hashCode = getMemberMethod(ObjectsClass, nme.hashCode_)
+
     // boxed classes
     lazy val ObjectRefClass         = requiredClass[scala.runtime.ObjectRef[_]]
     lazy val VolatileObjectRefClass = requiredClass[scala.runtime.VolatileObjectRef[_]]

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -428,6 +428,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.Object_asInstanceOf
     definitions.Object_synchronized
     definitions.String_$plus
+    definitions.ObjectsClass
     definitions.ObjectRefClass
     definitions.VolatileObjectRefClass
     definitions.RuntimeStaticsModule

--- a/test/files/run/t12405.check
+++ b/test/files/run/t12405.check
@@ -20,7 +20,7 @@ package <empty> {
     def unapply[T](c: C[T]): C[T] = c;
     final def isEmpty$extension[A]($this: C[A]): Boolean = scala.Predef.???;
     final def get$extension[A]($this: C[A]): A = scala.Predef.???;
-    final <synthetic> def hashCode$extension[A]($this: C[A])(): Int = $this.x.hashCode();
+    final <synthetic> def hashCode$extension[A]($this: C[A])(): Int = java.util.Objects.hashCode($this.x);
     final <synthetic> def equals$extension[A]($this: C[A])(x$1: Any): Boolean = {
   case <synthetic> val x1: Any = x$1;
   case5(){

--- a/test/files/run/t7396.scala
+++ b/test/files/run/t7396.scala
@@ -1,0 +1,42 @@
+class L(val x: Int) extends AnyVal
+class M(val s: String) extends AnyVal
+class N[T](val t: T) extends AnyVal
+case class O(s: String) extends AnyVal
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val l = new L(0)
+    assert(l.hashCode == 0)
+    assert(l.toString == "L@0")
+
+    val m = new M(null)
+    assert(m.hashCode == 0)
+    assert(m.toString == "M@0")
+    assert(m == new M(null))
+    val mm = new M("")
+    assert(mm.toString == "M@0")
+    assert(mm.hashCode == 0)
+    assert(m != mm)
+
+    val n = new N(new N(new M(null)))
+    assert(n.hashCode == 0)
+    assert(n.toString == "N@0")
+    assert(n != new N(new M(null)))
+
+    val o = O(null)
+    assert(o.hashCode == 0)
+    assert(o.toString == "O(null)")
+    assert(o == O(null))
+    val oo = O("")
+    assert(oo.hashCode == 0)
+    assert(oo.toString == "O()")
+    assert(o != oo)
+
+    val map = collection.mutable.HashMap.empty[M, Int]
+    map(m) = 1
+    map(mm) = 2
+    assert(map(m) == 1)
+    assert(map(new M(null)) == 1)
+    assert(map(new M("")) == 2)
+  }
+}


### PR DESCRIPTION
Change the synthetic `hashCode` for value classes from

`def hashCode(): Int = this.underlying.hashCode`

to

`def hashCode(): Int = java.util.Objects.hashCode(this.underlying)`

(unless the underlying value is primitive)

Fixes https://github.com/scala/bug/issues/7396