### PR TITLE
Don't infer implicits from non-accessible companion

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -185,11 +185,6 @@ trait Implicits extends splain.SplainData {
               context.warning(result.tree.pos, s"Implicit resolves to enclosing $encl$help", WFlagSelfImplicit)
           }
       }
-      if (infoSym.exists && infoSym.owner.isModuleClass) {
-        val companion = companionSymbolOf(infoSym.owner, context)
-        if (companion.exists && !context.isAccessible(companion, result.implicitInfo.pre.prefix))
-          context.deprecationWarning(result.tree.pos, infoSym, s"Usage of implicit $infoSym defined in $companion, which is not accessible here. In Scala 2.13.20, this implicit will no longer be found.", "2.13.19")
-      }
       if (result.inPackagePrefix && currentRun.isScala3) {
         val msg =
           s"""Implicit $rts was found in a package prefix of the required type, which is not part of the implicit scope in Scala 3 (or with -Xsource-features:package-prefix-implicits).
@@ -1410,13 +1405,19 @@ trait Implicits extends splain.SplainData {
             if (symInfos.exists(_.isSearchedPrefix))
               infoMap(sym) = SearchedPrefixImplicitInfo(pre) :: symInfos
             else if (pre.isStable && !pre.typeSymbol.isExistentiallyBound) {
-              val (pre1, inPackagePrefix) =
-                if (sym.isPackageClass) (sym.packageObject.typeOfThis, true)
-                else (singleType(pre, companionSymbolOf(sym, context)), false)
-              val preInfos = {
-                if (currentRun.sourceFeatures.packagePrefixImplicits && inPackagePrefix) Iterator.empty
+              var inPackagePrefix = false
+              val pre1 =
+                if (sym.isPackageClass) {
+                  inPackagePrefix = true
+                  sym.packageObject.typeOfThis
+                } else {
+                  val companion = companionSymbolOf(sym, context)
+                  if (companion.exists && context.isAccessible(companion, pre)) singleType(pre, companion)
+                  else null
+                }
+              val preInfos =
+                if (pre1 == null || currentRun.sourceFeatures.packagePrefixImplicits && inPackagePrefix) Iterator.empty
                 else pre1.implicitMembers.iterator.map(mem => new ImplicitInfo(mem.name, pre1, mem, inPackagePrefix = inPackagePrefix))
-              }
               val mergedInfos = if (symInfos.isEmpty) preInfos else {
                 if (shouldLogAtThisPhase && symInfos.exists(!_.dependsOnPrefix)) log {
                   val nonDepInfos = symInfos.iterator.filterNot(_.dependsOnPrefix).mkString("(", ", ", ")")

--- a/test/files/neg/t13160.check
+++ b/test/files/neg/t13160.check
@@ -1,9 +1,11 @@
-t13160.scala:33: warning: Usage of implicit method d2i defined in object D, which is not accessible here. In Scala 2.13.20, this implicit will no longer be found.
+t13160.scala:31: error: type mismatch;
+ found   : p.Test.j.D
+ required: Int
     d // not
     ^
-t13160.scala:42: warning: Usage of implicit method e2i defined in object E, which is not accessible here. In Scala 2.13.20, this implicit will no longer be found.
+t13160.scala:40: error: type mismatch;
+ found   : t.E
+ required: Int
     e // not
     ^
-error: No warnings can be incurred under -Werror.
-2 warnings
-1 error
+2 errors

--- a/test/files/neg/t13160.scala
+++ b/test/files/neg/t13160.scala
@@ -1,5 +1,3 @@
-//> using options -deprecation -Werror
-
 package p
 
 import scala.language.implicitConversions


### PR DESCRIPTION
Implicits found in the companion object of a type should not be inferred if the companion object is not accessible.

It used to work because the compiler calls `makeNotPrivate` on the companion, but in separate compilation that could result in a `NoSuchMethodError` at runtime.

Fixes https://github.com/scala/bug/issues/13160. To be merged for 2.13.20, deprecation in 2.13.19 (https://github.com/scala/scala3/pull/25367).