### PR TITLE
Improve Vector's performance for 1-4 elements by inlining storage 

### DIFF
--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -64,6 +64,7 @@ object MimaFilters extends AutoPlugin {
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.InlineVector2"),
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.InlineVector3"),
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.InlineVector4"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.InlineVectorIterator"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.VectorStatics.smallVector"),
   )
 

--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -57,6 +57,14 @@ object MimaFilters extends AutoPlugin {
     // scala/scala#11242
     ProblemFilters.exclude[MissingTypesProblem]("scala.collection.immutable.LazyList"), // superclass change from AbstractSeq to LazyListBase
     ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.LazyListBase*"), // private[immutable]
+
+    // package-private classes, inline representation for Vectors of size 1-4
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.InlineVector"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.InlineVector1"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.InlineVector2"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.InlineVector3"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.InlineVector4"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.VectorStatics.smallVector"),
   )
 
   override val buildSettings = Seq(

--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -41,12 +41,23 @@ object Vector extends StrictOptimizedSeqFactory[Vector] {
       case _ =>
         val knownSize = it.knownSize
         if (knownSize == 0) empty[E]
-        else if (knownSize == 1) {
-          val head = it match {
-            case it: Iterable[E] => it.head
-            case _               => it.iterator.next()
+        else if (knownSize >= 1 && knownSize <= 4) {
+          it match {
+            case is: collection.IndexedSeq[E] => knownSize match {
+              case 1 => new InlineVector1[E](is(0))
+              case 2 => new InlineVector2[E](is(0), is(1))
+              case 3 => new InlineVector3[E](is(0), is(1), is(2))
+              case _ => new InlineVector4[E](is(0), is(1), is(2), is(3))
+            }
+            case _ =>
+              val i = it.iterator
+              knownSize match {
+                case 1 => new InlineVector1[E](i.next())
+                case 2 => new InlineVector2[E](i.next(), i.next())
+                case 3 => new InlineVector3[E](i.next(), i.next(), i.next())
+                case _ => new InlineVector4[E](i.next(), i.next(), i.next(), i.next())
+              }
           }
-          new InlineVector1[E](head)
         }
         else if (knownSize > 0 && knownSize <= WIDTH) {
           val a1: Arr1 = it match {

--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -41,6 +41,13 @@ object Vector extends StrictOptimizedSeqFactory[Vector] {
       case _ =>
         val knownSize = it.knownSize
         if (knownSize == 0) empty[E]
+        else if (knownSize == 1) {
+          val head = it match {
+            case it: Iterable[E] => it.head
+            case _               => it.iterator.next()
+          }
+          new InlineVector1[E](head)
+        }
         else if (knownSize > 0 && knownSize <= WIDTH) {
           val a1: Arr1 = it match {
             case as: ArraySeq.ofRef[_] if as.elemTag.runtimeClass == classOf[AnyRef] =>
@@ -125,13 +132,19 @@ sealed abstract class Vector[+A] private[immutable] (private[immutable] final va
 
   override final def length: Int =
     if(this.isInstanceOf[BigVector[_]]) this.asInstanceOf[BigVector[_]].length0
-    else prefix1.length
+    else {
+      val p = prefix1
+      if (p eq null) this.asInstanceOf[InlineVector[_]].inlineLength // null prefix1 marks the inline variants
+      else p.length
+    }
 
   override final def iterator: Iterator[A] =
     if(this.isInstanceOf[Vector0.type]) Vector.emptyIterator
     else new NewVectorIterator(this, length, vectorSliceCount)
 
   override final protected[collection] def filterImpl(pred: A => Boolean, isFlipped: Boolean): Vector[A] = {
+    if (this.isInstanceOf[InlineVector[_]]) // no prefix1 array to walk
+      return this.asInstanceOf[InlineVector[A]].inlineFilter(pred, isFlipped)
     var i = 0
     val len = prefix1.length
     while (i != len) {
@@ -285,19 +298,30 @@ sealed abstract class Vector[+A] private[immutable] (private[immutable] final va
   protected[this] def ioob(index: Int): IndexOutOfBoundsException =
     CommonErrors.indexOutOfBounds(index = index, max = length - 1)
 
-  override final def head: A =
-    if (prefix1.length == 0) throw new NoSuchElementException("empty.head")
-    else prefix1(0).asInstanceOf[A]
+  override final def head: A = {
+    val p = prefix1
+    if (p eq null) this.asInstanceOf[InlineVector[A]].elem1
+    else if (p.length == 0) throw new NoSuchElementException("empty.head")
+    else p(0).asInstanceOf[A]
+  }
 
   override final def last: A = {
     if(this.isInstanceOf[BigVector[_]]) {
       val suffix = this.asInstanceOf[BigVector[_]].suffix1
       if(suffix.length == 0) throw new NoSuchElementException("empty.tail")
       else suffix(suffix.length-1)
-    } else prefix1(prefix1.length-1)
+    } else {
+      val p = prefix1
+      if (p eq null) this.asInstanceOf[InlineVector[_]].lastElem.asInstanceOf[AnyRef]
+      else p(p.length-1)
+    }
   }.asInstanceOf[A]
 
   override final def foreach[U](f: A => U): Unit = {
+    if (this.isInstanceOf[InlineVector[_]]) { // no slices to walk
+      this.asInstanceOf[InlineVector[A]].inlineForeach(f)
+      return
+    }
     val c = vectorSliceCount
     var i = 0
     while (i < c) {
@@ -348,9 +372,9 @@ private object Vector0 extends BigVector[Nothing](empty1, empty1, 0) {
 
   override def updated[B >: Nothing](index: Int, elem: B): Vector[B] = throw ioob(index)
 
-  override def appended[B >: Nothing](elem: B): Vector[B] = new Vector1(wrap1(elem))
+  override def appended[B >: Nothing](elem: B): Vector[B] = new InlineVector1(elem)
 
-  override def prepended[B >: Nothing](elem: B): Vector[B] = new Vector1(wrap1(elem))
+  override def prepended[B >: Nothing](elem: B): Vector[B] = new InlineVector1(elem)
 
   override def map[B](f: Nothing => B): Vector[B] = this
 
@@ -381,6 +405,200 @@ private object Vector0 extends BigVector[Nothing](empty1, empty1, 0) {
   override protected[this] def ioob(index: Int): IndexOutOfBoundsException =
     new IndexOutOfBoundsException(s"$index is out of bounds (empty vector)")
 }
+
+/** Base of inline vector variants.
+  * 
+  * Inline variants are fixed-size and store contents directly in fields.
+  */
+private sealed abstract class InlineVector[+A] extends VectorImpl[A](null) {
+
+  private[immutable] def inlineLength: Int
+  private[immutable] def elem1: A
+  private[immutable] def lastElem: A
+  private[immutable] def inlineForeach[U](f: A => U): Unit
+
+  private[immutable] final def inlineFilter(pred: A => Boolean, isFlipped: Boolean): Vector[A] = {
+    val n   = inlineLength
+    val buf = new Arr1(n)
+    var k   = 0
+    var i   = 0
+    while (i < n) {
+      val e = apply(i)
+      if (pred(e) != isFlipped) { buf(k) = e.asInstanceOf[AnyRef]; k += 1 }
+      i += 1
+    }
+    if (k == n) this else smallVector(buf, 0, k)
+  }
+
+  protected[this] final def slice0(lo: Int, hi: Int): Vector[A] = (hi - lo) match {
+    case 1 => new InlineVector1(apply(lo))
+    case 2 => new InlineVector2(apply(lo), apply(lo + 1))
+    case _ => new InlineVector3(apply(lo), apply(lo + 1), apply(lo + 2))
+  }
+
+  protected[immutable] final def vectorSliceCount: Int = 1
+  protected[immutable] final def vectorSlice(idx: Int): Array[_ <: AnyRef] = {
+    val n = inlineLength
+    val a = new Arr1(n)
+    var i = 0
+    while (i < n) { a(i) = apply(i).asInstanceOf[AnyRef]; i += 1 }
+    a
+  }
+  protected[immutable] final def vectorSlicePrefixLength(idx: Int): Int = inlineLength
+}
+
+
+private final class InlineVector1[+A](private[immutable] val elem1: A) extends InlineVector[A] {
+  private[immutable] def inlineLength: Int = 1
+  private[immutable] def lastElem: A = elem1
+  private[immutable] def inlineForeach[U](f: A => U): Unit = { f(elem1); () }
+
+  @inline def apply(index: Int): A =
+    if (index == 0) elem1 else throw ioob(index)
+
+  override def updated[B >: A](index: Int, elem: B): Vector[B] =
+    if (index == 0) new InlineVector1(elem) else throw ioob(index)
+
+  override def appended[B >: A](elem: B): Vector[B] = new InlineVector2(elem1, elem)
+
+  override def prepended[B >: A](elem: B): Vector[B] = new InlineVector2(elem, elem1)
+
+  override def map[B](f: A => B): Vector[B] = new InlineVector1(f(elem1))
+
+  override def tail: Vector[A] = Vector0
+
+  override def init: Vector[A] = Vector0
+
+  override def foldLeft[B](z: B)(f: (B, A) => B): B = f(z, elem1)
+}
+
+
+private final class InlineVector2[+A](
+  private[immutable] val elem1: A,
+  private[immutable] val elem2: A,
+) extends InlineVector[A] {
+  private[immutable] def inlineLength: Int = 2
+  private[immutable] def lastElem: A = elem2
+  private[immutable] def inlineForeach[U](f: A => U): Unit = { f(elem1); f(elem2); () }
+
+  @inline def apply(index: Int): A = index match {
+    case 0 => elem1
+    case 1 => elem2
+    case _ => throw ioob(index)
+  }
+
+  override def updated[B >: A](index: Int, elem: B): Vector[B] = index match {
+    case 0 => new InlineVector2(elem, elem2)
+    case 1 => new InlineVector2(elem1, elem)
+    case _ => throw ioob(index)
+  }
+
+  override def appended[B >: A](elem: B): Vector[B] = new InlineVector3(elem1, elem2, elem)
+
+  override def prepended[B >: A](elem: B): Vector[B] = new InlineVector3(elem, elem1, elem2)
+
+  override def map[B](f: A => B): Vector[B] = new InlineVector2(f(elem1), f(elem2))
+
+  override def tail: Vector[A] = new InlineVector1(elem2)
+
+  override def init: Vector[A] = new InlineVector1(elem1)
+
+  override def foldLeft[B](z: B)(f: (B, A) => B): B = f(f(z, elem1), elem2)
+}
+
+
+private final class InlineVector3[+A](
+  private[immutable] val elem1: A,
+  private[immutable] val elem2: A,
+  private[immutable] val elem3: A,
+) extends InlineVector[A] {
+  private[immutable] def inlineLength: Int = 3
+  private[immutable] def lastElem: A = elem3
+  private[immutable] def inlineForeach[U](f: A => U): Unit = { f(elem1); f(elem2); f(elem3); () }
+
+  @inline def apply(index: Int): A = index match {
+    case 0 => elem1
+    case 1 => elem2
+    case 2 => elem3
+    case _ => throw ioob(index)
+  }
+
+  override def updated[B >: A](index: Int, elem: B): Vector[B] = index match {
+    case 0 => new InlineVector3(elem, elem2, elem3)
+    case 1 => new InlineVector3(elem1, elem, elem3)
+    case 2 => new InlineVector3(elem1, elem2, elem)
+    case _ => throw ioob(index)
+  }
+
+  override def appended[B >: A](elem: B): Vector[B] = new InlineVector4(elem1, elem2, elem3, elem)
+
+  override def prepended[B >: A](elem: B): Vector[B] = new InlineVector4(elem, elem1, elem2, elem3)
+
+  override def map[B](f: A => B): Vector[B] = new InlineVector3(f(elem1), f(elem2), f(elem3))
+
+  override def tail: Vector[A] = new InlineVector2(elem2, elem3)
+
+  override def init: Vector[A] = new InlineVector2(elem1, elem2)
+
+  override def foldLeft[B](z: B)(f: (B, A) => B): B = f(f(f(z, elem1), elem2), elem3)
+}
+
+
+private final class InlineVector4[+A](
+  private[immutable] val elem1: A,
+  private[immutable] val elem2: A,
+  private[immutable] val elem3: A,
+  private[immutable] val elem4: A,
+) extends InlineVector[A] {
+  private[immutable] def inlineLength: Int = 4
+  private[immutable] def lastElem: A = elem4
+  private[immutable] def inlineForeach[U](f: A => U): Unit = { f(elem1); f(elem2); f(elem3); f(elem4); () }
+
+  @inline def apply(index: Int): A = index match {
+    case 0 => elem1
+    case 1 => elem2
+    case 2 => elem3
+    case 3 => elem4
+    case _ => throw ioob(index)
+  }
+
+  override def updated[B >: A](index: Int, elem: B): Vector[B] = index match {
+    case 0 => new InlineVector4(elem, elem2, elem3, elem4)
+    case 1 => new InlineVector4(elem1, elem, elem3, elem4)
+    case 2 => new InlineVector4(elem1, elem2, elem, elem4)
+    case 3 => new InlineVector4(elem1, elem2, elem3, elem)
+    case _ => throw ioob(index)
+  }
+
+  override def appended[B >: A](elem: B): Vector[B] = {
+    val a = new Arr1(5)
+    a(0) = elem1.asInstanceOf[AnyRef]
+    a(1) = elem2.asInstanceOf[AnyRef]
+    a(2) = elem3.asInstanceOf[AnyRef]
+    a(3) = elem4.asInstanceOf[AnyRef]
+    a(4) = elem.asInstanceOf[AnyRef]
+    new Vector1(a)
+  }
+
+  override def prepended[B >: A](elem: B): Vector[B] = {
+    val a = new Arr1(5)
+    a(0) = elem.asInstanceOf[AnyRef]
+    a(1) = elem1.asInstanceOf[AnyRef]
+    a(2) = elem2.asInstanceOf[AnyRef]
+    a(3) = elem3.asInstanceOf[AnyRef]
+    a(4) = elem4.asInstanceOf[AnyRef]
+    new Vector1(a)
+  }
+
+  override def map[B](f: A => B): Vector[B] = new InlineVector4(f(elem1), f(elem2), f(elem3), f(elem4))
+
+  override def tail: Vector[A] = new InlineVector3(elem2, elem3, elem4)
+
+  override def init: Vector[A] = new InlineVector3(elem1, elem2, elem3)
+
+  override def foldLeft[B](z: B)(f: (B, A) => B): B = f(f(f(f(z, elem1), elem2), elem3), elem4)
+}
+
 
 /** Flat ArraySeq-like structure */
 private final class Vector1[+A](_data1: Arr1) extends VectorImpl[A](_data1) {
@@ -415,11 +633,11 @@ private final class Vector1[+A](_data1: Arr1) extends VectorImpl[A](_data1) {
     new Vector1(copyOfRange(prefix1, lo, hi))
 
   override def tail: Vector[A] =
-    if(prefix1.length == 1) Vector0
+    if(prefix1.length <= 5) smallVector(prefix1, 1, prefix1.length - 1)
     else new Vector1(copyTail(prefix1))
 
   override def init: Vector[A] =
-    if(prefix1.length == 1) Vector0
+    if(prefix1.length <= 5) smallVector(prefix1, 0, prefix1.length - 1)
     else new Vector1(copyInit(prefix1))
 
   protected[immutable] def vectorSliceCount: Int = 1
@@ -1249,7 +1467,8 @@ private final class VectorSliceBuilder(lo: Int, hi: Int) {
               suffix2(0)
             }
           }
-        new Vector1(a)
+        if (len <= 4) smallVector[A](a, 0, len)
+        else new Vector1(a)
       }
     } else {
       balancePrefix(1)
@@ -1472,10 +1691,20 @@ final class VectorBuilder[A] extends ReusableBuilder[A, Vector[A]] {
     (v.vectorSliceCount: @switch) match {
       case 0 =>
       case 1 =>
-        val v1 = v.asInstanceOf[Vector1[_]]
-        depth = 1
-        setLen(v1.prefix1.length)
-        a1 = copyOrUse(v1.prefix1, 0, WIDTH)
+        v match { // the inline variants have the same sliceCount as Vector1 but no array
+          case iv: InlineVector[_] =>
+            val n = iv.inlineLength
+            depth = 1
+            setLen(n)
+            a1 = new Arr1(WIDTH)
+            var i = 0
+            while (i < n) { a1(i) = iv(i).asInstanceOf[AnyRef]; i += 1 }
+          case v1: Vector1[_] =>
+            depth = 1
+            setLen(v1.prefix1.length)
+            a1 = copyOrUse(v1.prefix1, 0, WIDTH)
+          case _ => throw new MatchError(v)
+        }
       case 3 =>
         val v2 = v.asInstanceOf[Vector2[_]]
         val d2 = v2.data2
@@ -1576,6 +1805,7 @@ final class VectorBuilder[A] extends ReusableBuilder[A, Vector[A]] {
       throw new UnsupportedOperationException("A non-empty VectorBuilder cannot be aligned retrospectively. Please call .reset() or use a new VectorBuilder.")
     val (prefixLength, maxPrefixLength) = bigVector match {
       case Vector0 => (0, 1)
+      case _: InlineVector[_] => (0, 1)
       case v1: Vector1[_] => (0, 1)
       case v2: Vector2[_] => (v2.len1, WIDTH)
       case v3: Vector3[_] => (v3.len12, WIDTH2)
@@ -1895,7 +2125,8 @@ final class VectorBuilder[A] extends ReusableBuilder[A, Vector[A]] {
     if(realLen == 0) Vector.empty
     else if(len < 0) throw new IndexOutOfBoundsException(s"Vector cannot have negative size $len")
     else if(len <= WIDTH) {
-      new Vector1(copyIfDifferentSize(a1, realLen))
+      if (realLen <= 4) smallVector[A](a1, 0, realLen)
+      else new Vector1(copyIfDifferentSize(a1, realLen))
     } else if(len <= WIDTH2) {
       val i1 = (len-1) & MASK
       val i2 = (len-1) >>> BITS
@@ -2082,6 +2313,15 @@ private[immutable] object VectorInline {
 /** Helper methods and constants for Vector. */
 private object VectorStatics {
 
+  final def smallVector[A](a: Arr1, start: Int, len: Int): Vector[A] = len match {
+    case 0 => Vector0
+    case 1 => new InlineVector1(a(start).asInstanceOf[A])
+    case 2 => new InlineVector2(a(start).asInstanceOf[A], a(start + 1).asInstanceOf[A])
+    case 3 => new InlineVector3(a(start).asInstanceOf[A], a(start + 1).asInstanceOf[A], a(start + 2).asInstanceOf[A])
+    case 4 => new InlineVector4(a(start).asInstanceOf[A], a(start + 1).asInstanceOf[A], a(start + 2).asInstanceOf[A], a(start + 3).asInstanceOf[A])
+    case _ => new Vector1(copyOrUse(a, start, start + len))
+  }
+
   final def copyAppend1(a: Arr1, elem: Any): Arr1 = {
     val alen = a.length
     val ac = new Arr1(alen+1)
@@ -2238,7 +2478,11 @@ private object VectorStatics {
 
 private final class NewVectorIterator[A](v: Vector[A], private[this] var totalLength: Int, private[this] val sliceCount: Int) extends AbstractIterator[A] with java.lang.Cloneable {
 
-  private[this] var a1: Arr1 = v.prefix1
+  private[this] var a1: Arr1 = {
+    val p = v.prefix1
+    if (p ne null) p
+    else v.vectorSlice(0).asInstanceOf[Arr1]
+  }
   private[this] var a2: Arr2 = _
   private[this] var a3: Arr3 = _
   private[this] var a4: Arr4 = _

--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -416,12 +416,130 @@ private object Vector0 extends BigVector[Nothing](empty1, empty1, 0) {
   * 
   * Inline variants are fixed-size and store contents directly in fields.
   */
-private sealed abstract class InlineVector[+A] extends VectorImpl[A](null) {
+private sealed abstract class InlineVector[+A](private[immutable] val elem1: A) extends VectorImpl[A](null) {
 
-  private[immutable] def inlineLength: Int
-  private[immutable] def elem1: A
-  private[immutable] def lastElem: A
-  private[immutable] def inlineForeach[U](f: A => U): Unit
+  private[immutable] final def inlineLength: Int = this match {
+    case _: InlineVector1[_] => 1
+    case _: InlineVector2[_] => 2
+    case _: InlineVector3[_] => 3
+    case _: InlineVector4[_] => 4
+  }
+
+  private[immutable] final def lastElem: A = this match {
+    case v: InlineVector1[A @unchecked] => v.elem1
+    case v: InlineVector2[A @unchecked] => v.elem2
+    case v: InlineVector3[A @unchecked] => v.elem3
+    case v: InlineVector4[A @unchecked] => v.elem4
+  }
+
+  private[immutable] final def inlineForeach[U](f: A => U): Unit = this match {
+    case _: InlineVector1[_]            => f(elem1); ()
+    case v: InlineVector2[A @unchecked] => f(elem1); f(v.elem2); ()
+    case v: InlineVector3[A @unchecked] => f(elem1); f(v.elem2); f(v.elem3); ()
+    case v: InlineVector4[A @unchecked] => f(elem1); f(v.elem2); f(v.elem3); f(v.elem4); ()
+  }
+
+  final def apply(index: Int): A = this match {
+    case _: InlineVector1[_] =>
+      if (index == 0) elem1 else throw ioob(index)
+    case v: InlineVector2[A @unchecked] => index match {
+      case 0 => elem1
+      case 1 => v.elem2
+      case _ => throw ioob(index)
+    }
+    case v: InlineVector3[A @unchecked] => index match {
+      case 0 => elem1
+      case 1 => v.elem2
+      case 2 => v.elem3
+      case _ => throw ioob(index)
+    }
+    case v: InlineVector4[A @unchecked] => index match {
+      case 0 => elem1
+      case 1 => v.elem2
+      case 2 => v.elem3
+      case 3 => v.elem4
+      case _ => throw ioob(index)
+    }
+  }
+
+  final override def updated[B >: A](index: Int, elem: B): Vector[B] = this match {
+    case _: InlineVector1[_] =>
+      if (index == 0) new InlineVector1(elem) else throw ioob(index)
+    case v: InlineVector2[A @unchecked] => index match {
+      case 0 => new InlineVector2(elem, v.elem2)
+      case 1 => new InlineVector2(elem1, elem)
+      case _ => throw ioob(index)
+    }
+    case v: InlineVector3[A @unchecked] => index match {
+      case 0 => new InlineVector3(elem, v.elem2, v.elem3)
+      case 1 => new InlineVector3(elem1, elem, v.elem3)
+      case 2 => new InlineVector3(elem1, v.elem2, elem)
+      case _ => throw ioob(index)
+    }
+    case v: InlineVector4[A @unchecked] => index match {
+      case 0 => new InlineVector4(elem, v.elem2, v.elem3, v.elem4)
+      case 1 => new InlineVector4(elem1, elem, v.elem3, v.elem4)
+      case 2 => new InlineVector4(elem1, v.elem2, elem, v.elem4)
+      case 3 => new InlineVector4(elem1, v.elem2, v.elem3, elem)
+      case _ => throw ioob(index)
+    }
+  }
+
+  final override def appended[B >: A](elem: B): Vector[B] = this match {
+    case _: InlineVector1[_]            => new InlineVector2(elem1, elem)
+    case v: InlineVector2[A @unchecked] => new InlineVector3(elem1, v.elem2, elem)
+    case v: InlineVector3[A @unchecked] => new InlineVector4(elem1, v.elem2, v.elem3, elem)
+    case v: InlineVector4[A @unchecked] =>
+      val a = new Arr1(5)
+      a(0) = elem1.asInstanceOf[AnyRef]
+      a(1) = v.elem2.asInstanceOf[AnyRef]
+      a(2) = v.elem3.asInstanceOf[AnyRef]
+      a(3) = v.elem4.asInstanceOf[AnyRef]
+      a(4) = elem.asInstanceOf[AnyRef]
+      new Vector1(a)
+  }
+
+  final override def prepended[B >: A](elem: B): Vector[B] = this match {
+    case _: InlineVector1[_]            => new InlineVector2(elem, elem1)
+    case v: InlineVector2[A @unchecked] => new InlineVector3(elem, elem1, v.elem2)
+    case v: InlineVector3[A @unchecked] => new InlineVector4(elem, elem1, v.elem2, v.elem3)
+    case v: InlineVector4[A @unchecked] =>
+      val a = new Arr1(5)
+      a(0) = elem.asInstanceOf[AnyRef]
+      a(1) = elem1.asInstanceOf[AnyRef]
+      a(2) = v.elem2.asInstanceOf[AnyRef]
+      a(3) = v.elem3.asInstanceOf[AnyRef]
+      a(4) = v.elem4.asInstanceOf[AnyRef]
+      new Vector1(a)
+  }
+
+  final override def map[B](f: A => B): Vector[B] = this match {
+    case _: InlineVector1[_]            => new InlineVector1(f(elem1))
+    case v: InlineVector2[A @unchecked] => new InlineVector2(f(elem1), f(v.elem2))
+    case v: InlineVector3[A @unchecked] => new InlineVector3(f(elem1), f(v.elem2), f(v.elem3))
+    case v: InlineVector4[A @unchecked] => new InlineVector4(f(elem1), f(v.elem2), f(v.elem3), f(v.elem4))
+  }
+
+  final override def tail: Vector[A] = this match {
+    case _: InlineVector1[_]            => Vector0
+    case v: InlineVector2[A @unchecked] => new InlineVector1(v.elem2)
+    case v: InlineVector3[A @unchecked] => new InlineVector2(v.elem2, v.elem3)
+    case v: InlineVector4[A @unchecked] => new InlineVector3(v.elem2, v.elem3, v.elem4)
+  }
+
+  final override def init: Vector[A] = this match {
+    case _: InlineVector1[_]            => Vector0
+    case _: InlineVector2[_]            => new InlineVector1(elem1)
+    case v: InlineVector3[A @unchecked] => new InlineVector2(elem1, v.elem2)
+    case v: InlineVector4[A @unchecked] => new InlineVector3(elem1, v.elem2, v.elem3)
+  }
+
+  final override def foldLeft[B](z: B)(f: (B, A) => B): B = this match {
+    case _: InlineVector1[_]            => f(z, elem1)
+    case v: InlineVector2[A @unchecked] => f(f(z, elem1), v.elem2)
+    case v: InlineVector3[A @unchecked] => f(f(f(z, elem1), v.elem2), v.elem3)
+    case v: InlineVector4[A @unchecked] => f(f(f(f(z, elem1), v.elem2), v.elem3), v.elem4)
+  }
 
   private[immutable] final def inlineFilter(pred: A => Boolean, isFlipped: Boolean): Vector[A] = {
     val n   = inlineLength
@@ -488,156 +606,25 @@ private sealed abstract class InlineVector[+A] extends VectorImpl[A](null) {
 }
 
 
-private final class InlineVector1[+A](private[immutable] val elem1: A) extends InlineVector[A] {
-  private[immutable] def inlineLength: Int = 1
-  private[immutable] def lastElem: A = elem1
-  private[immutable] def inlineForeach[U](f: A => U): Unit = { f(elem1); () }
-
-  @inline def apply(index: Int): A =
-    if (index == 0) elem1 else throw ioob(index)
-
-  override def updated[B >: A](index: Int, elem: B): Vector[B] =
-    if (index == 0) new InlineVector1(elem) else throw ioob(index)
-
-  override def appended[B >: A](elem: B): Vector[B] = new InlineVector2(elem1, elem)
-
-  override def prepended[B >: A](elem: B): Vector[B] = new InlineVector2(elem, elem1)
-
-  override def map[B](f: A => B): Vector[B] = new InlineVector1(f(elem1))
-
-  override def tail: Vector[A] = Vector0
-
-  override def init: Vector[A] = Vector0
-
-  override def foldLeft[B](z: B)(f: (B, A) => B): B = f(z, elem1)
-}
-
+private final class InlineVector1[+A](_elem1: A) extends InlineVector[A](_elem1)
 
 private final class InlineVector2[+A](
-  private[immutable] val elem1: A,
+  _elem1: A,
   private[immutable] val elem2: A,
-) extends InlineVector[A] {
-  private[immutable] def inlineLength: Int = 2
-  private[immutable] def lastElem: A = elem2
-  private[immutable] def inlineForeach[U](f: A => U): Unit = { f(elem1); f(elem2); () }
-
-  @inline def apply(index: Int): A = index match {
-    case 0 => elem1
-    case 1 => elem2
-    case _ => throw ioob(index)
-  }
-
-  override def updated[B >: A](index: Int, elem: B): Vector[B] = index match {
-    case 0 => new InlineVector2(elem, elem2)
-    case 1 => new InlineVector2(elem1, elem)
-    case _ => throw ioob(index)
-  }
-
-  override def appended[B >: A](elem: B): Vector[B] = new InlineVector3(elem1, elem2, elem)
-
-  override def prepended[B >: A](elem: B): Vector[B] = new InlineVector3(elem, elem1, elem2)
-
-  override def map[B](f: A => B): Vector[B] = new InlineVector2(f(elem1), f(elem2))
-
-  override def tail: Vector[A] = new InlineVector1(elem2)
-
-  override def init: Vector[A] = new InlineVector1(elem1)
-
-  override def foldLeft[B](z: B)(f: (B, A) => B): B = f(f(z, elem1), elem2)
-}
-
+) extends InlineVector[A](_elem1)
 
 private final class InlineVector3[+A](
-  private[immutable] val elem1: A,
+  _elem1: A,
   private[immutable] val elem2: A,
   private[immutable] val elem3: A,
-) extends InlineVector[A] {
-  private[immutable] def inlineLength: Int = 3
-  private[immutable] def lastElem: A = elem3
-  private[immutable] def inlineForeach[U](f: A => U): Unit = { f(elem1); f(elem2); f(elem3); () }
-
-  @inline def apply(index: Int): A = index match {
-    case 0 => elem1
-    case 1 => elem2
-    case 2 => elem3
-    case _ => throw ioob(index)
-  }
-
-  override def updated[B >: A](index: Int, elem: B): Vector[B] = index match {
-    case 0 => new InlineVector3(elem, elem2, elem3)
-    case 1 => new InlineVector3(elem1, elem, elem3)
-    case 2 => new InlineVector3(elem1, elem2, elem)
-    case _ => throw ioob(index)
-  }
-
-  override def appended[B >: A](elem: B): Vector[B] = new InlineVector4(elem1, elem2, elem3, elem)
-
-  override def prepended[B >: A](elem: B): Vector[B] = new InlineVector4(elem, elem1, elem2, elem3)
-
-  override def map[B](f: A => B): Vector[B] = new InlineVector3(f(elem1), f(elem2), f(elem3))
-
-  override def tail: Vector[A] = new InlineVector2(elem2, elem3)
-
-  override def init: Vector[A] = new InlineVector2(elem1, elem2)
-
-  override def foldLeft[B](z: B)(f: (B, A) => B): B = f(f(f(z, elem1), elem2), elem3)
-}
-
+) extends InlineVector[A](_elem1)
 
 private final class InlineVector4[+A](
-  private[immutable] val elem1: A,
+  _elem1: A,
   private[immutable] val elem2: A,
   private[immutable] val elem3: A,
   private[immutable] val elem4: A,
-) extends InlineVector[A] {
-  private[immutable] def inlineLength: Int = 4
-  private[immutable] def lastElem: A = elem4
-  private[immutable] def inlineForeach[U](f: A => U): Unit = { f(elem1); f(elem2); f(elem3); f(elem4); () }
-
-  @inline def apply(index: Int): A = index match {
-    case 0 => elem1
-    case 1 => elem2
-    case 2 => elem3
-    case 3 => elem4
-    case _ => throw ioob(index)
-  }
-
-  override def updated[B >: A](index: Int, elem: B): Vector[B] = index match {
-    case 0 => new InlineVector4(elem, elem2, elem3, elem4)
-    case 1 => new InlineVector4(elem1, elem, elem3, elem4)
-    case 2 => new InlineVector4(elem1, elem2, elem, elem4)
-    case 3 => new InlineVector4(elem1, elem2, elem3, elem)
-    case _ => throw ioob(index)
-  }
-
-  override def appended[B >: A](elem: B): Vector[B] = {
-    val a = new Arr1(5)
-    a(0) = elem1.asInstanceOf[AnyRef]
-    a(1) = elem2.asInstanceOf[AnyRef]
-    a(2) = elem3.asInstanceOf[AnyRef]
-    a(3) = elem4.asInstanceOf[AnyRef]
-    a(4) = elem.asInstanceOf[AnyRef]
-    new Vector1(a)
-  }
-
-  override def prepended[B >: A](elem: B): Vector[B] = {
-    val a = new Arr1(5)
-    a(0) = elem.asInstanceOf[AnyRef]
-    a(1) = elem1.asInstanceOf[AnyRef]
-    a(2) = elem2.asInstanceOf[AnyRef]
-    a(3) = elem3.asInstanceOf[AnyRef]
-    a(4) = elem4.asInstanceOf[AnyRef]
-    new Vector1(a)
-  }
-
-  override def map[B](f: A => B): Vector[B] = new InlineVector4(f(elem1), f(elem2), f(elem3), f(elem4))
-
-  override def tail: Vector[A] = new InlineVector3(elem2, elem3, elem4)
-
-  override def init: Vector[A] = new InlineVector3(elem1, elem2, elem3)
-
-  override def foldLeft[B](z: B)(f: (B, A) => B): B = f(f(f(f(z, elem1), elem2), elem3), elem4)
-}
+) extends InlineVector[A](_elem1)
 
 
 private final class InlineVectorIterator[+A](v: InlineVector[A]) extends AbstractIterator[A] {

--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -340,7 +340,7 @@ sealed abstract class Vector[+A] private[immutable] (private[immutable] final va
   private[collection] def startIndex: Int = 0
   private[collection] def endIndex: Int = length
   private[collection] def initIterator[B >: A](s: VectorIterator[B]): Unit =
-    s.it = fullIterator.asInstanceOf[NewVectorIterator[B]]
+    s.it = fullIterator
 }
 
 
@@ -440,6 +440,40 @@ private sealed abstract class InlineVector[+A] extends VectorImpl[A](null) {
     case 1 => new InlineVector1(apply(lo))
     case 2 => new InlineVector2(apply(lo), apply(lo + 1))
     case _ => new InlineVector3(apply(lo), apply(lo + 1), apply(lo + 2))
+  }
+
+  override protected[this] final def appendedAll0[B >: A](suffix: collection.IterableOnce[B], k: Int): Vector[B] = {
+    val n = inlineLength
+    if (n + k > 4 && k <= WIDTH - n) {
+      val a = new Arr1(n + k)
+      var i = 0
+      while (i < n) {
+        a(i) = apply(i).asInstanceOf[AnyRef]
+        i += 1
+      }
+      @annotation.unused val copied = suffix match {
+        case it: Iterable[B] => it.copyToArray(a.asInstanceOf[Array[Any]], n)
+        case _               => suffix.iterator.copyToArray(a.asInstanceOf[Array[Any]], n)
+      }
+      new Vector1(a)
+    } else super.appendedAll0(suffix, k)
+  }
+
+  override protected[this] final def prependedAll0[B >: A](prefix: collection.IterableOnce[B], k: Int): Vector[B] = {
+    val n = inlineLength
+    if (n + k > 4 && k <= WIDTH - n) {
+      val a = new Arr1(k + n)
+      @annotation.unused val copied = prefix match {
+        case it: Iterable[B] => it.copyToArray(a.asInstanceOf[Array[Any]], 0)
+        case _               => prefix.iterator.copyToArray(a.asInstanceOf[Array[Any]], 0)
+      }
+      var i = 0
+      while (i < n) {
+        a(k + i) = apply(i).asInstanceOf[AnyRef]
+        i += 1
+      }
+      new Vector1(a)
+    } else super.prependedAll0(prefix, k)
   }
 
   protected[immutable] final def vectorSliceCount: Int = 1

--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -95,7 +95,8 @@ object Vector extends StrictOptimizedSeqFactory[Vector] {
       case _: SecurityException => 250
     }
 
-  private val emptyIterator = new NewVectorIterator(Vector0, 0, 0)
+  private val emptyIterator: NewVectorIterator[Nothing] =
+    new NewVectorIterator(Vector0, 0, 0)
 }
 
 
@@ -139,6 +140,11 @@ sealed abstract class Vector[+A] private[immutable] (private[immutable] final va
     }
 
   override final def iterator: Iterator[A] =
+    if(this.isInstanceOf[Vector0.type]) Vector.emptyIterator
+    else if (this.isInstanceOf[InlineVector[_]]) new InlineVectorIterator(this.asInstanceOf[InlineVector[A]])
+    else new NewVectorIterator(this, length, vectorSliceCount)
+
+  private[this] def fullIterator: NewVectorIterator[A] =
     if(this.isInstanceOf[Vector0.type]) Vector.emptyIterator
     else new NewVectorIterator(this, length, vectorSliceCount)
 
@@ -287,10 +293,10 @@ sealed abstract class Vector[+A] private[immutable] (private[immutable] final va
 
   override def stepper[S <: Stepper[_]](implicit shape: StepperShape[A, S]): S with EfficientSplit = {
     val s = shape.shape match {
-      case StepperShape.IntShape    => new IntVectorStepper(iterator.asInstanceOf[NewVectorIterator[Int]])
-      case StepperShape.LongShape   => new LongVectorStepper(iterator.asInstanceOf[NewVectorIterator[Long]])
-      case StepperShape.DoubleShape => new DoubleVectorStepper(iterator.asInstanceOf[NewVectorIterator[Double]])
-      case _                        => shape.parUnbox(new AnyVectorStepper[A](iterator.asInstanceOf[NewVectorIterator[A]]))
+      case StepperShape.IntShape    => new IntVectorStepper(fullIterator.asInstanceOf[NewVectorIterator[Int]])
+      case StepperShape.LongShape   => new LongVectorStepper(fullIterator.asInstanceOf[NewVectorIterator[Long]])
+      case StepperShape.DoubleShape => new DoubleVectorStepper(fullIterator.asInstanceOf[NewVectorIterator[Double]])
+      case _                        => shape.parUnbox(new AnyVectorStepper[A](fullIterator.asInstanceOf[NewVectorIterator[A]]))
     }
     s.asInstanceOf[S with EfficientSplit]
   }
@@ -334,7 +340,7 @@ sealed abstract class Vector[+A] private[immutable] (private[immutable] final va
   private[collection] def startIndex: Int = 0
   private[collection] def endIndex: Int = length
   private[collection] def initIterator[B >: A](s: VectorIterator[B]): Unit =
-    s.it = iterator.asInstanceOf[NewVectorIterator[B]]
+    s.it = fullIterator.asInstanceOf[NewVectorIterator[B]]
 }
 
 
@@ -597,6 +603,20 @@ private final class InlineVector4[+A](
   override def init: Vector[A] = new InlineVector3(elem1, elem2, elem3)
 
   override def foldLeft[B](z: B)(f: (B, A) => B): B = f(f(f(f(z, elem1), elem2), elem3), elem4)
+}
+
+
+private final class InlineVectorIterator[+A](v: InlineVector[A]) extends AbstractIterator[A] {
+  private[this] val n = v.inlineLength
+  private[this] var i = 0
+
+  override def knownSize: Int = n - i
+
+  def hasNext: Boolean = i < n
+
+  def next(): A =
+    if (i < n) { val r = v(i); i += 1; r }
+    else Iterator.empty.next()
 }
 
 
@@ -2476,7 +2496,7 @@ private object VectorStatics {
 }
 
 
-private final class NewVectorIterator[A](v: Vector[A], private[this] var totalLength: Int, private[this] val sliceCount: Int) extends AbstractIterator[A] with java.lang.Cloneable {
+private final class NewVectorIterator[+A](v: Vector[A], private[this] var totalLength: Int, private[this] val sliceCount: Int) extends AbstractIterator[A] with java.lang.Cloneable {
 
   private[this] var a1: Arr1 = {
     val p = v.prefix1

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/SmallVectorBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/SmallVectorBenchmark.scala
@@ -1,0 +1,300 @@
+package scala.collection.immutable
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+/** Benchmarks for the InlineVector1..4 change: a matrix of sizes x operations.
+  *
+  * Sizes 1-4 use the inline representation (when built incrementally or via builder),
+  * 5 is the smallest array-backed Vector1 under the new scheme, 1000 is a Vector2+,
+  * 100000 is a Vector3+ (regression check for the extra branches added to
+  * length/head/last/foreach/filter and the iterator constructor).
+  */
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(1)
+@Threads(1)
+@Warmup(iterations = 8, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 7, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class SmallVectorBenchmark {
+
+  @Param(Array("1", "2", "3", "4", "5", "1000", "100000"))
+  var size: Int = _
+
+  var v: Vector[Integer] = _
+  var elem: Integer = _
+  var list: List[Integer] = _
+  var arraySeq: ArraySeq[Integer] = _
+  var midIdx: Int = _
+
+  private[this] var sink: Long = 0
+
+  private[this] val inc: Integer => Integer = x => Integer.valueOf(x.intValue + 1)
+  private[this] val add: (Int, Integer) => Int = (acc, x) => acc + x.intValue
+  private[this] val isEven: Integer => Boolean = x => (x.intValue & 1) == 0
+  private[this] val never: Integer => Boolean = x => x.intValue == Int.MinValue
+  private[this] val consumeF: Integer => Unit = x => sink += x.intValue
+
+  @Setup(Level.Trial) def setup(): Unit = {
+    // build incrementally so small sizes actually use the representation produced by :+
+    var b: Vector[Integer] = Vector.empty
+    var i = 0
+    while (i < size) { b = b :+ Integer.valueOf(i); i += 1 }
+    v = b
+    elem = Integer.valueOf(-1)
+    list = List.tabulate(size)(Integer.valueOf(_))
+    arraySeq = ArraySeq.tabulate(size)(Integer.valueOf(_))
+    midIdx = size / 2
+  }
+
+  // --- reads ---
+
+  @Benchmark def length: Int = v.length
+  @Benchmark def head: Integer = v.head
+  @Benchmark def last: Integer = v.last
+  @Benchmark def applyMid: Integer = v(midIdx)
+
+  // --- structural ops ---
+
+  @Benchmark def tail: Vector[Integer] = v.tail
+  @Benchmark def init: Vector[Integer] = v.init
+  @Benchmark def appended: Vector[Integer] = v :+ elem
+  @Benchmark def prepended: Vector[Integer] = elem +: v
+  @Benchmark def updatedMid: Vector[Integer] = v.updated(midIdx, elem)
+  @Benchmark def concatSelf: Vector[Integer] = v ++ v
+
+  // --- traversals ---
+
+  @Benchmark def map: Vector[Integer] = v.map(inc)
+  @Benchmark def foldLeftSum: Int = v.foldLeft(0)(add)
+  @Benchmark def foreachSum: Long = { sink = 0; v.foreach(consumeF); sink }
+  @Benchmark def iteratorSum: Int = {
+    var s = 0
+    val it = v.iterator
+    while (it.hasNext) s += it.next().intValue
+    s
+  }
+  @Benchmark def filterHalf: Vector[Integer] = v.filter(isEven)
+  @Benchmark def existsNotFound: Boolean = v.exists(never)
+
+  // --- construction ---
+
+  @Benchmark def fromArraySeq: Vector[Integer] = Vector.from(arraySeq)
+  @Benchmark def fromList: Vector[Integer] = list.toVector
+  @Benchmark def buildByAppend: Vector[Integer] = {
+    var b: Vector[Integer] = Vector.empty
+    var i = 0
+    while (i < size) { b = b :+ elem; i += 1 }
+    b
+  }
+  @Benchmark def drainByTail(bh: Blackhole): Unit = {
+    var x = v
+    while (x.nonEmpty) x = x.tail
+    bh.consume(x)
+  }
+}
+
+/** Call sites that see a mix of small-vector sizes: measures the cost of the
+  * larger class polymorphism (Vector0 + 4 inline classes + Vector1 vs
+  * Vector0 + Vector1 before the change).
+  */
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(1)
+@Threads(1)
+@Warmup(iterations = 8, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 7, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class SmallVectorMixedBenchmark {
+
+  // 1024 vectors with sizes cycling through 0..6 (mix of representations)
+  var vs: Array[Vector[Integer]] = _
+  private[this] val inc: Integer => Integer = x => Integer.valueOf(x.intValue + 1)
+
+  @Setup(Level.Trial) def setup(): Unit = {
+    vs = Array.tabulate(1024) { i =>
+      val n = i % 7
+      var b: Vector[Integer] = Vector.empty
+      var j = 0
+      while (j < n) { b = b :+ Integer.valueOf(j); j += 1 }
+      b
+    }
+  }
+
+  @Benchmark def lengthSum: Int = {
+    var s = 0
+    var i = 0
+    while (i < vs.length) { s += vs(i).length; i += 1 }
+    s
+  }
+
+  @Benchmark def headSumNonEmpty: Int = {
+    var s = 0
+    var i = 0
+    while (i < vs.length) {
+      val v = vs(i)
+      if (v.nonEmpty) s += v.head.intValue
+      i += 1
+    }
+    s
+  }
+
+  @Benchmark def applyZeroSum: Int = {
+    var s = 0
+    var i = 0
+    while (i < vs.length) {
+      val v = vs(i)
+      if (v.nonEmpty) s += v(0).intValue
+      i += 1
+    }
+    s
+  }
+
+  @Benchmark def appendedAll(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < vs.length) { bh.consume(vs(i) :+ i); i += 1 }
+  }
+
+  @Benchmark def mapAll(bh: Blackhole): Unit = {
+    var i = 0
+    while (i < vs.length) { bh.consume(vs(i).map(inc)); i += 1 }
+  }
+
+  @Benchmark def iterateAll: Int = {
+    var s = 0
+    var i = 0
+    while (i < vs.length) {
+      val it = vs(i).iterator
+      while (it.hasNext) s += it.next().intValue
+      i += 1
+    }
+    s
+  }
+}
+
+/** Allocation-churn benchmarks, intended to be run with `-prof gc` and different
+  * heap sizes (e.g. -Xmx4g low pressure vs -Xmx64m high pressure).
+  * `retained` vectors keep a slice of the allocations alive so that some churn
+  * is promoted out of the young generation.
+  */
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(1)
+@Threads(1)
+@Warmup(iterations = 6, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 6, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class SmallVectorChurnBenchmark {
+
+  @Param(Array("4", "100000"))
+  var size: Int = _
+
+  var v: Vector[Integer] = _
+  var elem: Integer = _
+  var retained: Array[Vector[Integer]] = _
+  private[this] var rIdx = 0
+  private[this] val inc: Integer => Integer = x => Integer.valueOf(x.intValue + 1)
+
+  @Setup(Level.Trial) def setup(): Unit = {
+    var b: Vector[Integer] = Vector.empty
+    var i = 0
+    while (i < size) { b = b :+ Integer.valueOf(i); i += 1 }
+    v = b
+    elem = Integer.valueOf(-1)
+    // retain up to ~8k small vectors / ~16 large ones to create old-gen pressure
+    retained = new Array[Vector[Integer]](if (size <= 64) 8192 else 16)
+  }
+
+  @Benchmark def mapChurnRetained: Vector[Integer] = {
+    val r = v.map(inc)
+    retained(rIdx) = r
+    rIdx += 1
+    if (rIdx == retained.length) rIdx = 0
+    r
+  }
+
+  @Benchmark def appendTailChurn: Vector[Integer] = {
+    val r = (v :+ elem).tail
+    retained(rIdx) = r
+    rIdx += 1
+    if (rIdx == retained.length) rIdx = 0
+    r
+  }
+}
+
+/** Dissects the mixed-dispatch cost: is it the number of receiver classes or the number of
+  * distinct method implementations? Same call sites, different class mixes.
+  * - m1:   size 2 only            -> 1 class  (InlineVector2), monomorphic
+  * - m2i:  sizes 1,2              -> 2 inline classes, one shared implementation
+  * - m4i:  sizes 1,2,3,4          -> 4 inline classes, one shared implementation
+  * - m2x:  sizes 2,5              -> 2 classes (InlineVector2, Vector1), two implementations
+  * - m5x:  sizes 1,2,3,4,5        -> 5 classes, two implementations
+  * - mv:   sizes 5,6              -> 1 class (Vector1), monomorphic array-backed
+  */
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(1)
+@Threads(1)
+@Warmup(iterations = 8, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 7, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class SmallVectorDispatchBenchmark {
+
+  @Param(Array("m1", "m2i", "m4i", "m2x", "m5x", "mv"))
+  var mix: String = _
+
+  var vs: Array[Vector[Integer]] = _
+
+  @Setup(Level.Trial) def setup(): Unit = {
+    val sizes: Array[Int] = mix match {
+      case "m1"  => Array(2)
+      case "m2i" => Array(1, 2)
+      case "m4i" => Array(1, 2, 3, 4)
+      case "m2x" => Array(2, 5)
+      case "m5x" => Array(1, 2, 3, 4, 5)
+      case "mv"  => Array(5, 6)
+    }
+    vs = Array.tabulate(1024) { i =>
+      val n = sizes(i % sizes.length)
+      var b: Vector[Integer] = Vector.empty
+      var j = 0
+      while (j < n) { b = b :+ Integer.valueOf(j); j += 1 }
+      b
+    }
+  }
+
+  @Benchmark def lengthSum: Int = {
+    var s = 0
+    var i = 0
+    while (i < vs.length) { s += vs(i).length; i += 1 }
+    s
+  }
+
+  @Benchmark def headSum: Int = {
+    var s = 0
+    var i = 0
+    while (i < vs.length) { s += vs(i).head.intValue; i += 1 }
+    s
+  }
+
+  @Benchmark def applyZeroSum: Int = {
+    var s = 0
+    var i = 0
+    while (i < vs.length) { s += vs(i)(0).intValue; i += 1 }
+    s
+  }
+
+  @Benchmark def iterateAll: Int = {
+    var s = 0
+    var i = 0
+    while (i < vs.length) {
+      val it = vs(i).iterator
+      while (it.hasNext) s += it.next().intValue
+      i += 1
+    }
+    s
+  }
+}

--- a/test/junit/scala/collection/immutable/VectorTest.scala
+++ b/test/junit/scala/collection/immutable/VectorTest.scala
@@ -267,7 +267,8 @@ class VectorTest {
   }
 
   @Test def factoryReuseArraySet(): Unit = {
-    val arraySeq = ArraySeq[AnyRef]("a", "b")
+    // Has to be between 5 and 32, as 1-4 elements are InlineVector, and 33+ elements become Vector2+
+    val arraySeq = ArraySeq[AnyRef]("a", "b", "c", "d", "e")
     val vectorFromArraySeq = Vector.from(arraySeq)
     val prefix1Field = classOf[Vector[_]].getDeclaredField("prefix1")
     prefix1Field.setAccessible(true)


### PR DESCRIPTION
My main goal is to improve performance and memory footprint of 1-element Vector values. This is one thing where Vector is better than List, because it's 1-element representation is `::(value, Nil)`. Current implementation of Vector models 1-element value as `Vector1(Array(value))`, which is an additional allocation and an indirection when accessing `head`. 

Inspired by [smallvec](https://github.com/servo/rust-smallvec) in Rust's ecosystem.

The downsides of my approach is increased number of possible classes when calling dynamic methods on `Vector`-typed values, such as `apply`. HotSpot struggles to de-virtualize such calls.
As a compromise, we can remove InlineVector2-4 variants, and either:
1. Keep only a special case for a single-element Vector. This is a more conservative choice, `Vector1` will continue to cover cases for 2-4 element Vectors.
2. Introduce a generic `case class InlineVector[T](slot1: T, slot2: T, slot3: T, slot4: T, length: Int)` that will cover all 1-4 cases, storing nulls for unused slots. Downside is this wasted memory by keeping unused reference slots and the length field.

Upsides are performance improvements for small-sized vectors with minimal effect on performance of large vectors. Benchmark results with help from an LLM agent:
<img width="979" height="647" alt="Screenshot 2026-09-08 at 01 30 07" src="https://github.com/user-attachments/assets/b72e3fda-303f-41d8-8b55-acaba78cc4fd" />
