### PR TITLE
CI: add JDK 26 to mergely matrix

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: [8, 11, 17, 21, 25]
+        java: [8, 11, 17, 21, 25, 26]
     runs-on: ${{matrix.os}}
     steps:
       - run: git config --global core.autocrlf false

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,6 +1,7 @@
 name: Scala Merge CI
 
 on:
+  pull_request:
   push:
     branches: ['2.*.x']
   workflow_dispatch:


### PR DESCRIPTION
includes an extra commit, to be dropped before merge, that will make it run during PR validation, too