### PR TITLE
Parse Java annotations on array dimensions (Scala 3 backport)

### DIFF
--- a/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
@@ -268,13 +268,15 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
     }
 
     @tailrec
-    final def optArrayBrackets(tpt: Tree): Tree =
+    final def optArrayBrackets(tpt: Tree): Tree = {
+      annotations()
       if (in.token == LBRACKET) {
         val tpt1 = atPos(in.pos) { arrayOf(tpt) }
         in.nextToken()
         accept(RBRACKET)
         optArrayBrackets(tpt1)
       } else tpt
+    }
 
     def basicType(): Tree =
       atPos(in.pos) {

--- a/test/files/pos/java-type-annotations/Test.java
+++ b/test/files/pos/java-type-annotations/Test.java
@@ -1,4 +1,7 @@
 public class Test {
 	static class C<@NotNull T> {};
 	@NotNull String foo() { return ""; }
+	String @NotNull [] values;
+	String @NotNull [] @NotNull [] nestedValues;
+	void varargs(String @NotNull ... values) {}
 }


### PR DESCRIPTION
Backport the Scala 3 Java parser fix for annotations that appear before array brackets, such as `String @Nullable []` and nested annotated arrays.

Scala 3 fixed the same parser gap in scala/scala3#22391. This applies the corresponding `optArrayBrackets` change to the Scala 2 Java parser and extends the existing Java type annotation positive test.

Scala 3 related issues/PRs/commits:
- https://github.com/scala/scala3/issues/19642
- https://github.com/scala/scala3/pull/22391
- commit: https://github.com/scala/scala3/commit/9c971be202ab73688dbcff50a8240cb2878097aa
- backport commit for Scala 3.3.x: https://github.com/scala/scala3/commit/75450da4c18ac177b997bfb4f061b571bf8cdc07

---

## To reproduce:

`J.java`
```java
public interface J {
  String @Nullable [] values();
}
```

`Nullable.java`
```java
import java.lang.annotation.ElementType;
import java.lang.annotation.Target;

@Target(ElementType.TYPE_USE)
public @interface Nullable {}
```

Compiling with Java 8 works and produces class files:

```
$ java -version
openjdk version "1.8.0_492"
OpenJDK Runtime Environment (Temurin)(build 1.8.0_492-b09)
OpenJDK 64-Bit Server VM (Temurin)(build 25.492-b09, mixed mode)

$ javac Nullable.java J.java
$ ls -1 *.class
J.class
Nullable.class
```

The Scala 3.3 compiler accepts the files (does not create the class files however which I guess is expected):
```
$ scala -version
Scala code runner version 3.3.7 -- Copyright 2002-2025, LAMP/EPFL

$ scalac -usejavacp Nullable.java J.java
$ echo $?
0
```

Scala 2.13 fails:

```
$ scala -version
Scala code runner version 2.13.18 -- Copyright 2002-2025, LAMP/EPFL and Lightbend, Inc. dba Akka

$ scalac -usejavacp Nullable.java J.java
J.java:2: error: identifier expected but `@` found.
  String @Nullable [] values();
         ^
1 error
```

