### PR TITLE
Use individual JLine modules, bump to 3.30.16

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,15 +35,20 @@
 import scala.build._, VersionUtil._
 
 // Non-Scala dependencies:
-val junitDep          = "junit"                          % "junit"                            % "4.13.2"
-val junitInterfaceDep = "com.github.sbt"                 % "junit-interface"                  % "0.13.3"                          % Test
-val scalacheckDep     = "org.scalacheck"                %% "scalacheck"                       % "1.18.1"                          % Test
-val jolDep            = "org.openjdk.jol"                % "jol-core"                         % "0.16"
-val asmDep            = "org.scala-lang.modules"         % "scala-asm"                        % versionProps("scala-asm.version")
-val jlineDep          = "org.jline"                      % "jline"                            % versionProps("jline.version")     classifier "jdk8"
-val testInterfaceDep  = "org.scala-sbt"                  % "test-interface"                   % "1.0"
-val diffUtilsDep      = "io.github.java-diff-utils"      % "java-diff-utils"                  % "4.16"
-val compilerInterfaceDep = "org.scala-sbt"               % "compiler-interface"               % "1.10.8"
+val junitDep             = "junit"                          % "junit"                            % "4.13.2"
+val junitInterfaceDep    = "com.github.sbt"                 % "junit-interface"                  % "0.13.3"                          % Test
+val scalacheckDep        = "org.scalacheck"                %% "scalacheck"                       % "1.18.1"                          % Test
+val jolDep               = "org.openjdk.jol"                % "jol-core"                         % "0.16"
+val asmDep               = "org.scala-lang.modules"         % "scala-asm"                        % versionProps("scala-asm.version")
+val jlineVersion         = versionProps("jline.version")
+val jlineTerminalDep     = "org.jline"                      % "jline-terminal"                   % jlineVersion
+val jlineTerminalJniDep  = "org.jline"                      % "jline-terminal-jni"               % jlineVersion
+val jlineReaderDep       = "org.jline"                      % "jline-reader"                     % jlineVersion
+val jlineBuiltinsDep     = "org.jline"                      % "jline-builtins"                   % jlineVersion // for InputRC
+val jlineDeps            = Seq(jlineTerminalDep, jlineTerminalJniDep, jlineReaderDep, jlineBuiltinsDep)
+val testInterfaceDep     = "org.scala-sbt"                  % "test-interface"                   % "1.0"
+val diffUtilsDep         = "io.github.java-diff-utils"      % "java-diff-utils"                  % "4.16"
+val compilerInterfaceDep = "org.scala-sbt"                  % "compiler-interface"               % "1.10.8"
 
 val projectFolder = settingKey[String]("subfolder in src when using configureAsSubproject, else the project name")
 
@@ -512,7 +517,7 @@ lazy val compiler = configureAsSubproject(project)
     libraryDependencies += diffUtilsDep,
     // This is only needed for the POM:
     // TODO: jline dependency is only needed for the REPL shell, which should move to its own jar
-    libraryDependencies += jlineDep,
+    libraryDependencies ++= jlineDeps,
     buildCharacterPropertiesFile := (Compile / resourceManaged).value / "scala-buildcharacter.properties",
     Compile / resourceGenerators += generateBuildCharacterPropertiesFile.map(file => Seq(file)).taskValue,
     // this a way to make sure that classes from interactive and scaladoc projects
@@ -560,9 +565,7 @@ lazy val compiler = configureAsSubproject(project)
       "-doc-root-content", (Compile / sourceDirectory).value + "/rootdoc.txt"
     ),
     Osgi.headers ++= Seq(
-      "Import-Package" -> raw"""org.jline.keymap.*;resolution:=optional
-                            |org.jline.reader.*;resolution:=optional
-                            |org.jline.style.*;resolution:=optional
+      "Import-Package" -> raw"""org.jline.reader.*;resolution:=optional
                             |org.jline.terminal;resolution:=optional
                             |org.jline.terminal.impl;resolution:=optional
                             |org.jline.terminal.spi;resolution:=optional
@@ -609,7 +612,7 @@ lazy val replFrontend = configureAsSubproject(project, srcdir = Some("repl-front
   .settings(fatalWarningsSettings)
   .settings(publish / skip := true)
   .settings(
-    libraryDependencies += jlineDep,
+    libraryDependencies ++= jlineDeps,
     name := "scala-repl-frontend",
   )
   .settings(
@@ -1149,7 +1152,7 @@ lazy val scalaDist = Project("scalaDist", file(".") / "target" / "scala-dist-dis
       (htmlOut ** "*.html").get ++ (fixedManOut ** "*.1").get
     }.taskValue,
     Compile / managedResourceDirectories := Seq((Compile / resourceManaged).value),
-    libraryDependencies += jlineDep,
+    libraryDependencies ++= jlineDeps,
     apiURL := None,
     fixPom(
       "/project/name" -> <name>Scala Distribution Artifacts</name>,
@@ -1312,7 +1315,7 @@ lazy val distDependencies = Seq(replFrontend, compiler, library, reflect, scalap
 lazy val dist = (project in file("dist"))
   .settings(commonSettings)
   .settings(
-    libraryDependencies += jlineDep,
+    libraryDependencies ++= jlineDeps,
     mkBin := mkBinImpl.value,
     mkQuick := Def.task {
       val cp = (testP / IntegrationTest / fullClasspath).value
@@ -1326,8 +1329,9 @@ lazy val dist = (project in file("dist"))
     target := (ThisBuild / target).value / projectFolder.value,
     Compile / packageBin := {
       val targetDir = (ThisBuild / buildDirectory).value / "pack" / "lib"
-      val jlineJAR = findJar((Compile / dependencyClasspath).value, jlineDep).get.data
-      val mappings = Seq((jlineJAR, targetDir / "jline.jar"))
+      val mappings = (Compile / dependencyClasspath).value.flatMap { entry =>
+        entry.get(moduleID.key).filter(_.organization == "org.jline").map(m => (entry.data, targetDir / s"${m.name}.jar"))
+      }
       IO.copy(mappings, CopyOptions() withOverwrite true)
       targetDir
     },
@@ -1454,12 +1458,6 @@ addCommandAlias("scalap",   "scalap/compile:runMain              scala.tools.sca
 
 // aliases to projects to prevent name clashes
 def testP = test
-
-/** Find a specific module's JAR in a classpath, comparing only organization and name */
-def findJar(files: Seq[Attributed[File]], dep: ModuleID): Option[Attributed[File]] = {
-  def extract(m: ModuleID) = (m.organization, m.name)
-  files.find(_.get(moduleID.key).map(extract _) == Some(extract(dep)))
-}
 
 {
   scala.build.TravisOutput.installIfOnTravis()

--- a/versions.properties
+++ b/versions.properties
@@ -3,10 +3,10 @@ starr.version=2.13.18
 
 # These are the versions of the modules that go with this release.
 # Artifact dependencies:
-#  - scala-compiler: jline (% "optional")
+#  - scala-compiler: jline-terminal, jline-terminal-jni, jline-reader, jline-builtins
 # Other usages:
 #  - scala-asm: jar content included in scala-compiler
 scala-asm.version=9.9.0-scala-1
 
 # REPL
-jline.version=3.29.0
+jline.version=3.30.16


### PR DESCRIPTION
The `jdk8` classifier is no longer needed, the individual modules have Java 8 classfiles.

Drop two `Import-Package` entries that bnd reported as unused.

Fixes https://github.com/scala/bug/issues/13185
Fixes https://github.com/scala/scala-dev/issues/912