### PR TITLE
Replace CountDownLatch inside InRace with a custom one-time latch.

### DIFF
--- a/src/library/scala/collection/immutable/LazyListBase.scala
+++ b/src/library/scala/collection/immutable/LazyListBase.scala
@@ -50,11 +50,7 @@ private[immutable] object LazyListBase {
     // Implements a one-time latch
     final private class Sync extends AbstractQueuedSynchronizer {
       override def tryAcquireShared(unused: Int): Int = if (getState == 0) -1 else 1
-
-      override def tryReleaseShared(unused: Int): Boolean = {
-        setState(1)
-        true
-      }
+      override def tryReleaseShared(unused: Int): Boolean = getState == 0 && compareAndSetState(0, 1)
     }
 
     private val sync = new Sync()

--- a/src/library/scala/collection/immutable/LazyListBase.scala
+++ b/src/library/scala/collection/immutable/LazyListBase.scala
@@ -12,8 +12,8 @@
 
 package scala.collection.immutable
 
-import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater
+import java.util.concurrent.locks.AbstractQueuedSynchronizer
 
 /**
  * Base class for [[LazyList]] to split out code that uses concurrency utilities that are not available
@@ -47,18 +47,19 @@ private[immutable] object LazyListBase {
   def InRace(t: Thread) = new InRace(t)
 
   final class InRace private[LazyListBase] (val owner: Thread) {
-    private val done: CountDownLatch = new CountDownLatch(1)
+    // Implements a one-time latch
+    final private class Sync extends AbstractQueuedSynchronizer {
+      override def tryAcquireShared(unused: Int): Int = if (getState == 0) -1 else 1
 
-    def await(): Unit = {
-      var interrupted = false
-      while (done.getCount > 0) {
-        try done.await() catch {
-          case _: InterruptedException => interrupted = true
-        }
+      override def tryReleaseShared(unused: Int): Boolean = {
+        setState(1)
+        true
       }
-      if (interrupted) Thread.currentThread().interrupt()
     }
 
-    def countDown(): Unit = done.countDown()
+    private val sync = new Sync()
+
+    def await(): Unit = sync.acquireShared(0)
+    def countDown(): Unit = sync.releaseShared(0)
   }
 }


### PR DESCRIPTION
The `InRace` class, used to block threads during concurrent initialization, uses a `CountDownLatch`. However, `CountDownLatch` uses an interruptible `await`, while the desired semantics here is to wait uninterruptibly.

This implementation replaces the `CountDownLatch` with a custom one-time latch, using `acquireShared` from `AbstractQueuedSynchronizer` (instead of `acquireSharedInterruptibly` inside `CountDownLatch).

Additionally, this saves one instance (`InRace` + `Sync` instead of `InRace` + `CountDownLatch` + `Sync`). (We could save another by having `InRace` extend `AbstractQueuedSynchronizer` directly, since `InRace` is private, but that is not a standard design.)