### PR TITLE
Parse Java annotations on wildcard type arguments

### DIFF
--- a/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
@@ -322,7 +322,8 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
 
     def typeArgs(t: Tree): Tree = {
       val wildcards = new ListBuffer[TypeDef]
-      def typeArg(): Tree =
+      def typeArg(): Tree = {
+        annotations()
         if (in.token == QMARK) {
           val pos = in.currentPos
           in.nextToken()
@@ -340,6 +341,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
         } else {
           typ()
         }
+      }
       if (in.token == LT) {
         in.nextToken()
         val t1 = convertToTypeId(t)

--- a/test/files/pos/java-annotated-wildcards/J.java
+++ b/test/files/pos/java-annotated-wildcards/J.java
@@ -1,0 +1,7 @@
+package app;
+
+import java.util.function.Function;
+
+public interface J {
+  Function<@lib.Nullable ? super String, @lib.Nullable ? extends Object> mappingFunction();
+}

--- a/test/files/pos/java-annotated-wildcards/Nullable.java
+++ b/test/files/pos/java-annotated-wildcards/Nullable.java
@@ -1,0 +1,7 @@
+package lib;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE_USE)
+public @interface Nullable {}


### PR DESCRIPTION
Java permits type-use annotations before wildcard type arguments, for example
```java
Function<@Nullable ? super String, @Nullable ? extends Object>
```

This is actually a Scala 3 backport of 
- https://github.com/scala/scala3/pull/26187

## Reproduce

You can use this repo's test files:
```
$ cd test/files/pos/java-annotated-wildcards/

$ scala -version
Scala code runner version 2.13.18 -- Copyright 2002-2025, LAMP/EPFL and Lightbend, Inc. dba Akka

$ scalac -usejavacp Nullable.java J.java 
J.java:6: error: illegal start of type
  Function<@lib.Nullable ? super String, @lib.Nullable ? extends Object> mappingFunction();
                         ^
J.java:6: error: `>` expected but `;` found.
  Function<@lib.Nullable ? super String, @lib.Nullable ? extends Object> mappingFunction();
                                                                                          ^
2 errors
```

Java however can compile it:
```
$ java -version
openjdk version "1.8.0_492"
OpenJDK Runtime Environment (Temurin)(build 1.8.0_492-b09)
OpenJDK 64-Bit Server VM (Temurin)(build 25.492-b09, mixed mode)

$ javac Nullable.java J.java 
$ ls -1 *.class
J.class
Nullable.class
```