### PR TITLE
Fix bugs and performance of `indexOfSlice` (leverage kmp more) [ci: last-only]

### DIFF
--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -12,10 +12,11 @@
 
 package scala.collection
 
-import scala.collection.immutable.Range
-import scala.util.hashing.MurmurHash3
-import Searching.{Found, InsertionPoint, SearchResult}
 import scala.annotation.nowarn
+import scala.util.hashing.MurmurHash3
+
+import immutable.Range
+import Searching.{Found, InsertionPoint, SearchResult}
 
 /** Base trait for sequence collections
   *
@@ -412,8 +413,9 @@ trait SeqOps[+A, +CC[_], +C] extends Any
   @deprecatedOverriding("Override lastIndexWhere(p, end) instead - lastIndexWhere(p) calls lastIndexWhere(p, Int.MaxValue)", "2.13.0")
   def lastIndexWhere(p: A => Boolean): Int = lastIndexWhere(p, Int.MaxValue)
 
-  @inline private[this] def toGenericSeq: scala.collection.Seq[A] = this match {
-    case s: scala.collection.Seq[A] => s
+  /** Avoid constructing an `immutable.Seq` if possible. */
+  @inline private[this] def toGenericSeq: Seq[A] = this match {
+    case s: Seq[A] => s
     case _ => toSeq
   }
 
@@ -424,31 +426,28 @@ trait SeqOps[+A, +CC[_], +C] extends Any
    *  @return  the first index `>= from` such that the elements of this $coll starting at this index
    *           match the elements of sequence `that`, or `-1` if no such subsequence exists.
    */
-  // TODO Should be implemented in a way that preserves laziness
   def indexOfSlice[B >: A](that: Seq[B], from: Int): Int =
     if (that.isEmpty && from == 0) 0
     else {
+      val s = toGenericSeq
       val l = knownSize
       val tl = that.knownSize
+      val clippedFrom = math.max(0, from)
       if (l >= 0 && tl >= 0) {
-        val clippedFrom = math.max(0, from)
         if (from >= l) -1
         else if (tl == 0) clippedFrom
         else if (l < tl) -1
-        else
-          SeqOps.kmpSearch(S = toGenericSeq, m0 = clippedFrom, m1 = l, W = that, n0 = 0, n1 = tl, forward = true)
+        else SeqOps.kmpSearch(S = s, m0 = clippedFrom, m1 = l, W = that, n0 = 0, n1 = tl, forward = true)
       }
       else {
-        var i = from
-        var s: scala.collection.Seq[A] = toGenericSeq.drop(i)
-        while (!s.isEmpty) {
-          if (s startsWith that)
-            return i
-
-          i += 1
-          s = s.tail
-        }
-        -1
+        val thisLength =
+          if (l < 0) {
+            if (this.isInstanceOf[IndexedSeq[_]]) this.length // probably weird but OK
+            else Int.MaxValue // for nonindexed, it will iterate
+          }
+          else l
+        val otherLength = if (tl < 0) that.length else tl
+        SeqOps.kmpSearch(S = s, m0 = clippedFrom, m1 = thisLength, W = that, n0 = 0, n1 = otherLength, forward = true)
       }
     }
 
@@ -471,13 +470,13 @@ trait SeqOps[+A, +CC[_], +C] extends Any
    *           match the elements of sequence `that`, or `-1` if no such subsequence exists.
    */
   def lastIndexOfSlice[B >: A](that: Seq[B], end: Int): Int = {
-    val l = length
+    val l = knownSize
     val tl = that.length
-    val clippedL = math.min(l-tl, end)
+    val clippedL = if (l < 0) end else math.min(l-tl, end)
 
     if (end < 0) -1
     else if (tl < 1) clippedL
-    else if (l < tl) -1
+    else if (l >= 0 && l < tl) -1
     else SeqOps.kmpSearch(S = toGenericSeq, m0 = 0, m1 = clippedL+tl, W = that, n0 = 0, n1 = tl, forward = false)
   }
 
@@ -1065,7 +1064,7 @@ object SeqOps {
           def apply(x: Int) = iso(n0 + x)
         }
         else new AbstractIndexedSeqView[B] {
-          def length = n1 - n0
+          val length = n1 - n0
           def apply(x: Int) = iso(n1 - 1 - x)
         }
       case _ =>
@@ -1116,17 +1115,73 @@ object SeqOps {
       arr
     }
 
-    // Check for redundant case when target has single valid element
-    def clipR(x: Int, y: Int) = if (x < y) x else -1
-    def clipL(x: Int, y: Int) = if (x > y) x else -1
+    // We can index into S directly; it should be adequately fast
+    def kmpIndexed(S: IndexedSeq[B]): Int = {
+      val Wopt = kmpOptimizeWord(W, n0, n1, forward)
+      val T = kmpJumpTable(Wopt, n1-n0)
+      var i, m = 0
+      val zero = if (forward) m0 else m1-1
+      val delta = if (forward) 1 else -1
+      while (i+m < m1-m0) {
+        if (Wopt(i) == S(zero+delta*(i+m))) {
+          i += 1
+          if (i == n1-n0) return (if (forward) m+m0 else m1-m-i)
+        }
+        else {
+          val ti = T(i)
+          m += i - ti
+          if (i > 0) i = ti
+        }
+      }
+      -1
+    }
 
+    // We had better not index into S directly!
+    def kmpUnindexed(): Int = {
+      val iter = S.iterator.drop(m0)
+      val Wopt = kmpOptimizeWord(W, n0, n1, forward = true)
+      val T = kmpJumpTable(Wopt, n1-n0)
+      val cache = Array.ofDim[AnyRef](n1-n0)  // Ring buffer--need a quick way to do a look-behind
+      var largest = 0
+      var i, m = 0
+      var answer = -1
+      while (m+m0+n1-n0 <= m1) {
+        while (i+m >= largest) {
+          if (!iter.hasNext) return answer
+          cache(largest%(n1-n0)) = iter.next().asInstanceOf[AnyRef]
+          largest += 1
+        }
+        if (Wopt(i) == cache((i+m)%(n1-n0)).asInstanceOf[B]) {
+          i += 1
+          if (i == n1-n0) {
+            if (forward) return m+m0
+            else {
+              i -= 1
+              answer = m+m0
+              val ti = T(i)
+              m += i - ti
+              if (i > 0) i = ti
+            }
+          }
+        }
+        else {
+          val ti = T(i)
+          m += i - ti
+          if (i > 0) i = ti
+        }
+      }
+      answer
+    }
+
+    // Check for redundant case when target has single valid element
     if (n1 == n0+1) {
+      def clipR(x: Int, y: Int) = if (x < y) x else -1
+      def clipL(x: Int, y: Int) = if (x > y) x else -1
       if (forward)
         clipR(S.indexOf(W(n0), m0), m1)
       else
         clipL(S.lastIndexOf(W(n0), m1-1), m0-1)
     }
-
     // Check for redundant case when both sequences are same size
     else if (m1-m0 == n1-n0) {
       // Accepting a little slowness for the uncommon case.
@@ -1135,59 +1190,8 @@ object SeqOps {
     }
     // Now we know we actually need KMP search, so do it
     else S match {
-      case xs: scala.collection.IndexedSeq[_] =>
-        // We can index into S directly; it should be adequately fast
-        val Wopt = kmpOptimizeWord(W, n0, n1, forward)
-        val T = kmpJumpTable(Wopt, n1-n0)
-        var i, m = 0
-        val zero = if (forward) m0 else m1-1
-        val delta = if (forward) 1 else -1
-        while (i+m < m1-m0) {
-          if (Wopt(i) == S(zero+delta*(i+m))) {
-            i += 1
-            if (i == n1-n0) return (if (forward) m+m0 else m1-m-i)
-          }
-          else {
-            val ti = T(i)
-            m += i - ti
-            if (i > 0) i = ti
-          }
-        }
-        -1
-      case _ =>
-        // We had better not index into S directly!
-        val iter = S.iterator.drop(m0)
-        val Wopt = kmpOptimizeWord(W, n0, n1, forward = true)
-        val T = kmpJumpTable(Wopt, n1-n0)
-        val cache = new Array[AnyRef](n1-n0)  // Ring buffer--need a quick way to do a look-behind
-        var largest = 0
-        var i, m = 0
-        var answer = -1
-        while (m+m0+n1-n0 <= m1) {
-          while (i+m >= largest) {
-            cache(largest%(n1-n0)) = iter.next().asInstanceOf[AnyRef]
-            largest += 1
-          }
-          if (Wopt(i) == cache((i+m)%(n1-n0)).asInstanceOf[B]) {
-            i += 1
-            if (i == n1-n0) {
-              if (forward) return m+m0
-              else {
-                i -= 1
-                answer = m+m0
-                val ti = T(i)
-                m += i - ti
-                if (i > 0) i = ti
-              }
-            }
-          }
-          else {
-            val ti = T(i)
-            m += i - ti
-            if (i > 0) i = ti
-          }
-        }
-        answer
+      case xs: IndexedSeq[B] => kmpIndexed(xs)
+      case _ => kmpUnindexed()
     }
   }
 }

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -421,7 +421,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
 
   /** Finds first index at or after a start index where this $coll contains a given sequence as a slice.
    *  $mayNotTerminateInf
-   *  @param  that    the pattern sequence to search for
+   *  @param  that    the pattern sequence to search for, must be finite
    *  @param  from    the start index
    *  @return  the first index `>= from` such that the elements of this $coll starting at this index
    *           match the elements of sequence `that`, or `-1` if no such subsequence exists.
@@ -443,7 +443,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
 
   /** Finds first index where this $coll contains a given sequence as a slice.
    *  $mayNotTerminateInf
-   *  @param  that    the sequence to test
+   *  @param  that    the sequence to test, must be finite
    *  @return  the first index `>= 0` such that the elements of this $coll starting at this index
    *           match the elements of sequence `that`, or `-1` if no such subsequence exists.
    */
@@ -454,7 +454,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
    *
    *  $willNotTerminateInf
    *
-   *  @param  that    the sequence to test
+   *  @param  that    the sequence to test, must be finite
    *  @param  end     the end index
    *  @return  the last index `<= end` such that the elements of this $coll starting at this index
    *           match the elements of sequence `that`, or `-1` if no such subsequence exists.
@@ -468,6 +468,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     else if (l >= 0 && l < tl) -1
     else {
       val clippedL = if (l < 0) end else math.min(l - tl, end)
+      // if `clippedL + tl` overflows that's correct, a negative `m1` means "unbounded"
       SeqOps.kmpSearch(S = toGenericSeq, m0 = 0, m1 = clippedL + tl, W = that, n0 = 0, n1 = tl, forward = false)
     }
   }
@@ -476,7 +477,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     *
     *  $willNotTerminateInf
     *
-    *  @param  that    the sequence to test
+    *  @param  that    the sequence to test, must be finite
     *  @return  the last index such that the elements of this $coll starting at this index
     *           match the elements of sequence `that`, or `-1` if no such subsequence exists.
     */
@@ -502,7 +503,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
 
   /** Tests whether this $coll contains a given sequence as a slice.
    *  $mayNotTerminateInf
-   *  @param  that    the sequence to test
+   *  @param  that    the sequence to test, must be finite
    *  @return  `true` if this $coll contains a slice with the same elements
    *           as `that`, otherwise `false`.
    */

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -417,9 +417,9 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     case _ => toSeq
   }
 
-  /** Finds first index after or at a start index where this $coll contains a given sequence as a slice.
+  /** Finds first index at or after a start index where this $coll contains a given sequence as a slice.
    *  $mayNotTerminateInf
-   *  @param  that    the sequence to test
+   *  @param  that    the pattern sequence to search for
    *  @param  from    the start index
    *  @return  the first index `>= from` such that the elements of this $coll starting at this index
    *           match the elements of sequence `that`, or `-1` if no such subsequence exists.
@@ -435,7 +435,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
         if (from > l) -1
         else if (tl < 1) clippedFrom
         else if (l < tl) -1
-        else SeqOps.kmpSearch(toGenericSeq, clippedFrom, l, that, 0, tl, forward = true)
+        else SeqOps.kmpSearch(S = toGenericSeq, m0 = clippedFrom, m1 = l, W = that, n0 = 0, n1 = tl, forward = true)
       }
       else {
         var i = from
@@ -477,7 +477,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     if (end < 0) -1
     else if (tl < 1) clippedL
     else if (l < tl) -1
-    else SeqOps.kmpSearch(toGenericSeq, 0, clippedL+tl, that, 0, tl, forward = false)
+    else SeqOps.kmpSearch(S = toGenericSeq, m0 = 0, m1 = clippedL+tl, W = that, n0 = 0, n1 = tl, forward = false)
   }
 
   /** Finds last index where this $coll contains a given sequence as a slice.
@@ -1052,9 +1052,10 @@ object SeqOps {
      *  @param  W    The target sequence
      *  @param  n0   The first element in the target sequence that we should use
      *  @param  n1   The far end of the target sequence that we should use (exclusive)
+     *  @param  forward Direction of search (from beginning==true, from end==false)
      *  @return Target packed in an IndexedSeq (taken from iterator unless W already is an IndexedSeq)
      */
-    def kmpOptimizeWord[B](W: Seq[B], n0: Int, n1: Int, forward: Boolean): IndexedSeqView[B] = W match {
+    def kmpOptimizeWord(W: Seq[B], n0: Int, n1: Int, forward: Boolean): IndexedSeqView[B] = W match {
       case iso: IndexedSeq[B] =>
         // Already optimized for indexing--use original (or custom view of original)
         if (forward && n0==0 && n1==W.length) iso.view
@@ -1091,7 +1092,7 @@ object SeqOps {
      *  @param  wlen Just in case we're only IndexedSeq and not IndexedSeqOptimized
      *  @return KMP jump table for target sequence
      */
-    def kmpJumpTable[B](Wopt: IndexedSeqView[B], wlen: Int) = {
+    def kmpJumpTable(Wopt: IndexedSeqView[B], wlen: Int) = {
       val arr = Array.ofDim[Int](wlen)
       var pos = 2
       var cnd = 0

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -452,11 +452,11 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     }
 
   /** Finds first index where this $coll contains a given sequence as a slice.
-    *  $mayNotTerminateInf
-    *  @param  that    the sequence to test
-    *  @return  the first index `>= 0` such that the elements of this $coll starting at this index
-    *           match the elements of sequence `that`, or `-1` if no such subsequence exists.
-    */
+   *  $mayNotTerminateInf
+   *  @param  that    the sequence to test
+   *  @return  the first index `>= 0` such that the elements of this $coll starting at this index
+   *           match the elements of sequence `that`, or `-1` if no such subsequence exists.
+   */
   @deprecatedOverriding("Override indexOfSlice(that, from) instead - indexOfSlice(that) calls indexOfSlice(that, 0)", "2.13.0")
   def indexOfSlice[B >: A](that: Seq[B]): Int = indexOfSlice(that, 0)
 

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -1134,11 +1134,12 @@ object SeqOps {
       def clipL(x: Int, y: Int) = if (x > y) x else -1
       if (forward) {
         val x = S.indexOf(W(n0), m0)
-        if (m1 >= 0) clipR(x, m1)
-        else x
+        if (m1 >= 0) clipR(x, m1) else x
       }
-      else
-        clipL(S.lastIndexOf(W(n0), m1-1), m0-1)
+      else {
+        val x = if (m1 >= 0) S.lastIndexOf(W(n0), m1-1) else S.lastIndexOf(W(n0))
+        clipL(x, m0-1)
+      }
     }
 
     // We had better not index into S directly!
@@ -1219,7 +1220,8 @@ object SeqOps {
     }
     // Now we know we actually need KMP search, so do it
     else S match {
-      case xs: IndexedSeq[B] if sized => kmpIndexed(xs)
+      // `m1` may exceed the length if the source is indexed but reports an unknown `knownSize`
+      case xs: IndexedSeq[B] if sized && m1 <= xs.length => kmpIndexed(xs)
       case _ => kmpUnindexed()
     }
   }

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -1035,21 +1035,85 @@ trait SeqOps[+A, +CC[_], +C] extends Any
 
 object SeqOps {
 
-  // KMP search utilities
+ /** A KMP implementation.
+  *
+  *  @param  S       Sequence that may contain target
+  *  @param  m0      First index of S to consider
+  *  @param  m1      Last index of S to consider (exclusive)
+  *  @param  W       Target sequence
+  *  @param  n0      First index of W to match
+  *  @param  n1      Last index of W to match (exclusive)
+  *  @param  forward Direction of search (from beginning==true, from end==false)
+  *  @return Index of start of sequence if found, -1 if not (relative to beginning of S, not m0).
+  */
+  private def kmpSearch[B](S: Seq[B], m0: Int, m1: Int, W: Seq[B], n0: Int, n1: Int, forward: Boolean): Int = {
+    /** Makes sure a target sequence has fast, correctly-ordered indexing for KMP.
+     *
+     *  @param  W    The target sequence
+     *  @param  n0   The first element in the target sequence that we should use
+     *  @param  n1   The far end of the target sequence that we should use (exclusive)
+     *  @return Target packed in an IndexedSeq (taken from iterator unless W already is an IndexedSeq)
+     */
+    def kmpOptimizeWord[B](W: Seq[B], n0: Int, n1: Int, forward: Boolean): IndexedSeqView[B] = W match {
+      case iso: IndexedSeq[B] =>
+        // Already optimized for indexing--use original (or custom view of original)
+        if (forward && n0==0 && n1==W.length) iso.view
+        else if (forward) new AbstractIndexedSeqView[B] {
+          val length = n1 - n0
+          def apply(x: Int) = iso(n0 + x)
+        }
+        else new AbstractIndexedSeqView[B] {
+          def length = n1 - n0
+          def apply(x: Int) = iso(n1 - 1 - x)
+        }
+      case _ =>
+        // W is probably bad at indexing.  Pack in array (in correct orientation)
+        // Would be marginally faster to special-case each direction
+        new AbstractIndexedSeqView[B] {
+          private[this] val Warr = new Array[AnyRef](n1-n0)
+          private[this] val delta = if (forward) 1 else -1
+          private[this] val done = if (forward) n1-n0 else -1
+          val wit = W.iterator.drop(n0)
+          var i = if (forward) 0 else (n1-n0-1)
+          while (i != done) {
+            Warr(i) = wit.next().asInstanceOf[AnyRef]
+            i += delta
+          }
 
- /**  A KMP implementation, based on the undoubtedly reliable wikipedia entry.
-   *  Note: I made this private to keep it from entering the API.  That can be reviewed.
-   *
-   *  @param  S       Sequence that may contain target
-   *  @param  m0      First index of S to consider
-   *  @param  m1      Last index of S to consider (exclusive)
-   *  @param  W       Target sequence
-   *  @param  n0      First index of W to match
-   *  @param  n1      Last index of W to match (exclusive)
-   *  @param  forward Direction of search (from beginning==true, from end==false)
-   *  @return Index of start of sequence if found, -1 if not (relative to beginning of S, not m0).
-   */
-  private def kmpSearch[B](S: scala.collection.Seq[B], m0: Int, m1: Int, W: scala.collection.Seq[B], n0: Int, n1: Int, forward: Boolean): Int = {
+          val length = n1 - n0
+          def apply(x: Int) = Warr(x).asInstanceOf[B]
+        }
+    }
+
+    /** Makes a jump table for KMP search.
+     *
+     *  @param  Wopt The target sequence
+     *  @param  wlen Just in case we're only IndexedSeq and not IndexedSeqOptimized
+     *  @return KMP jump table for target sequence
+     */
+    def kmpJumpTable[B](Wopt: IndexedSeqView[B], wlen: Int) = {
+      val arr = Array.ofDim[Int](wlen)
+      var pos = 2
+      var cnd = 0
+      arr(0) = -1
+      arr(1) = 0
+      while (pos < wlen) {
+        if (Wopt(pos-1) == Wopt(cnd)) {
+          arr(pos) = cnd + 1
+          pos += 1
+          cnd += 1
+        }
+        else if (cnd > 0) {
+          cnd = arr(cnd)
+        }
+        else {
+          arr(pos) = 0
+          pos += 1
+        }
+      }
+      arr
+    }
+
     // Check for redundant case when target has single valid element
     def clipR(x: Int, y: Int) = if (x < y) x else -1
     def clipL(x: Int, y: Int) = if (x > y) x else -1
@@ -1123,73 +1187,6 @@ object SeqOps {
         }
         answer
     }
-  }
-
-  /** Makes sure a target sequence has fast, correctly-ordered indexing for KMP.
-   *
-   *  @param  W    The target sequence
-   *  @param  n0   The first element in the target sequence that we should use
-   *  @param  n1   The far end of the target sequence that we should use (exclusive)
-   *  @return Target packed in an IndexedSeq (taken from iterator unless W already is an IndexedSeq)
-   */
-  private def kmpOptimizeWord[B](W: scala.collection.Seq[B], n0: Int, n1: Int, forward: Boolean): IndexedSeqView[B] = W match {
-    case iso: IndexedSeq[B] =>
-      // Already optimized for indexing--use original (or custom view of original)
-      if (forward && n0==0 && n1==W.length) iso.view
-      else if (forward) new AbstractIndexedSeqView[B] {
-        val length = n1 - n0
-        def apply(x: Int) = iso(n0 + x)
-      }
-      else new AbstractIndexedSeqView[B] {
-        def length = n1 - n0
-        def apply(x: Int) = iso(n1 - 1 - x)
-      }
-    case _ =>
-      // W is probably bad at indexing.  Pack in array (in correct orientation)
-      // Would be marginally faster to special-case each direction
-      new AbstractIndexedSeqView[B] {
-        private[this] val Warr = new Array[AnyRef](n1-n0)
-        private[this] val delta = if (forward) 1 else -1
-        private[this] val done = if (forward) n1-n0 else -1
-        val wit = W.iterator.drop(n0)
-        var i = if (forward) 0 else (n1-n0-1)
-        while (i != done) {
-          Warr(i) = wit.next().asInstanceOf[AnyRef]
-          i += delta
-        }
-
-        val length = n1 - n0
-        def apply(x: Int) = Warr(x).asInstanceOf[B]
-      }
-  }
-
- /** Makes a jump table for KMP search.
-   *
-   *  @param  Wopt The target sequence
-   *  @param  wlen Just in case we're only IndexedSeq and not IndexedSeqOptimized
-   *  @return KMP jump table for target sequence
-   */
-  private def kmpJumpTable[B](Wopt: IndexedSeqView[B], wlen: Int) = {
-    val arr = new Array[Int](wlen)
-    var pos = 2
-    var cnd = 0
-    arr(0) = -1
-    arr(1) = 0
-    while (pos < wlen) {
-      if (Wopt(pos-1) == Wopt(cnd)) {
-        arr(pos) = cnd + 1
-        pos += 1
-        cnd += 1
-      }
-      else if (cnd > 0) {
-        cnd = arr(cnd)
-      }
-      else {
-        arr(pos) = 0
-        pos += 1
-      }
-    }
-    arr
   }
 }
 

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -433,22 +433,12 @@ trait SeqOps[+A, +CC[_], +C] extends Any
       val l = knownSize
       val tl = that.knownSize
       val clippedFrom = math.max(0, from)
-      if (l >= 0 && tl >= 0) {
-        if (from >= l) -1
-        else if (tl == 0) clippedFrom
-        else if (l < tl) -1
-        else SeqOps.kmpSearch(S = s, m0 = clippedFrom, m1 = l, W = that, n0 = 0, n1 = tl, forward = true)
+      if (l >= 0) {
+        if (from > l) return -1
+        if (tl == 0) return clippedFrom
+        if (tl >= 0 && l < tl) return -1
       }
-      else {
-        val thisLength =
-          if (l < 0) {
-            if (this.isInstanceOf[IndexedSeq[_]]) this.length // probably weird but OK
-            else Int.MaxValue // for nonindexed, it will iterate
-          }
-          else l
-        val otherLength = if (tl < 0) that.length else tl
-        SeqOps.kmpSearch(S = s, m0 = clippedFrom, m1 = thisLength, W = that, n0 = 0, n1 = otherLength, forward = true)
-      }
+      SeqOps.kmpSearch(S = s, m0 = clippedFrom, m1 = l, W = that, n0 = 0, n1 = tl, forward = true)
     }
 
   /** Finds first index where this $coll contains a given sequence as a slice.
@@ -523,7 +513,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
    *  @return     `true` if this $coll has an element that is equal (as
    *              determined by `==`) to `elem`, `false` otherwise.
    */
-  def contains[A1 >: A](elem: A1): Boolean = exists (_ == elem)
+  def contains[A1 >: A](elem: A1): Boolean = exists(_ == elem)
 
   @deprecated("Use .reverseIterator.map(f).to(...) instead of .reverseMap(f)", "2.13.0")
   def reverseMap[B](f: A => B): CC[B] = iterableFactory.from(new View.Map(View.fromIteratorProvider(() => reverseIterator), f))
@@ -1041,8 +1031,8 @@ object SeqOps {
   *  @param  m0      First index of S to consider
   *  @param  m1      Last index of S to consider (exclusive)
   *  @param  W       Target sequence
-  *  @param  n0      First index of W to match
-  *  @param  n1      Last index of W to match (exclusive)
+  *  @param  n0      First index of W to match (0)
+  *  @param  n1      Last index of W to match (exclusive) (W.length if known)
   *  @param  forward Direction of search (from beginning==true, from end==false)
   *  @return Index of start of sequence if found, -1 if not (relative to beginning of S, not m0).
   */
@@ -1136,16 +1126,57 @@ object SeqOps {
       -1
     }
 
+    def clipped(): Int = {
+      def clipR(x: Int, y: Int) = if (x < y) x else -1
+      def clipL(x: Int, y: Int) = if (x > y) x else -1
+      if (forward) {
+        val x = S.indexOf(W(n0), m0)
+        if (m1 >= 0) clipR(x, m1)
+        else x
+      }
+      else
+        clipL(S.lastIndexOf(W(n0), m1-1), m0-1)
+    }
+
     // We had better not index into S directly!
+    // Also cope with m1 < 0 || n1 < 0 for collections of unknown size.
     def kmpUnindexed(): Int = {
-      val iter = S.iterator.drop(m0)
+      val iter = S.iterator.drop(m0).buffered
+      // on empty pattern, return m0 if it is a valid index in S or S.length for position to append
+      if (W.isEmpty)
+        if (iter.hasNext) return m0
+        else {
+          val len = S.length
+          if (m0 <= len) return len
+          else return -1
+        }
+      // enhance laziness by pre-scanning for head of pattern; T could be fully lazy.
+      var n1b = n1
+      var moffset = 0
+      if (n1b < 0) {
+        val head = W(0) // already forced isEmpty
+        while (iter.hasNext && iter.head != head) {
+          iter.next()
+          moffset += 1
+        }
+        if (!iter.hasNext)
+          return -1
+        n1b = W.length // force W
+      }
+      if (n1b == n0+1)
+        clipped()
+      else
+        kmpUnindexedN1(iter, moffset, n1b)
+    }
+    def kmpUnindexedN1(iter: Iterator[B], moffset: Int, n1: Int): Int = {
       val Wopt = kmpOptimizeWord(W, n0, n1, forward = true)
       val T = kmpJumpTable(Wopt, n1-n0)
       val cache = Array.ofDim[AnyRef](n1-n0)  // Ring buffer--need a quick way to do a look-behind
-      var largest = 0
-      var i, m = 0
+      var largest = moffset
+      var i = 0
+      var m = moffset
       var answer = -1
-      while (m+m0+n1-n0 <= m1) {
+      while (m1 < 0 || m+m0+n1-n0 <= m1) {
         while (i+m >= largest) {
           if (!iter.hasNext) return answer
           cache(largest%(n1-n0)) = iter.next().asInstanceOf[AnyRef]
@@ -1172,25 +1203,19 @@ object SeqOps {
       }
       answer
     }
-
+    val sized = m1 >= 0 && n1 >= 0
     // Check for redundant case when target has single valid element
-    if (n1 == n0+1) {
-      def clipR(x: Int, y: Int) = if (x < y) x else -1
-      def clipL(x: Int, y: Int) = if (x > y) x else -1
-      if (forward)
-        clipR(S.indexOf(W(n0), m0), m1)
-      else
-        clipL(S.lastIndexOf(W(n0), m1-1), m0-1)
-    }
+    if (sized && n1 == n0+1)
+      clipped()
     // Check for redundant case when both sequences are same size
-    else if (m1-m0 == n1-n0) {
+    else if (sized && m1-m0 == n1-n0) {
       // Accepting a little slowness for the uncommon case.
       if (S.iterator.slice(m0, m1).sameElements(W.iterator.slice(n0, n1))) m0
       else -1
     }
     // Now we know we actually need KMP search, so do it
     else S match {
-      case xs: IndexedSeq[B] => kmpIndexed(xs)
+      case xs: IndexedSeq[B] if sized => kmpIndexed(xs)
       case _ => kmpUnindexed()
     }
   }

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -462,12 +462,14 @@ trait SeqOps[+A, +CC[_], +C] extends Any
   def lastIndexOfSlice[B >: A](that: Seq[B], end: Int): Int = {
     val l = knownSize
     val tl = that.length
-    val clippedL = if (l < 0) end else math.min(l-tl, end)
 
     if (end < 0) -1
-    else if (tl < 1) clippedL
+    else if (tl < 1) math.min((if (l >= 0) l else length) - tl, end)
     else if (l >= 0 && l < tl) -1
-    else SeqOps.kmpSearch(S = toGenericSeq, m0 = 0, m1 = clippedL+tl, W = that, n0 = 0, n1 = tl, forward = false)
+    else {
+      val clippedL = if (l < 0) end else math.min(l - tl, end)
+      SeqOps.kmpSearch(S = toGenericSeq, m0 = 0, m1 = clippedL + tl, W = that, n0 = 0, n1 = tl, forward = false)
+    }
   }
 
   /** Finds last index where this $coll contains a given sequence as a slice.
@@ -1168,23 +1170,24 @@ object SeqOps {
       else
         kmpUnindexedN1(iter, moffset, n1b)
     }
-    def kmpUnindexedN1(iter: Iterator[B], moffset: Int, n1: Int): Int = {
-      val Wopt = kmpOptimizeWord(W, n0, n1, forward = true)
-      val T = kmpJumpTable(Wopt, n1-n0)
-      val cache = Array.ofDim[AnyRef](n1-n0)  // Ring buffer--need a quick way to do a look-behind
+    // `wlen` is the forced pattern length (outer `n1` may have been -1).
+    def kmpUnindexedN1(iter: Iterator[B], moffset: Int, wlen: Int): Int = {
+      val Wopt = kmpOptimizeWord(W, n0, wlen, forward = true)
+      val T = kmpJumpTable(Wopt, wlen-n0)
+      val cache = Array.ofDim[AnyRef](wlen-n0)  // Ring buffer--need a quick way to do a look-behind
       var largest = moffset
       var i = 0
       var m = moffset
       var answer = -1
-      while (m1 < 0 || m+m0+n1-n0 <= m1) {
+      while (m1 < 0 || m+m0+wlen-n0 <= m1) {
         while (i+m >= largest) {
           if (!iter.hasNext) return answer
-          cache(largest%(n1-n0)) = iter.next().asInstanceOf[AnyRef]
+          cache(largest%(wlen-n0)) = iter.next().asInstanceOf[AnyRef]
           largest += 1
         }
-        if (Wopt(i) == cache((i+m)%(n1-n0)).asInstanceOf[B]) {
+        if (Wopt(i) == cache((i+m)%(wlen-n0)).asInstanceOf[B]) {
           i += 1
-          if (i == n1-n0) {
+          if (i == wlen-n0) {
             if (forward) return m+m0
             else {
               i -= 1

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -432,10 +432,11 @@ trait SeqOps[+A, +CC[_], +C] extends Any
       val tl = that.knownSize
       if (l >= 0 && tl >= 0) {
         val clippedFrom = math.max(0, from)
-        if (from > l) -1
-        else if (tl < 1) clippedFrom
+        if (from >= l) -1
+        else if (tl == 0) clippedFrom
         else if (l < tl) -1
-        else SeqOps.kmpSearch(S = toGenericSeq, m0 = clippedFrom, m1 = l, W = that, n0 = 0, n1 = tl, forward = true)
+        else
+          SeqOps.kmpSearch(S = toGenericSeq, m0 = clippedFrom, m1 = l, W = that, n0 = 0, n1 = tl, forward = true)
       }
       else {
         var i = from

--- a/src/library/scala/collection/Seq.scala
+++ b/src/library/scala/collection/Seq.scala
@@ -116,7 +116,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     * Note that :-ending operators are right associative (see example).
     * A mnemonic for `+:` vs. `:+` is: the COLon goes on the COLlection side.
     */
-  @`inline` final def +: [B >: A](elem: B): CC[B] = prepended(elem)
+  @inline final def +: [B >: A](elem: B): CC[B] = prepended(elem)
 
   /** A copy of this $coll with an element appended.
     *
@@ -146,7 +146,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     * Note that :-ending operators are right associative (see example).
     * A mnemonic for `+:` vs. `:+` is: the COLon goes on the COLlection side.
     */
-  @`inline` final def :+ [B >: A](elem: B): CC[B] = appended(elem)
+  @inline final def :+ [B >: A](elem: B): CC[B] = appended(elem)
 
   /** As with `:++`, returns a new collection containing the elements from the left operand followed by the
     *  elements from the right operand.
@@ -166,7 +166,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
   })
 
   /** Alias for `prependedAll`. */
-  @`inline` override final def ++: [B >: A](prefix: IterableOnce[B]): CC[B] = prependedAll(prefix)
+  @inline override final def ++: [B >: A](prefix: IterableOnce[B]): CC[B] = prependedAll(prefix)
 
   /** Returns a new $coll containing the elements from the left hand operand followed by the elements from the
     *  right hand operand. The element type of the $coll is the most specific superclass encompassing
@@ -330,7 +330,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     *           such that every element of the segment satisfies the predicate `p`.
     */
   @deprecated("Use segmentLength instead of prefixLength", "2.13.0")
-  @`inline` final def prefixLength(p: A => Boolean): Int = segmentLength(p, 0)
+  @inline final def prefixLength(p: A => Boolean): Int = segmentLength(p, 0)
 
   /** Finds index of the first element satisfying some predicate after or at some start index.
     *

--- a/test/files/run/seqlike-kmp.check
+++ b/test/files/run/seqlike-kmp.check
@@ -1,90 +1,233 @@
-indexOfSlice
-  (97) with idx >= -1 = 97
-  (97) with idx >= 0 = 97
-  (97) with idx >= 1 = 97
-  (97) with idx >= 2 = 97
-  (97) with idx >= 97 = 97
-  (97) with idx >= 98 = -1
-  (97) with idx >= 99 = -1
-  (97) with idx >= 100 = -1
+indexOfSlice of class scala.collection.immutable.Vector1
+  (7) with idx >= -1 = 7
+  (7) with idx >= 0 = 7
+  (7) with idx >= 1 = 7
+  (7) with idx >= 2 = 7
+  (7) with idx >= 9 = -1
+  (7) with idx >= 10 = -1
 lastIndexOfSlice
-  (97) with idx <= -1 = -1
-  (97) with idx <= 0 = -1
-  (97) with idx <= 1 = -1
-  (97) with idx <= 2 = -1
-  (97) with idx <= 97 = 97
-  (97) with idx <= 98 = 97
-  (97) with idx <= 99 = 97
-  (97) with idx <= 100 = 97
-indexOfSlice
-  (97, 98) with idx >= -1 = 97
-  (97, 98) with idx >= 0 = 97
-  (97, 98) with idx >= 1 = 97
-  (97, 98) with idx >= 2 = 97
-  (97, 98) with idx >= 97 = 97
-  (97, 98) with idx >= 98 = -1
-  (97, 98) with idx >= 99 = -1
-  (97, 98) with idx >= 100 = -1
+  (7) with idx <= -1 = -1
+  (7) with idx <= 0 = -1
+  (7) with idx <= 1 = -1
+  (7) with idx <= 2 = -1
+  (7) with idx <= 9 = 7
+  (7) with idx <= 10 = 7
+indexOfSlice of class scala.collection.immutable.Vector1
+  (7, 8) with idx >= -1 = 7
+  (7, 8) with idx >= 0 = 7
+  (7, 8) with idx >= 1 = 7
+  (7, 8) with idx >= 2 = 7
+  (7, 8) with idx >= 9 = -1
+  (7, 8) with idx >= 10 = -1
 lastIndexOfSlice
-  (97, 98) with idx <= -1 = -1
-  (97, 98) with idx <= 0 = -1
-  (97, 98) with idx <= 1 = -1
-  (97, 98) with idx <= 2 = -1
-  (97, 98) with idx <= 97 = 97
-  (97, 98) with idx <= 98 = 97
-  (97, 98) with idx <= 99 = 97
-  (97, 98) with idx <= 100 = 97
-indexOfSlice
-  (97, 98, 99) with idx >= -1 = 97
-  (97, 98, 99) with idx >= 0 = 97
-  (97, 98, 99) with idx >= 1 = 97
-  (97, 98, 99) with idx >= 2 = 97
-  (97, 98, 99) with idx >= 97 = 97
-  (97, 98, 99) with idx >= 98 = -1
-  (97, 98, 99) with idx >= 99 = -1
-  (97, 98, 99) with idx >= 100 = -1
+  (7, 8) with idx <= -1 = -1
+  (7, 8) with idx <= 0 = -1
+  (7, 8) with idx <= 1 = -1
+  (7, 8) with idx <= 2 = -1
+  (7, 8) with idx <= 9 = 7
+  (7, 8) with idx <= 10 = 7
+indexOfSlice of class scala.collection.immutable.Vector1
+  (7, 8, 9) with idx >= -1 = 7
+  (7, 8, 9) with idx >= 0 = 7
+  (7, 8, 9) with idx >= 1 = 7
+  (7, 8, 9) with idx >= 2 = 7
+  (7, 8, 9) with idx >= 9 = -1
+  (7, 8, 9) with idx >= 10 = -1
 lastIndexOfSlice
-  (97, 98, 99) with idx <= -1 = -1
-  (97, 98, 99) with idx <= 0 = -1
-  (97, 98, 99) with idx <= 1 = -1
-  (97, 98, 99) with idx <= 2 = -1
-  (97, 98, 99) with idx <= 97 = 97
-  (97, 98, 99) with idx <= 98 = 97
-  (97, 98, 99) with idx <= 99 = 97
-  (97, 98, 99) with idx <= 100 = 97
-indexOfSlice
-  (98, 99) with idx >= -1 = 98
-  (98, 99) with idx >= 0 = 98
-  (98, 99) with idx >= 1 = 98
-  (98, 99) with idx >= 2 = 98
-  (98, 99) with idx >= 97 = 98
-  (98, 99) with idx >= 98 = 98
-  (98, 99) with idx >= 99 = -1
-  (98, 99) with idx >= 100 = -1
+  (7, 8, 9) with idx <= -1 = -1
+  (7, 8, 9) with idx <= 0 = -1
+  (7, 8, 9) with idx <= 1 = -1
+  (7, 8, 9) with idx <= 2 = -1
+  (7, 8, 9) with idx <= 9 = 7
+  (7, 8, 9) with idx <= 10 = 7
+indexOfSlice of class scala.collection.immutable.Vector1
+  (8, 9) with idx >= -1 = 8
+  (8, 9) with idx >= 0 = 8
+  (8, 9) with idx >= 1 = 8
+  (8, 9) with idx >= 2 = 8
+  (8, 9) with idx >= 9 = -1
+  (8, 9) with idx >= 10 = -1
 lastIndexOfSlice
-  (98, 99) with idx <= -1 = -1
-  (98, 99) with idx <= 0 = -1
-  (98, 99) with idx <= 1 = -1
-  (98, 99) with idx <= 2 = -1
-  (98, 99) with idx <= 97 = -1
-  (98, 99) with idx <= 98 = 98
-  (98, 99) with idx <= 99 = 98
-  (98, 99) with idx <= 100 = 98
-indexOfSlice
-  (99) with idx >= -1 = 99
-  (99) with idx >= 0 = 99
-  (99) with idx >= 1 = 99
-  (99) with idx >= 2 = 99
-  (99) with idx >= 97 = 99
-  (99) with idx >= 98 = 99
-  (99) with idx >= 99 = 99
-  (99) with idx >= 100 = -1
+  (8, 9) with idx <= -1 = -1
+  (8, 9) with idx <= 0 = -1
+  (8, 9) with idx <= 1 = -1
+  (8, 9) with idx <= 2 = -1
+  (8, 9) with idx <= 9 = 8
+  (8, 9) with idx <= 10 = 8
+indexOfSlice of class scala.collection.immutable.Vector1
+  (9) with idx >= -1 = 9
+  (9) with idx >= 0 = 9
+  (9) with idx >= 1 = 9
+  (9) with idx >= 2 = 9
+  (9) with idx >= 9 = 9
+  (9) with idx >= 10 = -1
 lastIndexOfSlice
-  (99) with idx <= -1 = -1
-  (99) with idx <= 0 = -1
-  (99) with idx <= 1 = -1
-  (99) with idx <= 2 = -1
-  (99) with idx <= 97 = -1
-  (99) with idx <= 98 = -1
-  (99) with idx <= 99 = 99
-  (99) with idx <= 100 = 99
+  (9) with idx <= -1 = -1
+  (9) with idx <= 0 = -1
+  (9) with idx <= 1 = -1
+  (9) with idx <= 2 = -1
+  (9) with idx <= 9 = 9
+  (9) with idx <= 10 = 9
+indexOfSlice of class scala.collection.mutable.ArraySeq$ofInt
+  (7) with idx >= -1 = 7
+  (7) with idx >= 0 = 7
+  (7) with idx >= 1 = 7
+  (7) with idx >= 2 = 7
+  (7) with idx >= 9 = -1
+  (7) with idx >= 10 = -1
+lastIndexOfSlice
+  (7) with idx <= -1 = -1
+  (7) with idx <= 0 = -1
+  (7) with idx <= 1 = -1
+  (7) with idx <= 2 = -1
+  (7) with idx <= 9 = 7
+  (7) with idx <= 10 = 7
+indexOfSlice of class scala.collection.mutable.ArraySeq$ofInt
+  (7, 8) with idx >= -1 = 7
+  (7, 8) with idx >= 0 = 7
+  (7, 8) with idx >= 1 = 7
+  (7, 8) with idx >= 2 = 7
+  (7, 8) with idx >= 9 = -1
+  (7, 8) with idx >= 10 = -1
+lastIndexOfSlice
+  (7, 8) with idx <= -1 = -1
+  (7, 8) with idx <= 0 = -1
+  (7, 8) with idx <= 1 = -1
+  (7, 8) with idx <= 2 = -1
+  (7, 8) with idx <= 9 = 7
+  (7, 8) with idx <= 10 = 7
+indexOfSlice of class scala.collection.mutable.ArraySeq$ofInt
+  (7, 8, 9) with idx >= -1 = 7
+  (7, 8, 9) with idx >= 0 = 7
+  (7, 8, 9) with idx >= 1 = 7
+  (7, 8, 9) with idx >= 2 = 7
+  (7, 8, 9) with idx >= 9 = -1
+  (7, 8, 9) with idx >= 10 = -1
+lastIndexOfSlice
+  (7, 8, 9) with idx <= -1 = -1
+  (7, 8, 9) with idx <= 0 = -1
+  (7, 8, 9) with idx <= 1 = -1
+  (7, 8, 9) with idx <= 2 = -1
+  (7, 8, 9) with idx <= 9 = 7
+  (7, 8, 9) with idx <= 10 = 7
+indexOfSlice of class scala.collection.mutable.ArraySeq$ofInt
+  (8, 9) with idx >= -1 = 8
+  (8, 9) with idx >= 0 = 8
+  (8, 9) with idx >= 1 = 8
+  (8, 9) with idx >= 2 = 8
+  (8, 9) with idx >= 9 = -1
+  (8, 9) with idx >= 10 = -1
+lastIndexOfSlice
+  (8, 9) with idx <= -1 = -1
+  (8, 9) with idx <= 0 = -1
+  (8, 9) with idx <= 1 = -1
+  (8, 9) with idx <= 2 = -1
+  (8, 9) with idx <= 9 = 8
+  (8, 9) with idx <= 10 = 8
+indexOfSlice of class scala.collection.mutable.ArraySeq$ofInt
+  (9) with idx >= -1 = 9
+  (9) with idx >= 0 = 9
+  (9) with idx >= 1 = 9
+  (9) with idx >= 2 = 9
+  (9) with idx >= 9 = 9
+  (9) with idx >= 10 = -1
+lastIndexOfSlice
+  (9) with idx <= -1 = -1
+  (9) with idx <= 0 = -1
+  (9) with idx <= 1 = -1
+  (9) with idx <= 2 = -1
+  (9) with idx <= 9 = 9
+  (9) with idx <= 10 = 9
+indexOfSlice of class scala.collection.immutable.$colon$colon
+  (7) with idx >= -1 = 7
+  (7) with idx >= 0 = 7
+  (7) with idx >= 1 = 7
+  (7) with idx >= 2 = 7
+  (7) with idx >= 9 = -1
+  (7) with idx >= 10 = -1
+lastIndexOfSlice
+  (7) with idx <= -1 = -1
+  (7) with idx <= 0 = -1
+  (7) with idx <= 1 = -1
+  (7) with idx <= 2 = -1
+  (7) with idx <= 9 = 7
+  (7) with idx <= 10 = 7
+indexOfSlice of class scala.collection.immutable.$colon$colon
+  (7, 8) with idx >= -1 = 7
+  (7, 8) with idx >= 0 = 7
+  (7, 8) with idx >= 1 = 7
+  (7, 8) with idx >= 2 = 7
+  (7, 8) with idx >= 9 = -1
+  (7, 8) with idx >= 10 = -1
+lastIndexOfSlice
+  (7, 8) with idx <= -1 = -1
+  (7, 8) with idx <= 0 = -1
+  (7, 8) with idx <= 1 = -1
+  (7, 8) with idx <= 2 = -1
+  (7, 8) with idx <= 9 = 7
+  (7, 8) with idx <= 10 = 7
+indexOfSlice of class scala.collection.immutable.$colon$colon
+  (7, 8, 9) with idx >= -1 = 7
+  (7, 8, 9) with idx >= 0 = 7
+  (7, 8, 9) with idx >= 1 = 7
+  (7, 8, 9) with idx >= 2 = 7
+  (7, 8, 9) with idx >= 9 = -1
+  (7, 8, 9) with idx >= 10 = -1
+lastIndexOfSlice
+  (7, 8, 9) with idx <= -1 = -1
+  (7, 8, 9) with idx <= 0 = -1
+  (7, 8, 9) with idx <= 1 = -1
+  (7, 8, 9) with idx <= 2 = -1
+  (7, 8, 9) with idx <= 9 = 7
+  (7, 8, 9) with idx <= 10 = 7
+indexOfSlice of class scala.collection.immutable.$colon$colon
+  (8, 9) with idx >= -1 = 8
+  (8, 9) with idx >= 0 = 8
+  (8, 9) with idx >= 1 = 8
+  (8, 9) with idx >= 2 = 8
+  (8, 9) with idx >= 9 = -1
+  (8, 9) with idx >= 10 = -1
+lastIndexOfSlice
+  (8, 9) with idx <= -1 = -1
+  (8, 9) with idx <= 0 = -1
+  (8, 9) with idx <= 1 = -1
+  (8, 9) with idx <= 2 = -1
+  (8, 9) with idx <= 9 = 8
+  (8, 9) with idx <= 10 = 8
+indexOfSlice of class scala.collection.immutable.$colon$colon
+  (9) with idx >= -1 = 9
+  (9) with idx >= 0 = 9
+  (9) with idx >= 1 = 9
+  (9) with idx >= 2 = 9
+  (9) with idx >= 9 = 9
+  (9) with idx >= 10 = -1
+lastIndexOfSlice
+  (9) with idx <= -1 = -1
+  (9) with idx <= 0 = -1
+  (9) with idx <= 1 = -1
+  (9) with idx <= 2 = -1
+  (9) with idx <= 9 = 9
+  (9) with idx <= 10 = 9
+indexOfSlice of class scala.collection.immutable.LazyList
+Adding 0 and 1
+Adding 1 and 1
+Adding 1 and 2
+Adding 2 and 3
+  (3, 5) with idx >= -1 = 4
+  (3, 5) with idx >= 0 = 4
+  (3, 5) with idx >= 1 = 4
+  (3, 5) with idx >= 2 = 4
+Adding 3 and 5
+Adding 5 and 8
+Adding 8 and 13
+Adding 13 and 21
+  (3, 5) with idx >= 9 = -1
+  (3, 5) with idx >= 10 = -1
+lastIndexOfSlice
+  (3, 5) with idx <= -1 = -1
+  (3, 5) with idx <= 0 = -1
+  (3, 5) with idx <= 1 = -1
+  (3, 5) with idx <= 2 = -1
+  (3, 5) with idx <= 9 = 4
+Adding 21 and 34
+  (3, 5) with idx <= 10 = 4

--- a/test/files/run/seqlike-kmp.scala
+++ b/test/files/run/seqlike-kmp.scala
@@ -1,32 +1,66 @@
+import collection.Seq
+import collection.immutable.LazyList
+import math.BigInt
+import util.chaining._
+
 object Test {
-  val source = 0 to 99
-  val idxes = (-1 to 2) ++ (97 to 100)
-  def str(xs: Seq[Int]) = xs.mkString("(", ", ", ")")
+  val idxes = (-1 to 2) ++ (9 to 10)
+  def str[A](xs: Seq[A]) = xs.mkString("(", ", ", ")")
 
-  def f(tgt: Seq[Int]) = {
-    println("indexOfSlice")
-    // the first index `>= from` such that...
-    for (x <- idxes) {
-      val res = source.indexOfSlice(tgt, x)
-      println("  %s with idx >= %d = %d".format(str(tgt), x, res))
+  // the first index `>= from` such that...
+  def first[A](source: Seq[A], tgt: Seq[A]) = {
+    println(s"indexOfSlice of ${source.getClass}")
+    for (from <- idxes) {
+      val res = source.indexOfSlice(tgt, from = from)
+      println(f"  ${str(tgt)} with idx >= $from%d = $res%d")
     }
-    // the last index `<= end` such that...
+  }
+  // the last index `<= end` such that...
+  def last[A](source: Seq[A], tgt: Seq[A]) = {
     println("lastIndexOfSlice")
-    for (x <- idxes) {
-      val res = source.lastIndexOfSlice(tgt, x)
-      println("  %s with idx <= %d = %d".format(str(tgt), x, res))
+    for (end <- idxes) {
+      val res = source.lastIndexOfSlice(tgt, end)
+      println(f"  ${str(tgt)} with idx <= $end%d = $res%d")
     }
   }
 
-  def g(idx: Int, len: Int) = {
-    f(source.slice(idx, idx + len))
+  def both(source: Seq[Int], idx: Int, len: Int) = {
+    first(source, source.slice(idx, idx + len))
+    last(source, source.slice(idx, idx + len))
   }
+
+  def listed(source: Seq[Int], idx: Int, len: Int) = {
+    first(source, source.slice(idx, idx + len).toList)
+    last(source, source.slice(idx, idx + len).toList)
+  }
+
+  val fibs: LazyList[BigInt] =
+    BigInt(0) #:: BigInt(1) #::
+      fibs.zip(fibs.tail).map{ n =>
+        println(s"Adding ${n._1} and ${n._2}")
+        n._1 + n._2
+      }
 
   def main(args: Array[String]): Unit = {
-    g(97, 1)
-    g(97, 2)
-    g(97, 3)
-    g(98, 2)
-    g(99, 1)
+    val source = (0 to 9).toVector
+    both(source, 7, 1)
+    both(source, 7, 2)
+    both(source, 7, 3)
+    both(source, 8, 2)
+    both(source, 9, 1)
+    val mut: Seq[Int] = source.toArray
+    listed(mut, 7, 1)
+    listed(mut, 7, 2)
+    listed(mut, 7, 3)
+    listed(mut, 8, 2)
+    listed(mut, 9, 1)
+    val xs: Seq[Int] = source.toList
+    listed(xs, 7, 1)
+    listed(xs, 7, 2)
+    listed(xs, 7, 3)
+    listed(xs, 8, 2)
+    listed(xs, 9, 1)
+    first(fibs.take(10), List(3,5))
+    last(fibs, List(3,5))
   }
 }

--- a/test/files/run/t1323.scala
+++ b/test/files/run/t1323.scala
@@ -19,7 +19,7 @@ object Test extends App {
   // Do some testing with infinite sequences
   def from(n: Int): LazyList[Int] = LazyList.cons(n, from(n + 1))
 
-  println("17:" + List(1,2,3,4).indexOfSlice(from(1)))          // -1
+  println("17:" + List(1,2,3,4).indexOfSlice(from(1).take(10)))          // -1
   println("18:" + from(1).indexOfSlice(List(4,5,6)))            // 3
 }
 

--- a/test/junit/scala/collection/SeqTest.scala
+++ b/test/junit/scala/collection/SeqTest.scala
@@ -132,6 +132,27 @@ class SeqTest extends AllocationTest {
     assertEquals(-1, List(0, 1, 2).lastIndexOfSlice(Nil, end = -1))
   }
 
+  // `knownSize` may be -1 even for an `IndexedSeq`, since -1 just means "not cheaply known".
+  // `lastIndexOfSlice` must then not hand `kmpSearch` an `m1` past the end of the source.
+  @Test
+  def lastIndexOfSliceIndexedWithUnknownSize(): Unit = {
+    class Unsized[A](u: Vector[A]) extends AbstractSeq[A] with IndexedSeq[A] {
+      def apply(i: Int) = u(i)
+      def length = u.length
+      override def knownSize = -1
+    }
+    val empty = new Unsized(Vector.empty[Int])
+    val two = new Unsized(Vector(1, 2))
+    assertEquals(-1, empty.lastIndexOfSlice(List(0, 0), end = 1))
+    assertEquals(-1, two.lastIndexOfSlice(List(9, 9), end = 5))
+    assertEquals(0, two.lastIndexOfSlice(List(1, 2), end = 5))
+    assertEquals(0, two.lastIndexOfSlice(List(1, 2)))
+    assertEquals(1, two.lastIndexOfSlice(List(2), end = 5))   // single element, via `clipped`
+    assertEquals(2, two.lastIndexOfSlice(Nil, end = 5))
+    assertEquals(-1, empty.indexOfSlice(List(0, 0)))
+    assertEquals(1, two.indexOfSlice(List(2), from = 1))
+  }
+
   @Test
   def hasCorrectDiff(): Unit = {
     val s1 = Seq(1, 2, 3, 4, 5)

--- a/test/junit/scala/collection/SeqTest.scala
+++ b/test/junit/scala/collection/SeqTest.scala
@@ -3,6 +3,7 @@ package scala.collection
 import org.junit.Assert.{assertThrows => _, _}
 import org.junit.Test
 
+import scala.collection.immutable.LazyList
 import scala.tools.testkit.{AllocationTest, AssertUtil, CompileTime}, AssertUtil.assertThrows
 
 class SeqTest extends AllocationTest {
@@ -49,6 +50,66 @@ class SeqTest extends AllocationTest {
     assertEquals(1, List(0, 1, 2).indexOfSlice(List(1, 2), from = -1))
   }
 
+  // Exercises KMP backtracking: the pattern has a self-overlapping prefix (1,2,1,2,3),
+  // which forces the matcher to reuse the jump table rather than restart from scratch.
+  @Test
+  def kmpBacktrackingIndexOfSlice(): Unit = {
+    // pattern (1,2,1,2,3) inside a source that contains several false partial matches
+    val source = List(1, 2, 1, 2, 1, 2, 3, 4)
+    val pattern = List(1, 2, 1, 2, 3)
+    assertEquals(2, source.indexOfSlice(pattern))                            // non-indexed source
+    assertEquals(2, source.toVector.indexOfSlice(pattern))                   // indexed source
+    assertEquals(2, source.to(LazyList).indexOfSlice(pattern))               // lazy source
+    assertEquals(2, source.indexOfSlice(pattern.to(LazyList)))               // lazy pattern
+    assertEquals(2, source.to(LazyList).indexOfSlice(pattern.to(LazyList)))  // both lazy
+
+    // no match: pattern has a trailing element that never appears
+    val miss = List(1, 2, 1, 2, 3, 9)
+    assertEquals(-1, source.indexOfSlice(miss))
+    assertEquals(-1, source.to(LazyList).indexOfSlice(miss))
+    assertEquals(-1, source.to(LazyList).indexOfSlice(miss.to(LazyList)))
+  }
+
+  @Test
+  def kmpBacktrackingLastIndexOfSlice(): Unit = {
+    // the only match of (1,2,3) starts at index 4
+    val source = List(1, 2, 1, 2, 1, 2, 3, 1, 2)
+    val pattern = List(1, 2, 3)
+    assertEquals(4, source.lastIndexOfSlice(pattern))
+    assertEquals(4, source.toVector.lastIndexOfSlice(pattern))
+    assertEquals(4, source.to(LazyList).lastIndexOfSlice(pattern))
+    // with end = 3 the single match at 4 is excluded
+    assertEquals(-1, source.to(LazyList).lastIndexOfSlice(pattern, end = 3))
+    assertEquals(-1, source.to(LazyList).lastIndexOfSlice(List(9, 9)))
+
+    // two matches of (1,2,1,2) — latest starts at index 2 (exercises KMP jump table on backward pass)
+    val src2 = List(1, 2, 1, 2, 1, 2, 3)
+    val pat2 = List(1, 2, 1, 2)
+    assertEquals(2, src2.lastIndexOfSlice(pat2))
+    assertEquals(2, src2.toVector.lastIndexOfSlice(pat2))
+    assertEquals(2, src2.to(LazyList).lastIndexOfSlice(pat2))
+  }
+
+  // LazyList pattern has knownSize == -1, so kmpSearch takes the "unknown pattern length"
+  // branch that pre-scans the source for the pattern head before forcing W.length.
+  @Test
+  def indexOfSliceLazyPattern(): Unit = {
+    val src = List(0, 1, 2, 3, 4, 5)
+    assertEquals(2, src.indexOfSlice(LazyList(2, 3)))
+    assertEquals(2, src.to(LazyList).indexOfSlice(LazyList(2, 3)))
+    assertEquals(2, src.to(LazyList).indexOfSlice(LazyList(2, 3), from = 2))
+    assertEquals(-1, src.to(LazyList).indexOfSlice(LazyList(2, 3), from = 3))
+    assertEquals(-1, src.to(LazyList).indexOfSlice(LazyList(9, 9)))
+    // single-element lazy pattern reaches the `clipped()` branch
+    assertEquals(3, src.to(LazyList).indexOfSlice(LazyList(3)))
+    assertEquals(-1, src.to(LazyList).indexOfSlice(LazyList(99)))
+    // empty lazy pattern
+    assertEquals(0, src.to(LazyList).indexOfSlice(LazyList.empty[Int]))
+    assertEquals(2, src.to(LazyList).indexOfSlice(LazyList.empty[Int], from = 2))
+    assertEquals(src.length, src.to(LazyList).indexOfSlice(LazyList.empty[Int], from = src.length))
+    assertEquals(-1, src.to(LazyList).indexOfSlice(LazyList.empty[Int], from = src.length + 1))
+  }
+
   @Test
   def hasCorrectLastIndexOfSlice(): Unit = {
     assertEquals(0, Vector(0, 1).lastIndexOfSlice(List(0, 1)))
@@ -56,6 +117,13 @@ class SeqTest extends AllocationTest {
     assertEquals(4, Vector(0, 1, 2, 0, 1, 2).lastIndexOfSlice(Vector(1, 2)))
     assertEquals(1, Vector(0, 1, 2, 0, 1, 2).lastIndexOfSlice(Vector(1, 2), end = 3))
     assertEquals(-1, List(0, 1).lastIndexOfSlice(List(1, 2)))
+    // List (non-indexed) with explicit end
+    assertEquals(4, List(0, 1, 2, 0, 1, 2).lastIndexOfSlice(List(1, 2)))
+    assertEquals(1, List(0, 1, 2, 0, 1, 2).lastIndexOfSlice(List(1, 2), end = 3))
+    assertEquals(-1, List(0, 1, 2, 0, 1, 2).lastIndexOfSlice(List(1, 2), end = -1))
+    // LazyList source — (0,1,2,3,4,5,1,2) has matches at 1 and 6, latest is 6
+    assertEquals(6, (0 to 5).to(LazyList).appendedAll(List(1, 2)).lastIndexOfSlice(List(1, 2)))
+    assertEquals(1, LazyList(0, 1, 2, 0, 1, 2).lastIndexOfSlice(List(1, 2), end = 3))
   }
 
   @Test

--- a/test/junit/scala/collection/SeqTest.scala
+++ b/test/junit/scala/collection/SeqTest.scala
@@ -124,6 +124,12 @@ class SeqTest extends AllocationTest {
     // LazyList source — (0,1,2,3,4,5,1,2) has matches at 1 and 6, latest is 6
     assertEquals(6, (0 to 5).to(LazyList).appendedAll(List(1, 2)).lastIndexOfSlice(List(1, 2)))
     assertEquals(1, LazyList(0, 1, 2, 0, 1, 2).lastIndexOfSlice(List(1, 2), end = 3))
+
+    // empty pattern on non-indexed sources — must return the (clipped) length
+    assertEquals(3, List(0, 1, 2).lastIndexOfSlice(Nil))
+    assertEquals(3, LazyList(0, 1, 2).lastIndexOfSlice(Nil))
+    assertEquals(2, List(0, 1, 2).lastIndexOfSlice(Nil, end = 2))
+    assertEquals(-1, List(0, 1, 2).lastIndexOfSlice(Nil, end = -1))
   }
 
   @Test

--- a/test/junit/scala/collection/SeqTest.scala
+++ b/test/junit/scala/collection/SeqTest.scala
@@ -41,7 +41,12 @@ class SeqTest extends AllocationTest {
     assertEquals(0, Vector(0, 1).indexOfSlice(Vector(0, 1)))
     assertEquals(1, Vector(0, 1, 2, 0, 1, 2).indexOfSlice(Vector(1, 2)))
     assertEquals(4, Vector(0, 1, 2, 0, 1, 2).indexOfSlice(Vector(1, 2), from = 2))
+    assertEquals(1, Vector(0, 1, 2).indexOfSlice(Vector(1, 2), from = -1))
     assertEquals(-1, List(0, 1).indexOfSlice(List(1, 2)))
+    assertEquals(1, List(0).indexOfSlice(Nil, from = 1))
+    assertEquals(-1, List(0).indexOfSlice(Nil, from = 2))
+    assertEquals(0, List(0).indexOfSlice(Nil, from = -1))
+    assertEquals(1, List(0, 1, 2).indexOfSlice(List(1, 2), from = -1))
   }
 
   @Test

--- a/test/junit/scala/collection/immutable/LazyListLazinessTest.scala
+++ b/test/junit/scala/collection/immutable/LazyListLazinessTest.scala
@@ -37,7 +37,7 @@ class LazyListLazinessTest {
     assertRepeatedlyLazy(op)
     assertLazyNextStateWhenStateEvaluated(op) // checked for completeness
     assertLazyAll(op)
-    assertLazyAllSkipping(op, 0) // checked for completeness
+    assertLazyAllSkipping(0)(op) // checked for completeness
     assertKnownEmptyYieldsKnownEmpty(op)
   }
 
@@ -49,12 +49,12 @@ class LazyListLazinessTest {
 
   @Test
   def head_properlyLazy(): Unit = {
-    assertLazyAllSkipping(_.head, 1)
+    assertLazyAllSkipping(1)(_.head)
   }
 
   @Test
   def tail_properlyLazy(): Unit = {
-    assertLazyAllSkipping(_.tail, 1)
+    assertLazyAllSkipping(1)(_.tail)
   }
 
   @Test
@@ -64,12 +64,12 @@ class LazyListLazinessTest {
 
   @Test
   def isEmpty_properlyLazy(): Unit = {
-    assertLazyAllSkipping(_.isEmpty, 1)
+    assertLazyAllSkipping(1)(_.isEmpty)
   }
 
   @Test
   def nonEmpty_properlyLazy(): Unit = {
-    assertLazyAllSkipping(_.nonEmpty, 1)
+    assertLazyAllSkipping(1)(_.nonEmpty)
   }
 
   private def genericFilter_properlyLazy(filter: (LazyList[Int], Int => Boolean) => LazyList[Int],
@@ -131,8 +131,8 @@ class LazyListLazinessTest {
 
   @Test
   def collectFirst_properlyLazy(): Unit = {
-    assertLazyAllSkipping(_ collectFirst { case i if i % 2 == 0 => i }, 1)
-    assertLazyAllSkipping(_ collectFirst { case i if i % 2 != 0 => i }, 2)
+    assertLazyAllSkipping(1)(_.collectFirst { case i if i % 2 == 0 => i })
+    assertLazyAllSkipping(2)(_.collectFirst { case i if i % 2 != 0 => i })
   }
 
   @Test // scala/scala#6960
@@ -289,14 +289,14 @@ class LazyListLazinessTest {
   def take_properlyLazy(): Unit = {
     val op = lazyListOp(_.take(4))
     genericLazyOp_properlyLazy(op)
-    assertLazyAllSkipping(op.thenForce, 4)
+    assertLazyAllSkipping(4)(op.thenForce)
   }
 
   @Test
   def takeWhile_properlyLazy(): Unit = {
     val op = lazyListOp(_.takeWhile(_ < 4))
     genericLazyOp_properlyLazy(op)
-    assertLazyAllSkipping(op.thenForce, 5)
+    assertLazyAllSkipping(5)(op.thenForce)
   }
 
   @Test
@@ -310,7 +310,7 @@ class LazyListLazinessTest {
   def slice_properlyLazy(): Unit = {
     val op = lazyListOp(_.slice(2, LazinessChecker.count - 2))
     genericLazyOp_properlyLazy(op, DropProfile(dropCount = 2, repeatedDrops = false))
-    assertLazyAllSkipping(op.thenForce, LazinessChecker.count - 2)
+    assertLazyAllSkipping(skip = LazinessChecker.count - 2)(op.thenForce)
   }
 
   @Test
@@ -322,18 +322,18 @@ class LazyListLazinessTest {
 
   @Test
   def apply_properlyLazy(): Unit = {
-    assertLazyAllSkipping(_.apply(4), 5)
+    assertLazyAllSkipping(5)(_.apply(4))
   }
 
   @Test
   def lengthCompare_properlyLazy(): Unit = {
-    assertLazyAllSkipping(_ lengthCompare 3, 4)
+    assertLazyAllSkipping(4)(_ lengthCompare 3)
   }
 
   @Test
   def sizeCompare_properlyLazy(): Unit = {
     for (factory <- List[SeqFactory[Seq]](LazyList, Vector)) {
-      assertLazyAllSkipping(_ sizeCompare factory.fill(3)(1), 4)
+      assertLazyAllSkipping(4)(_ sizeCompare factory.fill(3)(1))
     }
   }
 
@@ -354,14 +354,14 @@ class LazyListLazinessTest {
 
   @Test
   def contains_properlyLazy(): Unit = {
-    assertLazyAllSkipping(_ contains 0, 1)
-    assertLazyAllSkipping(_ contains 3, 4)
+    assertLazyAllSkipping(1)(_ contains 0)
+    assertLazyAllSkipping(4)(_ contains 3)
   }
 
   @Test
   def containsSlice_properlyLazy(): Unit = {
-    assertLazyAllSkipping(_ containsSlice (0 to 2), 3)
-    assertLazyAllSkipping(_ containsSlice (3 to 7), 8)
+    assertLazyAllSkipping(3)(_ containsSlice (0 to 2))
+    assertLazyAllSkipping(8)(_ containsSlice (3 to 7))
 
     // check laziness of slice when it is a `LazyList`
     val checker = new OpLazinessChecker
@@ -371,14 +371,14 @@ class LazyListLazinessTest {
 
   @Test
   def corresponds_properlyLazy(): Unit = {
-    assertLazyAllSkipping(_.corresponds(Iterator.empty[Int])(_ == _), 1)
-    assertLazyAllSkipping(_.corresponds(LazyList.empty[Int])(_ == _), 1)
+    assertLazyAllSkipping(1)(_.corresponds(Iterator.empty[Int])(_ == _))
+    assertLazyAllSkipping(1)(_.corresponds(LazyList.empty[Int])(_ == _))
 
-    assertLazyAllSkipping(_.corresponds(Iterator.from(1))(_ == _), 1)
-    assertLazyAllSkipping(_.corresponds(LazyList.from(1))(_ == _), 1)
+    assertLazyAllSkipping(1)(_.corresponds(Iterator.from(1))(_ == _))
+    assertLazyAllSkipping(1)(_.corresponds(LazyList.from(1))(_ == _))
 
-    assertLazyAllSkipping(_.corresponds(Iterator.from(0).take(1))(_ == _), 2)
-    assertLazyAllSkipping(_.corresponds(LazyList.from(0).take(1))(_ == _), 2)
+    assertLazyAllSkipping(2)(_.corresponds(Iterator.from(0).take(1))(_ == _))
+    assertLazyAllSkipping(2)(_.corresponds(LazyList.from(0).take(1))(_ == _))
 
     // check laziness of corresponding `LazyList`
     def check(lazyList: LazyList[Int], withChecker: OpLazinessChecker => Unit): Unit = {
@@ -413,26 +413,26 @@ class LazyListLazinessTest {
   @Test
   def startsWith_properlyLazy(): Unit = {
     import LazinessChecker._
-    assertLazyAllSkipping(_.startsWith(0 until halfCount), halfCount)
-    assertLazyAllSkipping(_.startsWith(halfCount to count), 1)
+    assertLazyAllSkipping(halfCount)(_.startsWith(0 until halfCount))
+    assertLazyAllSkipping(1)(_.startsWith(halfCount to count))
   }
 
   @Test
   def exists_properlyLazy(): Unit = {
-    assertLazyAllSkipping(_ exists { _ < 2 }, 1)
-    assertLazyAllSkipping(_ exists { _ > 2 }, 4)
+    assertLazyAllSkipping(1)(_ exists { _ < 2 })
+    assertLazyAllSkipping(4)(_ exists { _ > 2 })
   }
 
   @Test
   def find_properlyLazy(): Unit = {
-    assertLazyAllSkipping(_ find { _ < 2 }, 1)
-    assertLazyAllSkipping(_ find { _ > 2 }, 4)
+    assertLazyAllSkipping(1)(_ find { _ < 2 })
+    assertLazyAllSkipping(4)(_ find { _ > 2 })
   }
 
   @Test
   def forall_properlyLazy(): Unit = {
-    assertLazyAllSkipping(_ forall { _ > 2 }, 1)
-    assertLazyAllSkipping(_ forall { _ < 2 }, 3)
+    assertLazyAllSkipping(1)(_ forall { _ > 2 })
+    assertLazyAllSkipping(3)(_ forall { _ < 2 })
   }
 
   @Test
@@ -447,10 +447,14 @@ class LazyListLazinessTest {
                                           skip: Int = 0): Unit = {
     val op3 = lazyListOp(op(_, 3))
     assertLazyAll(op3)
-    assertLazyAllSkipping(op3 andThen { _.hasNext }, 1)
-    assertLazyAllSkipping(op3 andThen { _.next().force }, 3)
-    assertLazyAllSkipping(op3 andThen { _.drop(1).hasNext }, 4 + evalExtra + skip)
-    assertLazyAllSkipping(op3 andThen { _.drop(1).next().force }, 6 + skip)
+    assertLazyAllSkipping(1)(op3 andThen { _.hasNext })
+    assertLazyAllSkipping(3)(op3 andThen { _.next().force })
+    assertLazyAllSkipping(4 + evalExtra + skip) {
+      op3.andThen(_.drop(1).hasNext)
+    }
+    assertLazyAllSkipping(6 + skip) {
+      op3.andThen(_.drop(1).next().force)
+    }
     assertKnownEmptyYields(op3)(_ eq Iterator.empty)
   }
 
@@ -469,16 +473,16 @@ class LazyListLazinessTest {
 
   @Test
   def indexOf_properlyLazy(): Unit = {
-    assertLazyAllSkipping(_.indexOf(0), 1)
-    assertLazyAllSkipping(_.indexOf(2), 3)
-    assertLazyAllSkipping(_.indexOf(6, 5), 7)
+    assertLazyAllSkipping(1)(_.indexOf(0))
+    assertLazyAllSkipping(3)(_.indexOf(2))
+    assertLazyAllSkipping(7)(_.indexOf(6, 5))
   }
 
   @Test
   def indexOfSlice_properlyLazy(): Unit = {
-    assertLazyAllSkipping(_.indexOfSlice(0 to 5), 6)
-    assertLazyAllSkipping(_.indexOfSlice(1 to 3), 4)
-    assertLazyAllSkipping(_.indexOfSlice(6 to 9, 5), 10)
+    assertLazyAllSkipping(6)(_.indexOfSlice(0 to 5))
+    assertLazyAllSkipping(4)(_.indexOfSlice(1 to 3))
+    assertLazyAllSkipping(10)(_.indexOfSlice(6 to 9, 5))
 
     // check laziness of slice when it is a `LazyList`
     val checker = new OpLazinessChecker
@@ -488,15 +492,15 @@ class LazyListLazinessTest {
 
   @Test
   def indexWhere_properlyLazy(): Unit = {
-    assertLazyAllSkipping(_.indexWhere(_ < 2), 1)
-    assertLazyAllSkipping(_.indexWhere(_ > 2), 4)
-    assertLazyAllSkipping(_.indexWhere(_ > 2, 4), 5)
+    assertLazyAllSkipping(1)(_.indexWhere(_ < 2))
+    assertLazyAllSkipping(4)(_.indexWhere(_ > 2))
+    assertLazyAllSkipping(5)(_.indexWhere(_ > 2, 4))
   }
 
   @Test
   def init_properlyLazy(): Unit = {
     val op = lazyListOp(_.init)
-    assertLazyAllSkipping(op, 1)
+    assertLazyAllSkipping(1)(op)
     val d = DropProfile(dropCount = 1, repeatedDrops = false)
     assertLazyNextStateWhenStateEvaluated(op, d)
   }
@@ -505,7 +509,7 @@ class LazyListLazinessTest {
   def inits_properlyLazy(): Unit = {
     import LazinessChecker.halfCount
     val op = lazyListOp(_.inits.drop(halfCount).next())
-    assertLazyAllSkipping(op, halfCount + 1)
+    assertLazyAllSkipping(halfCount + 1)(op)
     val d = DropProfile(dropCount = halfCount + 1, repeatedDrops = false)
     assertLazyNextStateWhenStateEvaluated(op, d)
   }
@@ -514,7 +518,7 @@ class LazyListLazinessTest {
   def tails_properlyLazy(): Unit = {
     import LazinessChecker.halfCount
     def check(op: LazyListToLazyListOp, skip: Int): Unit = {
-      assertLazyAllSkipping(op, skip)
+      assertLazyAllSkipping(skip)(op)
       assertLazyNextStateWhenStateEvaluated(op, DropProfile(dropCount = skip, repeatedDrops = false))
     }
 
@@ -556,9 +560,9 @@ class LazyListLazinessTest {
 
     val rSame = (x: Seq[Int], y: Seq[Int]) => same(y, x)
     for (equal <- same :: rSame :: Nil) {
-      assertLazyAllSkipping(equal(_, Nil), 1)
-      assertLazyAllSkipping(equal(_, 1 to 10), 1)
-      assertLazyAllSkipping(equal(_, 0 until 10), 11)
+      assertLazyAllSkipping(1)(equal(_, Nil))
+      assertLazyAllSkipping(1)(equal(_, 1 to 10))
+      assertLazyAllSkipping(11)(equal(_, 0 until 10))
     }
   }
 
@@ -574,15 +578,15 @@ class LazyListLazinessTest {
 
   @Test
   def search_properlyLazy(): Unit = {
-    assertLazyAllSkipping(_.search(0), 1)
-    assertLazyAllSkipping(_.search(1), 2)
-    assertLazyAllSkipping(_.search(-1, 4, 7), 7)
+    assertLazyAllSkipping(1)(_.search(0))
+    assertLazyAllSkipping(2)(_.search(1))
+    assertLazyAllSkipping(7)(_.search(-1, 4, 7))
   }
 
   @Test
   def segmentLength_properlyLazy(): Unit = {
-    assertLazyAllSkipping(_.segmentLength(_ => false), 1)
-    assertLazyAllSkipping(_.segmentLength(_ => false, 4), 5)
+    assertLazyAllSkipping(1)(_.segmentLength(_ => false))
+    assertLazyAllSkipping(5)(_.segmentLength(_ => false, 4))
   }
 
   @Test
@@ -594,7 +598,7 @@ class LazyListLazinessTest {
     genericLazyOp_properlyLazy(op1)
     genericLazyOp_properlyLazy(op2, DropProfile(dropCount = 4, repeatedDrops = false))
 
-    assertLazyAllSkipping(op1.thenForce, 5)
+    assertLazyAllSkipping(5)(op1.thenForce)
     genericLazyOp_properlyLazy(op2.andThen(_.drop(1)), DropProfile(dropCount = 5, repeatedDrops = false))
   }
 
@@ -606,7 +610,7 @@ class LazyListLazinessTest {
   @Test
   def updated_properlyLazy(): Unit = {
     val op = lazyListOp(_.updated(1, 2))
-    assertLazyAllSkipping(op, 2)
+    assertLazyAllSkipping(2)(op)
     assertLazyNextStateWhenStateEvaluated(op.andThen(_.drop(2)), DropProfile(dropCount = 2, repeatedDrops = false))
   }
 
@@ -690,11 +694,11 @@ class LazyListLazinessTest {
       list.take(4).force
       serializeDeserialize(list)
     }
-    assertLazyAllSkipping(op, 4)
+    assertLazyAllSkipping(4)(op)
   }
 
   private def genericCons_unapply_properlyLazy(unapply: LazyList[Int] => Option[(Int, LazyList[Int])]): Unit = {
-    assertLazyAllSkipping(unapply, 1)
+    assertLazyAllSkipping(1)(unapply)
   }
 
   @Test
@@ -924,9 +928,21 @@ class LazyListLazinessTest {
     assertLazyAll(op)
     assertRepeatedlyLazy(op)
   }
+
+  @Test // it doesn't report its length without evaluating
+  def `length of bounded list`: Unit = {
+    val checker = fresh()
+    assertEquals(5, checker.lazyList.take(5).length)
+    checker.assertAllSkipping(evaluated = false, skip = 5)
+    for (i <- 0 until 5)
+      checker.assert(evaluated = true, index = i)
+  }
 }
 
 private object LazyListLazinessTest {
+
+  def fresh(): LazinessChecker = new OpLazinessChecker
+
   /* core laziness utilities */
 
   /** Note: not reusable. */
@@ -997,10 +1013,12 @@ private object LazyListLazinessTest {
     // for debugging
     final override def toString: String = {
       val sb = new java.lang.StringBuilder(getClass.getSimpleName).append("(")
-      for (i <- 0 until 8) { sb.append(s"state($i): ${states.array(i)}, ") }
-      sb.append("...)")
+      for (i <- 0 until states.length) { sb.append(s"state($i): ${states(i)}, ") }
+      sb.append(")")
       sb.toString
     }
+
+    def lazyList: LazyList[Int]
   }
 
   object LazinessChecker {
@@ -1079,7 +1097,7 @@ private object LazyListLazinessTest {
 
   /** Asserts that the operation does not evaluate any states or heads. */
   def assertLazyAll[U](op: LazyListOp[U]): Unit = {
-    val checker = new OpLazinessChecker
+    val checker = fresh()
     op(checker.lazyList)
     checker.assertAll(evaluated = false)
   }
@@ -1087,15 +1105,15 @@ private object LazyListLazinessTest {
   /** Asserts that the checker does not have any heads or states evaluated
     * other than the first `skip`.
     */
-  def assertNotEvaluatedSkipping(checker: OpLazinessChecker, skip: Int): Unit = {
+  def assertNotEvaluatedSkipping(checker: LazinessChecker, skip: Int): Unit = {
     checker.assertAllSkipping(evaluated = false, skip = skip)
   }
 
   /** Asserts that the operation does not evaluate any heads or states
     * other than the first `skip`.
     */
-  def assertLazyAllSkipping[U](op: LazyListOp[U], skip: Int): Unit = {
-    val checker = new OpLazinessChecker
+  def assertLazyAllSkipping[U](skip: Int)(op: LazyListOp[U]): Unit = {
+    val checker = fresh()
     op(checker.lazyList)
     assertNotEvaluatedSkipping(checker, skip)
   }

--- a/test/junit/scala/collection/immutable/LazyListLazinessTest.scala
+++ b/test/junit/scala/collection/immutable/LazyListLazinessTest.scala
@@ -484,10 +484,26 @@ class LazyListLazinessTest {
     assertLazyAllSkipping(4)(_.indexOfSlice(1 to 3))
     assertLazyAllSkipping(10)(_.indexOfSlice(6 to 9, from = 5))
 
+    // single-element slice hits the `clipped()` branch
+    assertLazyAllSkipping(4)(_.indexOfSlice(Seq(3)))
+    // empty slice short-circuits
+    assertLazyAll(_.indexOfSlice(Nil))
+
+    // pattern also a LazyList (unknown pattern length triggers the pre-scan in kmpUnindexed)
+    assertLazyAllSkipping(6)(_.indexOfSlice(LazyList(3, 4, 5)))
+
     // check laziness of slice when it is a `LazyList`
     val checker = new OpLazinessChecker
     assertEquals(-1, LazyList.from(3).take(LazinessChecker.doubleCount).indexOfSlice(checker.lazyList))
     assertNotEvaluatedSkipping(checker, 1)
+  }
+
+  // `lastIndexOfSlice` is documented `willNotTerminateInf` so it must walk the whole list
+  // in the unbounded case. We verify that a bounded `end` really does bound how much of
+  // the list gets forced.
+  @Test
+  def lastIndexOfSlice_properlyLazy(): Unit = {
+    assertLazyAllSkipping(6)(_.lastIndexOfSlice(0 to 2, end = 5))
   }
 
   @Test

--- a/test/junit/scala/collection/immutable/LazyListLazinessTest.scala
+++ b/test/junit/scala/collection/immutable/LazyListLazinessTest.scala
@@ -482,7 +482,7 @@ class LazyListLazinessTest {
   def indexOfSlice_properlyLazy(): Unit = {
     assertLazyAllSkipping(6)(_.indexOfSlice(0 to 5))
     assertLazyAllSkipping(4)(_.indexOfSlice(1 to 3))
-    assertLazyAllSkipping(10)(_.indexOfSlice(6 to 9, 5))
+    assertLazyAllSkipping(10)(_.indexOfSlice(6 to 9, from = 5))
 
     // check laziness of slice when it is a `LazyList`
     val checker = new OpLazinessChecker


### PR DESCRIPTION
Fixes scala/bug#13171
Fixes scala/bug#13172
Fixes scala/bug#13173

The point of the algorithm is that it advances without backtracking, so the iteration case (for nonindexed sequence) is quite natural.

The previous code was Urtext that predates much that was elaborated over the eons.