### PR TITLE
Replace synchronized(this) with lock-free initState in LazyList

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -50,6 +50,9 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.ArrayCharSequence.getChars"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.SeqCharSequence.getChars"),
 
+    // scala/scala#11242
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.LazyList$MidEvaluation$"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.LazyList$InRace"),
   )
 
   override val buildSettings = Seq(

--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -53,6 +53,10 @@ object MimaFilters extends AutoPlugin {
     // scala/scala#11242
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.LazyList$MidEvaluation$"),
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.LazyList$InRace"),
+
+    // scala/scala#11242
+    ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.LazyList"), // superclass change from AbstractSeq to LazyListBase
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.LazyListBase*"), // private[immutable]
   )
 
   override val buildSettings = Seq(

--- a/src/library/scala/collection/immutable/LazyList.scala
+++ b/src/library/scala/collection/immutable/LazyList.scala
@@ -16,10 +16,9 @@ package immutable
 
 import java.io.{ObjectInputStream, ObjectOutputStream}
 import java.lang.{StringBuilder => JStringBuilder}
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater
 import scala.annotation.tailrec
 import scala.collection.generic.SerializeEnd
+import scala.collection.immutable.LazyListBase.InRace
 import scala.collection.mutable.{Builder, ReusableBuilder, StringBuilder}
 import scala.language.implicitConversions
 import scala.runtime.Statics
@@ -265,7 +264,7 @@ import scala.runtime.Statics
   */
 @SerialVersionUID(4L)
 final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => LazyList[A] */)
-  extends AbstractSeq[A]
+  extends LazyListBase[A](if (lazyState eq LazyList.EmptyMarker) null else lazyState)
     with LinearSeq[A]
     with LinearSeqOps[A, LazyList, LazyList[A]]
     with IterableFactoryDefaults[A, LazyList]
@@ -277,32 +276,27 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
   private def this(head: A, tail: LazyList[A]) = {
     this(LazyList.EmptyMarker)
     _head = head
-    _tail = tail
+    setRawTail(tail)
   }
 
-  // used to synchronize lazy state evaluation
-  // after initialization (`_head ne Uninitialized`)
+  // `_head` and `_tail` are used to synchronize lazy state evaluation.
+  //
+  // initially, `_head` is `Uninitialized`. after initialization, `_head` holds:
   //   - `null` if this is an empty lazy list
-  //   - `head: A` otherwise (can be `null`, `_tail == null` is used to test emptiness)
+  //   - `head: A` otherwise (can be the `null` value, `_tail == null` is used to test emptiness)
+  //
+  // `_tail` (declared in `LazyListBase`) can hold the following values:
+  //   - when `_head eq Uninitialized`
+  //     - `lazyState: () => LazyList[A]`
+  //     - while evaluating `lazyState`: the evaluating `Thread`
+  //     - if multiple threads attempt initialization: an `InRace` instance
+  //   - when `_head ne Uninitialized`
+  //     - `null` if this is an empty lazy list
+  //     - `tail: LazyList[A]` otherwise
   @volatile private var _head: Any /* Uninitialized | A */ =
     if (lazyState eq EmptyMarker) null else Uninitialized
 
-  // when `_head eq Uninitialized`
-  //   - `lazyState: () => LazyList[A]`
-  //   - while evaluating `lazyState`: the evaluating `Thread`
-  //   - if multiple threads attempt initialization: an `InRace` instance
-  // when `_head ne Uninitialized`
-  //   - `null` if this is an empty lazy list
-  //   - `tail: LazyList[A]` otherwise
-  @volatile private var _tail: AnyRef /* () => LazyList[A] | Thread | InRace | LazyList[A] */ =
-    if (lazyState eq EmptyMarker) null else lazyState
-
   private def rawHead: Any = _head
-  private def rawTail: AnyRef = _tail
-
-  // `newUpdater` needs to be invoked in the `LazyList` class, it uses the caller class to check field access
-  @noinline private def makeTailUpdater: AtomicReferenceFieldUpdater[LazyList[_], AnyRef] =
-    AtomicReferenceFieldUpdater.newUpdater(classOf[LazyList[_]], classOf[AnyRef], "_tail")
 
   @inline private def isEvaluated: Boolean = _head.asInstanceOf[AnyRef] ne Uninitialized
 
@@ -313,17 +307,16 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
         "LazyList evaluation depends on its own result (self-reference); see docs for more info")
 
     while (!isEvaluated) {
-      _tail match {
-        case t: Thread if t eq Thread.currentThread => selfRef()
-        case ir: InRace if ir.owner eq Thread.currentThread => selfRef()
-
+      rawTail match {
         case t: Thread =>
-          val ir = new InRace(t)
+          if (LazyListBase.isCurrentThread(t)) selfRef()
+          val ir = InRace(t)
           if (_tailUpdater.compareAndSet(this, t, ir))
             ir.await()
           // loop on lost CAS
 
         case ir: InRace =>
+          if (LazyListBase.isCurrentThread(ir.owner)) selfRef()
           ir.await()
 
         case fun: Function0[_] =>
@@ -362,7 +355,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
 
   @tailrec private def evaluated: LazyList[A] =
     if (isEvaluated) {
-      if (_tail == null) Empty
+      if (rawTail == null) Empty
       else this
     } else {
       initState()
@@ -1088,19 +1081,7 @@ object LazyList extends SeqFactory[LazyList] {
 
   private val Empty: LazyList[Nothing] = new LazyList(EmptyMarker)
 
-  private final class InRace(val owner: Thread) {
-    private val done: CountDownLatch = new CountDownLatch(1)
-    def await(): Unit = {
-      var interrupted = false
-      while (done.getCount > 0) {
-        try done.await() catch { case _: InterruptedException => interrupted = true }
-      }
-      if (interrupted) Thread.currentThread().interrupt()
-    }
-    def countDown(): Unit = done.countDown()
-  }
-
-  private val _tailUpdater: AtomicReferenceFieldUpdater[LazyList[_], AnyRef] = Empty.makeTailUpdater
+  private val _tailUpdater: LazyListBase.TailUpdater = Empty.makeTailUpdater
 
   /** Creates a new LazyList. */
   @inline private def newLL[A](state: => LazyList[A]): LazyList[A] = new LazyList[A](() => state)

--- a/src/library/scala/collection/immutable/LazyList.scala
+++ b/src/library/scala/collection/immutable/LazyList.scala
@@ -16,7 +16,8 @@ package immutable
 
 import java.io.{ObjectInputStream, ObjectOutputStream}
 import java.lang.{StringBuilder => JStringBuilder}
-
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater
 import scala.annotation.tailrec
 import scala.collection.generic.SerializeEnd
 import scala.collection.mutable.{Builder, ReusableBuilder, StringBuilder}
@@ -283,43 +284,79 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
   // after initialization (`_head ne Uninitialized`)
   //   - `null` if this is an empty lazy list
   //   - `head: A` otherwise (can be `null`, `_tail == null` is used to test emptiness)
-  @volatile private[this] var _head: Any /* Uninitialized | A */ =
+  @volatile private var _head: Any /* Uninitialized | A */ =
     if (lazyState eq EmptyMarker) null else Uninitialized
 
   // when `_head eq Uninitialized`
-  //   - `lazySate: () => LazyList[A]`
-  //   - MidEvaluation while evaluating lazyState
+  //   - `lazyState: () => LazyList[A]`
+  //   - while evaluating `lazyState`: the evaluating `Thread`
+  //   - if multiple threads attempt initialization: an `InRace` instance
   // when `_head ne Uninitialized`
   //   - `null` if this is an empty lazy list
   //   - `tail: LazyList[A]` otherwise
-  private[this] var _tail: AnyRef /* () => LazyList[A] | MidEvaluation.type | LazyList[A] */ =
+  @volatile private var _tail: AnyRef /* () => LazyList[A] | Thread | InRace | LazyList[A] */ =
     if (lazyState eq EmptyMarker) null else lazyState
 
   private def rawHead: Any = _head
   private def rawTail: AnyRef = _tail
 
+  // `newUpdater` needs to be invoked in the `LazyList` class, it uses the caller class to check field access
+  @noinline private def makeTailUpdater: AtomicReferenceFieldUpdater[LazyList[_], AnyRef] =
+    AtomicReferenceFieldUpdater.newUpdater(classOf[LazyList[_]], classOf[AnyRef], "_tail")
+
   @inline private def isEvaluated: Boolean = _head.asInstanceOf[AnyRef] ne Uninitialized
 
-  private def initState(): Unit = synchronized {
-    if (!isEvaluated) {
-      // if it's already mid-evaluation, we're stuck in an infinite
-      // self-referential loop (also it's empty)
-      if (_tail eq MidEvaluation)
-        throw new RuntimeException(
-          "LazyList evaluation depends on its own result (self-reference); see docs for more info")
+  private def initState(): Unit = {
+    def selfRef(): Nothing =
+      // if it's already mid-evaluation, we're stuck in an infinite self-referential loop (also it's empty)
+      throw new RuntimeException(
+        "LazyList evaluation depends on its own result (self-reference); see docs for more info")
 
-      val fun = _tail.asInstanceOf[() => LazyList[A]]
-      _tail = MidEvaluation
-      val l =
-        // `fun` returns a LazyList that represents the state (head/tail) of `this`. We call `l.evaluated` to ensure
-        // `l` is initialized, to prevent races when reading `rawTail` / `rawHead` below.
-        // Often, lazy lists are created with `newLL(eagerCons(...))` so `l` is already initialized, but `newLL` also
-        // accepts non-evaluated lazy lists.
-        try fun().evaluated
-        // restore `fun` in finally so we can try again later if an exception was thrown (similar to lazy val)
-        finally _tail = fun
-      _tail = l.rawTail
-      _head = l.rawHead
+    while (!isEvaluated) {
+      _tail match {
+        case t: Thread if t eq Thread.currentThread => selfRef()
+        case ir: InRace if ir.owner eq Thread.currentThread => selfRef()
+
+        case t: Thread =>
+          val ir = new InRace(t)
+          if (_tailUpdater.compareAndSet(this, t, ir))
+            ir.await()
+          // loop on lost CAS
+
+        case ir: InRace =>
+          ir.await()
+
+        case fun: Function0[_] =>
+          // use the current thread as marker that `fun` is being evaluated.
+          // this way, there is no allocation in the common case where there's no race.
+          // if multiple threads attempt to initialize a LazyList, an `InRace` instance is created to coordinate.
+          if (_tailUpdater.compareAndSet(this, fun, Thread.currentThread)) {
+            var ex: Throwable = null
+            // `fun` returns a LazyList that represents the state (head/tail) of `this`. We call `evaluated` to ensure
+            // the result is initialized, to prevent races when reading `rawTail` / `rawHead` below.
+            // Often, lazy lists are created with `newLL(eagerCons(...))` so `l` is already initialized, but `newLL`
+            // also accepts non-evaluated lazy lists.
+            val l = try fun().asInstanceOf[LazyList[A]].evaluated catch {
+              case t: Throwable =>
+                ex = t
+                null
+            }
+            // update `_tail` before `_head`, because `_head` is used to test `isEvaluated`
+            val newTail = if (ex == null) l.rawTail else fun
+            val sentinel = _tailUpdater.getAndSet(this, newTail)
+            if (ex == null) _head = l.rawHead
+            sentinel match {
+              case ir: InRace => ir.countDown()
+              case _ =>
+            }
+            if (ex != null) throw ex
+          }
+          // loop on lost CAS
+
+        case _ =>
+          // loop when _tail is a LazyList but _head is still `Uninitialized`
+          // could call `Thread.onSpinWait()` on JDK 9+
+      }
     }
   }
 
@@ -1047,10 +1084,23 @@ object LazyList extends SeqFactory[LazyList] {
   // def kount(): Unit = k += 1
 
   private object Uninitialized extends Serializable
-  private object MidEvaluation
   private object EmptyMarker
 
   private val Empty: LazyList[Nothing] = new LazyList(EmptyMarker)
+
+  private final class InRace(val owner: Thread) {
+    private val done: CountDownLatch = new CountDownLatch(1)
+    def await(): Unit = {
+      var interrupted = false
+      while (done.getCount > 0) {
+        try done.await() catch { case _: InterruptedException => interrupted = true }
+      }
+      if (interrupted) Thread.currentThread().interrupt()
+    }
+    def countDown(): Unit = done.countDown()
+  }
+
+  private val _tailUpdater: AtomicReferenceFieldUpdater[LazyList[_], AnyRef] = Empty.makeTailUpdater
 
   /** Creates a new LazyList. */
   @inline private def newLL[A](state: => LazyList[A]): LazyList[A] = new LazyList[A](() => state)

--- a/src/library/scala/collection/immutable/LazyListBase.scala
+++ b/src/library/scala/collection/immutable/LazyListBase.scala
@@ -1,0 +1,64 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc. dba Akka
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection.immutable
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater
+
+/**
+ * Base class for [[LazyList]] to split out code that uses concurrency utilities that are not available
+ * on Scala.js. This way, Scala.js does not need to override all of LazyList.
+ *
+ * This class cannot be a trait because `AtomicReferenceFieldUpdater.newUpdater` checks if the caller
+ * class has access to the corresponding field. So it needs to be called in the class where the field is
+ * declared (fields are always private in Scala).
+ */
+abstract class LazyListBase[+A] private[immutable] (initialTail: AnyRef) extends scala.collection.AbstractSeq[A] with Serializable {
+  /** See [[LazyList._head]] for the possible states of this field. */
+  @volatile private var _tail: AnyRef /* () => LazyList[A] | Thread | InRace | LazyList[A] */ = initialTail
+
+  private[immutable] def rawTail: AnyRef = _tail
+
+  private[immutable] def setRawTail(value: AnyRef): Unit = _tail = value
+
+  @noinline private[immutable] def makeTailUpdater: LazyListBase.TailUpdater =
+    new LazyListBase.TailUpdater(AtomicReferenceFieldUpdater.newUpdater(classOf[LazyListBase[_]], classOf[AnyRef], "_tail"))
+}
+
+private[immutable] object LazyListBase {
+  final class TailUpdater(u: AtomicReferenceFieldUpdater[LazyListBase[_], AnyRef]) {
+    def compareAndSet(ll: LazyListBase[_], expected: AnyRef, value: AnyRef): Boolean = u.compareAndSet(ll, expected, value)
+    def getAndSet(ll: LazyListBase[_], value: AnyRef): AnyRef = u.getAndSet(ll, value)
+  }
+
+  // this utility is constant `true` on Scala.js -> enables DCE in LazyList
+  def isCurrentThread(t: Thread) = t eq Thread.currentThread
+  // also for Scala.js
+  def InRace(t: Thread) = new InRace(t)
+
+  final class InRace private[LazyListBase] (val owner: Thread) {
+    private val done: CountDownLatch = new CountDownLatch(1)
+
+    def await(): Unit = {
+      var interrupted = false
+      while (done.getCount > 0) {
+        try done.await() catch {
+          case _: InterruptedException => interrupted = true
+        }
+      }
+      if (interrupted) Thread.currentThread().interrupt()
+    }
+
+    def countDown(): Unit = done.countDown()
+  }
+}

--- a/test/junit/scala/collection/immutable/LazyListTest.scala
+++ b/test/junit/scala/collection/immutable/LazyListTest.scala
@@ -5,6 +5,8 @@ import org.junit.Assert._
 import org.junit.Test
 
 import java.io.NotSerializableException
+import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch}
+import java.util.concurrent.atomic.AtomicInteger
 import scala.annotation.unused
 import scala.collection.immutable.LazyListTest.sd
 import scala.collection.mutable.{Builder, ListBuffer}
@@ -58,7 +60,50 @@ class LazyListTest {
     val ll = 1 #:: { Thread.sleep(500); 2} #:: LazyList.empty
     new Thread(() => println(ll.toList)).start()
     Thread.sleep(200)
-    AssertUtil.assertThrows[NotSerializableException](serialize(ll), _.contains("MidEvaluation"))
+    AssertUtil.assertThrows[NotSerializableException](serialize(ll), msg => msg.contains("java.lang.Thread") || msg.contains("InRace"))
+  }
+
+  @Test def forceSameCellManyThreads(): Unit = {
+    val N = 8
+    val trials = 5
+    for (trial <- 1 to trials) {
+      val counts = Array.fill(20)(new AtomicInteger(0))
+      val ll = LazyList.tabulate(20) { i =>
+        counts(i).incrementAndGet()
+        i * 10
+      }
+      val go = new CountDownLatch(1)
+      val done = new CountDownLatch(N)
+      val results = new ConcurrentLinkedQueue[List[Int]]
+      for (_ <- 1 to N)
+        new Thread(() => {
+          go.await()
+          results.add(ll.toList)
+          done.countDown()
+        }).start()
+      go.countDown()
+      done.await()
+
+      val expected = (0 until 20).map(_ * 10).toList
+      val it = results.iterator
+      var seen = 0
+      while (it.hasNext) { assertEquals(s"trial $trial", expected, it.next()); seen += 1 }
+      assertEquals(s"trial $trial: result count", N, seen)
+      for (i <- 0 until 20)
+        assertEquals(s"trial $trial: element $i evaluated multiple times", 1, counts(i).get())
+    }
+  }
+
+  @Test def initStateExceptionRecovery(): Unit = {
+    var n = 0
+    val ll = 1 #:: {
+      n += 1
+      if (n == 1) throw new RuntimeException("first attempt throws") else 2
+    } #:: LazyList.empty
+
+    AssertUtil.assertThrows[RuntimeException](ll.toList, _.contains("first attempt throws"))
+    assertEquals(List(1, 2), ll.toList)
+    assertEquals(2, n)
   }
 
   @Test def storeNull(): Unit = {


### PR DESCRIPTION
For https://github.com/scala/scala3/issues/25777.

Claudia helped bisecting and diangosing this issue to the change from `LM_LEGACY` / `-XX:LockingMode=1` to `LM_LIGHTWEIGHT` / `-XX:LockingMode=2` in JDK 23+.

This commit replaces `synchronized` with a lock-free coordination.

Since there's no JEP, in the interest of (my) time, here's a generated explanation (sounds plausible, as LLMs often do):

> In LM_LEGACY, when the JVM enters a synchronized block on an uncontended object, it stashes the object's mark word into a "displaced header" slot on the thread's stack frame and overwrites the object header with a pointer to that slot. Because that slot lives in the stack frame the JVM was already going to allocate for the method, uncontended locking needs zero heap allocation no matter how many objects you lock. If contention occurs, it inflates into a full heavyweight ObjectMonitor. The downside is that this scheme racily overloads the object header, which doesn't play nicely with Project Lilliput's compact object headers.

> LM_LIGHTWEIGHT was introduced under JDK-8291555. Instead of storing the displaced header in the stack frame, each Java thread gets an 8-slot dedicated lock stack that just holds references to the objects it currently has locked. The object header is left alone (aside from a flag bit), so it works cleanly with compact headers. On contention or when the lock sack is full, it to an ObjectMonitor.

> `LazyList.initState` synchronizes on `this` while recursively forcing nested cells, so a chain more than 8 deep allocates one ObjectMonitor per extra level, and the async deflater can't keep up with the churn.