### PR TITLE
CI: add JDK 26 to mergely matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v5
         with:
-          distribution: temurin
+          distribution: zulu
           java-version: ${{matrix.java}}
           cache: sbt
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: [8, 11, 17, 21, 25]
+        java: [8, 11, 17, 21, 25, 26]
     runs-on: ${{matrix.os}}
     steps:
       - run: git config --global core.autocrlf false

--- a/test/files/neg/t6289.check
+++ b/test/files/neg/t6289.check
@@ -1,4 +1,8 @@
+#partest !java26+
 t6289/J.java:2: error: method does not override or implement a method from a supertype
+#partest java26+
+t6289/J.java:2: error: foo() in J does not override or implement a method from a supertype
+#partest
   @Override public void foo() { }
   ^
 1 error

--- a/test/files/pos/t2484.scala
+++ b/test/files/pos/t2484.scala
@@ -1,6 +1,9 @@
 import concurrent.ExecutionContext.Implicits.global
 
-class Admin extends javax.swing.JApplet {
+// this test used to use JApplet, which has ceased to exist
+// in JDK 26. I've substituted JFrame without checking to see whether
+// the original issue still reproduces on Scala 2.8 with the change, :shrug:
+class Admin extends javax.swing.JFrame {
   val jScrollPane = new javax.swing.JScrollPane (null, 0, 0)
   def t2484: Unit = {
     scala.concurrent.Future {jScrollPane.synchronized {

--- a/test/files/presentation/t13083.check
+++ b/test/files/presentation/t13083.check
@@ -3,5 +3,9 @@ reload: CompleteLocalImport.scala
 askTypeCompletion at CompleteLocalImport.scala(2,14)
 ================================================================================
 [response] askTypeCompletion at (2,14)
+#partest !java26+
 retrieved 14 members
+#partest java26+
+retrieved 13 members
+#partest
 ================================================================================

--- a/test/files/presentation/t13083/Runner.scala
+++ b/test/files/presentation/t13083/Runner.scala
@@ -1,5 +1,8 @@
 import scala.tools.nsc.interactive.tests._
 
 object Test extends InteractiveTest {
-  override protected def filterOutLines(line: String) = line.contains("package")
+  override protected def filterOutLines(line: String) =
+    line.contains("package") ||
+      // this disappeared on JDK 26
+      line.contains("applet")
 }

--- a/test/files/run/t8946.scala
+++ b/test/files/run/t8946.scala
@@ -30,6 +30,13 @@ object CanOpener {
     val unnamed = getClass.getClassLoader.getUnnamedModule
     val method = getMethodAccessible[Module]("implAddExportsOrOpens")
     for (base <- ModuleLayer.boot.findModule("java.base").toScala; pkg <- base.getPackages.asScala)
-      method.invokeAs[Unit](base, pkg, unnamed, True, True)
+      try
+        // the four-argument form works up through JDK 25
+        method.invokeAs[Unit](base, pkg, unnamed, True, True)
+      catch {
+        case _: java.lang.IllegalArgumentException =>
+          // but as of JDK 26, there's a fifth argument
+          method.invokeAs[Unit](base, pkg, unnamed, True, True, True)
+      }
   }
 }


### PR DESCRIPTION
I'm targeting 2.13.x only for now, as per remarks on #11234 and #11175

~PR temporarily includes an extra commit, to be dropped before merge, that will make it run during PR validation, too, so we can validate the change before merge~