### PR TITLE
Fix NPE in ArrayOps.transpose

### DIFF
--- a/src/library/scala/collection/ArrayOps.scala
+++ b/src/library/scala/collection/ArrayOps.scala
@@ -1289,22 +1289,40 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     (a1, a2, a3)
   }
 
-  /** Transposes a two dimensional array.
+  /** Transposes a two-dimensional array.
+    *
+    * Note: this method has known issues related to the handling of empty arrays. It will return an
+    * incorrectly typed empty array of runtime type `Array[A]` if it is called on an empty array,
+    * and if not handled with care may result in a [[java.lang.ClassCastException `ClassCastException`]].
+    * See [[https://github.com/scala/bug/issues/13178 scala/bug#13178]] for discussion.
+    *
+    * As a workaround, either convert to an iterable and use [[scala.collection.IterableOps!.transpose `IterableOps.transpose`]] instead,
+    * or call [[scala.collection.ArrayOps!.map `ArrayOps.map`]] beforehand instead of passing `asArray`.
     *
     *  @tparam B       Type of row elements.
-    *  @param asArray  A function that converts elements of this array to rows - arrays of type `B`.
-    *  @return         An array obtained by replacing elements of this arrays with rows the represent.
+    *  @param asArray  A function that converts elements of this array to rows — arrays of type `B`.
+    *  @return         An array obtained by replacing the elements of this array with the rows they represent and then transposing them.
     */
   def transpose[B](implicit asArray: A => Array[B]): Array[Array[B]] = {
-    val aClass = xs.getClass.getComponentType
-    val bb = new ArrayBuilder.ofRef[Array[B]]()(ClassTag[Array[B]](aClass))
-    if (xs.length == 0) bb.result()
-    else {
-      def mkRowBuilder() = ArrayBuilder.make[B](using ClassTag[B](aClass.getComponentType))
-      val bs = new ArrayOps(asArray(xs(0))).map((x: B) => mkRowBuilder())
+    if (xs.length == 0) {
+      val aClass = xs.getClass.getComponentType
+      val bb = ArrayBuilder.make(using ClassTag[A](aClass))
+      bb.result().asInstanceOf[Array[Array[B]]] // cast may be invalid, see Scaladoc
+    } else {
+      val first = asArray(xs(0))
+      val bb = new ArrayBuilder.ofRef[Array[B]]()(ClassTag[Array[B]](first.getClass))
+      def mkRowBuilder() = ArrayBuilder.make[B](using ClassTag[B](first.getClass.getComponentType))
+      val bs = new ArrayOps(first).map((x: B) => mkRowBuilder())
+      var isFirst = true
       for (xs <- this) {
         var i = 0
-        for (x <- new ArrayOps(asArray(xs))) {
+        // prevent double-evaluation for backwards compatibility
+        val subArray = if (isFirst) {
+          isFirst = false
+          first
+        } else asArray(xs)
+
+        for (x <- new ArrayOps(subArray)) {
           bs(i) += x
           i += 1
         }

--- a/test/junit/scala/collection/ArrayOpsTest.scala
+++ b/test/junit/scala/collection/ArrayOpsTest.scala
@@ -5,6 +5,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
+import scala.tools.testkit.AssertUtil.assertThrows
+
 @RunWith(classOf[JUnit4])
 class ArrayOpsTest {
 
@@ -121,6 +123,31 @@ class ArrayOpsTest {
   def t11499(): Unit = {
     val a: Array[Byte] = new Array[Byte](1000).sortWith { _ < _ }
     assertEquals(0, a(0))
+  }
+
+  @Test
+  def `transpose still incorrectly throws class cast exception`(): Unit = {
+    // If ArrayOps.transpose is fixed, this test should be updated to be positive
+    // and the method's Scaladoc should be updated to reflect the state of the method.
+    // See scala/bug#13178
+    assertThrows[ClassCastException] {
+      val _: Array[Array[Int]] = Array().transpose((_: Object) => Array(1))
+    }
+  }
+
+  @Test
+  def transpose(): Unit = {
+    assertArrayEquals(Array[Object](), Array(Array[Object]()).transpose.asInstanceOf[Array[Object]])
+
+    assertArrayEquals(
+      Array(Array(1, 3), Array(2, 4)).asInstanceOf[Array[Object]],
+      Array(Array(1, 2), Array(3, 4)).transpose.asInstanceOf[Array[Object]]
+    )
+
+    assertArrayEquals(
+      Array(Array(1, 1), Array(2, 2)).asInstanceOf[Array[Object]],
+      Array(new Object(), new Object()).transpose(_ => Array(1, 2)).asInstanceOf[Array[Object]]
+    )
   }
 
   @Test


### PR DESCRIPTION
This pull request fixes the issue where `ArrayOps.transpose` would use the receiver array's component type rather than the result type of the `asArray` parameter to infer the type of the transposed array. It does not fix the inference for empty arrays, because no class tag is available and there is no value to give to `asArray` for inference.

A test method for `transpose` is added `test/junit/scala/collection/ArrayOpsTest`, which tests the normal behaviour of transpose as well as the problematic cases. A comment re: the remaining broken functionality is included in the method body.

Fixes scala/bug#13178
