### PR TITLE
Further improve error pos in raw

### DIFF
--- a/src/compiler/scala/tools/reflect/FastStringInterpolator.scala
+++ b/src/compiler/scala/tools/reflect/FastStringInterpolator.scala
@@ -41,23 +41,24 @@ trait FastStringInterpolator extends FormatInterpolator {
       }
       val treated = parts.mapConserve {
         case lit @ Literal(Constant(stringVal: String)) =>
-          def asRaw = if (currentRun.sourceFeatures.unicodeEscapesRaw) stringVal else {
-            val processed = processUnicode(stringVal)
-            if (processed == stringVal) stringVal else {
-              val pos = {
-                val diffindex = processed.zip(stringVal).zipWithIndex.collectFirst {
-                  case ((p, o), i) if p != o => i
-                }.getOrElse(processed.length - 1)
-                lit.pos.withShift(diffindex)
-              }
-              def msg(fate: String) = s"Unicode escapes in raw interpolations are $fate; use literal characters instead"
-              if (currentRun.isScala3)
-                runReporting.warning(pos, msg("ignored in Scala 3 (or with -Xsource-features:unicode-escapes-raw)"), Scala3Migration, c.internal.enclosingOwner)
-              else
-                runReporting.deprecationWarning(pos, msg("deprecated"), "2.13.2", "", "")
-              processed
+          def asRaw = if (currentRun.sourceFeatures.unicodeEscapesRaw) stringVal else
+            processUnicode(stringVal) match {
+              case `stringVal` => stringVal
+              case processed =>
+                val pos = {
+                  val index = processed.zip(stringVal).indexWhere { case (p, s) => p != s }
+                  adjustedEscPos(lit.pos, index)
+                }
+                def msg(fate: String) =
+                  s"Unicode escapes in raw interpolations are $fate; use literal characters instead"
+                def ignored =
+                  msg("ignored in Scala 3 (or with -Xsource-features:unicode-escapes-raw)")
+                if (currentRun.isScala3)
+                  runReporting.warning(pos, msg=ignored, Scala3Migration, site=c.internal.enclosingOwner)
+                else
+                  runReporting.deprecationWarning(pos, msg=msg("deprecated"), since="2.13.2", site="", origin="")
+                processed
             }
-          }
           val value =
             try if (isRaw) asRaw else processEscapes(stringVal)
             catch {
@@ -65,7 +66,8 @@ trait FastStringInterpolator extends FormatInterpolator {
               case iue: InvalidUnicodeEscapeException => c.abort(adjustedEscPos(lit.pos, iue.index), iue.getMessage)
             }
           val k = Constant(value)
-          // To avoid the backlash of backslash, taken literally by Literal, escapes are processed strictly (scala/bug#11196)
+          // To avoid the backlash of backslash, taken literally by Literal, escapes are processed strictly.
+          // scala/bug#11196
           treeCopy.Literal(lit, k).setType(ConstantType(k))
         case x => throw new MatchError(x)
       }

--- a/test/files/neg/t13161.check
+++ b/test/files/neg/t13161.check
@@ -1,0 +1,6 @@
+[WARNING] [source-t13161.scala,line-8,offset=346]: Unicode escapes in triple quoted strings are deprecated; use the literal character instead
+[WARNING] [RangePosition(t13161.scala, 206, 206, 208)]: Unicode escapes in raw interpolations are deprecated; use literal characters instead
+[WARNING] [RangePosition(t13161.scala, 499, 499, 501)]: Unicode escapes in raw interpolations are deprecated; use literal characters instead
+[ERROR] [NoPosition]: No warnings can be incurred under -Werror.
+3 warnings
+1 error

--- a/test/files/neg/t13161.scala
+++ b/test/files/neg/t13161.scala
@@ -1,0 +1,10 @@
+//> using options -deprecation -Werror -Xreporter:scala.tools.partest.nest.PlainReporter
+//
+// todo -Yvalidate-pos:_
+
+object Scala2Module {
+  val singleLine = "string\u0023"
+  val singleLineRaw = raw"string\u0023" //Compiler warning: Unicode escapes in raw interpolations are deprecated; use literal characters instead
+  val multiline = """string\u0023""" //Compile warning: Unicode escapes in triple quoted strings are deprecated; use the literal character instead
+  val multilineRaw = raw"""string\u0023"""
+}


### PR DESCRIPTION
Fixes scala/bug#13161

The error pos is now just the `\u`.  Previously, the end was wrongly shifted.