### PR TITLE
Merge 2.12.x to 2.13.x [ci: last-only]

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ We are grateful for the following OSS licenses:
   - [JProfiler Java profiler](https://www.ej-technologies.com/products/jprofiler/overview.html)
   - [YourKit Java Profiler](https://www.yourkit.com/java/profiler/)
   - [IntelliJ IDEA](https://www.jetbrains.com/idea/download/)
-  - [![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://develocity.scala-lang.org)
 
 ## Build setup
 

--- a/build.sbt
+++ b/build.sbt
@@ -114,44 +114,6 @@ globalVersionSettings
      |""".stripMargin
 ))
 
-// Run `sbt -Dscala.build.publishDevelocity` to publish build scans to develocity.scala-lang.org
-// In Jenkins, the `...publishDevelocity=stage` value is used to set the `JENKINS_STAGE` value of the scan
-ThisBuild / develocityConfiguration := {
-  def pubDev = Option(System.getProperty("scala.build.publishDevelocity"))
-  val isInsideCI = sys.env.get("JENKINS_URL").exists(_.contains("scala-ci.typesafe.com"))
-  val config = develocityConfiguration.value
-  val buildScan = config.buildScan
-  val buildCache = config.buildCache
-  config
-    .withProjectId(ProjectId("scala2"))
-    .withServer(config.server.withUrl(Some(url("https://develocity.scala-lang.org"))))
-    .withBuildScan(
-      buildScan
-        .withPublishing(Publishing.onlyIf(ctx => pubDev.nonEmpty && ctx.authenticated))
-        .withBackgroundUpload(false)
-        .withTag(if (isInsideCI) "CI" else "Local")
-        .withTag("2.12")
-        .withLinks(buildScan.links ++
-          sys.env.get("BUILD_URL").map(u => "Jenkins Build" -> url(u)) ++
-          sys.env.get("repo_ref").map(sha => "GitHub Commit" -> url(s"https://github.com/scala/scala/commit/$sha")) ++
-          sys.env.get("_scabot_pr").map(pr => "GitHub PR " -> url(s"https://github.com/scala/scala/pull/$pr")))
-        .withValues(buildScan.values +
-          ("GITHUB_REPOSITORY" -> "scala/scala") +
-          ("GITHUB_BRANCH" -> "2.12.x") ++
-          pubDev.filterNot(_.isEmpty).map("JENKINS_STAGE" -> _) ++
-          sys.env.get("JOB_NAME").map("JENKINS_JOB_NAME" -> _) ++
-          sys.env.get("repo_ref").map("GITHUB_SHA" -> _) ++
-          sys.env.get("_scabot_pr").map("GITHUB_PR" -> _) ++
-          sys.env.get("NODE_NAME").map("JENKINS_NODE" -> _))
-        .withObfuscation(buildScan.obfuscation.withIpAddresses(_.map(_ => "0.0.0.0")))
-    )
-    .withBuildCache(
-      buildCache
-        .withLocal(buildCache.local.withEnabled(false))
-        .withRemote(buildCache.remote.withEnabled(false))
-    )
-}
-
 (Global / scalaVersion)         := versionProps("starr.version")
 
 lazy val instanceSettings = Seq[Setting[_]](

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.2
+sbt.version=1.12.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,7 +13,7 @@ libraryDependencies += "org.pantsbuild" % "jarjar" % "1.7.2"
 
 libraryDependencies += "biz.aQute.bnd" % "biz.aQute.bndlib" % "6.1.0"
 
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.4")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.5")
 
 libraryDependencies ++= Seq(
   "org.eclipse.jgit" % "org.eclipse.jgit" % "4.11.9.201909030838-r",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -28,5 +28,3 @@ concurrentRestrictions in Global := Seq(
 addSbtPlugin("com.github.sbt" % "sbt-header" % "5.11.0")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.8")
-
-addSbtPlugin("com.gradle" % "sbt-develocity" % "1.4.5")

--- a/scripts/jobs/validate/publish-core
+++ b/scripts/jobs/validate/publish-core
@@ -28,7 +28,7 @@ case $prDryRun in
     if $libraryAvailable && $reflectAvailable && $compilerAvailable; then
       echo "Scala core already built!"
     else
-      $SBT -Dscala.build.publishDevelocity=build -warn "setupPublishCore $prRepoUrl" publish
+      $SBT -warn "setupPublishCore $prRepoUrl" publish
     fi
 
     mv buildcharacter.properties jenkins.properties # parsed by the jenkins job

--- a/scripts/jobs/validate/test
+++ b/scripts/jobs/validate/test
@@ -18,7 +18,6 @@ case $prDryRun in
     # and run JUnit tests, ScalaCheck tests, partest, OSGi tests, MiMa and scaladoc
     $SBT \
        -Dstarr.version=$scalaVersion \
-       -Dscala.build.publishDevelocity=test \
        -warn \
        "setupValidateTest $prRepoUrl" \
        $testExtraArgs \


### PR DESCRIPTION
to remove the develocity config

```
$> git log HEAD --oneline -n 1 | cat
ce1569e7c4 Merge pull request #11219 from som-snytt/issue/13161-raw-warn-eof

$> git log upstream/2.12.x --oneline -n 1 | cat
db54b9d5e9 Merge pull request #11218 from lrytz/undev

$> export MB=$(git merge-base HEAD upstream/2.12.x)

$> git log --graph --oneline $MB..upstream/2.12.x | cat
*   db54b9d5e9 Merge pull request #11218 from lrytz/undev
|\
| * 0d3ce5da04 Remove sbt-develocity
|/
*   2d1c55206c Merge pull request #11217 from scala-steward/update/2.12.x/sbt-1.12.4
|\
| * ab4f96d0af Update sbt, scripted-plugin to 1.12.4 in 2.12.x
* 6da3aacd42 Merge pull request #11216 from scala-steward/update/2.12.x/sbt-mima-plugin-1.1.5
* 081836e56c Update sbt-mima-plugin to 1.1.5 in 2.12.x

$> git merge db54b9d5e9
```