### PR TITLE
Copy `protected` modifier to case apply method (case-apply-copy-access)

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala
@@ -108,7 +108,7 @@ trait Unapplies extends ast.TreeDSL {
   }
   private def applyAccess(mods: Modifiers): ApplyAccess.Flags = {
     import ApplyAccess._
-    val changeModsIn3 = mods.hasFlag(PRIVATE) || (!mods.hasFlag(PROTECTED) && mods.hasAccessBoundary)
+    val changeModsIn3 = mods.hasFlag(PRIVATE) || mods.hasFlag(PROTECTED) || mods.hasAccessBoundary
     if (!changeModsIn3) Default
     else if (currentRun.sourceFeatures.caseApplyCopyAccess) Inherit
     else if (currentRun.isScala3) Warn
@@ -169,7 +169,7 @@ trait Unapplies extends ast.TreeDSL {
     val inheritedMods = constrMods(cdef)
     val access = applyAccess(inheritedMods)
     val mods =
-      if (ApplyAccess.isInherit(access)) (caseMods | (inheritedMods.flags & PRIVATE)).copy(privateWithin = inheritedMods.privateWithin)
+      if (ApplyAccess.isInherit(access)) (caseMods | (inheritedMods.flags & (PRIVATE | PROTECTED))).copy(privateWithin = inheritedMods.privateWithin)
       else caseMods
     factoryMeth(mods, nme.apply, cdef).tap(m =>
       if (ApplyAccess.isWarn(access))

--- a/test/files/neg/caseclass_private_constructor.check
+++ b/test/files/neg/caseclass_private_constructor.check
@@ -30,12 +30,28 @@ possible cause: maybe a wrong Dynamic method signature?
 caseclass_private_constructor.scala:28: error: method copy in class D cannot be accessed as a member of qualified_private.D from object QPrivTest
   def d2: D = d1.copy(2) // error: copy is private
                  ^
+caseclass_private_constructor.scala:33: error: method apply in object E cannot be accessed as a member of object E from object ETest
+ Access to protected method apply not permitted because
+ enclosing object ETest is not a subclass of
+ object E where target is defined
+error after rewriting to E.<apply: error>
+possible cause: maybe a wrong Dynamic method signature?
+  def e1: E = E(1) // error: apply is protected
+              ^
 caseclass_private_constructor.scala:34: error: method copy in class E cannot be accessed as a member of E from object ETest
  Access to protected method copy not permitted because
  enclosing object ETest is not a subclass of
  class E where target is defined
   def e2: E = e2.copy(2) // error: copy is protected
                  ^
+caseclass_private_constructor.scala:42: error: method apply in object F cannot be accessed as a member of object qualified_protected.F from object QProtTest
+ Access to protected method apply not permitted because
+ enclosing object QProtTest is not a subclass of
+ object F in object qualified_protected where target is defined
+error after rewriting to qualified_protected.F.<apply: error>
+possible cause: maybe a wrong Dynamic method signature?
+  def f1: F = F(1) // error: apply is protected
+              ^
 caseclass_private_constructor.scala:43: error: method copy in class F cannot be accessed as a member of qualified_protected.F from object QProtTest
  Access to protected method copy not permitted because
  enclosing object QProtTest is not a subclass of
@@ -50,4 +66,4 @@ error after rewriting to OverrideCopy.<apply: error>
 possible cause: maybe a wrong Dynamic method signature?
   def oc = OverrideCopy(42) // error: apply is still private
            ^
-12 errors
+14 errors

--- a/test/files/neg/caseclass_private_constructor.scala
+++ b/test/files/neg/caseclass_private_constructor.scala
@@ -30,7 +30,7 @@ object QPrivTest {
 
 case class E protected (i: Int)
 object ETest {
-  def e1: E = E(1)
+  def e1: E = E(1) // error: apply is protected
   def e2: E = e2.copy(2) // error: copy is protected
 }
 
@@ -39,7 +39,7 @@ object qualified_protected {
 }
 object QProtTest {
   import qualified_protected._
-  def f1: F = F(1)
+  def f1: F = F(1) // error: apply is protected
   def f2: F = f2.copy(2) // error: copy is protected
 }
 

--- a/test/files/neg/t13163.check
+++ b/test/files/neg/t13163.check
@@ -1,0 +1,31 @@
+t13163.scala:7: error: method apply in object I1 cannot be accessed as a member of object O.this.I1 from class O
+ Access to protected method apply not permitted because
+ enclosing class O is not a subclass of
+ object I1 in class O where target is defined
+  def t1 = I1.apply(42) // error
+              ^
+t13163.scala:13: error: constructor I1 in class I1 cannot be accessed in class II1 from class II1 in class OO
+ Access to protected constructor I1 not permitted because
+ prefix type OO.this.I1 does not conform to
+ class II1 in class OO where the access takes place
+    def t1 = new I1(42)   // error
+             ^
+t13163.scala:14: error: method apply in object I1 cannot be accessed as a member of object OO.this.I1 from class II1 in class OO
+ Access to protected method apply not permitted because
+ enclosing class II1 in class OO is not a subclass of
+ object I1 in class O where target is defined
+    def t2 = I1.apply(42) // error
+                ^
+t13163.scala:17: error: constructor I1 in class I1 cannot be accessed in class OO from class OO
+ Access to protected constructor I1 not permitted because
+ enclosing class OO is not a subclass of
+ class I1 in class O where target is defined
+  def t1 = new I1(42) // error
+           ^
+t13163.scala:18: error: constructor I2 in class I2 cannot be accessed in class OO from class OO
+ Access to protected constructor I2 not permitted because
+ enclosing class OO is not a subclass of
+ class I2 in class O where target is defined
+  def t2 = new I2(42) // error
+           ^
+5 errors

--- a/test/files/neg/t13163.scala
+++ b/test/files/neg/t13163.scala
@@ -1,0 +1,19 @@
+//> using options -Xsource:3 -Xsource-features:case-apply-copy-access
+
+class O {
+  case class I1 protected (x: Int)
+  case class I2 protected[O] (x: Int)
+
+  def t1 = I1.apply(42) // error
+  def t2 = I2.apply(42) // ok
+}
+
+class OO extends O {
+  class II1 extends I1(42) {
+    def t1 = new I1(42)   // error
+    def t2 = I1.apply(42) // error
+  }
+
+  def t1 = new I1(42) // error
+  def t2 = new I2(42) // error
+}


### PR DESCRIPTION
Align with Scala 3. If a case class constructor is protected, copy the modifier to the synthetic `apply` method under
`-Xsource-features:case-apply-copy-access`.

Backport of https://github.com/scala/scala3/pull/14266

Fixes https://github.com/scala/bug/issues/13163