### PR TITLE
Fix variance direction in Checkable isNeverSubArg

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Checkable.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Checkable.scala
@@ -262,8 +262,8 @@ trait Checkable {
       def isNeverSubArg(t1: Type, t2: Type, tparam: Symbol) = {
         val variance = tparam.variance
         if (variance.isInvariant) isNeverSameType(t1, t2)
-        else if (variance.isCovariant) isNeverSubType(t2, t1)
-        else if (variance.isContravariant) isNeverSubType(t1, t2)
+        else if (variance.isCovariant) isNeverSubType(t1, t2)
+        else if (variance.isContravariant) isNeverSubType(t2, t1)
         else false
       }
       exists3(tps1, tps2, tparams)(isNeverSubArg)


### PR DESCRIPTION
## Summary

In `isNeverSubArgs`, `t1` / `t2` are the scrutinee and pattern type arguments. For subtyping `X <: P` at a covariant type parameter, we need `t1 <:< t2`; at a contravariant parameter, `t2 <:< t1`. The `isNeverSubType` checks used the opposite order for each variance.

This aligns with the commented variance formulation in `propagateKnownTypes` (covariant: `tp1 <:< tp2`; contravariant: `tp2 <:< tp1`).

## Testing

Not run locally (`sbt` unavailable in this environment). Please run `partest` on `test/files/neg/unchecked*.scala` and related patmat tests in CI.