### PR TITLE
TASTy reader: 3.7 is the last supported version

### DIFF
--- a/doc/internal/tastyreader.md
+++ b/doc/internal/tastyreader.md
@@ -1,6 +1,8 @@
 # TASTy Reader For Scala 2
 
-The [**TASTy Reader For Scala 2**](https://scala.epfl.ch/projects.html#tastyScala2), included in the Scala 2.x Compiler will enable usage in Scala `2.13.x` of dependencies that have been compiled with `dotc`, the reference compiler of Scala `3.0`.
+The [**TASTy Reader For Scala 2**](https://scala.epfl.ch/projects.html#tastyScala2), included in the Scala 2.13 compiler, enables using dependencies that have been compiled with Scala 3 in Scala 2.13.
+
+Scala 3.7 (TASTy version 28.7) is the final Scala 3 version supported by the TASTy reader; support for newer versions will not be added (see [scala/bug#13152](https://github.com/scala/bug/issues/13152)).
 
 TASTy is an intermediate representation of a Scala program after type checking and term elaboration, such as inference of implicit parameters. When compiling code with Scala 3, a single TASTy document is associated with each pair of root class and companion object. Within a TASTy document, the public API of those roots and any inner classes can be read, in a similar way to pickles in the Scala 2.x series.
 

--- a/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
+++ b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala
@@ -345,7 +345,7 @@ trait ScalaSettings extends StandardScalaSettings with Warnings { _: MutableSett
   val YmacroFresh     = BooleanSetting    ("-Ymacro-global-fresh-names", "Should fresh names in macros be unique across all compilation units")
   val YmacroAnnotations = BooleanSetting  ("-Ymacro-annotations", "Enable support for macro annotations, formerly in macro paradise.")
   val YtastyNoAnnotations = BooleanSetting("-Ytasty-no-annotations", "Disable support for reading annotations from TASTy, this will prevent safety features such as pattern match exhaustivity and reachability analysis.")
-  val YtastyReader        = BooleanSetting("-Ytasty-reader", "Enable support for reading Scala 3's TASTy files, allowing consumption of libraries compiled with Scala 3 (provided they don't use any Scala 3 only features).")
+  val YtastyReader        = BooleanSetting("-Ytasty-reader", "Enable support for reading Scala 3's TASTy files, allowing consumption of libraries compiled with Scala 3.7 or earlier (provided they don't use any Scala 3 only features).")
   val Yreplclassbased = BooleanSetting    ("-Yrepl-class-based", "Use classes to wrap REPL snippets instead of objects", default = true)
   val YreplMagicImport = BooleanSetting   ("-Yrepl-use-magic-imports", "In the code that wraps REPL snippets, use magic imports rather than nesting wrapper object/classes", default = true)
   val Yreploutdir     = StringSetting     ("-Yrepl-outdir", "path", "Write repl-generated classfiles to given output directory (use \"\" to generate a temporary dir)" , "")

--- a/src/compiler/scala/tools/nsc/tasty/TastyUnpickler.scala
+++ b/src/compiler/scala/tools/nsc/tasty/TastyUnpickler.scala
@@ -88,7 +88,12 @@ object TastyUnpickler {
     final def upgradeReaderHowTo(version: TastyVersion): String =
       if (version.major == 28) {
         // scala 3.x.y series
-        if (version.experimental > 0)
+        if (version.minor > toolVersion.minor)
+          // TASTy from 3.8 or newer is not supported
+          s"""migrate to Scala 3; the TASTy reader in Scala 2.13
+             |  only supports Scala 3 versions up to 3.${toolVersion.minor}. Alternatively, use a version of the library
+             |  that is compatible with 3.${toolVersion.minor} (or with Scala 2.13)""".stripMargin
+        else if (version.experimental > 0)
           // scenario here is someone using 2.13.12 to read 3.4.1-RC1-NIGHTLY, in this case
           // Scala 2.13 can not read it.
           s"either use a stable version of the library, or try from the same Scala 3.x nightly or snapshot compiler"

--- a/src/compiler/scala/tools/tasty/TastyFormat.scala
+++ b/src/compiler/scala/tools/tasty/TastyFormat.scala
@@ -35,8 +35,10 @@ object TastyFormat {
    *  a series declared by the `MajorVersion`, breaks forward
    *  compatibility, but remains backwards compatible, with all
    *  preceding `MinorVersion`.
+   *
+   *  28.7 (Scala 3.7) is the final supported version.
    */
-  final val MinorVersion: Int = 6
+  final val MinorVersion: Int = 7
 
   /** Natural Number. The `ExperimentalVersion` allows for
    *  experimentation with changes to TASTy without committing

--- a/src/compiler/scala/tools/tasty/TastyHeaderUnpickler.scala
+++ b/src/compiler/scala/tools/tasty/TastyHeaderUnpickler.scala
@@ -106,7 +106,7 @@ class TastyHeaderUnpickler(config: UnpicklerConfig, reader: TastyReader) {
       )
 
       val possibles = config.toolOverrides
-      val validOverride = possibles.isEmpty || possibles.exists { overrideVersion =>
+      val validOverride = possibles.exists { overrideVersion =>
         TastyFormat.isVersionCompatible(
           fileMajor            = fileMajor,
           fileMinor            = fileMinor,

--- a/test/junit/scala/tools/tasty/TastyHeaderUnpicklerTest.scala
+++ b/test/junit/scala/tools/tasty/TastyHeaderUnpicklerTest.scala
@@ -1,0 +1,120 @@
+package scala.tools.tasty
+
+import org.junit.Assert._
+import org.junit.Test
+
+import scala.collection.mutable.ArrayBuffer
+import scala.tools.nsc.tasty.TastyUnpickler
+
+class TastyHeaderUnpicklerTest {
+  import TastyHeaderUnpicklerTest._
+
+  val currentTool = TastyVersion(TastyFormat.MajorVersion, TastyFormat.MinorVersion, TastyFormat.ExperimentalVersion)
+
+  @Test def readCurrentVersion(): Unit = {
+    runTest(currentTool, toolingVersion = "Scala 3.7.4")
+  }
+
+  @Test def readOlderStableMinor(): Unit = {
+    runTest(TastyVersion(TastyFormat.MajorVersion, 0, 0), toolingVersion = "Scala 3.0.0")
+  }
+
+  @Test def failNewerStableMinor(): Unit = {
+    // scala/bug#13152: Scala 3.8+ TASTy must be rejected with an explanation that
+    // the Scala 2 TASTy reader will never support it.
+    val file = TastyVersion(TastyFormat.MajorVersion, TastyFormat.MinorVersion + 1, 0)
+    expectUnpickleError(file, toolingVersion = s"Scala 3.${file.minor}.0") { msg =>
+      assertTrue(msg, msg.contains(s"Forward incompatible TASTy file has version ${file.show}"))
+      assertTrue(msg, msg.contains(s"expected stable TASTy from 28.0 to 28.${currentTool.minor}"))
+      assertTrue(msg, msg.contains(s"only supports Scala 3 versions up to 3.${currentTool.minor}"))
+    }
+  }
+
+  @Test def failNewerExperimentalMinor(): Unit = {
+    // e.g. a library built with a Scala 3.8 nightly
+    val file = TastyVersion(TastyFormat.MajorVersion, TastyFormat.MinorVersion + 1, 1)
+    expectUnpickleError(file, toolingVersion = s"Scala 3.${file.minor}.0-RC1-bin-SNAPSHOT") { msg =>
+      assertTrue(msg, msg.contains(s"only supports Scala 3 versions up to 3.${currentTool.minor}"))
+      // must hit the "unsupported version" branch, not the generic experimental advice
+      assertFalse(msg, msg.contains("use a stable version of the library"))
+    }
+  }
+
+  @Test def failExperimentalSameMinor(): Unit = {
+    // e.g. a library built with a Scala 3.7 nightly: recompile it with the stable release
+    val file = TastyVersion(TastyFormat.MajorVersion, TastyFormat.MinorVersion, 1)
+    expectUnpickleError(file, toolingVersion = s"Scala 3.${file.minor}.0-RC1-bin-SNAPSHOT") { msg =>
+      assertTrue(msg, msg.contains("Backward incompatible TASTy file"))
+      assertTrue(msg, msg.contains(s"recompiled by a Scala 3.${file.minor}.0 compiler or newer"))
+    }
+  }
+
+  @Test def toolOverridesExtendAcceptedVersions(): Unit = {
+    val overrideVersion = TastyVersion(TastyFormat.MajorVersion, TastyFormat.MinorVersion + 1, 1)
+    val config = configWithOverrides(List(overrideVersion))
+    // accepted via the override
+    unpickle(overrideVersion, "Scala next nightly", config)
+    // the tool's own version remains accepted
+    unpickle(currentTool, "Scala 3.7.4", config)
+    // other versions are still rejected
+    val rejected = TastyVersion(TastyFormat.MajorVersion, TastyFormat.MinorVersion + 2, 0)
+    try {
+      unpickle(rejected, "Scala newer", config)
+      fail("expected an UnpickleException")
+    } catch { case _: UnpickleException => () }
+  }
+}
+
+object TastyHeaderUnpicklerTest {
+
+  def fillHeader(fileVersion: TastyVersion, toolingVersion: String): Array[Byte] = {
+    val buf = new ArrayBuffer[Byte]
+    TastyFormat.header.foreach(b => buf += b.toByte)
+    writeNat(buf, fileVersion.major)
+    writeNat(buf, fileVersion.minor)
+    writeNat(buf, fileVersion.experimental)
+    val tooling = toolingVersion.getBytes(java.nio.charset.StandardCharsets.UTF_8)
+    writeNat(buf, tooling.length)
+    buf ++= tooling
+    for (_ <- 0 until 16) buf += 0.toByte // uuid
+    buf.toArray
+  }
+
+  // big endian base 128, bit 0x80 marks the last digit (see TastyReader.readNat)
+  private def writeNat(buf: ArrayBuffer[Byte], x: Int): Unit = {
+    assert(x >= 0)
+    var digits = List((x & 0x7f) | 0x80)
+    var rest = x >>> 7
+    while (rest != 0) {
+      digits ::= rest & 0x7f
+      rest >>>= 7
+    }
+    digits.foreach(d => buf += d.toByte)
+  }
+
+  def configWithOverrides(overrides: List[TastyVersion]): UnpicklerConfig =
+    new UnpicklerConfig with UnpicklerConfig.DefaultTastyVersion {
+      val toolOverrides: List[TastyVersion] = overrides
+      def upgradeReaderHowTo(version: TastyVersion): String = "upgrade the reader"
+      def upgradedProducerTool(version: TastyVersion): String = "a newer producer"
+      def recompileAdditionalInfo: String = ""
+      def upgradeAdditionalInfo(fileVersion: TastyVersion): String = ""
+    }
+
+  def unpickle(fileVersion: TastyVersion, toolingVersion: String, config: UnpicklerConfig): Unit = {
+    val bytes = fillHeader(fileVersion, toolingVersion)
+    new TastyHeaderUnpickler(config, bytes).readHeader()
+    ()
+  }
+
+  def runTest(fileVersion: TastyVersion, toolingVersion: String): Unit =
+    unpickle(fileVersion, toolingVersion, TastyUnpickler.scala2CompilerConfig)
+
+  def expectUnpickleError(fileVersion: TastyVersion, toolingVersion: String)(checkMessage: String => Unit): Unit = {
+    try {
+      runTest(fileVersion, toolingVersion)
+      fail("expected an UnpickleException")
+    }
+    catch { case err: UnpickleException => checkMessage(err.getMessage) }
+  }
+}


### PR DESCRIPTION
Bump the supported TASTy version to 28.7 (Scala 3.7).

The header version check was effectively disabled, because `toolOverrides` is always empty, so `validOverride` was always true.

Fixes https://github.com/scala/bug/issues/13152