### PR TITLE
Fix extraKeys bit check in LongMap.put for Long.MinValue

### DIFF
--- a/src/library/scala/collection/mutable/LongMap.scala
+++ b/src/library/scala/collection/mutable/LongMap.scala
@@ -291,7 +291,7 @@ final class LongMap[V] private[collection] (defaultEntry: Long => V, initialBuff
         ans
       }
       else {
-        val ans = if ((extraKeys&2) == 1) Some(minValue.asInstanceOf[V]) else None
+        val ans = if ((extraKeys&2) == 2) Some(minValue.asInstanceOf[V]) else None
         minValue = value.asInstanceOf[AnyRef]
         extraKeys |= 2
         ans


### PR DESCRIPTION
## Summary

Corrects the condition when updating the key `Long.MinValue` in `LongMap.put`: `(extraKeys & 2)` is `0` or `2`, so the previous value must be returned when it equals `2`, not `1`.

## Testing

- [ ] Not run (one-line fix; consider adding a JUnit test if reviewers want coverage)