### PR TITLE
remove CODEOWNERS (had entry for stdlib-officers)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,0 @@
-# Any changes to the Scala 2 Standard Library must be approve
-# by one of the officers responsible of maintaining it
-/src/library/      @scala/stdlib-officers
-/src/library-aux/  @scala/stdlib-officers


### PR DESCRIPTION
the same change was already made in Scala 3: https://github.com/scala/scala3/pull/25656 , see justifications there. (It was also discussed on LAMP Slack.)

the justification that most interests me is that the file was "Adding unnecessary pressure and notification noise for members of @scala/stdlib-officers" — my GitHub "participating" notifications, which are the heart of how I use GitHub, were made very noisy by this

anyway, in a Scala 2 context, we aren't normally accepting substantial stdlib changes that originate here; it's expected for a change to happen in Scala 3 first

in any case, we can always @-notify `@scala/stdlib-officers` as needed on individual PRs, I think there's little risk of anything getting merged here without appropriate review