### PR TITLE
split REPL :help into main vs additional

### DIFF
--- a/src/repl-frontend/scala/tools/nsc/interpreter/shell/LoopCommands.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/shell/LoopCommands.scala
@@ -89,9 +89,21 @@ trait LoopCommands {
     val formatStr  = s"%-${usageWidth}s %s"
 
     echo("All commands can be abbreviated, e.g., :he instead of :help.")
-
-    for (cmd <- commands) echo(formatStr.format(cmd.usageMsg, cmd.help))
     echo("")
+    echo("Core commands:")
+
+    val implementedInScala3 =
+      Set("help", "load", "quit", "type", "doc", "imports",
+        "reset", "settings", "silent")
+    val (main, more) = commands.partition(cmd => implementedInScala3(cmd.name))
+
+    for (cmd <- main) echo(formatStr.format(cmd.usageMsg, cmd.help))
+    echo("")
+
+    echo("Additional commands, not implemented in Scala 3:")
+    for (cmd <- more) echo(formatStr.format(cmd.usageMsg, cmd.help))
+    echo("")
+
     echo("Useful default key bindings:")
     echo("  TAB           code completion")
     echo("  CTRL-ALT-T    show type at cursor, hit again to show code with types/implicits inferred.")


### PR DESCRIPTION
fixes scala/bug#13080

```
All commands can be abbreviated, e.g., :he instead of :help.

Core commands:
:help [command]          print this summary or command-specific help
:imports [name name ...] show import history, identifying sources of names
:load <path>             interpret lines in a file
:quit                    exit the REPL
:reset [options]         reset the REPL to its initial state, forgetting all session entries
:settings <options>      update compiler options, if possible; see reset
:silent                  disable/enable automatic printing of results
:type [-v] <expr>        display the type of an expression without evaluating it

Additional commands, not implemented in Scala 3:
:completions <string>    output completions for the given string
:implicits [-v]          show the implicits in scope
:javap <path|class>      disassemble a file or class name
:line <id>|<line>        place line(s) at the end of history
:paste [-raw] [path]     enter paste mode or paste a file
:power                   enable power user mode
:replay [options]        reset the REPL and replay all previous commands
:require <path>          add a jar to the classpath
:save <path>             save replayable session to a file
:sh <command line>       run a shell command (result is implicitly => List[String])
:kind [-v] <type>        display the kind of a type. see also :help kind
:warnings                show the suppressed warnings from the most recent line which had any

Useful default key bindings:
  TAB           code completion
  CTRL-ALT-T    show type at cursor, hit again to show code with types/implicits inferred.
```