### PR TITLE
Fix jl.Long AccumulatorFactoryInfo to use LongAccumulator

### DIFF
--- a/src/library/scala/collection/convert/StreamExtensions.scala
+++ b/src/library/scala/collection/convert/StreamExtensions.scala
@@ -474,7 +474,7 @@ object StreamExtensions {
     }
 
     implicit val jIntegerAccumulatorFactoryInfo: AccumulatorFactoryInfo[jl.Integer, IntAccumulator] = intAccumulatorFactoryInfo.asInstanceOf[AccumulatorFactoryInfo[jl.Integer, IntAccumulator]]
-    implicit val jLongAccumulatorFactoryInfo: AccumulatorFactoryInfo[jl.Long, IntAccumulator] = longAccumulatorFactoryInfo.asInstanceOf[AccumulatorFactoryInfo[jl.Long, IntAccumulator]]
+    implicit val jLongAccumulatorFactoryInfo: AccumulatorFactoryInfo[jl.Long, LongAccumulator] = longAccumulatorFactoryInfo.asInstanceOf[AccumulatorFactoryInfo[jl.Long, LongAccumulator]]
     implicit val jDoubleAccumulatorFactoryInfo: AccumulatorFactoryInfo[jl.Double, IntAccumulator] = doubleAccumulatorFactoryInfo.asInstanceOf[AccumulatorFactoryInfo[jl.Double, IntAccumulator]]
   }
 }


### PR DESCRIPTION
## Summary

`jLongAccumulatorFactoryInfo` was incorrectly typed like the `jInteger` implicit, using `IntAccumulator` for both the value type and the `asInstanceOf` target. Boxed `java.lang.Long` streams should use `LongAccumulator`, matching `longAccumulatorFactoryInfo`.

## Testing

Not run (one-line type fix; can run `junit/test` if needed).