### PR TITLE
[2.12.x] Parse Java annotations on array dimensions (backport)

### DIFF
--- a/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
@@ -16,6 +16,7 @@
 package scala.tools.nsc
 package javac
 
+import scala.annotation.tailrec
 import scala.collection.mutable.ListBuffer
 import symtab.Flags
 import JavaTokens._
@@ -262,13 +263,16 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
       t
     }
 
-    def optArrayBrackets(tpt: Tree): Tree =
+    @tailrec
+    final def optArrayBrackets(tpt: Tree): Tree = {
+      annotations()
       if (in.token == LBRACKET) {
         val tpt1 = atPos(in.pos) { arrayOf(tpt) }
         in.nextToken()
         accept(RBRACKET)
         optArrayBrackets(tpt1)
       } else tpt
+    }
 
     def basicType(): Tree =
       atPos(in.pos) {

--- a/test/files/pos/java-type-annotations/Test.java
+++ b/test/files/pos/java-type-annotations/Test.java
@@ -1,4 +1,7 @@
 public class Test {
 	static class C<@NotNull T> {};
 	@NotNull String foo() { return ""; }
+	String @NotNull [] values;
+	String @NotNull [] @NotNull [] nestedValues;
+	void varargs(String @NotNull ... values) {}
 }


### PR DESCRIPTION
Backport the Scala 3 Java parser fix for annotations that appear before array brackets, such as `String @Nullable []` and nested annotated arrays.

Scala 3 fixed the same parser gap in scala/scala3#22391. This applies the corresponding `optArrayBrackets` change to the Scala 2 Java parser and extends the existing Java type annotation positive test.

- Cherry-picked from https://github.com/scala/scala/pull/11251 (see more details in that PR)