### PR TITLE
[backport] in mergely CI, add JDK 25 final, drop 24 and 25-ea

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: [8, 11, 17, 21, 24, 25-ea]
+        java: [8, 11, 17, 21, 25]
     runs-on: ${{matrix.os}}
     steps:
       - run: git config --global core.autocrlf false


### PR DESCRIPTION
The change won't actually get tested until it's merged. (I could add a commit that makes it get tested, then remove the commit, then merge, but it seems like unnecessary rigmarole as it's highly unlikely that the move from 25-ea to 25 will cause failures.)

backport of #11145 — I failed to notice at the time that that PR should have targeted 2.12.x

also note that rather than adding 26-ea now, I'm just going to wait until JDK 26 final is out, which it should be on March 17. (it might take some additional days for Temurin to make 26 available and for setup-java to pick it up.)