### PR TITLE
Make StubSymbols synchronized in SynchronizedSymbols

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -57,6 +57,10 @@ object MimaFilters extends AutoPlugin {
     // scala/scala#11242
     ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.LazyList"), // superclass change from AbstractSeq to LazyListBase
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.LazyListBase*"), // private[immutable]
+
+    // scala/bug#13183: new private classes in the private[reflect] trait SynchronizedSymbols
+    ProblemFilters.exclude[MissingClassProblem]("scala.reflect.runtime.SynchronizedSymbols$SynchronizedStubClassSymbol"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.reflect.runtime.SynchronizedSymbols$SynchronizedStubTermSymbol"),
   )
 
   override val buildSettings = Seq(

--- a/src/reflect/scala/reflect/runtime/SynchronizedSymbols.scala
+++ b/src/reflect/scala/reflect/runtime/SynchronizedSymbols.scala
@@ -43,6 +43,18 @@ private[reflect] trait SynchronizedSymbols extends internal.Symbols { self: Symb
 
   override protected def makeNoSymbol: NoSymbol = new NoSymbol with SynchronizedSymbol
 
+  // Note: `StubSymbol` is mixed in last, its `info` / `rawInfo` need to win over `SynchronizedSymbol`'s
+  private class SynchronizedStubClassSymbol(owner0: Symbol, name0: TypeName, val missingMessage: String)
+    extends ClassSymbol(owner0, owner0.pos, name0) with SynchronizedClassSymbol with StubSymbol
+  private class SynchronizedStubTermSymbol(owner0: Symbol, name0: TermName, val missingMessage: String)
+    extends TermSymbol(owner0, owner0.pos, name0) with SynchronizedTermSymbol with StubSymbol
+
+  // public (not protected) to match the widened override in `Global`, both are mixed into `ReflectGlobal`
+  override def newStubSymbol(owner: Symbol, name: Name, missingMessage: String): Symbol = name match {
+    case n: TypeName => new SynchronizedStubClassSymbol(owner, n, missingMessage)
+    case _           => new SynchronizedStubTermSymbol(owner, name.toTermName, missingMessage)
+  }
+
   trait SynchronizedSymbol extends Symbol {
 
     /** (Things written in this comment only applies to runtime reflection. Compile-time reflection,


### PR DESCRIPTION
The idea of stub symbols is to delay errors about missing symbols until they are actually looked at.

In runtime reflection this doesn't work because stub symbols are not a `SynchronizedSymbol`, which leads to an exception `unsafe symbol` being thrown.

If this change was in 2.13.16, it would have prevented https://github.com/scala/bug/issues/13183. We cannot retroactively fix 2.13.16 though.