### PR TITLE
Remove all uses of `String.format` from the standard library.

### DIFF
--- a/src/library/scala/collection/IndexedSeq.scala
+++ b/src/library/scala/collection/IndexedSeq.scala
@@ -92,7 +92,7 @@ trait IndexedSeqOps[+A, +CC[_], +C] extends Any with SeqOps[A, CC, C] { self =>
   override def slice(from: Int, until: Int): C = fromSpecific(new IndexedSeqView.Slice(this, from, until))
 
   override def sliding(size: Int, step: Int): Iterator[C] = {
-    require(size >= 1 && step >= 1, f"size=$size%d and step=$step%d, but both must be positive")
+    require(size >= 1 && step >= 1, s"size=$size and step=$step, but both must be positive")
     new IndexedSeqSlidingIterator[A, CC, C](this, size, step)
   }
 

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -155,7 +155,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
    */
   class GroupedIterator[B >: A](self: Iterator[B], size: Int, step: Int) extends AbstractIterator[immutable.Seq[B]] {
 
-    require(size >= 1 && step >= 1, f"size=$size%d and step=$step%d, but both must be positive")
+    require(size >= 1 && step >= 1, s"size=$size and step=$step, but both must be positive")
 
     private[this] var buffer: Array[B] = null                 // current result
     private[this] var prev: Array[B] = null                   // if sliding, overlap from previous result

--- a/src/library/scala/collection/concurrent/TrieMap.scala
+++ b/src/library/scala/collection/concurrent/TrieMap.scala
@@ -406,13 +406,17 @@ private[collection] final class INode[K, V](bn: MainNode[K, V], g: Gen, equiv: E
     GCAS_READ(ct).knownSize()
 
   /* this is a quiescent method! */
-  def string(lev: Int) = "%sINode -> %s".format("  " * lev, mainnode match {
-    case null => "<null>"
-    case tn: TNode[_, _] => "TNode(%s, %s, %d, !)".format(tn.k, tn.v, tn.hc)
-    case cn: CNode[_, _] => cn.string(lev)
-    case ln: LNode[_, _] => ln.string(lev)
-    case x => "<elem: %s>".format(x)
-  })
+  def string(lev: Int): String = {
+    val spaces = "  " * lev
+    val rhs = mainnode match {
+      case null => "<null>"
+      case tn: TNode[_, _] => s"TNode(${tn.k}, ${tn.v}, ${tn.hc}, !)"
+      case cn: CNode[_, _] => cn.string(lev)
+      case ln: LNode[_, _] => ln.string(lev)
+      case x => s"<elem: $x>"
+    }
+    s"${spaces}INode -> $rhs"
+  }
 
 }
 
@@ -442,7 +446,7 @@ private[concurrent] final class FailedNode[K, V](p: MainNode[K, V]) extends Main
 
   def knownSize: Int = throw new UnsupportedOperationException
 
-  override def toString = "FailedNode(%s)".format(p)
+  override def toString = s"FailedNode($p)"
 }
 
 
@@ -457,7 +461,7 @@ private[collection] final class SNode[K, V](final val k: K, final val v: V, fina
   def copyTombed = new TNode(k, v, hc)
   def copyUntombed = new SNode(k, v, hc)
   def kvPair = (k, v)
-  def string(lev: Int) = ("  " * lev) + "SNode(%s, %s, %x)".format(k, v, hc)
+  def string(lev: Int) = ("  " * lev) + s"SNode($k, $v, ${hc.toHexString})"
 }
 
 // Tomb Node, used to ensure proper ordering during removals
@@ -469,7 +473,7 @@ private[collection] final class TNode[K, V](final val k: K, final val v: V, fina
   def kvPair = (k, v)
   def cachedSize(ct: AnyRef): Int = 1
   def knownSize: Int = 1
-  def string(lev: Int) = ("  " * lev) + "TNode(%s, %s, %x, !)".format(k, v, hc)
+  def string(lev: Int) = ("  " * lev) + s"TNode($k, $v, ${hc.toHexString}, !)"
 }
 
 // List Node, leaf node that handles hash collisions
@@ -510,7 +514,7 @@ private[collection] final class LNode[K, V](val entries: List[(K, V)], equiv: Eq
 
   def knownSize: Int = -1 // shouldn't ever be empty, and the size of a list is not known
 
-  def string(lev: Int) = (" " * lev) + "LNode(%s)".format(entries.mkString(", "))
+  def string(lev: Int) = (" " * lev) + s"LNode(${entries.mkString(", ")})"
 
 }
 
@@ -637,7 +641,7 @@ private[collection] final class CNode[K, V](val bitmap: Int, val array: Array[Ba
     new CNode[K, V](bmp, tmparray, gen).toContracted(lev)
   }
 
-  def string(lev: Int): String = "CNode %x\n%s".format(bitmap, array.map(_.string(lev + 1)).mkString("\n"))
+  def string(lev: Int): String = s"CNode ${bitmap.toHexString}\n" + array.map(_.string(lev + 1)).mkString("\n")
 
   override def toString = {
     def elems: Seq[String] = array.flatMap {
@@ -645,7 +649,7 @@ private[collection] final class CNode[K, V](val bitmap: Int, val array: Array[Ba
       case in: INode[K, V] @uc => Iterable.single(augmentString(in.toString).drop(14) + "(" + in.gen + ")")
       case basicNode           => throw new MatchError(basicNode)
     }
-    f"CNode(sz: ${elems.size}%d; ${elems.sorted.mkString(", ")})"
+    s"CNode(sz: ${elems.size}; ${elems.sorted.mkString(", ")})"
   }
 }
 

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -1421,7 +1421,8 @@ private final class BitmapIndexedSetNode[A](
   override def hashCode(): Int =
     throw new UnsupportedOperationException("Trie nodes do not support hashing.")
 
-  override def toString: String = f"BitmapIndexedSetNode(size=$size, dataMap=$dataMap%x, nodeMap=$nodeMap%x)" // content=${scala.runtime.ScalaRunTime.stringOf(content)}
+  override def toString: String =
+    s"BitmapIndexedSetNode(size=$size, dataMap=${dataMap.toHexString}, nodeMap=${nodeMap.toHexString})" // content=${scala.runtime.ScalaRunTime.stringOf(content)}
 
   override def copy(): BitmapIndexedSetNode[A] = {
     val contentClone = content.clone()

--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -232,7 +232,7 @@ sealed abstract class Range(
     if (numRangeElements <= 0 && !isEmpty)
       fail()
   }
-  private[this] def description = "%d %s %d by %s".format(start, if (isInclusive) "to" else "until", end, step)
+  private[this] def description = s"$start ${if (isInclusive) "to" else "until"} $end by $step"
   private[this] def fail() = throw new IllegalArgumentException(description + ": seqs cannot contain more than Int.MaxValue elements.")
 
   @throws[IndexOutOfBoundsException]
@@ -545,7 +545,7 @@ sealed abstract class Range(
   override def distinct: Range = this
 
   override def grouped(size: Int): Iterator[Range] = {
-    require(size >= 1, f"size=$size%d, but size must be positive")
+    require(size >= 1, s"size=$size, but size must be positive")
     if (isEmpty) {
       Iterator.empty
     } else {

--- a/src/library/scala/collection/mutable/UnrolledBuffer.scala
+++ b/src/library/scala/collection/mutable/UnrolledBuffer.scala
@@ -435,7 +435,7 @@ object UnrolledBuffer extends StrictOptimizedClassTagSeqFactory[UnrolledBuffer] 
     }
 
     override def toString: String =
-      array.take(size).mkString("Unrolled@%08x".format(System.identityHashCode(this)) + "[" + size + "/" + array.length + "](", ", ", ")") + " -> " + (if (next ne null) next.toString else "")
+      array.take(size).mkString(s"Unrolled@${System.identityHashCode(this).toHexString}[$size/${array.length}](", ", ", ")") + " -> " + (if (next ne null) next.toString else "")
   }
 }
 

--- a/src/library/scala/io/Source.scala
+++ b/src/library/scala/io/Source.scala
@@ -326,7 +326,7 @@ abstract class Source extends Iterator[Char] with Closeable {
     val line  = Position line pos
     val col   = Position column pos
 
-    out println "%s:%d:%d: %s%s%s^".format(descr, line, col, msg, lineNum(line), spaces(col - 1))
+    out.println(s"$descr:$line:$col: $msg${lineNum(line)}${spaces(col - 1)}^")
   }
 
   /**

--- a/src/library/scala/reflect/NameTransformer.scala
+++ b/src/library/scala/reflect/NameTransformer.scala
@@ -85,7 +85,8 @@ object NameTransformer {
           buf = new StringBuilder()
           buf.append(name.substring(0, i))
         }
-        buf.append("$u%04X".format(c.toInt))
+        buf.append("$u")
+        appendHex4(buf, c)
       }
       else if (buf ne null) {
         buf.append(c)
@@ -93,6 +94,21 @@ object NameTransformer {
       i += 1
     }
     if (buf eq null) name else buf.toString()
+  }
+
+  /** Append a 4-uppercase-hex-digit representation of `c` to the given `buf`.
+   *
+   *  The result is '0'-padded if necessary.
+   */
+  private def appendHex4(buf: StringBuilder, c: Char): Unit = {
+    var x = c.toInt
+    var j = 0
+    while (j != 4) {
+      val d = (x >>> 12) & 0xf
+      buf.append((d + (if (d < 10) '0' else ('A' - 10))).toChar)
+      x <<= 4
+      j += 1
+    }
   }
 
   /** Replaces `\$opname` by corresponding operator symbol.

--- a/src/library/scala/sys/PropImpl.scala
+++ b/src/library/scala/sys/PropImpl.scala
@@ -43,7 +43,7 @@ private[sys] class PropImpl[+T](val key: String, valueFn: String => T) extends P
   protected def underlying: mutable.Map[String, String] = scala.sys.props
   protected def zero: T = null.asInstanceOf[T]
   private def getString = if (isSet) "currently: " + get else "unset"
-  override def toString = "%s (%s)".format(key, getString)
+  override def toString = s"$key ($getString)"
 }
 
 private[sys] abstract class CreatorImpl[+T](f: String => T) extends Prop.Creator[T] {


### PR DESCRIPTION
`String.format`, and the `f""` interpolator, are overkill when all we want is combine strings and numbers. It is slower than a straightforward `s""` interpolator.

More importantly, `String.format` brings all of `java.util.Formatter` to the generated code when compiling to non-JVM platforms, which has a significant cost.

The only non-trivial replacement was in `NameTransformer`, which actually wants 0-padding of a hex string. Even that is not too hard to do manually, and much more efficient this way.