### PR TITLE
Replace defunct link

### DIFF
--- a/src/compiler/scala/tools/nsc/util/EditDistance.scala
+++ b/src/compiler/scala/tools/nsc/util/EditDistance.scala
@@ -20,7 +20,7 @@ object EditDistance {
   /**
    * @author Paul Phillips
    * Translated from the java version at
-   *    https://www.merriampark.com/ld.htm
+   *    https://web.archive.org/web/20120526085419/http://www.merriampark.com/ld.htm
    *  which is declared to be public domain.
    */
   def levenshtein(


### PR DESCRIPTION
Link is defunct for a number of years already. Replaced with a link from the Internet Archive.