### PR TITLE
Remove incorrect equals implementations from ArrayBuilder

### DIFF
--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -800,7 +800,7 @@ private final class BitmapIndexedMapNode[K, +V](
       val key0UnimprovedHash = getHash(index)
       if (key0UnimprovedHash == originalHash && key0 == key) {
         val value0 = this.getValue(index)
-        if (!((key0.asInstanceOf[AnyRef] eq key.asInstanceOf[AnyRef]) && (value0.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef]))) {
+        if ((key0.asInstanceOf[AnyRef] ne key.asInstanceOf[AnyRef]) || (value0.asInstanceOf[AnyRef] ne value.asInstanceOf[AnyRef])) {
           val dataIx = dataIndex(bitpos)
           val idx = TupleLength * dataIx
           content(idx + 1) = value

--- a/src/library/scala/collection/immutable/List.scala
+++ b/src/library/scala/collection/immutable/List.scala
@@ -530,7 +530,7 @@ sealed abstract class List[+A]
       var currentLast = newHead
 
       // we know that all elements are :: until at least firstMiss.tail
-      while (!(toProcess eq firstMiss)) {
+      while (toProcess ne firstMiss) {
         val newElem = new ::(toProcess.head, Nil)
         currentLast.next = newElem
         currentLast = newElem
@@ -550,7 +550,7 @@ sealed abstract class List[+A]
           next = next.tail
         } else {
           // its not a match - do we have outstanding elements?
-          while (!(nextToCopy eq next)) {
+          while (nextToCopy ne next) {
             val newElem = new ::(nextToCopy.head, Nil)
             currentLast.next = newElem
             currentLast = newElem

--- a/src/library/scala/collection/mutable/ArrayBuilder.scala
+++ b/src/library/scala/collection/mutable/ArrayBuilder.scala
@@ -146,11 +146,6 @@ object ArrayBuilder {
       if(elems ne null) java.util.Arrays.fill(elems.asInstanceOf[Array[AnyRef]], null)
     }
 
-    override def equals(other: Any): Boolean = other match {
-      case x: ofRef[_] => (size == x.size) && (elems == x.elems)
-      case _ => false
-    }
-
     override def toString = "ArrayBuilder.ofRef"
   }
 
@@ -186,11 +181,6 @@ object ArrayBuilder {
         res
       }
       else mkArray(size)
-    }
-
-    override def equals(other: Any): Boolean = other match {
-      case x: ofByte => (size == x.size) && (elems == x.elems)
-      case _ => false
     }
 
     override def toString = "ArrayBuilder.ofByte"
@@ -230,11 +220,6 @@ object ArrayBuilder {
       else mkArray(size)
     }
 
-    override def equals(other: Any): Boolean = other match {
-      case x: ofShort => (size == x.size) && (elems == x.elems)
-      case _ => false
-    }
-
     override def toString = "ArrayBuilder.ofShort"
   }
 
@@ -270,11 +255,6 @@ object ArrayBuilder {
         res
       }
       else mkArray(size)
-    }
-
-    override def equals(other: Any): Boolean = other match {
-      case x: ofChar => (size == x.size) && (elems == x.elems)
-      case _ => false
     }
 
     override def toString = "ArrayBuilder.ofChar"
@@ -314,11 +294,6 @@ object ArrayBuilder {
       else mkArray(size)
     }
 
-    override def equals(other: Any): Boolean = other match {
-      case x: ofInt => (size == x.size) && (elems == x.elems)
-      case _ => false
-    }
-
     override def toString = "ArrayBuilder.ofInt"
   }
 
@@ -354,11 +329,6 @@ object ArrayBuilder {
         res
       }
       else mkArray(size)
-    }
-
-    override def equals(other: Any): Boolean = other match {
-      case x: ofLong => (size == x.size) && (elems == x.elems)
-      case _ => false
     }
 
     override def toString = "ArrayBuilder.ofLong"
@@ -398,11 +368,6 @@ object ArrayBuilder {
       else mkArray(size)
     }
 
-    override def equals(other: Any): Boolean = other match {
-      case x: ofFloat => (size == x.size) && (elems == x.elems)
-      case _ => false
-    }
-
     override def toString = "ArrayBuilder.ofFloat"
   }
 
@@ -438,11 +403,6 @@ object ArrayBuilder {
         res
       }
       else mkArray(size)
-    }
-
-    override def equals(other: Any): Boolean = other match {
-      case x: ofDouble => (size == x.size) && (elems == x.elems)
-      case _ => false
     }
 
     override def toString = "ArrayBuilder.ofDouble"
@@ -482,11 +442,6 @@ object ArrayBuilder {
       else mkArray(size)
     }
 
-    override def equals(other: Any): Boolean = other match {
-      case x: ofBoolean => (size == x.size) && (elems == x.elems)
-      case _ => false
-    }
-
     override def toString = "ArrayBuilder.ofBoolean"
   }
 
@@ -522,11 +477,6 @@ object ArrayBuilder {
       var i = 0
       while (i < size) { ans(i) = (); i += 1 }
       ans
-    }
-
-    override def equals(other: Any): Boolean = other match {
-      case x: ofUnit => (size == x.size)
-      case _ => false
     }
 
     protected[this] def resize(size: Int): Unit = capacity = size

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -5236,7 +5236,7 @@ trait Types
     case _                      => false
   }
   def isBoundedGeneric(tp: Type) = tp match {
-    case TypeRef(_, sym, _) if sym.isAbstractType => tp <:< AnyRefTpe && !(tp.upperBound eq ObjectTpeJava)
+    case TypeRef(_, sym, _) if sym.isAbstractType => tp <:< AnyRefTpe && (tp.upperBound ne ObjectTpeJava)
     case TypeRef(_, sym, _)                       => !isPrimitiveValueClass(sym)
     case _                                        => false
   }

--- a/test/files/jvm/serialization-new.check
+++ b/test/files/jvm/serialization-new.check
@@ -145,14 +145,6 @@ x = ArrayBuffer(one, two)
 y = ArrayBuffer(one, two)
 x equals y: true, y equals x: true
 
-x = ArrayBuilder.ofLong
-y = ArrayBuilder.ofLong
-x equals y: true, y equals x: true
-
-x = ArrayBuilder.ofFloat
-y = ArrayBuilder.ofFloat
-x equals y: true, y equals x: true
-
 x = BitSet(0, 8, 9)
 y = BitSet(0, 8, 9)
 x equals y: true, y equals x: true

--- a/test/files/jvm/serialization-new.scala
+++ b/test/files/jvm/serialization-new.scala
@@ -295,11 +295,11 @@ object Test3_mutable {
     // ArrayBuilder
     val abu1 = ArrayBuilder.make[Long]
     val _abu1: ArrayBuilder[ClassTag[Long]] = read(write(abu1))
-    check(abu1, _abu1)
+    assert(abu1 ne _abu1)
 
     val abu2 = ArrayBuilder.make[Float]
     val _abu2: ArrayBuilder[ClassTag[Float]] = read(write(abu2))
-    check(abu2, _abu2)
+    assert(abu2 ne _abu2)
 
     // BitSet
     val bs1 = new BitSet()

--- a/test/files/jvm/serialization.check
+++ b/test/files/jvm/serialization.check
@@ -145,14 +145,6 @@ x = ArrayBuffer(one, two)
 y = ArrayBuffer(one, two)
 x equals y: true, y equals x: true
 
-x = ArrayBuilder.ofLong
-y = ArrayBuilder.ofLong
-x equals y: true, y equals x: true
-
-x = ArrayBuilder.ofFloat
-y = ArrayBuilder.ofFloat
-x equals y: true, y equals x: true
-
 x = ArraySeq(1, 2, 3)
 y = ArraySeq(1, 2, 3)
 x equals y: true, y equals x: true

--- a/test/files/jvm/serialization.scala
+++ b/test/files/jvm/serialization.scala
@@ -296,11 +296,11 @@ object Test3_mutable {
     // ArrayBuilder
     val abu1 = ArrayBuilder.make[Long]
     val _abu1: ArrayBuilder[ClassManifest[Long]] = read(write(abu1))
-    check(abu1, _abu1)
+    assert(abu1 ne _abu1)
 
     val abu2 = ArrayBuilder.make[Float]
     val _abu2: ArrayBuilder[ClassManifest[Float]] = read(write(abu2))
-    check(abu2, _abu2)
+    assert(abu2 ne _abu2)
 
     // ArraySeq
     val aq1 = ArraySeq(1, 2, 3)

--- a/test/junit/scala/collection/SetMapConsistencyTest.scala
+++ b/test/junit/scala/collection/SetMapConsistencyTest.scala
@@ -389,7 +389,7 @@ class SetMapConsistencyTest {
     assert { 
       val m2 = lm.mapValuesNow(_+2)
       lm.transformValues(_+2)
-      m2 == lm && !(m2 eq lm) && (for ((_,v) <- lm) yield v).sum == 33L
+      m2 == lm && (m2 ne lm) && (for ((_,v) <- lm) yield v).sum == 33L
     }
 
     assert {
@@ -436,7 +436,7 @@ class SetMapConsistencyTest {
     assert { 
       val m2 = arm.mapValuesNow(_+2)
       arm.transformValues(_+2)
-      m2 == arm && !(m2 eq arm) && (for ((_,v) <- arm) yield v).sum == 33L
+      m2 == arm && (m2 ne arm) && (for ((_,v) <- arm) yield v).sum == 33L
     }
 
     assert {


### PR DESCRIPTION
ArrayBuilder subclasses overrode equals using array reference equality, which leads to incorrect results for non-empty builders and breaks expected collection semantics.

This change removes the custom equals implementations so builders fall back to reference equality, which is consistent with their mutable nature.

Backported from scala/scala3#25205