### PR TITLE
Remove dead code in LiveVariables.Graph.updateExit

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/async/LiveVariables.scala
+++ b/src/compiler/scala/tools/nsc/transform/async/LiveVariables.scala
@@ -142,11 +142,6 @@ trait LiveVariables extends ExprBuilder {
         } else (entry.cardinality() != card)
       }
       def updateExit(): Boolean = {
-        var changed = false
-        if (exit == null) {
-          changed = true
-          exit = new BitSet()
-        }
         var i = 0
         val card = exit.cardinality()
         while (i < succ.length) {


### PR DESCRIPTION
## Summary

`Node.exit` is initialized with `new BitSet` and never reassigned to `null`, so the `exit == null` branch in `updateExit` was dead code; `changed` was also unused.

## Testing

Not run (behavior-preserving cleanup).