### PR TITLE
merge 2.12 to 2.13 20260402  [ci: last-only]

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: [8, 11, 17, 21, 24, 25-ea]
+        java: [8, 11, 17, 21, 25]
     runs-on: ${{matrix.os}}
     steps:
       - run: git config --global core.autocrlf false

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.4
+sbt.version=1.12.5

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.5
+sbt.version=1.12.8


### PR DESCRIPTION
- SKIP **in mergely CI, add JDK 25 final, drop 24 and 25-ea**
- PICK **Update sbt, scripted-plugin to 1.12.5 in 2.12.x**
- PICK **Update sbt, scripted-plugin to 1.12.8 in 2.12.x**

so the end result is just to get sbt to 1.12.8