### PR TITLE
bugfix: Ignore unclosed string interpolation to allow completions

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Scanners.scala
@@ -695,7 +695,9 @@ trait Scanners extends ScannersCommon {
               } else {
                 offset += 1
                 getStringPart(multiLine = false)
-                sepRegions = STRINGLIT :: sepRegions // indicate single line string part
+                // don't enter the interpolation region if we recovered from an unclosed string
+                if (token != SEMI)
+                  sepRegions = STRINGLIT :: sepRegions // indicate single line string part
               }
             } else {
               nextChar()
@@ -958,7 +960,12 @@ trait Scanners extends ScannersCommon {
       val note =
         if (seenEscapedQuoteInInterpolation) "; note that `\\\"` no longer closes single-quoted interpolated string literals since 2.13.6, you can use a triple-quoted string instead"
         else ""
-      syntaxError(s"unclosed string literal$note")
+      error(offset, s"unclosed string literal$note")
+      // Recover as best we can by pretending the line has ended, so later
+      // statements (and completions) are not swallowed by the unclosed literal.
+      cbuf.clear()
+      adjustSepRegions(STRINGLIT)
+      token = SEMI
     }
 
     private def replaceUnicodeEscapesInTriple(): Unit = 

--- a/test/files/neg/t5510.check
+++ b/test/files/neg/t5510.check
@@ -16,4 +16,10 @@ t5510.scala:6: error: unclosed multi-line string literal
 t5510.scala:7: error: unclosed multi-line string literal
 }
  ^
-6 errors
+t5510.scala:5: error: ';' expected but string literal found.
+  val s4 = ""s"
+             ^
+t5510.scala:6: error: ';' expected but string literal found.
+  val s5 = ""s""" $s1 $s2 s"
+             ^
+8 errors

--- a/test/junit/scala/tools/nsc/interactive/PresentationCompilerTest.scala
+++ b/test/junit/scala/tools/nsc/interactive/PresentationCompilerTest.scala
@@ -9,6 +9,32 @@ class PresentationCompilerTest {
   @Test def run13112(): Unit = {
     t13112.main(null)
   }
+
+  // https://github.com/scalameta/metals/issues/8779
+  // completionsAt returns NoResults after a broken string interpolation
+  @Test
+  def completionsAtAfterBrokenInterpolation(): Unit = {
+    new completionsAfterBrokenLiteralTest(
+      """object M {
+        |  val myName = "x"
+        |  val a = s"$"
+        |  val b = myNa
+        |}
+        |""".stripMargin
+    ).main(null)
+  }
+
+  @Test
+  def completionsAtAfterBrokenString(): Unit = {
+    new completionsAfterBrokenLiteralTest(
+      """object M {
+        |  val myName = "x"
+        |  val a = "
+        |  val b = myNa
+        |}
+        |""".stripMargin
+    ).main(null)
+  }
 }
 
 object t13112 extends InteractiveTest {
@@ -30,5 +56,31 @@ object t13112 extends InteractiveTest {
     res.get
     val reloadRes = askLoadedTyped(source).get
     assert(reloadRes.isLeft)
+  }
+}
+
+// https://github.com/scalameta/metals/issues/8779
+class completionsAfterBrokenLiteralTest(code: String) extends InteractiveTest {
+  override def execute(): Unit = {
+    val source = new BatchSourceFile("Test.scala", code)
+
+    val res = new Response[Unit]
+    compiler.askReload(List(source), res)
+    res.get
+    askLoadedTyped(source).get
+
+    val nameOffset = code.lastIndexOf("myNa")
+    assert(nameOffset >= 0, "test code must contain 'myNa'")
+    val cursorPos = source.position(nameOffset + "myNa".length)
+
+    val result = compiler.ask(() => compiler.completionsAt(cursorPos))
+
+    result match {
+      case compiler.CompletionResult.NoResults =>
+        throw new AssertionError("completionsAt returned NoResults, expected completions including 'myName'")
+      case _ =>
+        val names = compiler.ask(() => result.matchingResults().map(_.sym.name.decoded.trim))
+        assert(names.contains("myName"), s"Expected 'myName' in completions, got: ${names.mkString(", ")}")
+    }
   }
 }

--- a/test/junit/scala/tools/nsc/interpreter/CompletionTest.scala
+++ b/test/junit/scala/tools/nsc/interpreter/CompletionTest.scala
@@ -149,6 +149,13 @@ class CompletionTest {
   }
 
   @Test
+  def completionsAfterBrokenInterpolation(): Unit = {
+    val completer = setup()
+    checkExact(completer, "val x_y_z = 1; val a = s\"$\"\nval b = x_y")("x_y_z")
+    checkExact(completer, "val x_y_z = 1; val a = \"\nval b = x_y")("x_y_z")
+  }
+
+  @Test
   def symbolically(): Unit = {
     val completer = setup()
     checkExact(completer, """class C { def +++(a: Any) = 0; def ---(a: Any) = 0; this.++""")("+++")


### PR DESCRIPTION
Port of https://github.com/scala/scala3/pull/26763

Fixes https://github.com/scalameta/metals/issues/8779