### PR TITLE
Make LazyList._tailUpdater a lazy val

### DIFF
--- a/src/library/scala/collection/immutable/LazyList.scala
+++ b/src/library/scala/collection/immutable/LazyList.scala
@@ -1081,7 +1081,8 @@ object LazyList extends SeqFactory[LazyList] {
 
   private val Empty: LazyList[Nothing] = new LazyList(EmptyMarker)
 
-  private val _tailUpdater: LazyListBase.TailUpdater = Empty.makeTailUpdater
+  // lazy val because `scala` package forces `LazyList`, `makeTailUpdater` uses `Predef.classOf`
+  private lazy val _tailUpdater: LazyListBase.TailUpdater = Empty.makeTailUpdater
 
   /** Creates a new LazyList. */
   @inline private def newLL[A](state: => LazyList[A]): LazyList[A] = new LazyList[A](() => state)

--- a/src/library/scala/collection/immutable/LazyListBase.scala
+++ b/src/library/scala/collection/immutable/LazyListBase.scala
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater
  * class has access to the corresponding field. So it needs to be called in the class where the field is
  * declared (fields are always private in Scala).
  */
-abstract class LazyListBase[+A] private[immutable] (initialTail: AnyRef) extends scala.collection.AbstractSeq[A] with Serializable {
+abstract class LazyListBase[+A] private[immutable] (initialTail: AnyRef) extends AbstractSeq[A] with Serializable {
   /** See [[LazyList._head]] for the possible states of this field. */
   @volatile private var _tail: AnyRef /* () => LazyList[A] | Thread | InRace | LazyList[A] */ = initialTail
 


### PR DESCRIPTION
The initialization checker on Scala 3 flagged a cycle. Perhaps the same cycle doesn't exist on 2.13 or it's benign, but it still seems good to dealy creating the `_tailUpdater`.

Follow-up for https://github.com/scala/scala/pull/11242