### PR TITLE
[2.12.x] Parse Java annotations on wildcard type arguments

### DIFF
--- a/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
+++ b/src/compiler/scala/tools/nsc/javac/JavaParsers.scala
@@ -313,7 +313,8 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
 
     def typeArgs(t: Tree): Tree = {
       val wildcards = new ListBuffer[TypeDef]
-      def typeArg(): Tree =
+      def typeArg(): Tree = {
+        annotations()
         if (in.token == QMARK) {
           val pos = in.currentPos
           in.nextToken()
@@ -331,6 +332,7 @@ trait JavaParsers extends ast.parser.ParsersCommon with JavaScanners {
         } else {
           typ()
         }
+      }
       if (in.token == LT) {
         in.nextToken()
         val t1 = convertToTypeId(t)

--- a/test/files/pos/java-annotated-wildcards/J.java
+++ b/test/files/pos/java-annotated-wildcards/J.java
@@ -1,0 +1,7 @@
+package app;
+
+import java.util.function.Function;
+
+public interface J {
+  Function<@lib.Nullable ? super String, @lib.Nullable ? extends Object> mappingFunction();
+}

--- a/test/files/pos/java-annotated-wildcards/Nullable.java
+++ b/test/files/pos/java-annotated-wildcards/Nullable.java
@@ -1,0 +1,7 @@
+package lib;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE_USE)
+public @interface Nullable {}


### PR DESCRIPTION
Backport scala/scala3#26187 so the Java parser accepts type-use annotations that appear before wildcard type arguments, such as `Function<@Nullable ? extends Object>`.

- Cherry-picked from https://github.com/scala/scala/pull/11252 (you can find more details and a reproducer there)