### PR TITLE
Deprecation when inferring implicit from non-accessible companion

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -132,12 +132,10 @@ trait Implicits extends splain.SplainData {
     if (settings.areStatisticsEnabled) statistics.stopCounter(subtypeImpl, subtypeStart)
 
     if (result.isSuccess) {
-      val rts = {
-        val infoSym = if (result.implicitInfo != null) result.implicitInfo.sym else NoSymbol
-        infoSym.orElse {
-          val rts0 = result.tree.symbol
-          if (rts0 != null) rts0 else NoSymbol
-        }
+      val infoSym = if (result.implicitInfo != null) result.implicitInfo.sym else NoSymbol
+      val rts = infoSym.orElse {
+        val rts0 = result.tree.symbol
+        if (rts0 != null) rts0 else NoSymbol
       }
       if (settings.lintImplicitRecursion) {
         val target =
@@ -186,6 +184,11 @@ trait Implicits extends splain.SplainData {
             if (doWarn)
               context.warning(result.tree.pos, s"Implicit resolves to enclosing $encl$help", WFlagSelfImplicit)
           }
+      }
+      if (infoSym.exists && infoSym.owner.isModuleClass) {
+        val companion = companionSymbolOf(infoSym.owner, context)
+        if (companion.exists && !context.isAccessible(companion, result.implicitInfo.pre.prefix))
+          context.deprecationWarning(result.tree.pos, infoSym, s"Usage of implicit $infoSym defined in $companion, which is not accessible here. In Scala 2.13.20, this implicit will no longer be found.", "2.13.19")
       }
       if (result.inPackagePrefix && currentRun.isScala3) {
         val msg =

--- a/test/files/neg/t13160.check
+++ b/test/files/neg/t13160.check
@@ -1,0 +1,9 @@
+t13160.scala:33: warning: Usage of implicit method d2i defined in object D, which is not accessible here. In Scala 2.13.20, this implicit will no longer be found.
+    d // not
+    ^
+t13160.scala:42: warning: Usage of implicit method e2i defined in object E, which is not accessible here. In Scala 2.13.20, this implicit will no longer be found.
+    e // not
+    ^
+error: No warnings can be incurred under -Werror.
+2 warnings
+1 error

--- a/test/files/neg/t13160.scala
+++ b/test/files/neg/t13160.scala
@@ -1,0 +1,44 @@
+//> using options -deprecation -Werror
+
+package p
+
+import scala.language.implicitConversions
+
+trait T {
+  object i {
+    class C
+    private[p] object C {
+      implicit def c2i(a: C): Int = 42
+    }
+  }
+  object j {
+    class D
+    private[j] object D {
+      implicit def d2i(a: D): Int = 42
+    }
+  }
+  class E
+  protected object E {
+    implicit def e2i(a: E): Int = 42
+  }
+}
+
+object Test extends T {
+  def t1: Int = {
+    val c = new i.C()
+    c // ok
+  }
+  def t2: Int = {
+    val d = new j.D()
+    d // not
+  }
+  def t3: Int = {
+    val e = new E()
+    e // ok
+  }
+  def t4: Int = {
+    val t = new T {}
+    val e = new t.E()
+    e // not
+  }
+}

--- a/test/files/run/t9516.check
+++ b/test/files/run/t9516.check
@@ -1,1 +1,0 @@
-warning: 12 deprecations (since 2.12.7); re-run with -deprecation for details


### PR DESCRIPTION
Implicits found in the companion object of a type should not be inferred if the companion object is not accessible.

Deprecation as a first step before actually changing implicit inference.